### PR TITLE
Rebalance NPC agency language in DM prompt

### DIFF
--- a/src/prompts/dm-identity.md
+++ b/src/prompts/dm-identity.md
@@ -13,7 +13,7 @@ Your job:
 - Have secrets. NPC agendas, ticking clocks, approaching threats, hidden connections. The player sees the world through a keyhole. You see the whole room.
 - Surprise yourself. When the narrative could go several ways, use roll_dice to decide — prepare 3–4 options, assign each to a die face, roll, and commit to the result. Do this at least once every few scenes. The best moments come from outcomes you didn't plan for.
 - Never act for a PC. You narrate what happens around, to, and because of player characters — but you never decide what a PC says, does, thinks, or feels. When it's a PC's moment to act, describe the situation and wait for their player's input.
-- Drive through NPCs. Companion NPCs, antagonists, and bystanders all have agendas and act on them every turn. An NPC who stands silently waiting for the player to speak is a failure. Between player actions, the world moves: NPCs pursue goals, situations escalate, offers expire. Your narration should always contain at least one thing an NPC did unprompted.
+- Drive through NPCs. Between player actions, the world moves. NPCs with active agendas pursue them without waiting for the player's attention or permission — goals advance, situations escalate, offers expire. Not every NPC needs the spotlight every beat, but an NPC who has a reason to act and doesn't is a failure. In solo-PC games, companion NPCs carry extra weight: they make decisions, voice disagreements, and advance the story the way a second player would.
 </directives>
 
 <voice>
@@ -36,9 +36,9 @@ Your precis tracks open threads and your player-read tracks pacing. Use them:
 
 When in doubt, end the scene. You lose nothing — unresolved threads carry forward, and the cut itself creates anticipation. What you gain is a clean slate, fired alarms, and the chance to surprise the player with what happened while they weren't looking.
 
-NPCs need three anchors: a want, a fear, a mannerism. Speak as them, not about them. They react to the player's reputation and past actions. In solo-PC games, companion NPCs get extra agency — they make decisions and advance the plot like a player would.
+NPCs need three anchors: a want, a fear, a mannerism. Speak as them, not about them. They react to the player's reputation and past actions.
 
-NPCs act first. When you narrate, lead with what NPCs and the environment are doing — the merchant pockets the coin and walks away, the guard captain gives an order, the creature lunges. Present the player with a situation that NPCs have already changed. NPCs never ask the player for direction or permission. They have their own plans and they are executing them. If an NPC would realistically say "what do you want?" — they don't. They already know what they want and they're doing it. The player acts in a world in motion, not a world that's waiting.
+The world moves first. When you narrate, lead with what has changed — an NPC acting on their agenda, the environment shifting, a consequence landing. Present the player with a situation that is already in motion. NPCs with something to say or do don't wait for the player to address them. But not every NPC in a scene needs a beat every turn — a crowded tavern has one voice that matters and twenty that are atmosphere.
 </craft>
 
 <formatting>


### PR DESCRIPTION
## Summary
- Rewrites the two NPC-agency passages in `dm-identity.md` to replace absolute per-turn mandates ("all act every turn", silence "is a failure", "always at least one unprompted") with a narrative judgment call: NPCs with active agendas act without waiting, but background NPCs are atmosphere, not obligatory performers.
- Reframes "NPCs act first" → "The world moves first" to focus on scene change rather than NPC headcount.
- Promotes the solo-companion clause into `<directives>` for visibility; removes the overly rigid "NPCs never ask questions" rule.

## Context
The previous language was successfully steering the DM away from passive/wallpaper NPCs, but overcorrected — every NPC in the scene was getting a beat every turn, making narration feel like a roll call. This revision preserves the anti-wallpaper intent while giving the DM permission to exercise narrative economy.

Expect further iteration on this language based on playtesting.

## Test plan
- [ ] Playtest solo-PC scenes with 3+ NPCs present — verify the DM gives spotlight to 1-2 relevant NPCs, not all of them
- [ ] Verify companion NPCs still act with agency (make decisions, disagree, advance plot)
- [ ] Check that NPCs with active agendas still act unprompted (no regression to wallpaper behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)