### PR TITLE
Show estimated token count in Campaign Explorer header

### DIFF
--- a/tools/campaign-explorer/src/client/components/ContentPane.tsx
+++ b/tools/campaign-explorer/src/client/components/ContentPane.tsx
@@ -5,6 +5,15 @@ import { ContextDumpViewer } from "./ContextDumpViewer";
 import { useAutoScroll } from "../hooks/useAutoScroll";
 import type { FileCategory } from "../../shared/protocol";
 
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function formatK(n: number): string {
+  if (n < 1000) return String(n);
+  return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+}
+
 interface ContentPaneProps {
   campaignSlug: string | null;
   selectedFile: string | null;
@@ -75,7 +84,10 @@ export function ContentPane({
 
   return (
     <div className="content-pane" ref={scrollRef}>
-      <div className="content-header">{selectedFile}</div>
+      <div className="content-header">
+        <span>{selectedFile}</span>
+        <span className="token-count">~{formatK(estimateTokens(content))} tokens</span>
+      </div>
       {isContextDump ? (
         <ContextDumpViewer content={content} />
       ) : isJson ? (

--- a/tools/campaign-explorer/src/client/styles/index.css
+++ b/tools/campaign-explorer/src/client/styles/index.css
@@ -211,11 +211,21 @@ body {
 }
 
 .content-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
   font-size: 11px;
   color: var(--text-muted);
   padding-bottom: 8px;
   margin-bottom: 12px;
   border-bottom: 1px solid var(--border);
+}
+
+.token-count {
+  color: var(--text-muted);
+  font-size: 10px;
+  flex-shrink: 0;
+  margin-left: 12px;
 }
 
 /* Markdown viewer */


### PR DESCRIPTION
## Summary
- Adds an approximate token count (`~Nk tokens`) right-aligned in the Campaign Explorer's document header bar
- Uses a cheap `chars / 4` heuristic inline in `ContentPane.tsx` — no new dependencies or imports from the main app
- Flexbox layout on `.content-header` pushes the count to the right edge with muted styling

## Test plan
- [x] `npm run check` passes (1283 tests, ESLint clean)
- [ ] Launch Campaign Explorer, select various files (.md, .json, context dumps) and confirm the token count appears right-aligned and updates on file switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)