### PR TITLE
Add /snapshot slash command for heap debugging

### DIFF
--- a/src/commands/slash-commands.test.ts
+++ b/src/commands/slash-commands.test.ts
@@ -19,6 +19,18 @@ vi.mock("../agents/subagents/dev-mode.js", () => ({
   summarizeGameState: vi.fn().mockReturnValue("summary"),
 }));
 
+vi.mock("node:v8", () => ({
+  default: { writeHeapSnapshot: vi.fn().mockReturnValue("heap-mock.heapsnapshot") },
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, writeFileSync: vi.fn() };
+});
+
+import { writeFileSync } from "node:fs";
+import v8 from "node:v8";
+
 // Prevent process.exit from actually exiting
 const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
 
@@ -332,6 +344,37 @@ describe("trySlashCommand", () => {
       expect(ctx.setActiveSession).toHaveBeenCalledWith(null);
       // Then entered Dev
       expect(createDevSession).toHaveBeenCalled();
+    });
+  });
+
+  describe("/snapshot", () => {
+    it("writes a heap snapshot file", () => {
+      const ctx = mockCtx();
+      trySlashCommand("/snapshot", ctx);
+
+      expect(v8.writeHeapSnapshot).toHaveBeenCalled();
+      expect(writeFileSync).toHaveBeenCalled();
+      const text = lastAppended(ctx).text;
+      expect(text).toContain("Heap snapshot written");
+    });
+
+    it("reports error when snapshot fails", () => {
+      const ctx = mockCtx();
+      vi.mocked(writeFileSync).mockImplementationOnce(() => {
+        throw new Error("ENOSPC");
+      });
+
+      trySlashCommand("/snapshot", ctx);
+
+      const text = lastAppended(ctx).text;
+      expect(text).toContain("Snapshot failed");
+      expect(text).toContain("ENOSPC");
+    });
+
+    it("appears in /help output", () => {
+      const ctx = mockCtx();
+      trySlashCommand("/help", ctx);
+      expect(lastAppended(ctx).text).toContain("/snapshot");
     });
   });
 

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -1,3 +1,5 @@
+import v8 from "node:v8";
+import { writeFileSync } from "node:fs";
 import type Anthropic from "@anthropic-ai/sdk";
 import type { NarrativeLine, StyleVariant } from "../types/tui.js";
 import type { GameEngine } from "../agents/game-engine.js";
@@ -205,6 +207,23 @@ const devCommand: SlashCommand = {
   },
 };
 
+const snapshotCommand: SlashCommand = {
+  name: "snapshot",
+  usage: "/snapshot",
+  description: "Write a V8 heap snapshot for memory debugging",
+  execute(_args, ctx) {
+    ctx.appendLine({ kind: "system", text: "[Writing heap snapshot — this may pause for a few seconds...]" });
+    const file = `heap-${Date.now()}.heapsnapshot`;
+    try {
+      writeFileSync(file, v8.writeHeapSnapshot());
+      ctx.appendLine({ kind: "system", text: `[Heap snapshot written: ${file}]` });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.appendLine({ kind: "system", text: `[Snapshot failed: ${msg}]` });
+    }
+  },
+};
+
 // --- Registry ---
 
 const commands: SlashCommand[] = [
@@ -215,6 +234,7 @@ const commands: SlashCommand[] = [
   sceneCommand,
   oocCommand,
   devCommand,
+  snapshotCommand,
 ];
 
 const commandMap = new Map<string, SlashCommand>(


### PR DESCRIPTION
## Summary
- Adds `/snapshot` slash command that writes a V8 heap snapshot (`.heapsnapshot`) to the working directory
- Enables memory leak investigation via Chrome DevTools without restarting the process
- Includes error handling with user-facing feedback on success/failure

## Context
First OOM crash after ~89 minutes of gameplay (V8 heap hit 4GB limit). This command lets us take snapshots at intervals during play to identify what's growing unboundedly.

## Test plan
- [x] 3 new tests: snapshot write, error handling, /help listing
- [x] All 1452 tests pass
- [x] ESLint clean, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)