### PR TITLE
Enable Dev Mode by default in npm run dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^20.11.0",
         "@types/react": "^18.3.0",
         "@vitest/coverage-v8": "^4.0.18",
+        "cross-env": "^10.1.0",
         "eslint": "^10.0.0",
         "ink-testing-library": "^4.0.0",
         "tsx": "^4.7.0",
@@ -133,6 +134,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -2011,6 +2019,24 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node dist/index.js",
-    "dev": "tsx src/index.tsx",
+    "dev": "cross-env DEV_MODE=true tsx src/index.tsx",
     "build": "tsc",
     "postbuild": "node -e \"const fs=require('fs'),p=require('path'),s='src/prompts',d='dist/prompts';fs.mkdirSync(d,{recursive:true});fs.readdirSync(s).filter(f=>f.endsWith('.md')).forEach(f=>fs.copyFileSync(p.join(s,f),p.join(d,f)))\"",
     "watch": "tsc --watch",
@@ -40,6 +40,7 @@
     "@types/node": "^20.11.0",
     "@types/react": "^18.3.0",
     "@vitest/coverage-v8": "^4.0.18",
+    "cross-env": "^10.1.0",
     "eslint": "^10.0.0",
     "ink-testing-library": "^4.0.0",
     "tsx": "^4.7.0",


### PR DESCRIPTION
## Summary
- Add `cross-env` devDependency for cross-platform env var support in npm scripts
- Update `npm run dev` to set `DEV_MODE=true` so the in-game developer console is always available during development

## Test plan
- [x] `npm run check` passes (1096 tests, ESLint clean, coverage thresholds met)
- [ ] Run `npm run dev` and verify "Dev Mode" appears in the ESC menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)