### PR TITLE
Highlight scroll arrows greenish-yellow when scrollable

### DIFF
--- a/src/tui/modals/ChoiceModal.tsx
+++ b/src/tui/modals/ChoiceModal.tsx
@@ -99,8 +99,8 @@ export function ChoiceOverlay({
         <Box flexGrow={1}>
           <Text>{displayPrompt}</Text>
         </Box>
-        <Text dimColor={!canScrollUp}>▲</Text>
-        <Text dimColor={!canScrollDown}>▼</Text>
+        <Text color={canScrollUp ? "#aaff00" : undefined} dimColor={!canScrollUp}>▲</Text>
+        <Text color={canScrollDown ? "#aaff00" : undefined} dimColor={!canScrollDown}>▼</Text>
       </Box>
 
       {/* Choice rows */}


### PR DESCRIPTION
## Summary
- ChoiceOverlay's ▲▼ scroll arrows now highlight in greenish-yellow (`#aaff00`) when scrolling is possible in that direction
- Replaces the previous dim-only indication with a color + dim approach: bright greenish-yellow when active, dimmed when inactive
- Single 2-line change in `src/tui/modals/ChoiceModal.tsx`

## Test plan
- [x] All 25 existing modal tests pass
- [ ] Visually verify: open a choice modal with >5 items, confirm arrows light up greenish-yellow when scrollable and dim when at the scroll boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)