### PR TITLE
Fix: persist and restore conversation window across save/resume

### DIFF
--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -227,6 +227,7 @@ export class GameEngine {
       playerReads: scene.playerReads,
       activePlayerIndex: this.gameState.activePlayerIndex,
     });
+    this.persister.persistConversation(this.conversation.getExchanges());
   }
 
   /** Get current engine state */
@@ -252,6 +253,11 @@ export class GameEngine {
   /** Get campaign repo (for shutdown use) */
   getRepo(): CampaignRepo | null {
     return this.repo;
+  }
+
+  /** Seed the conversation with previously-persisted exchanges (for resume). */
+  seedConversation(exchanges: import("../context/conversation.js").ConversationExchange[]): void {
+    this.conversation.seedExchanges(exchanges);
   }
 
   /** Update the UI state section of the DM's prefix (called from TUI layer). */
@@ -454,15 +460,18 @@ export class GameEngine {
           playerReads: scene.playerReads,
           activePlayerIndex: this.gameState.activePlayerIndex,
         });
+        this.persister.persistConversation(this.conversation.getExchanges());
       }
 
       // Track exchange for git auto-commit
       await this.repo?.trackExchange();
 
-      // Handle dropped exchange
+      // Handle dropped exchange — update precis, then re-persist scene
+      // so the precis written to disk includes the just-dropped content.
       if (dropped) {
         this.callbacks.onExchangeDropped();
         await this.handleDroppedExchange(dropped);
+        this.persistCurrentScene();
       }
 
       // Process TUI commands — intercept engine commands

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -409,6 +409,7 @@ export default function App({ shutdownRef }: AppProps) {
 
     hydrateGameState(gs, scene, loaded);
     if (loaded.scene) setActivePlayerIndex(loaded.scene.activePlayerIndex);
+    if (loaded.conversation) engine.seedConversation(loaded.conversation);
 
     // Restore theme — fall back to default if the persisted name is unknown
     if (loaded.ui) {

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -211,6 +211,78 @@ describe("ConversationManager", () => {
     mgr.addExchange(userMsg("Hello world"), assistantMsg("Hi there"));
     expect(mgr.getEstimatedTokens()).toBeGreaterThan(0);
   });
+
+  it("getExchanges returns current exchanges", () => {
+    const mgr = new ConversationManager(defaultContextConfig);
+    mgr.addExchange(userMsg("Hello"), assistantMsg("Hi"));
+    mgr.addExchange(userMsg("Attack"), assistantMsg("You swing"));
+
+    const exchanges = mgr.getExchanges();
+    expect(exchanges).toHaveLength(2);
+    expect(exchanges[0].user.content).toBe("Hello");
+    expect(exchanges[1].assistant.content).toBe("You swing");
+  });
+
+  it("seedExchanges restores conversation with recomputed tokens", () => {
+    const mgr = new ConversationManager(defaultContextConfig);
+    mgr.seedExchanges([
+      {
+        user: userMsg("Search the room"),
+        assistant: assistantMsg("You find a chest."),
+        toolResults: [],
+        estimatedTokens: 0, // intentionally wrong — should be recomputed
+        stubbed: false,
+      },
+    ]);
+
+    expect(mgr.size).toBe(1);
+    expect(mgr.getEstimatedTokens()).toBeGreaterThan(0);
+    const messages = mgr.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toBe("Search the room");
+    expect(messages[1].content).toBe("You find a chest.");
+  });
+
+  it("seedExchanges preserves tool results and stubbed state", () => {
+    const mgr = new ConversationManager(defaultContextConfig);
+    mgr.seedExchanges([
+      {
+        user: userMsg("Roll"),
+        assistant: assistantMsg("You rolled 15"),
+        toolResults: [toolResultMsg("toolu_1", "[stub] 1d20: [15]")],
+        estimatedTokens: 0,
+        stubbed: true,
+      },
+    ]);
+
+    const messages = mgr.getMessages();
+    expect(messages).toHaveLength(3);
+    expect(messages[1].role).toBe("user"); // tool_result
+  });
+
+  it("seeded exchanges participate in normal retention", () => {
+    const config: ContextConfig = { ...defaultContextConfig, retention_exchanges: 2 };
+    const mgr = new ConversationManager(config);
+
+    // Seed one exchange
+    mgr.seedExchanges([
+      {
+        user: userMsg("Old input"),
+        assistant: assistantMsg("Old response"),
+        toolResults: [],
+        estimatedTokens: 0,
+        stubbed: false,
+      },
+    ]);
+
+    // Add two more — should drop the seeded one
+    mgr.addExchange(userMsg("New 1"), assistantMsg("Resp 1"));
+    const dropped = mgr.addExchange(userMsg("New 2"), assistantMsg("Resp 2"));
+
+    expect(mgr.size).toBe(2);
+    expect(dropped).not.toBeNull();
+    expect(dropped!.exchange.user.content).toBe("Old input");
+  });
 });
 
 describe("buildCachedPrefix", () => {

--- a/src/context/conversation.ts
+++ b/src/context/conversation.ts
@@ -77,6 +77,27 @@ export class ConversationManager {
     this.exchanges = [];
   }
 
+  /** Get raw exchanges for persistence. */
+  getExchanges(): ConversationExchange[] {
+    return this.exchanges;
+  }
+
+  /**
+   * Seed the conversation with previously-persisted exchanges.
+   * Token estimates are recomputed; retention is NOT enforced
+   * (the exchanges already survived retention when they were live).
+   */
+  seedExchanges(exchanges: ConversationExchange[]): void {
+    for (const ex of exchanges) {
+      // Recompute token estimates (they may have been serialized wrong)
+      ex.estimatedTokens =
+        estimateMessageTokens(ex.user) +
+        estimateMessageTokens(ex.assistant) +
+        ex.toolResults.reduce((sum, tr) => sum + estimateMessageTokens(tr), 0);
+      this.exchanges.push(ex);
+    }
+  }
+
   /** Replace tool results older than stub_after with one-line stubs */
   private stubOldToolResults(): void {
     const stubAfter = this.config.tool_result_stub_after;

--- a/src/context/state-persistence.test.ts
+++ b/src/context/state-persistence.test.ts
@@ -113,6 +113,33 @@ describe("StatePersister", () => {
     expect(loaded.scene).toEqual(scene);
   });
 
+  it("round-trips conversation exchanges", async () => {
+    const fio = mockFileIO();
+    const persister = new StatePersister("/tmp/campaign", fio);
+    const exchanges = [
+      {
+        user: { role: "user" as const, content: "I search the room." },
+        assistant: { role: "assistant" as const, content: "You find a dusty chest." },
+        toolResults: [],
+        estimatedTokens: 50,
+        stubbed: false,
+      },
+      {
+        user: { role: "user" as const, content: "I open it." },
+        assistant: { role: "assistant" as const, content: "Inside is a golden key." },
+        toolResults: [],
+        estimatedTokens: 40,
+        stubbed: false,
+      },
+    ];
+
+    persister.persistConversation(exchanges);
+    await vi.waitFor(() => expect(fio.writeFile).toHaveBeenCalled());
+
+    const loaded = await persister.loadAll();
+    expect(loaded.conversation).toEqual(exchanges);
+  });
+
   it("loadAll returns undefined for missing files", async () => {
     const fio = mockFileIO();
     const persister = new StatePersister("/tmp/campaign", fio);
@@ -123,6 +150,7 @@ describe("StatePersister", () => {
     expect(loaded.maps).toBeUndefined();
     expect(loaded.decks).toBeUndefined();
     expect(loaded.scene).toBeUndefined();
+    expect(loaded.conversation).toBeUndefined();
     expect(loaded.ui).toBeUndefined();
   });
 

--- a/src/context/state-persistence.ts
+++ b/src/context/state-persistence.ts
@@ -6,6 +6,7 @@ import type { ClocksState } from "../types/clocks.js";
 import type { DecksState } from "../types/cards.js";
 import type { MapData } from "../types/maps.js";
 import type { SceneState } from "../agents/scene-manager.js";
+import type { ConversationExchange } from "./conversation.js";
 import type { StyleVariant } from "../types/tui.js";
 import { tailLines } from "./display-log.js";
 
@@ -16,6 +17,7 @@ export const STATE_FILES = {
   maps: "state/maps.json",
   decks: "state/decks.json",
   scene: "state/scene.json",
+  conversation: "state/conversation.json",
   ui: "state/ui.json",
   displayLog: "state/display-log.md",
 } as const;
@@ -46,6 +48,7 @@ export interface LoadedState {
   maps?: Record<string, MapData>;
   decks?: DecksState;
   scene?: PersistedSceneState;
+  conversation?: ConversationExchange[];
   ui?: PersistedUIState;
 }
 
@@ -136,6 +139,10 @@ export class StatePersister {
     this.enqueueWrite(STATE_FILES.scene, JSON.stringify(scene, null, 2));
   }
 
+  persistConversation(exchanges: ConversationExchange[]): void {
+    this.enqueueWrite(STATE_FILES.conversation, JSON.stringify(exchanges));
+  }
+
   persistUI(state: PersistedUIState): void {
     this.enqueueWrite(STATE_FILES.ui, JSON.stringify(state, null, 2));
   }
@@ -167,15 +174,16 @@ export class StatePersister {
 
   /** Load all persisted state files. Missing files return undefined per key. */
   async loadAll(): Promise<LoadedState> {
-    const [combat, clocks, maps, decks, scene, ui] = await Promise.all([
+    const [combat, clocks, maps, decks, scene, conversation, ui] = await Promise.all([
       this.readJSON<CombatState>(STATE_FILES.combat),
       this.readJSON<ClocksState>(STATE_FILES.clocks),
       this.readJSON<Record<string, MapData>>(STATE_FILES.maps),
       this.readJSON<DecksState>(STATE_FILES.decks),
       this.readJSON<PersistedSceneState>(STATE_FILES.scene),
+      this.readJSON<ConversationExchange[]>(STATE_FILES.conversation),
       this.readJSON<PersistedUIState>(STATE_FILES.ui),
     ]);
 
-    return { combat, clocks, maps, decks, scene, ui };
+    return { combat, clocks, maps, decks, scene, conversation, ui };
   }
 }


### PR DESCRIPTION
## Summary
- **Conversation persistence**: The DM's conversation window (up to `retention_exchanges` exchanges) is now serialized to `state/conversation.json` after every turn and restored on resume via `seedExchanges()`, so the DM picks up exactly where it left off instead of starting with an empty context window.
- **Precis persist timing**: `persistCurrentScene()` is now called *after* `handleDroppedExchange()` so the precis on disk always includes the latest dropped-exchange summary. Previously the last update before quit was lost.

## Test plan
- [x] All 1486 tests pass, lint clean
- [x] New tests: conversation round-trip persistence, `seedExchanges` with recomputed tokens, seeded exchanges participate in normal retention
- [ ] Manual: play a few exchanges, quit, resume — DM should have full conversation context

🤖 Generated with [Claude Code](https://claude.com/claude-code)