### PR TITLE
Move session recap into cached prefix zone

### DIFF
--- a/design-docs/context-management.md
+++ b/design-docs/context-management.md
@@ -15,8 +15,8 @@ The entity filesystem, campaign log, and scene transcripts are the DM's long-ter
 │ System prompt: DM identity                     ~800t  │
 │ Tool definitions: all available tools         ~2000t  │
 │ Rules appendix: distilled rule cards          ~1500t  │
-│ Campaign summary: log with wikilinks           ~800t  │
 │ Session recap: "last time..."                  ~300t  │
+│ Campaign summary: log with wikilinks           ~800t  │
 │ Active state: location, PC summaries, alarms  ~1500t  │
 │ Current scene summary: running precis          ~500t  │
 │                                        Total: ~7500t  │

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -243,4 +243,24 @@ describe("buildCachedPrefix", () => {
     const allText = blocks.map((b) => b.text).join("\n");
     expect(allText).not.toContain("Scene Pacing");
   });
+
+  it("places session recap before campaign summary so it falls inside BP3 cache", () => {
+    const blocks = buildCachedPrefix(mockConfig, {
+      dmPrompt: "You are the DM.",
+      personality: "Terse.",
+      rulesAppendix: "Some rules.",
+      campaignSummary: "Scene 1: Party entered dungeon.",
+      sessionRecap: "Last time, the party fought goblins.",
+    });
+
+    const recapIndex = blocks.findIndex((b) => b.text.includes("Last Session"));
+    const summaryIndex = blocks.findIndex((b) => b.text.includes("Campaign Log"));
+    expect(recapIndex).toBeGreaterThan(-1);
+    expect(summaryIndex).toBeGreaterThan(-1);
+    expect(recapIndex).toBeLessThan(summaryIndex);
+
+    // Campaign summary (BP3) should have cache_control, covering the recap
+    const summaryBlock = blocks[summaryIndex] as unknown as Record<string, unknown>;
+    expect(summaryBlock["cache_control"]).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
 });

--- a/src/context/prefix-builder.ts
+++ b/src/context/prefix-builder.ts
@@ -7,8 +7,8 @@ import type { CampaignConfig } from "../types/config.js";
  *   1. DM identity prompt
  *   2. DM personality fragment
  *   3. Rules appendix (distilled rule cards)
- *   4. Campaign summary (log with wikilinks)
- *   5. Session recap
+ *   4. Session recap
+ *   5. Campaign summary (log with wikilinks)
  *   6. Active state (location, PC summaries, alarms)
  *   7. Current scene summary (running precis)
  */
@@ -84,6 +84,14 @@ export function buildCachedPrefix(
     } as Anthropic.TextBlockParam);
   }
 
+  // Session recap (session-stable — benefits from BP3 cache below)
+  if (sections.sessionRecap) {
+    blocks.push({
+      type: "text",
+      text: `\n\n## Last Session\n${sections.sessionRecap}`,
+    });
+  }
+
   // Campaign summary (cached — stable within a scene)
   if (sections.campaignSummary) {
     blocks.push({
@@ -91,14 +99,6 @@ export function buildCachedPrefix(
       text: `\n\n## Campaign Log\n${sections.campaignSummary}`,
       cache_control: { type: "ephemeral", ttl: "1h" },
     } as Anthropic.TextBlockParam);
-  }
-
-  // Session recap (changes once at session start)
-  if (sections.sessionRecap) {
-    blocks.push({
-      type: "text",
-      text: `\n\n## Last Session\n${sections.sessionRecap}`,
-    });
   }
 
   // Active state (changes during play)


### PR DESCRIPTION
## Summary

- Reorders the system prompt so session recap (~300t, session-stable) is placed **before** the campaign summary cache breakpoint (BP3), rather than after it
- Session recap now benefits from prompt caching at ~10% input cost instead of paying full price every turn
- Adds a test asserting the ordering invariant (recap before summary, covered by BP3's `cache_control`)

## Context

The DM agent's system prompt uses 3 cache breakpoints (BP1: DM identity, BP2: rules, BP3: campaign summary). Anthropic's prompt caching is prefix-matched, so content *before* a breakpoint is cached along with it. Session recap is written once at session start and never changes — it was the only session-stable block sitting in the uncached volatile tail.

## Test plan

- [x] New test verifies recap block index < summary block index and that BP3 has `cache_control`
- [x] All 1226 tests pass, ESLint clean, coverage thresholds met (`npm run check`)
- [ ] Manual: verify cache hit rate doesn't regress (session recap tokens should appear in `cache_read_input_tokens`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)