### PR TITLE
Consolidate rollback into single performRollback() code path

### DIFF
--- a/src/agents/game-engine.test.ts
+++ b/src/agents/game-engine.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Anthropic from "@anthropic-ai/sdk";
-import { GameEngine, pruneEmptyDirs } from "./game-engine.js";
+import { GameEngine } from "./game-engine.js";
+import { pruneEmptyDirs } from "../tools/git/index.js";
 import type { EngineCallbacks, EngineState } from "./game-engine.js";
 import type { GameState } from "./game-state.js";
 import type { SceneState, FileIO } from "./scene-manager.js";

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -19,7 +19,7 @@ import { aiPlayerTurn } from "./subagents/ai-player.js";
 import { campaignPaths, parseFrontMatter, serializeEntity, formatChangelogEntry } from "../tools/filesystem/index.js";
 import { norm } from "../utils/paths.js";
 import { validateCampaign } from "../tools/validation/index.js";
-import { CampaignRepo } from "../tools/git/index.js";
+import { CampaignRepo, performRollback } from "../tools/git/index.js";
 import type { GitIO } from "../tools/git/index.js";
 import { writeDebugDump } from "../tools/filesystem/debug-dump.js";
 
@@ -501,9 +501,7 @@ export class GameEngine {
       return;
     }
     this.callbacks.onDevLog?.(`[dev] rollback: rolling back to "${target}"`);
-    const result = await this.repo.rollback(target);
-    // isomorphic-git doesn't remove directories emptied by checkout — clean them up
-    await pruneEmptyDirs(this.gameState.campaignRoot, this.fileIO);
+    const result = await performRollback(this.repo, target, this.gameState.campaignRoot, this.fileIO);
     console.log(`\nRolled back to: ${result.summary}\nRelaunch the game to resume from this point.\n`);
     process.exit(0);
   }
@@ -860,70 +858,4 @@ export class GameEngine {
   }
 }
 
-// --- Post-rollback cleanup ---
-
-/**
- * Recursively remove empty directories under known campaign subdirectories.
- * isomorphic-git's checkout removes files but leaves empty parent directories
- * behind, which confuses scene detection.
- *
- * Safety: only walks known campaign subdirectories (characters, locations, etc.)
- * and requires config.json to exist at root — won't accidentally nuke anything
- * if called with a wrong path.
- */
-export async function pruneEmptyDirs(root: string, io: FileIO): Promise<number> {
-  // Safety: verify this looks like a campaign root
-  const configPath = norm(root) + "/config.json";
-  if (!(await io.exists(configPath))) return 0;
-
-  let removed = 0;
-  const normalizedRoot = norm(root);
-
-  async function walk(dir: string): Promise<void> {
-    let entries: string[];
-    try {
-      entries = await io.listDir(dir);
-    } catch {
-      return;
-    }
-    // Recurse into subdirectories first (depth-first)
-    for (const entry of entries) {
-      const child = norm(dir) + "/" + entry;
-      // Skip dotfiles/dirs (e.g. .git)
-      if (entry.startsWith(".")) continue;
-      // Heuristic: entries without a dot extension are likely directories
-      if (!entry.includes(".")) {
-        await walk(child);
-      }
-    }
-    // Re-read after pruning children
-    try {
-      entries = await io.listDir(dir);
-    } catch {
-      return;
-    }
-    // Don't prune the root or top-level subdirs themselves
-    if (entries.length === 0 && norm(dir) !== normalizedRoot) {
-      try {
-        await io.rmdir?.(dir);
-        removed++;
-      } catch {
-        // Directory not empty or permission error — skip
-      }
-    }
-  }
-
-  // Only walk known campaign subdirectories — never arbitrary paths
-  const campaignSubdirs = [
-    "campaign/scenes", "campaign/session-recaps",
-    "characters", "locations", "factions", "lore", "players",
-  ];
-  for (const sub of campaignSubdirs) {
-    const subPath = normalizedRoot + "/" + sub;
-    if (await io.exists(subPath)) {
-      await walk(subPath);
-    }
-  }
-  return removed;
-}
 

--- a/src/agents/subagents/dev-mode.ts
+++ b/src/agents/subagents/dev-mode.ts
@@ -12,7 +12,7 @@ import { repairState } from "./repair-state.js";
 import { norm } from "../../utils/paths.js";
 import * as path from "node:path";
 import type { CampaignRepo } from "../../tools/git/index.js";
-import { queryCommitLog } from "../../tools/git/index.js";
+import { queryCommitLog, performRollback } from "../../tools/git/index.js";
 import { ToolRegistry } from "../tool-registry.js";
 import { findReferences, renameEntity, mergeEntities, resolveDeadLinks } from "../../tools/campaign-ops/index.js";
 import type { ModeSession } from "../../tui/game-context.js";
@@ -424,7 +424,7 @@ export function buildDevToolHandler(
                 if (!repo) {
                   return { content: "Rollback unavailable: git is disabled.", is_error: true };
                 }
-                const rb = await repo.rollback(parsed.target as string);
+                const rb = await performRollback(repo, parsed.target as string, root, fileIO);
                 console.log(`\nRolled back to: ${rb.summary}\nRelaunch the game to resume from this point.\n`);
                 process.exit(0);
               }

--- a/src/agents/subagents/ooc-mode.test.ts
+++ b/src/agents/subagents/ooc-mode.test.ts
@@ -711,26 +711,44 @@ describe("buildOOCToolHandler (DM tools)", () => {
     expect(result.content).toContain("not found");
   });
 
-  it("rollback calls repo.rollback()", async () => {
+  it("rollback calls performRollback and exits", async () => {
     const git = mockGitIO();
     const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
     await repo.sceneCommit("The Dragon's Lair");
     await repo.autoCommit("auto: exchanges");
 
+    const fio = mockFileIO({ "/camp/config.json": "{}" });
     const gs = mockGameState();
-    const handler = buildOOCToolHandler(repo, "/camp", undefined, undefined, undefined, gs);
-    const result = await handler("rollback", { target: "last" });
-    expect(result.is_error).toBeUndefined();
-    expect(result.content).toContain("Rolled back to");
-    expect(git.checkout).toHaveBeenCalled();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    try {
+      const handler = buildOOCToolHandler(repo, "/camp", fio, undefined, undefined, gs);
+      await handler("rollback", { target: "last" });
+      expect(git.checkout).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 
   it("rollback without repo returns error", async () => {
     const gs = mockGameState();
-    const handler = buildOOCToolHandler(undefined, "/camp", undefined, undefined, undefined, gs);
+    const fio = mockFileIO();
+    const handler = buildOOCToolHandler(undefined, "/camp", fio, undefined, undefined, gs);
     const result = await handler("rollback", { target: "last" });
     expect(result.is_error).toBe(true);
     expect(result.content).toContain("not available");
+  });
+
+  it("rollback without fileIO returns error", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
+    await repo.sceneCommit("The Dragon's Lair");
+
+    const gs = mockGameState();
+    const handler = buildOOCToolHandler(repo, "/camp", undefined, undefined, undefined, gs);
+    const result = await handler("rollback", { target: "last" });
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("File I/O not available");
   });
 
   it("entity tools without fileIO return error", async () => {

--- a/src/agents/subagents/ooc-mode.ts
+++ b/src/agents/subagents/ooc-mode.ts
@@ -12,7 +12,7 @@ import { TOKEN_LIMITS } from "../../config/tokens.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
 import type { CampaignConfig } from "../../types/config.js";
 import type { CampaignRepo } from "../../tools/git/index.js";
-import { queryCommitLog } from "../../tools/git/index.js";
+import { queryCommitLog, performRollback } from "../../tools/git/index.js";
 import type { MapData } from "../../types/maps.js";
 import type { ClocksState } from "../../types/clocks.js";
 import { findReferences } from "../../tools/campaign-ops/index.js";
@@ -384,9 +384,9 @@ async function dispatchDMTool(
     return await executeEntityCommand(name, input, gameState, fileIO, campaignRoot);
   }
 
-  // Rollback — execute via repo
+  // Rollback — execute via repo (prunes ghost dirs + exits)
   if (OOC_RECOVERY_TOOLS.includes(name)) {
-    return await executeRollback(input, repo);
+    return await executeRollback(input, repo, campaignRoot, fileIO);
   }
 
   return { content: `Unknown OOC tool: ${name}`, is_error: true };
@@ -454,18 +454,23 @@ async function executeEntityCommand(
   return { content: `Unknown entity command: ${name}`, is_error: true };
 }
 
-/** Execute rollback via CampaignRepo. */
+/** Execute rollback via performRollback — prunes ghost dirs then exits. */
 async function executeRollback(
   input: Record<string, unknown>,
   repo?: CampaignRepo,
+  campaignRoot?: string,
+  fileIO?: FileIO,
 ): Promise<{ content: string; is_error?: boolean }> {
   if (!repo) {
     return { content: "Git is not available for rollback", is_error: true };
   }
+  if (!campaignRoot || !fileIO) {
+    return { content: "File I/O not available for rollback cleanup", is_error: true };
+  }
   const target = input.target as string;
-  const result = await repo.rollback(target);
-  const shortHash = result.restoredTo.slice(0, 8);
-  return { content: `Rolled back to ${shortHash}: ${result.summary}` };
+  const result = await performRollback(repo, target, campaignRoot, fileIO);
+  console.log(`\nRolled back to: ${result.summary}\nRelaunch the game to resume from this point.\n`);
+  process.exit(0);
 }
 
 /**

--- a/src/tools/git/campaign-repo.ts
+++ b/src/tools/git/campaign-repo.ts
@@ -288,6 +288,97 @@ function formatLocalTime(epochSeconds: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+// --- FileIO subset needed for pruneEmptyDirs ---
+
+interface PruneFileIO {
+  exists(path: string): Promise<boolean>;
+  listDir(path: string): Promise<string[]>;
+  rmdir?(path: string): Promise<void>;
+}
+
+/**
+ * Canonical rollback: git restore + ghost-dir cleanup.
+ * All callsites must use this — callers handle process.exit themselves.
+ */
+export async function performRollback(
+  repo: CampaignRepo,
+  target: string,
+  campaignRoot: string,
+  fileIO: PruneFileIO,
+): Promise<RollbackResult> {
+  const result = await repo.rollback(target);
+  await pruneEmptyDirs(campaignRoot, fileIO);
+  return result;
+}
+
+/**
+ * Recursively remove empty directories under known campaign subdirectories.
+ * isomorphic-git's checkout removes files but leaves empty parent directories
+ * behind, which confuses scene detection.
+ *
+ * Safety: only walks known campaign subdirectories (characters, locations, etc.)
+ * and requires config.json to exist at root — won't accidentally nuke anything
+ * if called with a wrong path.
+ */
+export async function pruneEmptyDirs(root: string, io: PruneFileIO): Promise<number> {
+  // Normalize to forward slashes
+  const norm = (p: string) => p.replace(/\\/g, "/");
+
+  // Safety: verify this looks like a campaign root
+  const configPath = norm(root) + "/config.json";
+  if (!(await io.exists(configPath))) return 0;
+
+  let removed = 0;
+  const normalizedRoot = norm(root);
+
+  async function walk(dir: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await io.listDir(dir);
+    } catch {
+      return;
+    }
+    // Recurse into subdirectories first (depth-first)
+    for (const entry of entries) {
+      const child = norm(dir) + "/" + entry;
+      // Skip dotfiles/dirs (e.g. .git)
+      if (entry.startsWith(".")) continue;
+      // Heuristic: entries without a dot extension are likely directories
+      if (!entry.includes(".")) {
+        await walk(child);
+      }
+    }
+    // Re-read after pruning children
+    try {
+      entries = await io.listDir(dir);
+    } catch {
+      return;
+    }
+    // Don't prune the root or top-level subdirs themselves
+    if (entries.length === 0 && norm(dir) !== normalizedRoot) {
+      try {
+        await io.rmdir?.(dir);
+        removed++;
+      } catch {
+        // Directory not empty or permission error — skip
+      }
+    }
+  }
+
+  // Only walk known campaign subdirectories — never arbitrary paths
+  const campaignSubdirs = [
+    "campaign/scenes", "campaign/session-recaps",
+    "characters", "locations", "factions", "lore", "players",
+  ];
+  for (const sub of campaignSubdirs) {
+    const subPath = normalizedRoot + "/" + sub;
+    if (await io.exists(subPath)) {
+      await walk(subPath);
+    }
+  }
+  return removed;
+}
+
 function resolveTarget(log: CommitInfo[], target: string): CommitInfo | null {
   if (target === "last") {
     return log[0] ?? null;

--- a/src/tools/git/index.ts
+++ b/src/tools/git/index.ts
@@ -1,3 +1,3 @@
-export { CampaignRepo, queryCommitLog } from "./campaign-repo.js";
+export { CampaignRepo, queryCommitLog, performRollback, pruneEmptyDirs } from "./campaign-repo.js";
 export type { CommitInfo, CommitType, GitIO, RollbackResult } from "./campaign-repo.js";
 export { createGitIO } from "./isogit-adapter.js";


### PR DESCRIPTION
## Summary

- Extract canonical `performRollback()` function into `src/tools/git/campaign-repo.ts` that does git restore + ghost-dir cleanup (`pruneEmptyDirs`)
- All three rollback callsites (GameEngine, OOC mode, Dev mode) now use the same code path: `performRollback` → console message → `process.exit(0)`
- Move `pruneEmptyDirs()` from `game-engine.ts` to `campaign-repo.ts` where it belongs (git layer)

Previously OOC mode skipped `pruneEmptyDirs` and didn't exit (leaving stale in-memory state), and Dev mode skipped `pruneEmptyDirs`. Now all paths are consistent.

## Test plan

- [x] All 1243 tests pass (`npm run check`)
- [x] ESLint clean
- [x] OOC rollback test updated to verify `process.exit(0)` is called
- [x] New test for OOC rollback without fileIO returns error
- [x] `pruneEmptyDirs` import updated in `game-engine.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)