### PR TITLE
Derive modal colors: complementary hue + inverted lightness

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -198,21 +198,46 @@ The composition engine (`composeTopFrame`, `composeBottomFrame`, `composeSideCol
 
 Colors are generated at runtime from an OKLCH arc generator (`src/tui/color/`). A **swatch** is an array of hex color strings produced by walking a parametric curve through OKLCH color space:
 
-- **Hue arc**: start hue → end hue (degrees)
-- **Chroma curve**: min/max chroma envelope
-- **Lightness curve**: min/max lightness envelope
-- **Steps**: number of colors to generate
+- **Hue arc**: start hue → end hue (degrees), direction (cw/ccw/shortest)
+- **Chroma curve**: composable `CurveFunction` (t ∈ [0,1] → value) mapped to a min/max range
+- **Lightness curve**: same, mapped to a min/max lightness range
+- **Steps**: number of colors to generate (typically 8–10)
 
-Built-in swatch presets: `foliage`, `cyberpunk`, `ember`, `ethereal`. Each preset defines hue/chroma/lightness parameters tuned for a genre feel.
+Curve primitives (`src/tui/color/curves.ts`): `constant`, `linearRamp`, `sinePulse`, `easeInOut`, `bell`, `compose`. Presets combine these to define genre-specific palette shapes.
 
-A `ThemeColorMap` assigns swatch indices to frame parts:
+Built-in swatch presets: `foliage`, `cyberpunk`, `ember`, `ethereal`. Each preset defines a `PresetFactory` that builds `SwatchParams` from a base hex color.
+
+#### Harmony swatches
+
+A single arc produces one row of colors (anchor 0). A **harmony swatch** extends this to multiple rows by generating parallel arcs centered on different hue anchors derived from color theory:
+
+| Harmony type | Anchors | Hue offsets |
+|---|---|---|
+| `analogous` | 3 | 0°, −30°, +30° |
+| `complementary` | 2 | 0°, 180° |
+| `split-complementary` | 3 | 0°, 150°, 210° |
+| `triadic` | 3 | 0°, 120°, 240° |
+| `tetradic` | 4 | 0°, 90°, 180°, 270° |
+
+Row 0 is always the key color arc. Each subsequent row uses the same preset but centered on a different harmony anchor hue.
+
+**Code:** `generateHarmonySwatch(preset, keyColor, harmony)` in `src/tui/color/swatch.ts`
+
+#### Color map encoding
+
+A `ThemeColorMap` assigns encoded swatch indices to frame parts. Values encode a position in the 2D harmony swatch grid:
+
+- **0–99**: index into anchor 0 (key color arc). `value` = step.
+- **≥ 100**: `anchor = floor(value / 100)`, `step = value % 100`. E.g., `102` = anchor 1 step 2.
 
 | Color map key | Applied to |
 |---|---|
 | `border` | Top/bottom frame edges |
+| `corner` | Corner decorations |
 | `title` | Resource display text, turn indicator text |
 | `sideFrame` | Left/right side columns |
 | `separator` | Activity line separator, turn separator flourish |
+| `turnIndicator` | Turn indicator text |
 
 ### Variants
 
@@ -232,8 +257,9 @@ The DM switches variants via `style_scene` tool calls, or the engine switches au
 
 A `ThemeDefinition` specifies the theme asset name, base swatch configuration, and per-variant overrides. `resolveTheme(definition, variant, keyColor?)` produces a `ResolvedTheme` containing:
 - The parsed `ThemeAsset` (art components)
-- A generated swatch (hex color array) for the active variant
+- A generated `swatch` (anchor 0 arc) and `harmonySwatch` (full 2D grid) for the active variant
 - A `ThemeColorMap` mapping frame parts to swatch colors
+- The `keyColor` and `variant` used to generate it
 
 An optional `keyColor` (hex) shifts the swatch hue to center on that color, allowing location-specific tinting without changing the theme art.
 
@@ -392,13 +418,22 @@ ESC key opens the game menu modal:
 
 Standard navigation (arrow keys + Enter). Settings covers choice frequency, display preferences, and other player-level configuration. OOC Mode from here is equivalent to the DM detecting an OOC request.
 
+### Color Swatch Modal
+
+The `/swatch` command opens a debug modal showing the full harmony swatch grid, column step indices, row anchor labels (0, 100, 200, ...), and current `colorMap` assignments. Useful for tuning color maps and verifying swatch generation. Dismissed with any key.
+
+**Code:** `src/tui/modals/SwatchModal.tsx`
+
 ### Modal behavior
 
 - Modals overlay the narrative area, not the full screen. The modeline and player selector remain visible underneath.
 - Modals inherit the active theme variant (a combat choice modal uses the combat theme variant).
+- **Modal colors are derived from the main theme** — `deriveModalTheme()` shifts all colorMap values to anchor 1 (complementary hue, 180° away) and mirrors step indices (inverted lightness). This makes modals visually distinct from the game frame without requiring separate color configuration.
 - Modals are dismissed with ESC (back to game), Enter (confirm selection), or the relevant hotkey.
 - When modal content exceeds available height, it scrolls with a scroll indicator (e.g. `scroll (5) more`) and supports PageUp/PageDown navigation.
 - At minimal viewport sizes, modals take the full screen.
+
+**Code:** `deriveModalTheme()` in `src/tui/themes/color-resolve.ts`, applied automatically in `CenteredModal` and `Modal`.
 
 
 ## DM Tool Interface

--- a/src/tui/modals/CenteredModal.tsx
+++ b/src/tui/modals/CenteredModal.tsx
@@ -5,7 +5,7 @@ import type { ScrollViewRef } from "ink-scroll-view";
 import type { FormattingNode } from "../../types/tui.js";
 import type { ResolvedTheme } from "../themes/types.js";
 import { ThemedHorizontalBorder, ThemedSideFrame } from "../components/ThemedFrame.js";
-import { themeColor } from "../themes/color-resolve.js";
+import { themeColor, deriveModalTheme } from "../themes/color-resolve.js";
 import { stringWidth } from "../frames/index.js";
 import { wrapNodes, toPlainText } from "../formatting.js";
 import { renderNodes } from "../render-nodes.js";
@@ -83,6 +83,9 @@ export const CenteredModal = forwardRef<CenteredModalHandle, CenteredModalProps>
     topOffset = 0,
     contentHeight,
   }, ref) {
+    // Derive modal-specific colors: complementary hue + inverted lightness
+    const modalTheme = useMemo(() => deriveModalTheme(theme), [theme]);
+
     const sideWidth = theme.asset.components.edge_left.width;
     const borderHeight = theme.asset.height;
     const sidePadding = 1;
@@ -135,8 +138,8 @@ export const CenteredModal = forwardRef<CenteredModalHandle, CenteredModalProps>
 
     useScrollHandle(ref, scrollRef);
 
-    const textColor = themeColor(theme, "sideFrame");
-    const resolvedFooterColor = footerColor ?? themeColor(theme, "title");
+    const textColor = themeColor(modalTheme, "sideFrame");
+    const resolvedFooterColor = footerColor ?? themeColor(modalTheme, "title");
 
     // Build an opaque blank line that fills the full content area (inner + side padding).
     // Every row in the modal must emit real characters to cover what's behind it.
@@ -196,13 +199,13 @@ export const CenteredModal = forwardRef<CenteredModalHandle, CenteredModalProps>
     return (
       <Box position="absolute" flexDirection="column" marginTop={topMargin} marginLeft={leftPad}>
         <ThemedHorizontalBorder
-          theme={theme}
+          theme={modalTheme}
           width={modalWidth}
           position="top"
           centerText={title}
         />
         <Box height={visibleRows} flexDirection="row">
-          <ThemedSideFrame theme={theme} side="left" height={visibleRows} />
+          <ThemedSideFrame theme={modalTheme} side="left" height={visibleRows} />
           <Box flexDirection="column" width={fullRowWidth}>
             <ScrollView ref={scrollRef} onScroll={handleScroll}>
               {contentRows}
@@ -213,10 +216,10 @@ export const CenteredModal = forwardRef<CenteredModalHandle, CenteredModalProps>
               </Box>
             )}
           </Box>
-          <ThemedSideFrame theme={theme} side="right" height={visibleRows} />
+          <ThemedSideFrame theme={modalTheme} side="right" height={visibleRows} />
         </Box>
         <ThemedHorizontalBorder
-          theme={theme}
+          theme={modalTheme}
           width={modalWidth}
           position="bottom"
           centerText={footer}

--- a/src/tui/modals/Modal.tsx
+++ b/src/tui/modals/Modal.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Text, Box } from "ink";
 import type { ResolvedTheme } from "../themes/types.js";
 import { ThemedHorizontalBorder, ThemedSideFrame } from "../components/ThemedFrame.js";
-import { themeColor } from "../themes/color-resolve.js";
+import { themeColor, deriveModalTheme } from "../themes/color-resolve.js";
 import { stringWidth } from "../frames/index.js";
 
 interface ModalProps {
@@ -17,16 +17,17 @@ interface ModalProps {
  * Renders below the layout. No scroll support.
  */
 export function Modal({ theme, width, title, lines }: ModalProps) {
+  const modalTheme = useMemo(() => deriveModalTheme(theme), [theme]);
   const sideWidth = theme.asset.components.edge_left.width;
   const sidePadding = 1;
   const innerWidth = width - 2 * sideWidth - 2 * sidePadding;
-  const textColor = themeColor(theme, "sideFrame");
+  const textColor = themeColor(modalTheme, "sideFrame");
 
   return (
     <Box flexDirection="column">
-      <ThemedHorizontalBorder theme={theme} width={width} position="top" centerText={title} />
+      <ThemedHorizontalBorder theme={modalTheme} width={width} position="top" centerText={title} />
       <Box flexDirection="row">
-        <ThemedSideFrame theme={theme} side="left" height={lines.length} />
+        <ThemedSideFrame theme={modalTheme} side="left" height={lines.length} />
         <Box flexDirection="column">
           {lines.map((line, i) => {
             const pad = Math.max(0, innerWidth - stringWidth(line));
@@ -37,9 +38,9 @@ export function Modal({ theme, width, title, lines }: ModalProps) {
             );
           })}
         </Box>
-        <ThemedSideFrame theme={theme} side="right" height={lines.length} />
+        <ThemedSideFrame theme={modalTheme} side="right" height={lines.length} />
       </Box>
-      <ThemedHorizontalBorder theme={theme} width={width} position="bottom" />
+      <ThemedHorizontalBorder theme={modalTheme} width={width} position="bottom" />
     </Box>
   );
 }

--- a/src/tui/themes/color-resolve.test.ts
+++ b/src/tui/themes/color-resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSwatchColor, themeColor } from "./color-resolve.js";
+import { resolveSwatchColor, themeColor, deriveModalTheme } from "./color-resolve.js";
 import type { ResolvedTheme } from "./types.js";
 
 function makeTheme(overrides?: Partial<ResolvedTheme>): ResolvedTheme {
@@ -66,5 +66,42 @@ describe("themeColor", () => {
 
   it("resolves harmony index (separator = 201)", () => {
     expect(themeColor(theme, "separator")).toBe("#0000bb");
+  });
+});
+
+describe("deriveModalTheme", () => {
+  it("shifts all colorMap values to anchor 1 with mirrored steps", () => {
+    // 4 steps per row (0,1,2,3). Mirror: 0→3, 1→2, 2→1, 3→0
+    const theme = makeTheme({
+      colorMap: { border: 2, corner: 3, separator: 0, title: 1, turnIndicator: 0, sideFrame: 1 },
+    });
+    const modal = deriveModalTheme(theme);
+    // border: step 2 → mirror 1 → 101
+    expect(modal.colorMap.border).toBe(101);
+    // corner: step 3 → mirror 0 → 100
+    expect(modal.colorMap.corner).toBe(100);
+    // separator: step 0 → mirror 3 → 103
+    expect(modal.colorMap.separator).toBe(103);
+    // title: step 1 → mirror 2 → 102
+    expect(modal.colorMap.title).toBe(102);
+  });
+
+  it("resolves derived colors from anchor 1 row", () => {
+    const theme = makeTheme({
+      colorMap: { border: 2, corner: 3, separator: 0, title: 1, turnIndicator: 0, sideFrame: 1 },
+    });
+    const modal = deriveModalTheme(theme);
+    // border → 101 → anchor 1 step 1 → #bb0000
+    expect(themeColor(modal, "border")).toBe("#bb0000");
+    // corner → 100 → anchor 1 step 0 → #aa0000
+    expect(themeColor(modal, "corner")).toBe("#aa0000");
+  });
+
+  it("preserves non-colorMap theme properties", () => {
+    const theme = makeTheme();
+    const modal = deriveModalTheme(theme);
+    expect(modal.swatch).toBe(theme.swatch);
+    expect(modal.harmonySwatch).toBe(theme.harmonySwatch);
+    expect(modal.asset).toBe(theme.asset);
   });
 });

--- a/src/tui/themes/color-resolve.ts
+++ b/src/tui/themes/color-resolve.ts
@@ -21,3 +21,24 @@ export function resolveSwatchColor(theme: ResolvedTheme, value: number): string 
 export function themeColor(theme: ResolvedTheme, part: keyof ResolvedTheme["colorMap"]): string | undefined {
   return resolveSwatchColor(theme, theme.colorMap[part]);
 }
+
+/**
+ * Derive a modal-specific theme by shifting colors to anchor 1 (complementary
+ * hue, 180° away) and mirroring step indices (inverted lightness).
+ *
+ * This makes modals visually offset from the main game frame — darker where the
+ * frame is light, and in the complementary hue.
+ */
+export function deriveModalTheme(theme: ResolvedTheme): ResolvedTheme {
+  const steps = theme.swatch.length;
+  const mirrorStep = (step: number): number =>
+    steps > 1 ? steps - 1 - Math.min(step, steps - 1) : 0;
+
+  const newColorMap = {} as ResolvedTheme["colorMap"];
+  for (const [part, value] of Object.entries(theme.colorMap)) {
+    const step = value % 100;
+    newColorMap[part as keyof ResolvedTheme["colorMap"]] = 100 + mirrorStep(step);
+  }
+
+  return { ...theme, colorMap: newColorMap };
+}


### PR DESCRIPTION
## Summary
- **`deriveModalTheme()`** shifts all modal colorMap values to anchor 1 (complementary hue, 180° away) and mirrors step indices (inverted lightness), making modals visually distinct from the main game frame
- Applied automatically inside `CenteredModal` and `Modal` — no caller changes needed
- Updated `docs/tui-design.md` with harmony swatch documentation, color map encoding scheme, swatch modal section, and modal color derivation behavior

## Test plan
- [x] 3 new unit tests for `deriveModalTheme()` (mirroring math, resolved colors, property preservation)
- [x] All 1514 existing tests pass
- [x] Visual smoke test confirms complementary hue + inverted lightness on character sheet modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)