### PR TITLE
Fix additional_names crash when DM passes an array

### DIFF
--- a/src/agents/game-engine.test.ts
+++ b/src/agents/game-engine.test.ts
@@ -657,6 +657,40 @@ describe("GameEngine Worldbuilding Entity I/O", () => {
     expect(combined).toContain("Grimjaw (also: Captain Grimjaw)");
   });
 
+  it("update_entity handles additional_names passed as array (#15)", async () => {
+    files[norm("/tmp/test-campaign/characters/grimjaw.md")] =
+      "# Grimjaw\n\n**Type:** character\n\nA scarred orc.\n";
+
+    const client = mockClient([
+      ...toolAndTextMessages("update_entity", {
+        entity_type: "character",
+        name: "Grimjaw",
+        file_path: "/tmp/test-campaign/characters/grimjaw.md",
+        front_matter_updates: { additional_names: ["Captain Grimjaw", "The Scarred"] },
+        body_append: "Now an ally.",
+      }, "The orc nods."),
+    ]);
+    const { callbacks } = mockCallbacks();
+    const fio = mockFileIO();
+
+    const engine = new GameEngine({
+      client,
+      gameState: mockState(),
+      scene: mockScene(),
+      sessionState: mockSessionState(),
+      fileIO: fio,
+      callbacks,
+      model: "claude-haiku-4-5-20251001",
+    });
+
+    await engine.processInput("Aldric", "I befriend the orc.");
+
+    const sm = engine.getSceneManager();
+    const prompt = sm.getSystemPrompt();
+    const combined = prompt.map((b) => b.text).join("");
+    expect(combined).toContain("Grimjaw (also: Captain Grimjaw, The Scarred)");
+  });
+
   it("update_entity silently handles missing files", async () => {
     const client = mockClient([
       ...toolAndTextMessages("update_entity", {

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -601,7 +601,8 @@ export class GameEngine {
       const updated = serializeEntity(title as string, frontMatter, newBody, newChangelog);
       await this.fileIO.writeFile(filePath, updated);
 
-      const aliases = (frontMatter.additional_names as string | undefined)?.trim() || undefined;
+      const rawAliases = frontMatter.additional_names;
+      const aliases = (Array.isArray(rawAliases) ? rawAliases.join(", ") : typeof rawAliases === "string" ? rawAliases : undefined)?.trim() || undefined;
       this.sceneManager.notifyEntityTouched(filePath, title as string, aliases);
       this.callbacks.onDevLog?.(`[dev] update_entity: updated "${name}" — ${parts.join(", ")}`);
     } catch (e) {

--- a/src/agents/scene-manager.ts
+++ b/src/agents/scene-manager.ts
@@ -656,7 +656,8 @@ export class SceneManager {
         if (await this.fileIO.exists(filePath)) {
           const raw = await this.fileIO.readFile(filePath);
           const { frontMatter } = parseFrontMatter(raw);
-          const aliases = frontMatter.additional_names as string | undefined;
+          const rawAliases = frontMatter.additional_names;
+          const aliases = Array.isArray(rawAliases) ? rawAliases.join(", ") : typeof rawAliases === "string" ? rawAliases : undefined;
           if (aliases?.trim()) {
             line += ` (also: ${aliases.trim()})`;
           }
@@ -674,7 +675,8 @@ export class SceneManager {
       try {
         const raw = await this.fileIO.readFile(fullPath);
         const { frontMatter } = parseFrontMatter(raw);
-        const aliases = frontMatter.additional_names as string | undefined;
+        const rawAliases = frontMatter.additional_names;
+        const aliases = Array.isArray(rawAliases) ? rawAliases.join(", ") : typeof rawAliases === "string" ? rawAliases : undefined;
         if (aliases?.trim()) {
           lines.push(`${file}: also known as ${aliases.trim()}`);
         }


### PR DESCRIPTION
## Summary
- Fixes #15 — `frontMatter.additional_names?.trim is not a function`
- The DM can pass `additional_names` as an array in `front_matter_updates`, but all three usage sites assumed it was always a string and called `.trim()`
- Now coerces arrays to comma-separated strings before trimming, at all three sites (`game-engine.ts`, `scene-manager.ts` x2)

## Test plan
- [x] Added test: `update_entity handles additional_names passed as array (#15)`
- [x] All 1225 tests pass, ESLint clean, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)