### PR TITLE
Documentation overhaul + dump-state debugging skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,8 @@
       "Read(vitest.config.ts)",
       "Read(CLAUDE.md)",
       "Read(.claude/**)",
+      "Read(scripts/**)",
+      "Bash(npx tsx scripts/dump-state.ts:*)",
       "Edit(src/**)",
       "Edit(design-docs/**)",
       "Write(src/**)",

--- a/.claude/skills/dump-state/SKILL.md
+++ b/.claude/skills/dump-state/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: dump-state
+description: Dump persisted game state for debugging. Use when investigating game bugs, empty conversation logs, missing state, or crash recovery issues.
+disable-model-invocation: true
+allowed-tools: Bash(npx:*), Read
+---
+
+# Dump Game State
+
+Inspect the persisted game state files on disk for a campaign.
+
+## Usage
+
+`/dump-state` — list available campaigns
+`/dump-state <campaign-name>` — dump all state for that campaign
+
+## State dump
+
+!`npx tsx scripts/dump-state.ts $ARGUMENTS 2>&1`
+
+## What to look for
+
+When analyzing the state dump above:
+
+- **Empty conversation.json** (`[]`) — normal after a scene transition (conversation is pruned). Check scene.json precis for whether context was preserved.
+- **Missing state files** — if a file like `state/combat.json` is absent, that subsystem hasn't been initialized yet (normal).
+- **pending-operation.json exists** — a scene transition or session end was interrupted. The `currentStep` field shows where it stopped. This needs `resumePendingTransition()` to complete.
+- **scene.json** — `sceneNumber`, `slug`, `precis`, `openThreads`, `npcIntents`, `playerReads`. If precis is empty on scene > 1, the precis updater may not be running.
+- **conversation.json** — the exchange history. Each entry has `role`, `content`, and `usage`. If this is large (>10 exchanges), retention enforcement may not be triggering.
+- **ui.json** — persisted theme state (`styleName`, `variant`, `keyColor`). If the UI looks wrong on resume, check here.
+- **campaign/log.md** — append-only campaign history. If empty after multiple scenes, the scene summarizer subagent isn't running.
+- **config.json** — campaign configuration. Check `players`, `choices`, `context` settings.

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -269,7 +269,9 @@ The TUI targets **80×25 minimum**, with **80×40 for the full experience**. Two
 | **Full** | ≥80 cols, ≥40 rows | All elements visible. Side frames, top frame, activity line, lower frame. |
 | **Standard** | Everything else | Top frame and activity line dropped. Activity glyph moves to modeline. |
 
-Below 80×25 the standard tier still renders (no crash) but isn't designed for it.
+Below 80×25, the game replaces the entire UI with a fullscreen `TerminalTooSmall` blocker showing the current dimensions, the minimum required (80×25), and "Resize your terminal to continue." The blocker clears automatically when the terminal is resized above the minimum. Both `PlayingPhase` and `SetupPhase` enforce this.
+
+**Code:** `src/tui/components/TerminalTooSmall.tsx`, checked in `src/phases/PlayingPhase.tsx` and `src/phases/SetupPhase.tsx`
 
 ### Drop order (full → standard)
 
@@ -310,7 +312,7 @@ present_choices({})
 → subagent generates options from recent context, displays modal
 ```
 
-Explicit choices: The DM sets specific options when it matters narratively.
+Explicit choices: The DM sets specific options when it matters narratively. Optional `descriptions` provide per-choice detail shown in a fixed-height region (3 rows) that updates as the player highlights each option.
 
 ```
 present_choices({
@@ -319,9 +321,18 @@ present_choices({
     "Take its hand",
     "Refuse",
     "Ask its name first"
+  ],
+  descriptions: [
+    "Trust this being and accept whatever bond it offers.",
+    "Step back. You owe this creature nothing.",
+    "Buy time. Learn what you're dealing with before committing."
   ]
 })
 ```
+
+**Player Pane expansion:** Choices render inside the Player Pane, not as a floating modal. When descriptions are present, the Player Pane expands by `DESCRIPTION_ROWS` (3) to accommodate the description region above the choice list. The Conversation Pane shrinks to compensate. Without descriptions, the standard 7-row Player Pane layout is used.
+
+**Code:** `src/tui/modals/ChoiceModal.tsx` (`ChoiceOverlay`, `DESCRIPTION_ROWS`), `src/tui/layout.tsx` (`playerPaneExtraHeight`)
 
 The player's selection (or freeform text) is returned to the DM as the player's action, tagged normally: `[Aldric] Take its hand`.
 

--- a/scripts/dump-state.ts
+++ b/scripts/dump-state.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env npx tsx
+/**
+ * Dump persisted game state for debugging.
+ *
+ * Usage:
+ *   npx tsx scripts/dump-state.ts [campaign-name]
+ *
+ * If campaign-name is omitted, lists available campaigns.
+ * If provided, dumps all state/*.json files, pending-operation.json,
+ * config.json, and the tail of campaign/log.md.
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join, basename } from "node:path";
+import { defaultCampaignRoot } from "../src/tools/filesystem/platform.js";
+
+// --- Resolve campaigns directory ---
+
+function getCampaignsDir(): string {
+  const configPath = join(process.cwd(), "config.json");
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw);
+    if (config.campaigns_dir) return config.campaigns_dir;
+  } catch {
+    // fall through to default
+  }
+  return join(defaultCampaignRoot(), "campaigns");
+}
+
+function listCampaigns(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter((name) => {
+      const configPath = join(dir, name, "config.json");
+      return existsSync(configPath);
+    });
+  } catch {
+    return [];
+  }
+}
+
+function readJsonPretty(path: string): string {
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    return JSON.stringify(parsed, null, 2);
+  } catch (e) {
+    return `(error reading: ${e instanceof Error ? e.message : String(e)})`;
+  }
+}
+
+function readFileSafe(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function tailLines(text: string, n: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= n) return text;
+  return `... (${lines.length - n} lines omitted)\n` + lines.slice(-n).join("\n");
+}
+
+// --- Main ---
+
+const campaignsDir = getCampaignsDir();
+const requestedCampaign = process.argv[2];
+
+if (!requestedCampaign) {
+  const campaigns = listCampaigns(campaignsDir);
+  if (campaigns.length === 0) {
+    console.log(`No campaigns found in ${campaignsDir}`);
+  } else {
+    console.log(`Campaigns in ${campaignsDir}:\n`);
+    for (const name of campaigns) {
+      const stateDir = join(campaignsDir, name, "state");
+      const hasState = existsSync(stateDir);
+      console.log(`  ${name}${hasState ? "" : "  (no state/)"}`);
+    }
+    console.log(`\nUsage: npx tsx scripts/dump-state.ts <campaign-name>`);
+  }
+  process.exit(0);
+}
+
+const campaignRoot = join(campaignsDir, requestedCampaign);
+if (!existsSync(join(campaignRoot, "config.json"))) {
+  console.error(`Campaign not found: ${campaignRoot}`);
+  console.error(`(No config.json in that directory)`);
+  process.exit(1);
+}
+
+console.log(`=== Campaign: ${requestedCampaign} ===`);
+console.log(`Root: ${campaignRoot}\n`);
+
+// Campaign config
+console.log(`--- config.json ---`);
+console.log(readJsonPretty(join(campaignRoot, "config.json")));
+console.log();
+
+// State files
+const stateFiles = [
+  "state/combat.json",
+  "state/clocks.json",
+  "state/maps.json",
+  "state/decks.json",
+  "state/scene.json",
+  "state/conversation.json",
+  "state/ui.json",
+];
+
+for (const file of stateFiles) {
+  const fullPath = join(campaignRoot, file);
+  if (!existsSync(fullPath)) continue;
+  const stat = statSync(fullPath);
+  console.log(`--- ${file} --- (${stat.size} bytes, modified ${stat.mtime.toISOString()})`);
+  console.log(readJsonPretty(fullPath));
+  console.log();
+}
+
+// Pending operation (crash recovery)
+const pendingOpPath = join(campaignRoot, "state", "pending-operation.json");
+if (existsSync(pendingOpPath)) {
+  console.log(`--- state/pending-operation.json --- (ACTIVE)`);
+  console.log(readJsonPretty(pendingOpPath));
+  console.log();
+}
+
+// Display log
+const displayLogPath = join(campaignRoot, "state", "display-log.md");
+if (existsSync(displayLogPath)) {
+  const content = readFileSafe(displayLogPath);
+  if (content) {
+    console.log(`--- state/display-log.md --- (last 30 lines)`);
+    console.log(tailLines(content, 30));
+    console.log();
+  }
+}
+
+// Campaign log tail
+const campaignLogPath = join(campaignRoot, "campaign", "log.md");
+if (existsSync(campaignLogPath)) {
+  const content = readFileSafe(campaignLogPath);
+  if (content) {
+    console.log(`--- campaign/log.md --- (last 30 lines)`);
+    console.log(tailLines(content, 30));
+    console.log();
+  }
+}
+
+// Scene directories — just list them
+const scenesDir = join(campaignRoot, "campaign", "scenes");
+if (existsSync(scenesDir)) {
+  try {
+    const scenes = readdirSync(scenesDir).sort();
+    if (scenes.length > 0) {
+      console.log(`--- Scenes ---`);
+      for (const scene of scenes) {
+        console.log(`  ${scene}/`);
+      }
+      console.log();
+    }
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary

- **Consolidate `design-docs/` into `docs/`** — single documentation directory with navigation hub (`index.md`), architecture overview, and module map
- **Audit all design docs against implementation** — fix stale signatures, remove unimplemented features (moved to GitHub issues #67-#70), correct model tiers and state schemas
- **Add documentation maintenance loop** — `docs/maintenance.md` + CLAUDE.md directives for check docs → make changes → update docs → commit together
- **Remove derived counts** from tools catalog, subagents catalog, and TODO file (drift-prone, low value)
- **Update `tui-design.md`** — document `TerminalTooSmall` fullscreen blocker, choice descriptions with Player Pane expansion
- **Add `/dump-state` debugging skill** — CLI script (`scripts/dump-state.ts`) + Claude Code skill for inspecting persisted campaign state on disk
- **Fix scribe bugs** — guard `write_entity` against missing name field, fix usage accumulation calling missing method

## Test plan

- [x] `npm run check` passes (lint + tests + coverage)
- [ ] Verify all `docs/` relative links resolve on GitHub
- [ ] Test `/dump-state` skill lists campaigns and dumps state correctly
- [ ] Spot-check doc accuracy against current code


🤖 Generated with [Claude Code](https://claude.com/claude-code)