### PR TITLE
Track dev-config.json in repo to fix thinking trace leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,6 @@ web_modules/
 .env.*
 !.env.example
 
-# Dev model overrides
-dev-config.json
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npx tsx src/index.tsx    # launch (needs ANTHROPIC_API_KEY in .env)
 | `medium` | Sonnet | OOC mode, AI players |
 | `small` | Haiku | All mechanical subagents (summarizer, precis, changelog, choices, resolve, promotion) |
 
-Configured in `src/config/models.ts`. Override with `dev-config.json` (gitignored):
+Configured in `src/config/models.ts`. Override with `dev-config.json`:
 ```json
 { "models": { "large": "claude-sonnet-4-5-20250929" } }
 ```

--- a/dev-config.json
+++ b/dev-config.json
@@ -1,0 +1,21 @@
+{
+  "models": {
+    "large": "claude-sonnet-4-6"
+  },
+  "thinking": {
+    "default": 0,
+    "dm": 1024,
+    "ooc": "adaptive",
+    "dev-mode": "adaptive",
+    "ai-player": 512,
+    "setup": "adaptive",
+    "setup-gen": "adaptive",
+    "scene-summarizer": 0,
+    "precis-updater": 0,
+    "changelog-updater": 0,
+    "choice-generator": 0,
+    "resolve_action": 0,
+    "promote_character": 0,
+    "repair-state": "adaptive"
+  }
+}


### PR DESCRIPTION
## Summary

- Un-gitignore `dev-config.json` so the committed config (which enables extended thinking for the DM agent) is present in worktrees and fresh clones
- Without a thinking channel, the model outputs reasoning directly in its text blocks, causing internal planning traces to appear as narration
- Anyone running unpackaged source is a developer, so dev defaults should ship with the repo

Closes #14

## Test plan

- [x] `npm run check` passes (1224 tests, ESLint clean)
- [ ] Launch in a fresh worktree and verify DM narration contains no reasoning preambles

🤖 Generated with [Claude Code](https://claude.com/claude-code)