### PR TITLE
Dense linear token display in Esc menu footer

### DIFF
--- a/src/context/cost-tracker.test.ts
+++ b/src/context/cost-tracker.test.ts
@@ -71,31 +71,32 @@ describe("CostTracker", () => {
   });
 
   describe("formatTokens", () => {
-    it("returns empty string when no tokens recorded", () => {
+    it("shows zeros for all tiers when no tokens recorded", () => {
       const tracker = new CostTracker();
-      expect(tracker.formatTokens()).toBe("");
+      expect(tracker.formatTokens()).toBe("0/0/0 | 0/0/0 | 0/0/0");
     });
 
-    it("formats single tier", () => {
+    it("formats single tier with zeros for unused tiers", () => {
       const tracker = new CostTracker();
       tracker.record({ inputTokens: 5000, outputTokens: 200, cacheReadTokens: 40000, cacheCreationTokens: 0 }, "large");
-      expect(tracker.formatTokens()).toBe("L 5.2k/40k");
+      // small | medium | large
+      expect(tracker.formatTokens()).toBe("0/0/0 | 0/0/0 | 5k/200/40k");
     });
 
-    it("formats multiple tiers, skips empty ones", () => {
+    it("formats multiple tiers, shows zeros for unused", () => {
       const tracker = new CostTracker();
       tracker.record({ inputTokens: 5000, outputTokens: 200, cacheReadTokens: 40000, cacheCreationTokens: 0 }, "large");
       tracker.record({ inputTokens: 2000, outputTokens: 0, cacheReadTokens: 15000, cacheCreationTokens: 0 }, "medium");
-      // small has nothing
-      expect(tracker.formatTokens()).toBe("L 5.2k/40k | M 2k/15k");
+      // small | medium | large
+      expect(tracker.formatTokens()).toBe("0/0/0 | 2k/0/15k | 5k/200/40k");
     });
 
-    it("shows all three tiers when all have usage", () => {
+    it("shows all three tiers in order small | medium | large", () => {
       const tracker = new CostTracker();
       tracker.record({ inputTokens: 5000, outputTokens: 200, cacheReadTokens: 40000, cacheCreationTokens: 0 }, "large");
       tracker.record({ inputTokens: 2000, outputTokens: 0, cacheReadTokens: 15000, cacheCreationTokens: 0 }, "medium");
       tracker.record({ inputTokens: 8000, outputTokens: 0, cacheReadTokens: 60000, cacheCreationTokens: 0 }, "small");
-      expect(tracker.formatTokens()).toBe("L 5.2k/40k | M 2k/15k | S 8k/60k");
+      expect(tracker.formatTokens()).toBe("8k/0/60k | 2k/0/15k | 5k/200/40k");
     });
   });
 });

--- a/src/context/cost-tracker.ts
+++ b/src/context/cost-tracker.ts
@@ -36,8 +36,8 @@ export function formatK(n: number): string {
   return m >= 10 ? `${Math.round(m)}M` : `${+m.toFixed(1)}M`;
 }
 
-// Tier display labels
-const TIER_LABELS: Record<ModelTier, string> = { large: "L", medium: "M", small: "S" };
+// Tier display order: small → medium → large (cheapest first)
+const TIER_ORDER: ModelTier[] = ["small", "medium", "large"];
 
 // --- Session token tracker ---
 
@@ -84,16 +84,14 @@ export class CostTracker {
 
   /**
    * Format a compact token summary for display in the Esc menu footer.
-   * Example: "L 5.2k/40k | M 2k/15k | S 8k/60k"
-   * Tiers with 0 input and 0 cached are omitted.
+   * Each tier shows in/out/cached. Order: small | medium | large.
+   * Example: "8k/0/60k | 2k/0/15k | 5k/200/40k"
    */
   formatTokens(): string {
-    const parts: string[] = [];
-    for (const tier of ["large", "medium", "small"] as ModelTier[]) {
+    return TIER_ORDER.map((tier) => {
       const t = this.breakdown.byTier[tier];
-      if (t.input === 0 && t.cached === 0) continue;
-      parts.push(`${TIER_LABELS[tier]} ${formatK(t.input)}/${formatK(t.cached)}`);
-    }
-    return parts.join(" | ");
+      const pureInput = t.input - t.output;
+      return `${formatK(pureInput)}/${formatK(t.output)}/${formatK(t.cached)}`;
+    }).join(" | ");
   }
 }

--- a/src/tui/modals/modals.test.tsx
+++ b/src/tui/modals/modals.test.tsx
@@ -226,12 +226,12 @@ describe("GameMenu", () => {
           width={60}
           height={24}
           selectedIndex={0}
-          tokenSummary="L 5.2k/40k | M 2k/15k"
+          tokenSummary="0/0/0 | 2k/0/15k | 5k/200/40k"
         />
       </Box>,
     );
     const frame = lastFrame();
-    expect(frame).toContain("L 5.2k/40k | M 2k/15k");
+    expect(frame).toContain("0/0/0 | 2k/0/15k | 5k/200/40k");
   });
 
   it("highlights selected item", () => {


### PR DESCRIPTION
## Summary
- Token display now shows all three tiers always (small | medium | large), with zeros instead of omitting unused tiers
- Each tier shows `in/out/cached` separately instead of combined `input/cached`
- Dropped tier labels (L/M/S) for a denser format: `8k/0/60k | 2k/0/15k | 5k/200/40k`

## Test plan
- [x] All 1283 tests pass (`npm run check`)
- [ ] Launch game, open Esc menu, verify token counts render in new format with yellow coloring

🤖 Generated with [Claude Code](https://claude.com/claude-code)