### PR TITLE
Fix DM context loss after scene transitions

### DIFF
--- a/src/agents/game-engine.test.ts
+++ b/src/agents/game-engine.test.ts
@@ -326,6 +326,71 @@ describe("GameEngine", () => {
     expect(engine.getState()).toBe("waiting_input");
   });
 
+  it("refreshes context after scene transition", async () => {
+    const client = mockClient([textMessage("- Party met in tavern")]);
+    const { callbacks } = mockCallbacks();
+    const fileIO = mockFileIO();
+    const state = mockState();
+
+    // Pre-populate a campaign log file so contextRefresh can read it
+    files[norm("/tmp/test-campaign/campaign/log.md")] = "# Campaign Log\n\n## Scene 1\nOld entry";
+
+    const sessionState = mockSessionState();
+    const engine = new GameEngine({
+      client,
+      gameState: state,
+      scene: mockScene(),
+      sessionState,
+      fileIO,
+      callbacks,
+      model: "claude-haiku-4-5-20251001",
+    });
+
+    await engine.transitionScene("Tavern Meeting", 60);
+
+    // After transition, campaign log should have been re-read by contextRefresh
+    // The appendFile from the transition adds the new entry, then contextRefresh re-reads it
+    expect(fileIO.readFile).toHaveBeenCalled();
+    const readCalls = (fileIO.readFile as ReturnType<typeof vi.fn>).mock.calls
+      .map(([p]: unknown[]) => norm(p as string));
+    expect(readCalls.some((p: string) => p.includes("log.md"))).toBe(true);
+
+    // The session state should have the updated campaign summary
+    expect(sessionState.campaignSummary).toContain("Party met in tavern");
+  });
+
+  it("refreshes context after resumePendingTransition", async () => {
+    const client = mockClient([textMessage("- Resumed summary")]);
+    const { callbacks } = mockCallbacks();
+    const fileIO = mockFileIO();
+    const state = mockState();
+
+    files[norm("/tmp/test-campaign/campaign/log.md")] = "# Campaign Log\nOld data";
+
+    const sessionState = mockSessionState();
+    const engine = new GameEngine({
+      client,
+      gameState: state,
+      scene: mockScene(),
+      sessionState,
+      fileIO,
+      callbacks,
+      model: "claude-haiku-4-5-20251001",
+    });
+
+    await engine.resumePendingTransition({
+      type: "scene_transition",
+      step: "subagent_updates" as import("./scene-manager.js").PendingStep,
+      sceneNumber: 1,
+      title: "Resume Test",
+    });
+
+    // contextRefresh should have re-read the campaign log
+    const readCalls = (fileIO.readFile as ReturnType<typeof vi.fn>).mock.calls
+      .map(([p]: unknown[]) => norm(p as string));
+    expect(readCalls.some((p: string) => p.includes("log.md"))).toBe(true);
+  });
+
   it("ends session", async () => {
     const client = mockClient([textMessage("- Session summary")]);
     const { callbacks, log } = mockCallbacks();

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -445,6 +445,9 @@ export class GameEngine {
       // Persist the reset scene state (new sceneNumber, cleared precis/transcript)
       this.persistCurrentScene();
 
+      // Refresh context so the DM sees the updated campaign log
+      await this.sceneManager.contextRefresh();
+
       // Auto-apply theme from location entity if it has theme metadata
       await this.applyLocationTheme(title);
 
@@ -512,6 +515,9 @@ export class GameEngine {
         accUsage(this.sessionUsage, result.usage);
         this.callbacks.onUsageUpdate(this.sessionUsage);
       }
+
+      this.persistCurrentScene();
+      await this.sceneManager.contextRefresh();
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
       await this.dumpDebugInfo(error);

--- a/src/agents/scene-manager.test.ts
+++ b/src/agents/scene-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Anthropic from "@anthropic-ai/sdk";
-import { SceneManager, parseTranscriptEntries, classifyTranscriptEntry, buildScenePacing, detectSceneState } from "./scene-manager.js";
+import { SceneManager, parseTranscriptEntries, classifyTranscriptEntry, buildScenePacing, buildSceneAnchor, detectSceneState } from "./scene-manager.js";
 import type { SceneState, FileIO } from "./scene-manager.js";
 import type { CampaignRepo } from "../tools/git/index.js";
 import type { GameState } from "./game-state.js";
@@ -286,7 +286,8 @@ describe("SceneManager", () => {
     // Scene advanced
     expect(mgr.getScene().sceneNumber).toBe(2);
     expect(mgr.getScene().transcript).toHaveLength(0);
-    expect(mgr.getScene().precis).toBe("");
+    // Precis is seeded with an anchor from the campaign log
+    expect(mgr.getScene().precis).toContain("Previous scene (Tavern Meeting):");
 
     // Pending op cleared
     expect(mgr.getPendingOp()).toBeNull();
@@ -1238,6 +1239,105 @@ describe("buildScenePacing", () => {
     scene.openThreads = "";
     const result = buildScenePacing(scene)!;
     expect(result).toContain("Open threads: 0");
+  });
+});
+
+describe("buildSceneAnchor", () => {
+  it("extracts last 3 bullets from campaign log entry", () => {
+    const logEntry = "- Aldric arrived at Euston Station\n- Met the conductor\n- Boarded the midnight express\n- Reached the dining car";
+    const result = buildSceneAnchor("Midnight Express", logEntry, []);
+    expect(result).toContain("Previous scene (Midnight Express):");
+    expect(result).toContain("- Met the conductor");
+    expect(result).toContain("- Boarded the midnight express");
+    expect(result).toContain("- Reached the dining car");
+    // First bullet excluded (only last 3)
+    expect(result).not.toContain("Aldric arrived");
+  });
+
+  it("returns empty string for empty campaign log", () => {
+    const result = buildSceneAnchor("Empty Scene", "", []);
+    expect(result).toBe("");
+  });
+
+  it("includes alarms fired section", () => {
+    const result = buildSceneAnchor("Test", "", ["The clock strikes midnight", "Guards change shift"]);
+    expect(result).toContain("Alarms fired during transition:");
+    expect(result).toContain("- The clock strikes midnight");
+    expect(result).toContain("- Guards change shift");
+  });
+
+  it("takes all bullets when fewer than 3", () => {
+    const logEntry = "- Single bullet point";
+    const result = buildSceneAnchor("Short Scene", logEntry, []);
+    expect(result).toContain("Previous scene (Short Scene):");
+    expect(result).toContain("- Single bullet point");
+  });
+
+  it("combines campaign log tail with alarms", () => {
+    const logEntry = "- Arrived at the castle";
+    const result = buildSceneAnchor("Castle", logEntry, ["Drawbridge raised"]);
+    expect(result).toContain("Previous scene (Castle):");
+    expect(result).toContain("- Arrived at the castle");
+    expect(result).toContain("Alarms fired during transition:");
+    expect(result).toContain("- Drawbridge raised");
+  });
+});
+
+describe("scene transition seeds precis", () => {
+  it("sceneTransition seeds precis with campaign log anchor", async () => {
+    const client = mockClient([
+      textResponse("- Aldric entered the tavern\n- Met the innkeeper\n- Ordered a drink\n- Heard a rumor"),
+      textResponse(""),
+    ]);
+
+    const fileIO = mockFileIO();
+    (fileIO.listDir as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const mgr = new SceneManager(
+      mockState(),
+      mockScene(),
+      new ConversationManager({ retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 }),
+      mockSessionState(),
+      fileIO,
+    );
+
+    await mgr.sceneTransition(client, "Tavern Meeting");
+
+    const scene = mgr.getScene();
+    expect(scene.precis).toContain("Previous scene (Tavern Meeting):");
+    expect(scene.precis).toContain("- Met the innkeeper");
+    expect(scene.precis).toContain("- Ordered a drink");
+    expect(scene.precis).toContain("- Heard a rumor");
+  });
+
+  it("resumePendingTransition seeds precis with campaign log anchor", async () => {
+    const client = mockClient([
+      textResponse("- Explored the dungeon\n- Found a key"),
+      textResponse(""),
+    ]);
+
+    const fileIO = mockFileIO();
+    (fileIO.listDir as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const mgr = new SceneManager(
+      mockState(),
+      mockScene(),
+      new ConversationManager({ retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 }),
+      mockSessionState(),
+      fileIO,
+    );
+
+    await mgr.resumePendingTransition(client, {
+      type: "scene_transition",
+      step: "subagent_updates" as import("./scene-manager.js").PendingStep,
+      sceneNumber: 1,
+      title: "Dungeon Depths",
+    });
+
+    const scene = mgr.getScene();
+    expect(scene.precis).toContain("Previous scene (Dungeon Depths):");
+    expect(scene.precis).toContain("- Explored the dungeon");
+    expect(scene.precis).toContain("- Found a key");
   });
 });
 

--- a/src/agents/scene-manager.ts
+++ b/src/agents/scene-manager.ts
@@ -267,6 +267,9 @@ export class SceneManager {
     this.scene.slug = "";
     this.scene.transcript = [];
 
+    // Seed precis with an anchor so the DM has context before any exchanges drop
+    this.scene.precis = buildSceneAnchor(title, result.campaignLogEntry, result.alarmsFired);
+
     return result;
   }
 
@@ -364,6 +367,13 @@ export class SceneManager {
     this.scene.sceneNumber++;
     this.scene.slug = "";
     this.scene.transcript = [];
+
+    // Seed precis with an anchor so the DM has context before any exchanges drop
+    this.scene.precis = buildSceneAnchor(
+      pendingOp.title,
+      result.campaignLogEntry,
+      result.alarmsFired,
+    );
 
     return result;
   }
@@ -827,6 +837,37 @@ export async function detectSceneState(campaignRoot: string, io: FileIO): Promis
 }
 
 // --- Helpers ---
+
+/**
+ * Build a brief scene-opening anchor from the previous scene's campaign log entry.
+ * Seeded into precis after a transition so the DM has compact context for where
+ * the story left off, even before any exchanges are dropped.
+ */
+export function buildSceneAnchor(
+  title: string,
+  campaignLogEntry: string,
+  alarmsFired: string[],
+): string {
+  const lines: string[] = [];
+  if (campaignLogEntry) {
+    const bullets = campaignLogEntry
+      .split("\n")
+      .filter((l) => l.trim().startsWith("- "));
+    // Last 3 bullets describe where the previous scene ended = where we are now
+    const tail = bullets.slice(-3);
+    if (tail.length > 0) {
+      lines.push(`Previous scene (${title}):`);
+      lines.push(...tail);
+    }
+  }
+  if (alarmsFired.length > 0) {
+    lines.push("Alarms fired during transition:");
+    for (const alarm of alarmsFired) {
+      lines.push(`- ${alarm}`);
+    }
+  }
+  return lines.join("\n");
+}
 
 /**
  * Parse a transcript.md file into the original entry array.


### PR DESCRIPTION
## Summary
- **Refresh campaign log after transition:** `transitionScene()` and `resumePendingTransition()` in game-engine now call `contextRefresh()` so `sessionState.campaignSummary` reflects the newly-appended campaign log entry instead of stale data.
- **Seed new scene precis with anchor:** After a transition, `buildSceneAnchor()` extracts the last 3 bullets from the campaign log entry (plus any alarms fired) and seeds `scene.precis`, so the DM's "Scene So Far" block is populated immediately rather than omitted entirely.
- **Prompt tweaks (prior commits):** Comment stripping in prompt loader; pacing note and companion NPC directive adjustment in dm-identity.

## Test plan
- [x] `buildSceneAnchor` unit tests: last-3 bullets, empty log, alarms, fewer than 3, combined
- [x] Integration: `sceneTransition()` and `resumePendingTransition()` seed precis with anchor
- [x] Integration: `transitionScene()` and `resumePendingTransition()` re-read campaign log via `contextRefresh()`
- [x] Existing test updated: cascade test now asserts precis contains anchor instead of empty string
- [x] All 1270 tests pass, `npm run check` clean
- [x] Manual smoke test: scene transition produces populated "Scene So Far" and up-to-date campaign log in DM context

🤖 Generated with [Claude Code](https://claude.com/claude-code)