### PR TITLE
Expand OOC agent with 14 DM tools

### DIFF
--- a/src/agents/subagents/ooc-mode.test.ts
+++ b/src/agents/subagents/ooc-mode.test.ts
@@ -3,9 +3,14 @@ import type Anthropic from "@anthropic-ai/sdk";
 import { buildOOCPrompt, buildOOCTools, buildOOCToolHandler, enterOOC } from "./ooc-mode.js";
 import type { DMSessionState } from "../dm-prompt.js";
 import type { FileIO } from "../scene-manager.js";
+import type { GameState } from "../game-state.js";
+import type { TuiCommand } from "../agent-loop.js";
 import { CampaignRepo } from "../../tools/git/index.js";
 import type { GitIO } from "../../tools/git/index.js";
 import type { CampaignConfig } from "../../types/config.js";
+import { createClocksState } from "../../tools/clocks/index.js";
+import { createCombatState, createDefaultConfig } from "../../tools/combat/index.js";
+import { createDecksState } from "../../tools/cards/index.js";
 import { loadModelConfig } from "../../config/models.js";
 import { resetPromptCache } from "../../prompts/load-prompt.js";
 
@@ -417,17 +422,26 @@ function mockFileIO(
   files: Record<string, string> = {},
   dirs: Record<string, string[]> = {},
 ): FileIO {
+  // Normalize paths for cross-platform matching
+  const n = (p: string) => p.replace(/\\/g, "/");
+  const normFiles: Record<string, string> = {};
+  for (const [k, v] of Object.entries(files)) normFiles[n(k)] = v;
+  const normDirs: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(dirs)) normDirs[n(k)] = v;
+
   return {
     readFile: vi.fn(async (p: string) => {
-      if (p in files) return files[p];
+      const np = n(p);
+      if (np in normFiles) return normFiles[np];
       throw new Error(`ENOENT: ${p}`);
     }),
     writeFile: vi.fn(async () => {}),
     appendFile: vi.fn(async () => {}),
     mkdir: vi.fn(async () => {}),
-    exists: vi.fn(async (p: string) => p in files || p in dirs),
+    exists: vi.fn(async (p: string) => n(p) in normFiles || n(p) in normDirs),
     listDir: vi.fn(async (p: string) => {
-      if (p in dirs) return dirs[p];
+      const np = n(p);
+      if (np in normDirs) return normDirs[np];
       throw new Error(`ENOENT: ${p}`);
     }),
     deleteFile: vi.fn(async () => {}),
@@ -435,17 +449,38 @@ function mockFileIO(
 }
 
 describe("buildOOCTools", () => {
-  it("returns only get_commit_log when no fileIO", () => {
-    const tools = buildOOCTools(false);
+  it("returns only get_commit_log when no fileIO and no gameState", () => {
+    const tools = buildOOCTools(false, false);
     expect(tools).toHaveLength(1);
     expect(tools[0].name).toBe("get_commit_log");
   });
 
-  it("returns 4 tools when fileIO is available", () => {
-    const tools = buildOOCTools(true);
+  it("returns 4 tools when fileIO is available but no gameState", () => {
+    const tools = buildOOCTools(true, false);
     expect(tools).toHaveLength(4);
     const names = tools.map((t) => t.name);
     expect(names).toEqual(["get_commit_log", "read_file", "find_references", "validate_campaign"]);
+  });
+
+  it("returns 18 tools when both fileIO and gameState are available", () => {
+    const tools = buildOOCTools(true, true);
+    expect(tools).toHaveLength(18);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("roll_dice");
+    expect(names).toContain("check_clocks");
+    expect(names).toContain("create_entity");
+    expect(names).toContain("update_entity");
+    expect(names).toContain("set_theme");
+    expect(names).toContain("show_character_sheet");
+    expect(names).toContain("rollback");
+  });
+
+  it("returns 15 tools when gameState but no fileIO", () => {
+    const tools = buildOOCTools(false, true);
+    expect(tools).toHaveLength(15);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("roll_dice");
+    expect(names).not.toContain("read_file");
   });
 });
 
@@ -551,5 +586,223 @@ describe("buildOOCToolHandler", () => {
     const parsed = JSON.parse(result.content);
     expect(parsed).toHaveProperty("issues");
     expect(parsed).toHaveProperty("errorCount");
+  });
+});
+
+// --- GameState mock ---
+
+function mockGameState(overrides?: Partial<GameState>): GameState {
+  return {
+    maps: {},
+    clocks: createClocksState(),
+    combat: createCombatState(),
+    combatConfig: createDefaultConfig(),
+    decks: createDecksState(),
+    config: {
+      name: "TestCampaign",
+      dm_personality: { name: "Narrator", prompt_fragment: "terse" },
+      players: [{ name: "Player1", character: "Kael", type: "human" }],
+      combat: createDefaultConfig(),
+      context: { retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 },
+      recovery: { auto_commit_interval: 300, max_commits: 100, enable_git: false },
+      choices: { campaign_default: "often", player_overrides: {} },
+    },
+    campaignRoot: "/camp",
+    activePlayerIndex: 0,
+    ...overrides,
+  };
+}
+
+describe("buildOOCToolHandler (DM tools)", () => {
+  it("roll_dice dispatches and returns result directly", async () => {
+    const gs = mockGameState();
+    const handler = buildOOCToolHandler(undefined, "/camp", undefined, undefined, undefined, gs);
+    const result = await handler("roll_dice", { expression: "1d6" });
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toContain("1d6");
+    expect(result.content).toContain("→");
+  });
+
+  it("check_clocks dispatches and returns result directly", async () => {
+    const gs = mockGameState();
+    const handler = buildOOCToolHandler(undefined, "/camp", undefined, undefined, undefined, gs);
+    const result = await handler("check_clocks", {});
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toContain("calendar");
+  });
+
+  it("set_theme dispatches and calls onTuiCommand", async () => {
+    const gs = mockGameState();
+    const onTuiCommand = vi.fn();
+    const handler = buildOOCToolHandler(undefined, "/camp", undefined, undefined, undefined, gs, onTuiCommand);
+    const result = await handler("set_theme", { theme: "gothic", key_color: "#8844aa" });
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toBe("Applied: set_theme");
+    expect(onTuiCommand).toHaveBeenCalledOnce();
+    const cmd = onTuiCommand.mock.calls[0][0] as TuiCommand;
+    expect(cmd.type).toBe("set_theme");
+    expect(cmd.theme).toBe("gothic");
+  });
+
+  it("show_character_sheet dispatches and calls onTuiCommand", async () => {
+    const gs = mockGameState();
+    const onTuiCommand = vi.fn();
+    const handler = buildOOCToolHandler(undefined, "/camp", undefined, undefined, undefined, gs, onTuiCommand);
+    const result = await handler("show_character_sheet", { character: "Kael" });
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toBe("Applied: show_character_sheet");
+    expect(onTuiCommand).toHaveBeenCalledOnce();
+    const cmd = onTuiCommand.mock.calls[0][0] as TuiCommand;
+    expect(cmd.type).toBe("show_character_sheet");
+    expect(cmd.character).toBe("Kael");
+  });
+
+  it("create_entity writes file via FileIO", async () => {
+    const gs = mockGameState();
+    const fio = mockFileIO();
+    const handler = buildOOCToolHandler(undefined, "/camp", fio, undefined, undefined, gs);
+    const result = await handler("create_entity", {
+      entity_type: "character",
+      name: "Grimjaw",
+      front_matter: { disposition: "hostile" },
+      body: "A scarred orc.",
+    });
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toContain("Created character");
+    expect(result.content).toContain("Grimjaw");
+    expect(fio.writeFile).toHaveBeenCalledOnce();
+    expect(fio.mkdir).toHaveBeenCalledOnce();
+    const writtenContent = (fio.writeFile as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(writtenContent).toContain("# Grimjaw");
+    expect(writtenContent).toContain("hostile");
+  });
+
+  it("update_entity reads/merges/writes file via FileIO", async () => {
+    const existingFile = "# Grimjaw\n\n**Type:** character\n**Disposition:** hostile\n\nA scarred orc.\n";
+    const gs = mockGameState();
+    const fio = mockFileIO({ "/camp/characters/grimjaw.md": existingFile });
+    const handler = buildOOCToolHandler(undefined, "/camp", fio, undefined, undefined, gs);
+    const result = await handler("update_entity", {
+      entity_type: "character",
+      name: "Grimjaw",
+      front_matter_updates: { disposition: "friendly" },
+      body_append: "Now an ally.",
+      changelog_entry: "Befriended by Kael",
+    });
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toContain("Updated character");
+    expect(fio.writeFile).toHaveBeenCalledOnce();
+    const writtenContent = (fio.writeFile as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(writtenContent).toContain("friendly");
+    expect(writtenContent).toContain("Now an ally.");
+    expect(writtenContent).toContain("Befriended by Kael");
+  });
+
+  it("update_entity returns error when file not found", async () => {
+    const gs = mockGameState();
+    const fio = mockFileIO();
+    const handler = buildOOCToolHandler(undefined, "/camp", fio, undefined, undefined, gs);
+    const result = await handler("update_entity", {
+      entity_type: "character",
+      name: "Nobody",
+      front_matter_updates: { disposition: "friendly" },
+    });
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("not found");
+  });
+
+  it("rollback calls repo.rollback()", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
+    await repo.sceneCommit("The Dragon's Lair");
+    await repo.autoCommit("auto: exchanges");
+
+    const gs = mockGameState();
+    const handler = buildOOCToolHandler(repo, "/camp", undefined, undefined, undefined, gs);
+    const result = await handler("rollback", { target: "last" });
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toContain("Rolled back to");
+    expect(git.checkout).toHaveBeenCalled();
+  });
+
+  it("rollback without repo returns error", async () => {
+    const gs = mockGameState();
+    const handler = buildOOCToolHandler(undefined, "/camp", undefined, undefined, undefined, gs);
+    const result = await handler("rollback", { target: "last" });
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("not available");
+  });
+
+  it("entity tools without fileIO return error", async () => {
+    const gs = mockGameState();
+    const handler = buildOOCToolHandler(undefined, undefined, undefined, undefined, undefined, gs);
+    const result = await handler("create_entity", {
+      entity_type: "character",
+      name: "Test",
+      body: "test",
+    });
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("File I/O not available");
+  });
+});
+
+describe("enterOOC with gameState", () => {
+  it("passes 18 tools when gameState and fileIO are provided", async () => {
+    const gs = mockGameState();
+    const fio = mockFileIO();
+    const client = mockClient([textResponse("Done.")]);
+    await enterOOC(client, "test", {
+      campaignName: "Test",
+      previousVariant: "playing",
+      fileIO: fio,
+      campaignRoot: "/camp",
+      gameState: gs,
+    });
+
+    const createCall = (client.messages.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    if (createCall) {
+      expect(createCall.tools).toHaveLength(18);
+      const names = createCall.tools.map((t: { name: string }) => t.name);
+      expect(names).toContain("roll_dice");
+      expect(names).toContain("create_entity");
+      expect(names).toContain("set_theme");
+      expect(names).toContain("rollback");
+    }
+  });
+
+  it("still passes only 4 tools without gameState", async () => {
+    const fio = mockFileIO();
+    const client = mockClient([textResponse("Done.")]);
+    await enterOOC(client, "test", {
+      campaignName: "Test",
+      previousVariant: "playing",
+      fileIO: fio,
+      campaignRoot: "/camp",
+    });
+
+    const createCall = (client.messages.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    if (createCall) {
+      expect(createCall.tools).toHaveLength(4);
+    }
+  });
+
+  it("uses maxToolRounds=8 when tools are available", async () => {
+    const gs = mockGameState();
+    const fio = mockFileIO();
+    const client = mockClient([textResponse("Done.")]);
+    await enterOOC(client, "test", {
+      campaignName: "Test",
+      previousVariant: "playing",
+      fileIO: fio,
+      campaignRoot: "/camp",
+      gameState: gs,
+    });
+
+    const createCall = (client.messages.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    if (createCall) {
+      // maxToolRounds is passed internally to spawnSubagent, not directly to API
+      // We verify tools exist to confirm hasTools path was taken
+      expect(createCall.tools).toBeDefined();
+    }
   });
 });

--- a/src/agents/subagents/ooc-mode.ts
+++ b/src/agents/subagents/ooc-mode.ts
@@ -4,6 +4,9 @@ import { spawnSubagent } from "../subagent.js";
 import type { SubagentResult } from "../subagent.js";
 import type { DMSessionState } from "../dm-prompt.js";
 import type { FileIO } from "../scene-manager.js";
+import type { GameState } from "../game-state.js";
+import type { TuiCommand } from "../agent-loop.js";
+import { registry } from "../tool-registry.js";
 import { getModel } from "../../config/models.js";
 import { TOKEN_LIMITS } from "../../config/tokens.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
@@ -14,8 +17,31 @@ import type { MapData } from "../../types/maps.js";
 import type { ClocksState } from "../../types/clocks.js";
 import { findReferences } from "../../tools/campaign-ops/index.js";
 import { validateCampaign } from "../../tools/validation/index.js";
+import { parseFrontMatter, serializeEntity } from "../../tools/filesystem/index.js";
 import { norm } from "../../utils/paths.js";
 import type { ModeSession } from "../../tui/game-context.js";
+
+// --- DM tool categories available in OOC mode ---
+
+const OOC_READONLY_TOOLS = [
+  "roll_dice", "view_area", "distance", "path_between",
+  "line_of_sight", "tiles_in_range", "find_nearest", "check_clocks",
+];
+
+const OOC_ENTITY_TOOLS = ["create_entity", "update_entity"];
+
+const OOC_TUI_TOOLS = ["set_theme", "set_display_resources", "show_character_sheet"];
+
+const OOC_RECOVERY_TOOLS = ["rollback"];
+
+const OOC_DM_TOOL_NAMES = [
+  ...OOC_READONLY_TOOLS,
+  ...OOC_ENTITY_TOOLS,
+  ...OOC_TUI_TOOLS,
+  ...OOC_RECOVERY_TOOLS,
+];
+
+const OOC_DM_TOOL_SET = new Set(OOC_DM_TOOL_NAMES);
 
 /**
  * Context snapshot for OOC mode — captured when entering, restored when exiting.
@@ -191,7 +217,7 @@ function buildOOCPromptCached(opts: Required<Pick<OOCPromptOptions, "config" | "
 }
 
 /** Build OOC tool definitions (available when repo or fileIO is provided). */
-export function buildOOCTools(hasFileIO: boolean): Anthropic.Tool[] {
+export function buildOOCTools(hasFileIO: boolean, hasGameState: boolean): Anthropic.Tool[] {
   const tools: Anthropic.Tool[] = [
     {
       name: "get_commit_log",
@@ -244,6 +270,11 @@ export function buildOOCTools(hasFileIO: boolean): Anthropic.Tool[] {
     );
   }
 
+  // Append DM tool definitions when game state is available
+  if (hasGameState) {
+    tools.push(...registry.getDefinitionsFor(OOC_DM_TOOL_NAMES));
+  }
+
   return tools;
 }
 
@@ -254,6 +285,8 @@ export function buildOOCToolHandler(
   fileIO?: FileIO,
   maps?: Record<string, MapData>,
   clocks?: ClocksState,
+  gameState?: GameState,
+  onTuiCommand?: (cmd: TuiCommand) => void,
 ): (name: string, input: Record<string, unknown>) => Promise<{ content: string; is_error?: boolean }> {
   return async (name: string, input: Record<string, unknown>) => {
     try {
@@ -303,6 +336,10 @@ export function buildOOCToolHandler(
         }
 
         default:
+          // DM tool dispatch
+          if (OOC_DM_TOOL_SET.has(name) && gameState) {
+            return await dispatchDMTool(name, input, gameState, repo, fileIO, campaignRoot, onTuiCommand);
+          }
           return { content: `Unknown tool: ${name}`, is_error: true };
       }
     } catch (err) {
@@ -310,6 +347,125 @@ export function buildOOCToolHandler(
       return { content: msg, is_error: true };
     }
   };
+}
+
+/** Dispatch a DM tool from OOC context, post-processing based on category. */
+async function dispatchDMTool(
+  name: string,
+  input: Record<string, unknown>,
+  gameState: GameState,
+  repo?: CampaignRepo,
+  fileIO?: FileIO,
+  campaignRoot?: string,
+  onTuiCommand?: (cmd: TuiCommand) => void,
+): Promise<{ content: string; is_error?: boolean }> {
+  // Read-only tools — dispatch directly and return result
+  if (OOC_READONLY_TOOLS.includes(name)) {
+    const result = registry.dispatch(gameState, name, input);
+    return result;
+  }
+
+  // TUI tools — dispatch to get the command JSON, then forward via callback
+  if (OOC_TUI_TOOLS.includes(name)) {
+    const result = registry.dispatch(gameState, name, input);
+    if (result.is_error) return result;
+    if (onTuiCommand) {
+      const cmd = JSON.parse(result.content) as TuiCommand;
+      onTuiCommand(cmd);
+    }
+    return { content: `Applied: ${name}` };
+  }
+
+  // Entity tools — execute file I/O directly
+  if (OOC_ENTITY_TOOLS.includes(name)) {
+    if (!fileIO || !campaignRoot) {
+      return { content: "File I/O not available for entity operations", is_error: true };
+    }
+    return await executeEntityCommand(name, input, gameState, fileIO, campaignRoot);
+  }
+
+  // Rollback — execute via repo
+  if (OOC_RECOVERY_TOOLS.includes(name)) {
+    return await executeRollback(input, repo);
+  }
+
+  return { content: `Unknown OOC tool: ${name}`, is_error: true };
+}
+
+/** Execute entity create/update via FileIO. */
+async function executeEntityCommand(
+  name: string,
+  input: Record<string, unknown>,
+  gameState: GameState,
+  fileIO: FileIO,
+  _campaignRoot: string,
+): Promise<{ content: string; is_error?: boolean }> {
+  // Use registry.dispatch to get the validated command structure
+  const result = registry.dispatch(gameState, name, input);
+  if (result.is_error) return result;
+
+  const cmd = JSON.parse(result.content);
+
+  if (name === "create_entity") {
+    const dirPath = cmd.file_path.substring(0, cmd.file_path.lastIndexOf("/"));
+    await fileIO.mkdir(dirPath);
+    await fileIO.writeFile(cmd.file_path, cmd.content);
+    return { content: `Created ${cmd.entity_type} "${cmd.name}" at ${cmd.file_path}` };
+  }
+
+  if (name === "update_entity") {
+    // Read existing file
+    let existing: string;
+    try {
+      existing = await fileIO.readFile(cmd.file_path);
+    } catch {
+      return { content: `Entity file not found: ${cmd.file_path}`, is_error: true };
+    }
+
+    // Parse, merge, re-serialize
+    const { frontMatter, body, changelog } = parseFrontMatter(existing);
+    const title = frontMatter._title ?? cmd.name;
+
+    // Merge front matter updates (null = remove key)
+    if (cmd.front_matter_updates) {
+      for (const [key, value] of Object.entries(cmd.front_matter_updates)) {
+        if (value === null) {
+          frontMatter[key] = undefined;
+        } else {
+          frontMatter[key] = value;
+        }
+      }
+    }
+
+    // Append body text
+    const newBody = cmd.body_append ? (body ? body + "\n\n" + cmd.body_append : cmd.body_append) : body;
+
+    // Add changelog entry (no scene prefix in OOC)
+    const newChangelog = [...changelog];
+    if (cmd.changelog_entry) {
+      newChangelog.push(cmd.changelog_entry);
+    }
+
+    const updated = serializeEntity(title, frontMatter, newBody, newChangelog);
+    await fileIO.writeFile(cmd.file_path, updated);
+    return { content: `Updated ${cmd.entity_type} "${cmd.name}"` };
+  }
+
+  return { content: `Unknown entity command: ${name}`, is_error: true };
+}
+
+/** Execute rollback via CampaignRepo. */
+async function executeRollback(
+  input: Record<string, unknown>,
+  repo?: CampaignRepo,
+): Promise<{ content: string; is_error?: boolean }> {
+  if (!repo) {
+    return { content: "Git is not available for rollback", is_error: true };
+  }
+  const target = input.target as string;
+  const result = await repo.rollback(target);
+  const shortHash = result.restoredTo.slice(0, 8);
+  return { content: `Rolled back to ${shortHash}: ${result.summary}` };
 }
 
 /**
@@ -334,6 +490,8 @@ export async function enterOOC(
     campaignRoot?: string;
     maps?: Record<string, MapData>;
     clocks?: ClocksState;
+    gameState?: GameState;
+    onTuiCommand?: (cmd: TuiCommand) => void;
   },
   onStream?: SubagentStreamCallback,
 ): Promise<OOCResult> {
@@ -351,10 +509,11 @@ export async function enterOOC(
   };
 
   const hasFileIO = !!(options.fileIO && options.campaignRoot);
-  const hasTools = !!options.repo || hasFileIO;
-  const tools = hasTools ? buildOOCTools(hasFileIO) : undefined;
+  const hasGameState = !!options.gameState;
+  const hasTools = !!options.repo || hasFileIO || hasGameState;
+  const tools = hasTools ? buildOOCTools(hasFileIO, hasGameState) : undefined;
   const toolHandler = hasTools
-    ? buildOOCToolHandler(options.repo, options.campaignRoot, options.fileIO, options.maps, options.clocks)
+    ? buildOOCToolHandler(options.repo, options.campaignRoot, options.fileIO, options.maps, options.clocks, options.gameState, options.onTuiCommand)
     : undefined;
 
   const result = await spawnSubagent(
@@ -367,7 +526,7 @@ export async function enterOOC(
       maxTokens: hasTools ? TOKEN_LIMITS.SUBAGENT_LARGE : TOKEN_LIMITS.SUBAGENT_MEDIUM,
       ...(tools ? { tools } : {}),
       ...(toolHandler ? { toolHandler } : {}),
-      maxToolRounds: hasTools ? 5 : undefined,
+      maxToolRounds: hasTools ? 8 : undefined,
     },
     playerMessage,
     onStream,
@@ -415,6 +574,8 @@ export function createOOCSession(
     campaignRoot?: string;
     maps?: Record<string, MapData>;
     clocks?: ClocksState;
+    gameState?: GameState;
+    onTuiCommand?: (cmd: TuiCommand) => void;
   },
 ): ModeSession {
   return {

--- a/src/agents/tool-registry.test.ts
+++ b/src/agents/tool-registry.test.ts
@@ -312,6 +312,20 @@ describe("ToolRegistry", () => {
     expect(result.content).toContain("At least one");
   });
 
+  it("getDefinitionsFor returns only requested tools, skips unknown", () => {
+    const reg = new ToolRegistry();
+    const defs = reg.getDefinitionsFor(["roll_dice", "nonexistent", "check_clocks"]);
+    expect(defs).toHaveLength(2);
+    expect(defs[0].name).toBe("roll_dice");
+    expect(defs[1].name).toBe("check_clocks");
+  });
+
+  it("getDefinitionsFor returns empty array for all-unknown names", () => {
+    const reg = new ToolRegistry();
+    const defs = reg.getDefinitionsFor(["fake1", "fake2"]);
+    expect(defs).toHaveLength(0);
+  });
+
   it("dispatches context_refresh and returns TUI command JSON", () => {
     const reg = new ToolRegistry();
     const state = mockState();

--- a/src/agents/tool-registry.ts
+++ b/src/agents/tool-registry.ts
@@ -1046,6 +1046,14 @@ export class ToolRegistry {
     return [...this.tools.values()].map((t) => t.definition);
   }
 
+  /** Get tool definitions for a specific subset of tool names (skips unknown names) */
+  getDefinitionsFor(names: string[]): Tool[] {
+    return names
+      .map((name) => this.tools.get(name))
+      .filter((t): t is RegisteredTool => !!t)
+      .map((t) => t.definition);
+  }
+
   /** Dispatch a tool_use block to the appropriate handler */
   dispatch(state: GameState, name: string, input: Record<string, unknown>): ToolResult {
     const tool = this.tools.get(name);

--- a/src/prompts/ooc-mode.md
+++ b/src/prompts/ooc-mode.md
@@ -24,4 +24,16 @@ Do NOT narrate game events or play the DM role.
 Browse campaign snapshot history. Optional params: `depth` (default 20, max 100), `type` (auto|scene|session|checkpoint|character), `search` (case-insensitive message filter).
 Use this to help the player review what happened (scene/session commits), check save points, or investigate issues.
 
+**Dice & queries:** `roll_dice`, `check_clocks`, `view_area`, `distance`, `path_between`, `line_of_sight`, `tiles_in_range`, `find_nearest`
+Roll dice for the player (rules lookups, test rolls). Query map state and clock/alarm status. These are read-only — they don't change game state.
+
+**Entity management:** `create_entity`, `update_entity`
+Fix entity file errors, add missing NPCs, correct front matter. `create_entity` writes a new entity file. `update_entity` merges front matter, appends body text, and/or adds changelog entries to an existing entity. Use these when the player reports wrong stats, missing characters, or data errors.
+
+**UI customization:** `set_theme`, `set_display_resources`, `show_character_sheet`
+Let the player customize their UI. `set_theme` changes colors and style. `set_display_resources` controls which resource keys appear in the top frame. `show_character_sheet` opens the character sheet modal.
+
+**Recovery:** `rollback`
+Roll back game state to a previous checkpoint. Targets: `last`, `scene:Title`, `session:N`, `exchanges_ago:N`, or a commit hash. Always confirm with the player before rolling back — this is destructive.
+
 When the player is done, summarize what was discussed in one terse sentence for the DM's context. This may be in the form of a correction for an AI-related mistake; just return a description of the reported mistake and correct approach.

--- a/src/tui/hooks/useGameCallbacks.ts
+++ b/src/tui/hooks/useGameCallbacks.ts
@@ -131,6 +131,8 @@ export function useGameCallbacks(deps: GameCallbackDeps): GameCallbackResult {
             repo: engine?.getRepo() ?? undefined,
             fileIO: sm?.getFileIO(),
             campaignRoot: gs.campaignRoot,
+            gameState: gs,
+            onTuiCommand: (cmd) => dispatchTuiCommand(cmd),
           }));
         }
         setVariant("ooc");


### PR DESCRIPTION
## Summary

- Adds 14 DM tools to the OOC agent via registry dispatch so it can fix entity errors, customize UI, query game state, and roll back mistakes — all without polluting the DM's context window
- Tools organized by category: read-only queries (8), entity management (2), TUI customization (3), recovery (1) — bringing total OOC tools from 4 to 18
- Wires `gameState` and `onTuiCommand` through `useGameCallbacks` so OOC tools use the same dispatch path as the DM

## Test plan

- [x] `npm run check` passes (ESLint clean, 1235 tests pass, coverage thresholds met)
- [ ] Spot-check: `buildOOCTools(true, true)` returns 18 tools with correct names
- [ ] Spot-check: entity tool handler reads, parses, merges, and writes correctly
- [ ] Spot-check: TUI tools dispatch through callback
- [ ] Manual: enter OOC mode, roll dice, check clocks, set theme, create/update entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)