### PR TITLE
Hide session handoff message from narrative view

### DIFF
--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -278,8 +278,9 @@ export class GameEngine {
       this.aiTurnDepth = 0;
     }
 
-    // Fire player turn lifecycle (skipped for AI — executeAITurn already fired it)
-    if (!opts?.fromAI) {
+    // Fire player turn lifecycle (skipped for AI — executeAITurn already fired it,
+    // and skipped for system instructions like session open/resume)
+    if (!opts?.fromAI && !opts?.skipTranscript) {
       this.turnCounter++;
       const playerTurn: TurnInfo = {
         turnNumber: this.turnCounter,


### PR DESCRIPTION
## Summary
- The `skipTranscript` flag already suppressed transcript logging for internal system messages (session open/resume), but the player turn lifecycle callbacks (`onTurnStart`/`onTurnEnd`) still fired, causing the handoff prompt (e.g. `[Session begins. Set the scene. Campaign premise: ...]`) to render in the TUI narrative area.
- Added `!opts?.skipTranscript` to the guard in `GameEngine.processInput()` so those callbacks are also skipped for internal messages.

## Test plan
- [x] All 47 `game-engine.test.ts` tests pass
- [ ] Launch a new campaign and verify the handoff prompt no longer appears in the narrative view
- [ ] Resume an existing campaign and verify the resume prompt is also hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)