### PR TITLE
Incremental narrative pipeline + React.memo

### DIFF
--- a/src/tui/components/NarrativeArea.test.tsx
+++ b/src/tui/components/NarrativeArea.test.tsx
@@ -1,0 +1,127 @@
+import React, { useRef, useEffect } from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { Text } from "ink";
+import type { NarrativeLine, ProcessedLine } from "../../types/tui.js";
+import { processNarrativeLines, toPlainText } from "../formatting.js";
+import { useProcessedLines } from "./NarrativeArea.js";
+
+// ---------------------------------------------------------------------------
+// Test harness: renders the hook result as plain text so we can inspect it
+// ---------------------------------------------------------------------------
+
+function HookHarness({
+  lines,
+  width,
+  quoteColor,
+  onResult,
+}: {
+  lines: NarrativeLine[];
+  width: number;
+  quoteColor?: string;
+  onResult: (result: ProcessedLine[]) => void;
+}) {
+  const result = useProcessedLines(lines, width, quoteColor);
+  const onResultRef = useRef(onResult);
+  onResultRef.current = onResult;
+  useEffect(() => { onResultRef.current(result); });
+  const text = result.map((l) => toPlainText(l.nodes)).join("|");
+  return <Text>{text || " "}</Text>;
+}
+
+const dm = (text: string): NarrativeLine => ({ kind: "dm", text });
+
+describe("useProcessedLines", () => {
+  it("returns same output as direct processNarrativeLines", () => {
+    const lines = [dm("Hello."), dm(""), dm("World.")];
+    const expected = processNarrativeLines(lines, 80);
+
+    let captured: ProcessedLine[] = [];
+    render(
+      <HookHarness lines={lines} width={80} onResult={(r) => { captured = r; }} />,
+    );
+
+    expect(captured).toEqual(expected);
+  });
+
+  it("frozen ProcessedLine objects are reference-stable across calls", () => {
+    const line1 = dm("Paragraph one.");
+    const blank = dm("");
+    const line3 = dm("Streaming...");
+
+    const initial = [line1, blank, line3];
+    let prev: ProcessedLine[] = [];
+    let current: ProcessedLine[] = [];
+
+    const { rerender } = render(
+      <HookHarness lines={initial} width={80} onResult={(r) => { prev = r; }} />,
+    );
+
+    // Append a new line in the same tail paragraph (prefix unchanged)
+    const line4 = dm("More streaming.");
+    const updated = [line1, blank, line3, line4];
+
+    rerender(
+      <HookHarness lines={updated} width={80} onResult={(r) => { current = r; }} />,
+    );
+
+    // The frozen prefix lines (before blank) should be reference-equal
+    expect(current.length).toBeGreaterThan(prev.length);
+    // First line should be the same object (from frozen cache)
+    expect(current[0]).toBe(prev[0]);
+  });
+
+  it("cache invalidates on width change", () => {
+    const lines = [dm("Hello world."), dm(""), dm("End.")];
+
+    let result80: ProcessedLine[] = [];
+    let result40: ProcessedLine[] = [];
+
+    const { rerender } = render(
+      <HookHarness lines={lines} width={80} onResult={(r) => { result80 = r; }} />,
+    );
+
+    rerender(
+      <HookHarness lines={lines} width={40} onResult={(r) => { result40 = r; }} />,
+    );
+
+    // Width change should produce fresh results (not referencing old cache)
+    const expected40 = processNarrativeLines(lines, 40);
+    expect(result40).toEqual(expected40);
+    // Should differ from 80-width result (though in this case text is short
+    // enough that wrapping doesn't change — but the cache should still recompute)
+    expect(result40).not.toBe(result80);
+  });
+
+  it("cache invalidates on quoteColor change", () => {
+    const lines = [dm('She said "hello."'), dm(""), dm("End.")];
+
+    let resultA: ProcessedLine[] = [];
+    let resultB: ProcessedLine[] = [];
+
+    const { rerender } = render(
+      <HookHarness lines={lines} width={80} quoteColor="#aaa" onResult={(r) => { resultA = r; }} />,
+    );
+
+    rerender(
+      <HookHarness lines={lines} width={80} quoteColor="#bbb" onResult={(r) => { resultB = r; }} />,
+    );
+
+    const expectedB = processNarrativeLines(lines, 80, "#bbb");
+    expect(resultB).toEqual(expectedB);
+    // Different quoteColor should produce different results for the quoted line
+    expect(resultB).not.toBe(resultA);
+  });
+
+  it("handles no blank DM lines (full process)", () => {
+    const lines = [dm("Line one."), dm("Line two.")];
+
+    let captured: ProcessedLine[] = [];
+    render(
+      <HookHarness lines={lines} width={80} onResult={(r) => { captured = r; }} />,
+    );
+
+    const expected = processNarrativeLines(lines, 80);
+    expect(captured).toEqual(expected);
+  });
+});

--- a/src/tui/components/NarrativeArea.tsx
+++ b/src/tui/components/NarrativeArea.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, useCallback, useMemo, forwardRef } from "react";
+import React, { useRef, useEffect, useState, useCallback, forwardRef } from "react";
 import { Text, Box } from "ink";
 import { ScrollView } from "ink-scroll-view";
 import type { ScrollViewRef } from "ink-scroll-view";
@@ -9,6 +9,91 @@ import { useScrollHandle } from "../hooks/useScrollHandle.js";
 import type { ScrollHandle } from "../hooks/useScrollHandle.js";
 import { composeTurnSeparator } from "../themes/composer.js";
 import type { ThemeAsset } from "../themes/types.js";
+
+// ---------------------------------------------------------------------------
+// Incremental narrative processing hook
+// ---------------------------------------------------------------------------
+
+/** Scan backward for last blank DM line; returns index or -1. */
+function findLastBlankDm(lines: NarrativeLine[]): number {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].kind === "dm" && lines[i].text.trim() === "") return i;
+  }
+  return -1;
+}
+
+/** Check that the first `count` elements are reference-equal. */
+function prefixStable(a: NarrativeLine[], b: NarrativeLine[], count: number): boolean {
+  if (a.length < count || b.length < count) return false;
+  for (let i = 0; i < count; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Incrementally process narrative lines by caching the "frozen" prefix
+ * (everything before the last blank DM line) and only reprocessing
+ * the current paragraph tail on each call.
+ */
+export function useProcessedLines(
+  lines: NarrativeLine[],
+  width: number,
+  quoteColor?: string,
+): ProcessedLine[] {
+  const cacheRef = useRef<{
+    lines: NarrativeLine[];
+    width: number;
+    quoteColor: string | undefined;
+    splitIdx: number;            // index of blank DM line where we split
+    frozenResult: ProcessedLine[];
+    fullResult: ProcessedLine[];
+  } | null>(null);
+
+  const splitIdx = findLastBlankDm(lines);
+  const cache = cacheRef.current;
+
+  // Can we reuse the frozen prefix?
+  if (
+    cache !== null &&
+    cache.width === width &&
+    cache.quoteColor === quoteColor &&
+    cache.splitIdx === splitIdx &&
+    splitIdx >= 0 &&
+    cache.lines.length <= lines.length &&
+    prefixStable(cache.lines, lines, splitIdx + 1)
+  ) {
+    // Frozen prefix is still valid — only reprocess the tail
+    const tail = lines.slice(splitIdx + 1);
+    const tailResult = processNarrativeLines(tail, width, quoteColor);
+    const fullResult = [...cache.frozenResult, ...tailResult];
+    cacheRef.current = {
+      lines,
+      width,
+      quoteColor,
+      splitIdx,
+      frozenResult: cache.frozenResult,
+      fullResult,
+    };
+    return fullResult;
+  }
+
+  // Full recompute
+  if (splitIdx >= 0) {
+    const prefix = lines.slice(0, splitIdx + 1);
+    const tail = lines.slice(splitIdx + 1);
+    const frozenResult = processNarrativeLines(prefix, width, quoteColor);
+    const tailResult = processNarrativeLines(tail, width, quoteColor);
+    const fullResult = [...frozenResult, ...tailResult];
+    cacheRef.current = { lines, width, quoteColor, splitIdx, frozenResult, fullResult };
+    return fullResult;
+  }
+
+  // No blank DM line — no split possible, process everything
+  const fullResult = processNarrativeLines(lines, width, quoteColor);
+  cacheRef.current = { lines, width, quoteColor, splitIdx, frozenResult: [], fullResult };
+  return fullResult;
+}
 
 export type NarrativeAreaHandle = ScrollHandle;
 
@@ -90,11 +175,8 @@ export const NarrativeArea = forwardRef<NarrativeAreaHandle, NarrativeAreaProps>
     return () => { process.stdout.off("resize", onResize); };
   }, [updateScrollState]);
 
-  // Single-pass AST pipeline: parse → heal → wrap → pad → quote highlight
-  const processedLines = useMemo(
-    () => processNarrativeLines(lines, width ?? 0, quoteColor),
-    [lines, width, quoteColor],
-  );
+  // Incremental pipeline: frozen prefix cached, only tail reprocessed
+  const processedLines = useProcessedLines(lines, width ?? 0, quoteColor);
 
   return (
     <Box height={maxRows} flexDirection="column">
@@ -119,14 +201,18 @@ export const NarrativeArea = forwardRef<NarrativeAreaHandle, NarrativeAreaProps>
   );
 });
 
-/** A single narrative line rendered based on its kind. */
-function NarrativeLineComponent({ line, playerColor, width, themeAsset, separatorColor }: {
+interface NarrativeLineProps {
   line: ProcessedLine;
   playerColor?: string;
   width?: number;
   themeAsset?: ThemeAsset;
   separatorColor?: string;
-}) {
+}
+
+/** A single narrative line rendered based on its kind. */
+const NarrativeLineComponent = React.memo(function NarrativeLineComponent({
+  line, playerColor, width, themeAsset, separatorColor,
+}: NarrativeLineProps) {
   // Separator lines always render the turn separator pattern
   if (line.kind === "separator") {
     if (themeAsset && width && width > 0) {
@@ -192,4 +278,4 @@ function NarrativeLineComponent({ line, playerColor, width, themeAsset, separato
       return <Text wrap="truncate">{renderNodes(line.nodes)}</Text>;
     }
   }
-}
+});

--- a/src/tui/formatting.test.ts
+++ b/src/tui/formatting.test.ts
@@ -725,3 +725,111 @@ describe("processNarrativeLines", () => {
     }
   });
 });
+
+describe("paragraph boundary split", () => {
+  // Proves that processing [prefix .. blank] ++ [tail] separately matches
+  // processing everything together — the invariant that makes incremental
+  // caching correct.
+  const dm = (text: string): NarrativeLine => ({ kind: "dm", text });
+  const WIDTH = 80;
+
+  function splitAndProcess(lines: NarrativeLine[], splitIdx: number, width: number, quoteColor?: string) {
+    const prefix = lines.slice(0, splitIdx + 1);
+    const tail = lines.slice(splitIdx + 1);
+    return [
+      ...processNarrativeLines(prefix, width, quoteColor),
+      ...processNarrativeLines(tail, width, quoteColor),
+    ];
+  }
+
+  it("basic split matches full process", () => {
+    const lines = [dm("Hello."), dm(""), dm("World.")];
+    const full = processNarrativeLines(lines, WIDTH);
+    const split = splitAndProcess(lines, 1, WIDTH);
+    expect(split).toEqual(full);
+  });
+
+  it("cross-line bold/italic within a paragraph", () => {
+    const lines = [
+      dm("<b>bold start"),
+      dm("still bold</b>"),
+      dm(""),
+      dm("clean paragraph"),
+    ];
+    const full = processNarrativeLines(lines, WIDTH);
+    const split = splitAndProcess(lines, 2, WIDTH);
+    expect(split).toEqual(full);
+  });
+
+  it("quote highlighting across paragraphs resets at boundary", () => {
+    const quoteColor = "#aabbcc";
+    const lines = [
+      dm('She said "hello" softly.'),
+      dm(""),
+      dm("Normal text."),
+    ];
+    const full = processNarrativeLines(lines, WIDTH, quoteColor);
+    const split = splitAndProcess(lines, 1, WIDTH, quoteColor);
+    expect(split).toEqual(full);
+  });
+
+  it("unbalanced quote does not leak past boundary when split", () => {
+    const quoteColor = "#aabbcc";
+    const lines = [
+      dm('He said "hello'),
+      dm(""),
+      dm("Not quoted."),
+    ];
+    const full = processNarrativeLines(lines, WIDTH, quoteColor);
+    const split = splitAndProcess(lines, 1, WIDTH, quoteColor);
+    expect(split).toEqual(full);
+  });
+
+  it("mixed line kinds (player, separator, system) around boundary", () => {
+    const lines: NarrativeLine[] = [
+      dm("DM text."),
+      { kind: "player", text: "> I attack." },
+      dm(""),
+      { kind: "system", text: "Combat started." },
+      dm("The blow lands."),
+    ];
+    const full = processNarrativeLines(lines, WIDTH);
+    const split = splitAndProcess(lines, 2, WIDTH);
+    expect(split).toEqual(full);
+  });
+
+  it("no blank DM lines — no split possible, full process required", () => {
+    const lines = [dm("Line one."), dm("Line two."), dm("Line three.")];
+    const full = processNarrativeLines(lines, WIDTH);
+    // With no blank DM line, splitIdx would be -1; there's nothing to split.
+    // This just verifies full process is coherent.
+    expect(full).toHaveLength(3);
+    expect(toPlainText(full[0].nodes)).toBe("Line one.");
+  });
+
+  it("multiple paragraph boundaries — split at last one", () => {
+    const lines = [
+      dm("Para 1."),
+      dm(""),
+      dm("Para 2."),
+      dm(""),
+      dm("Para 3."),
+    ];
+    const full = processNarrativeLines(lines, WIDTH);
+    // Split at the last blank (index 3)
+    const split = splitAndProcess(lines, 3, WIDTH);
+    expect(split).toEqual(full);
+  });
+
+  it("alignment padding at boundary", () => {
+    const lines = [
+      dm("Before."),
+      dm("<center>Title</center>"),
+      dm(""),
+      dm("After."),
+    ];
+    const full = processNarrativeLines(lines, WIDTH);
+    const split = splitAndProcess(lines, 2, WIDTH);
+    expect(split).toEqual(full);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `useProcessedLines` hook that splits narrative processing at the last blank DM line (paragraph boundary), caching the frozen prefix and only reprocessing the current paragraph tail on streaming deltas
- Wrap `NarrativeLineComponent` in `React.memo` so frozen lines skip re-render entirely
- During streaming (500+ line history), this reduces per-keystroke work from processing all 500 lines to only the current paragraph (~5 lines)

## Test plan

- [x] 8 new paragraph-boundary-split invariant tests in `formatting.test.ts` (proves split processing matches full processing)
- [x] 5 new hook/memo tests in `NarrativeArea.test.tsx` (output correctness, reference stability, cache invalidation)
- [x] All 1265 existing tests pass, ESLint clean, coverage maintained
- [ ] Manual: launch game, play through a few DM turns, verify narrative renders correctly
- [ ] Manual: during streaming, observe that keystrokes in the Esc menu are responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)