### PR TITLE
Fix empty transcript after rollback

### DIFF
--- a/src/agents/game-engine.test.ts
+++ b/src/agents/game-engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Anthropic from "@anthropic-ai/sdk";
-import { GameEngine } from "./game-engine.js";
+import { GameEngine, pruneEmptyDirs } from "./game-engine.js";
 import type { EngineCallbacks, EngineState } from "./game-engine.js";
 import type { GameState } from "./game-state.js";
 import type { SceneState, FileIO } from "./scene-manager.js";
@@ -1218,5 +1218,90 @@ describe("GameEngine Behavioral Reminder", () => {
     await engine.processInput("Aldric", "Four.");
 
     expect(log.devLogs.some((m) => m.includes("[dm-note]"))).toBe(true);
+  });
+});
+
+describe("pruneEmptyDirs", () => {
+  it("removes empty directories under campaign subdirs", async () => {
+    const io = mockFileIO();
+    const rmdirCalls: string[] = [];
+    io.rmdir = vi.fn(async (path: string) => { rmdirCalls.push(norm(path)); });
+
+    // config.json must exist (safety check)
+    files[norm("/tmp/campaign/config.json")] = "{}";
+    dirs.add(norm("/tmp/campaign/campaign/scenes"));
+    dirs.add(norm("/tmp/campaign/campaign/scenes/002-tavern"));
+
+    // First listDir: scenes has one empty subdir
+    (io.listDir as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+      const p = norm(path);
+      if (p.endsWith("campaign/scenes")) return ["002-tavern"];
+      if (p.endsWith("002-tavern")) return []; // empty!
+      return [];
+    });
+
+    const removed = await pruneEmptyDirs("/tmp/campaign", io);
+    expect(removed).toBe(1);
+    expect(rmdirCalls[0]).toContain("002-tavern");
+  });
+
+  it("does nothing when config.json is missing (safety guard)", async () => {
+    const io = mockFileIO();
+    io.rmdir = vi.fn(async () => {});
+    // No config.json — not a campaign root
+    dirs.add(norm("/tmp/not-campaign/campaign/scenes"));
+
+    const removed = await pruneEmptyDirs("/tmp/not-campaign", io);
+    expect(removed).toBe(0);
+    expect(io.rmdir).not.toHaveBeenCalled();
+  });
+
+  it("does not remove non-empty directories", async () => {
+    const io = mockFileIO();
+    io.rmdir = vi.fn(async () => {});
+
+    files[norm("/tmp/campaign/config.json")] = "{}";
+    files[norm("/tmp/campaign/campaign/scenes/001-opening/transcript.md")] = "# Scene 1";
+    dirs.add(norm("/tmp/campaign/campaign/scenes"));
+    dirs.add(norm("/tmp/campaign/campaign/scenes/001-opening"));
+
+    (io.listDir as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+      const p = norm(path);
+      if (p.endsWith("campaign/scenes")) return ["001-opening"];
+      if (p.endsWith("001-opening")) return ["transcript.md"];
+      return [];
+    });
+
+    const removed = await pruneEmptyDirs("/tmp/campaign", io);
+    expect(removed).toBe(0);
+  });
+
+  it("prunes nested empty directories depth-first", async () => {
+    const io = mockFileIO();
+    const rmdirCalls: string[] = [];
+    io.rmdir = vi.fn(async (path: string) => { rmdirCalls.push(norm(path)); });
+
+    files[norm("/tmp/campaign/config.json")] = "{}";
+    dirs.add(norm("/tmp/campaign/locations"));
+    dirs.add(norm("/tmp/campaign/locations/old-tavern"));
+
+    let tavernPruned = false;
+    (io.listDir as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+      const p = norm(path);
+      if (p.endsWith("/locations") && tavernPruned) return [];
+      if (p.endsWith("/locations")) return ["old-tavern"];
+      if (p.endsWith("old-tavern")) {
+        tavernPruned = true;
+        return [];
+      }
+      return [];
+    });
+
+    const removed = await pruneEmptyDirs("/tmp/campaign", io);
+    // Both old-tavern and locations should be pruned
+    expect(removed).toBe(2);
+    // old-tavern should be pruned before locations (depth-first)
+    expect(rmdirCalls[0]).toContain("old-tavern");
+    expect(rmdirCalls[1]).toContain("locations");
   });
 });

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -502,6 +502,8 @@ export class GameEngine {
     }
     this.callbacks.onDevLog?.(`[dev] rollback: rolling back to "${target}"`);
     const result = await this.repo.rollback(target);
+    // isomorphic-git doesn't remove directories emptied by checkout — clean them up
+    await pruneEmptyDirs(this.gameState.campaignRoot, this.fileIO);
     console.log(`\nRolled back to: ${result.summary}\nRelaunch the game to resume from this point.\n`);
     process.exit(0);
   }
@@ -856,5 +858,72 @@ export class GameEngine {
       // Non-critical — precis update failure doesn't break gameplay
     }
   }
+}
+
+// --- Post-rollback cleanup ---
+
+/**
+ * Recursively remove empty directories under known campaign subdirectories.
+ * isomorphic-git's checkout removes files but leaves empty parent directories
+ * behind, which confuses scene detection.
+ *
+ * Safety: only walks known campaign subdirectories (characters, locations, etc.)
+ * and requires config.json to exist at root — won't accidentally nuke anything
+ * if called with a wrong path.
+ */
+export async function pruneEmptyDirs(root: string, io: FileIO): Promise<number> {
+  // Safety: verify this looks like a campaign root
+  const configPath = norm(root) + "/config.json";
+  if (!(await io.exists(configPath))) return 0;
+
+  let removed = 0;
+  const normalizedRoot = norm(root);
+
+  async function walk(dir: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await io.listDir(dir);
+    } catch {
+      return;
+    }
+    // Recurse into subdirectories first (depth-first)
+    for (const entry of entries) {
+      const child = norm(dir) + "/" + entry;
+      // Skip dotfiles/dirs (e.g. .git)
+      if (entry.startsWith(".")) continue;
+      // Heuristic: entries without a dot extension are likely directories
+      if (!entry.includes(".")) {
+        await walk(child);
+      }
+    }
+    // Re-read after pruning children
+    try {
+      entries = await io.listDir(dir);
+    } catch {
+      return;
+    }
+    // Don't prune the root or top-level subdirs themselves
+    if (entries.length === 0 && norm(dir) !== normalizedRoot) {
+      try {
+        await io.rmdir?.(dir);
+        removed++;
+      } catch {
+        // Directory not empty or permission error — skip
+      }
+    }
+  }
+
+  // Only walk known campaign subdirectories — never arbitrary paths
+  const campaignSubdirs = [
+    "campaign/scenes", "campaign/session-recaps",
+    "characters", "locations", "factions", "lore", "players",
+  ];
+  for (const sub of campaignSubdirs) {
+    const subPath = normalizedRoot + "/" + sub;
+    if (await io.exists(subPath)) {
+      await walk(subPath);
+    }
+  }
+  return removed;
 }
 

--- a/src/agents/scene-manager.test.ts
+++ b/src/agents/scene-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Anthropic from "@anthropic-ai/sdk";
-import { SceneManager, parseTranscriptEntries, classifyTranscriptEntry, buildScenePacing } from "./scene-manager.js";
+import { SceneManager, parseTranscriptEntries, classifyTranscriptEntry, buildScenePacing, detectSceneState } from "./scene-manager.js";
 import type { SceneState, FileIO } from "./scene-manager.js";
 import type { CampaignRepo } from "../tools/git/index.js";
 import type { GameState } from "./game-state.js";
@@ -1238,5 +1238,50 @@ describe("buildScenePacing", () => {
     scene.openThreads = "";
     const result = buildScenePacing(scene)!;
     expect(result).toContain("Open threads: 0");
+  });
+});
+
+describe("detectSceneState", () => {
+  it("skips scene folders without a transcript (ghost dirs from rollback)", async () => {
+    const io = mockFileIO();
+    // Scene 1 has a transcript, scene 2 is a ghost directory (no transcript.md)
+    files[norm("/tmp/test-campaign/campaign/scenes/001-opening/transcript.md")] =
+      "# Scene 1\n\n**DM:** Welcome.\n";
+    dirs.add(norm("/tmp/test-campaign/campaign/scenes"));
+    dirs.add(norm("/tmp/test-campaign/campaign/scenes/001-opening"));
+    dirs.add(norm("/tmp/test-campaign/campaign/scenes/002-tavern"));
+
+    (io.listDir as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+      const p = norm(path);
+      if (p.endsWith("campaign/scenes")) return ["001-opening", "002-tavern"];
+      if (p.endsWith("session-recaps")) return [];
+      return [];
+    });
+
+    const result = await detectSceneState("/tmp/test-campaign", io);
+    // Should pick scene 1 (has transcript), NOT scene 2 (ghost)
+    expect(result.sceneNumber).toBe(1);
+    expect(result.slug).toBe("opening");
+    expect(result.transcript).toHaveLength(1);
+    expect(result.transcript[0]).toContain("Welcome");
+  });
+
+  it("falls back to opening when all scene folders are ghosts", async () => {
+    const io = mockFileIO();
+    // Ghost directory — no transcript.md inside
+    dirs.add(norm("/tmp/test-campaign/campaign/scenes"));
+    dirs.add(norm("/tmp/test-campaign/campaign/scenes/001-opening"));
+
+    (io.listDir as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+      const p = norm(path);
+      if (p.endsWith("campaign/scenes")) return ["001-opening"];
+      if (p.endsWith("session-recaps")) return [];
+      return [];
+    });
+
+    const result = await detectSceneState("/tmp/test-campaign", io);
+    expect(result.sceneNumber).toBe(1);
+    expect(result.slug).toBe("opening");
+    expect(result.transcript).toHaveLength(0);
   });
 });

--- a/src/agents/scene-manager.ts
+++ b/src/agents/scene-manager.ts
@@ -74,6 +74,8 @@ export interface FileIO {
   exists(path: string): Promise<boolean>;
   listDir(path: string): Promise<string[]>;
   deleteFile?(path: string): Promise<void>;
+  /** Remove an empty directory. Rejects if the directory is not empty. */
+  rmdir?(path: string): Promise<void>;
 }
 
 /** Ordered cascade steps for scene transitions. Used for resume logic. */
@@ -781,7 +783,9 @@ export async function detectSceneState(campaignRoot: string, io: FileIO): Promis
       const match = entry.match(/^(\d+)-(.+)$/);
       if (match) {
         const n = parseInt(match[1], 10);
-        if (n > maxScene) {
+        // Skip ghost directories left behind by rollback (no transcript.md)
+        const tPath = paths.sceneTranscript(n, match[2]);
+        if (n > maxScene && await io.exists(tPath)) {
           maxScene = n;
           lastSlug = match[2];
         }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Text, Box, useInput } from "ink";
 import Anthropic from "@anthropic-ai/sdk";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { readFile, writeFile, appendFile, mkdir, readdir, stat, unlink } from "node:fs/promises";
+import { readFile, writeFile, appendFile, mkdir, readdir, stat, unlink, rmdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 
 import { getStyle } from "./tui/frames/index.js";
@@ -103,6 +103,9 @@ function createFileIO(): FileIO {
     },
     async deleteFile(path: string) {
       await unlink(path);
+    },
+    async rmdir(path: string) {
+      await rmdir(path);
     },
   };
 }


### PR DESCRIPTION
## Summary
- **detectSceneState** now verifies `transcript.md` exists before accepting a scene folder — ghost directories left by isomorphic-git checkout no longer cause empty transcript loads
- **pruneEmptyDirs** runs after rollback to clean up emptied directories under known campaign subdirs (campaign/scenes, characters, locations, etc.)
- Safety guardrails: requires `config.json` at root, only walks known subdirs, skips `.git`

## Test plan
- [x] New tests: ghost directory skip, fallback when all folders are ghosts
- [x] New tests: empty dir pruning, safety guard (missing config.json), non-empty preservation, nested depth-first pruning
- [x] All 1242 tests pass, ESLint clean, coverage threshold met

🤖 Generated with [Claude Code](https://claude.com/claude-code)