### PR TITLE
Fix scene thread inflation via precis updater

### DIFF
--- a/src/prompts/precis-updater.md
+++ b/src/prompts/precis-updater.md
@@ -11,7 +11,10 @@ Rules:
 Output order (all on separate lines):
 1. The precis summary line(s).
 2. NPC_NEXT: lines — if any NPC expressed an intention, made a plan, or is mid-action, write one line per NPC: `NPC_NEXT: [[Name]] intends to [action]`. Only for active, unresolved intentions. Omit if no NPCs have pending actions.
-3. OPEN: line — a comma-separated list of unresolved narrative threads still active in this scene: unexplored NPC motivations, unanswered questions, ongoing conflicts, unresolved offers or promises. Use wikilinks for named entities: [[name]]. Evolve the list from the current open threads provided — add new threads introduced in this exchange, remove any that were resolved or concluded. If no threads remain open, omit the OPEN: line entirely.
+3. OPEN: line — a comma-separated list of narrative threads with active momentum in this scene. A thread has momentum when the player is engaging with it, a conflict is unresolved, or consequences are pending. Use wikilinks for named entities: [[name]]. Evolve the list from the current open threads provided:
+   - Add threads introduced or advanced in this exchange.
+   - Remove threads that were resolved, concluded, or that the player passed over without engaging. A hook the DM offered that the player ignored or declined is not an open thread — drop it.
+   If no threads remain open, omit the OPEN: line entirely.
 4. PLAYER_READ: line with a JSON object analyzing the player's input:
   {"engagement":"high|moderate|low","focus":["tags"],"tone":"word","pacing":"exploratory|pushing_forward|hesitant","offScript":true|false}
   engagement: how invested the player seems (high=detailed/creative input, moderate=normal, low=minimal/disengaged)


### PR DESCRIPTION
## Summary
- Reframe OPEN thread criteria in `precis-updater.md` from "unresolved" to **active momentum** — threads need player engagement, unresolved conflict, or pending consequences
- Add **player ignored/declined** as an explicit removal criterion, so hooks the DM offered that the player walked past no longer inflate the thread list
- Restores credibility to pacing signals, making the DM more willing to end scenes naturally

## Test plan
- [x] `npm run check` passes (1089 tests, ESLint clean, coverage thresholds met)
- [ ] Manual: play a scene, offer hooks the player ignores, confirm `openThreads` in `state/scene.json` shrinks as ignored hooks drop off

🤖 Generated with [Claude Code](https://claude.com/claude-code)