### PR TITLE
ActivityLine: accumulate tool glyphs during DM turn

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -165,6 +165,7 @@ export default function App({ shutdownRef }: AppProps) {
   const [phase, setPhase] = useState<AppPhase>("loading");
   const { lines: narrativeLines, setLines: setNarrativeLines } = useBatchedNarrativeLines();
   const [engineState, setEngineState] = useState<string | null>(null);
+  const [toolGlyphs, setToolGlyphs] = useState<import("./tui/activity.js").ToolGlyph[]>([]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   // --- Game state refs (stable across renders) ---
@@ -311,7 +312,7 @@ export default function App({ shutdownRef }: AppProps) {
     setNarrativeLines, setEngineState, setErrorMsg, setModelines,
     setResources, setVariant, setThemeName, setKeyColor,
     setActiveModal, setChoiceIndex,
-    setActiveSession, setRetryOverlay,
+    setActiveSession, setRetryOverlay, setToolGlyphs,
     gameStateRef, clientRef, engineRef, activeModalRef, variantRef, previousVariantRef,
     costTracker, fileIO,
   });
@@ -623,7 +624,7 @@ export default function App({ shutdownRef }: AppProps) {
     narrativeLines, setNarrativeLines,
     theme, variant, setVariant, setTheme, keyColor, setKeyColor,
     campaignName, activePlayerIndex, setActivePlayerIndex,
-    engineState, resources, modelines,
+    engineState, toolGlyphs, resources, modelines,
     activeModal, setActiveModal,
     choiceIndex, setChoiceIndex,
     retryOverlay,

--- a/src/phases/PlayingPhase.tsx
+++ b/src/phases/PlayingPhase.tsx
@@ -20,7 +20,7 @@ export function PlayingPhase() {
     narrativeLines, setNarrativeLines,
     theme, variant, setVariant,
     campaignName, activePlayerIndex, setActivePlayerIndex,
-    engineState, resources, modelines,
+    engineState, toolGlyphs, resources, modelines,
     activeModal, setActiveModal,
     choiceIndex, setChoiceIndex,
     activeSession, setActiveSession, previousVariantRef,
@@ -440,6 +440,7 @@ export function PlayingPhase() {
         resources={resources}
         turnHolder={activeChar}
         engineState={engineState}
+        toolGlyphs={toolGlyphs}
         quoteColor="#ffffff"
         playerColor={gameStateRef.current?.config.players[activePlayerIndex]?.color}
         turnIndicatorColor={engineState === "waiting_input" ? gameStateRef.current?.config.players[activePlayerIndex]?.color : undefined}

--- a/src/tui/activity.test.ts
+++ b/src/tui/activity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getActivity, ACTIVITY_MAP, parseRetryState, retryLabel } from "./activity.js";
+import { getActivity, getToolGlyph, ACTIVITY_MAP, parseRetryState, retryLabel } from "./activity.js";
 
 describe("activity indicators", () => {
   it("returns indicator for known states", () => {
@@ -62,6 +62,37 @@ describe("retryLabel", () => {
   it("returns generic label for other statuses", () => {
     expect(retryLabel(500)).toBe("API error (500)");
     expect(retryLabel(502)).toBe("API error (502)");
+  });
+});
+
+describe("getToolGlyph", () => {
+  it("returns glyph for known tool names", () => {
+    const dice = getToolGlyph("roll_dice");
+    expect(dice).toBeDefined();
+    expect(dice!.glyph).toBe("⚄");
+    expect(dice!.color).toBe("yellow");
+  });
+
+  it("returns colored glyphs for combat tools", () => {
+    const combat = getToolGlyph("start_combat");
+    expect(combat).toBeDefined();
+    expect(combat!.glyph).toBe("⚔");
+    expect(combat!.color).toBe("red");
+  });
+
+  it("returns glyph for map tools", () => {
+    expect(getToolGlyph("move_entity")!.glyph).toBe("◈");
+    expect(getToolGlyph("view_area")!.glyph).toBe("◈");
+    expect(getToolGlyph("create_map")!.glyph).toBe("◈");
+  });
+
+  it("returns glyph for entity/scribe tools", () => {
+    expect(getToolGlyph("scribe")!.glyph).toBe("✎");
+    expect(getToolGlyph("dm_notes")!.glyph).toBe("✎");
+  });
+
+  it("returns undefined for unknown tool names", () => {
+    expect(getToolGlyph("nonexistent_tool")).toBeUndefined();
   });
 });
 

--- a/src/tui/activity.ts
+++ b/src/tui/activity.ts
@@ -9,6 +9,68 @@ export const ACTIVITY_MAP: Record<string, ActivityIndicator> = {
   dm_thinking: { label: "The DM is thinking...", glyph: "◆" },
 };
 
+/** A glyph with an optional color (for non-emoji unicode characters). */
+export interface ToolGlyph {
+  glyph: string;
+  color?: string;
+}
+
+/** Map tool names to glyphs that accumulate on the activity line during a DM turn. */
+const TOOL_GLYPH_MAP: Record<string, ToolGlyph> = {
+  // Dice
+  roll_dice:          { glyph: "⚄", color: "yellow" },
+  // Cards
+  deck:               { glyph: "♠", color: "cyan" },
+  // Map / spatial
+  view_area:          { glyph: "◈", color: "blue" },
+  distance:           { glyph: "◈", color: "blue" },
+  path_between:       { glyph: "◈", color: "blue" },
+  line_of_sight:      { glyph: "◈", color: "blue" },
+  tiles_in_range:     { glyph: "◈", color: "blue" },
+  find_nearest:       { glyph: "◈", color: "blue" },
+  place_entity:       { glyph: "◈", color: "blue" },
+  move_entity:        { glyph: "◈", color: "blue" },
+  remove_entity:      { glyph: "◈", color: "blue" },
+  set_terrain:        { glyph: "◈", color: "blue" },
+  annotate:           { glyph: "◈", color: "blue" },
+  define_region:      { glyph: "◈", color: "blue" },
+  create_map:         { glyph: "◈", color: "blue" },
+  import_entities:    { glyph: "◈", color: "blue" },
+  // Clocks / time
+  set_alarm:          { glyph: "⏲" },
+  clear_alarm:        { glyph: "⏲" },
+  advance_calendar:   { glyph: "⏲" },
+  next_round:         { glyph: "⏲" },
+  check_clocks:       { glyph: "⏲" },
+  // Combat
+  start_combat:       { glyph: "⚔", color: "red" },
+  end_combat:         { glyph: "⚔", color: "red" },
+  advance_turn:       { glyph: "⚔", color: "red" },
+  modify_initiative:  { glyph: "⚔", color: "red" },
+  // Entity / worldbuilding
+  scribe:             { glyph: "✎", color: "green" },
+  dm_notes:           { glyph: "✎", color: "green" },
+  // TUI / presentation
+  update_modeline:    { glyph: "◆", color: "magenta" },
+  style_scene:        { glyph: "◆", color: "magenta" },
+  set_display_resources: { glyph: "◆", color: "magenta" },
+  present_choices:    { glyph: "◆", color: "magenta" },
+  present_roll:       { glyph: "◆", color: "magenta" },
+  show_character_sheet: { glyph: "◆", color: "magenta" },
+  enter_ooc:          { glyph: "◆", color: "magenta" },
+  switch_player:      { glyph: "◆", color: "magenta" },
+  // Scene / session lifecycle
+  scene_transition:   { glyph: "⟳", color: "yellow" },
+  session_end:        { glyph: "⟳", color: "yellow" },
+  context_refresh:    { glyph: "⟳", color: "yellow" },
+  rollback:           { glyph: "⟳", color: "yellow" },
+};
+
+/** Look up the glyph for a tool name. Returns undefined for unknown tools. */
+export function getToolGlyph(toolName: string): ToolGlyph | undefined {
+  return TOOL_GLYPH_MAP[toolName];
+}
+
 /** Parsed retry info from an engine state string */
 export interface RetryInfo {
   status: number;

--- a/src/tui/components/ActivityLine.tsx
+++ b/src/tui/components/ActivityLine.tsx
@@ -1,23 +1,38 @@
 import React from "react";
 import { Text, Box } from "ink";
 import { getActivity } from "../activity.js";
+import type { ToolGlyph } from "../activity.js";
 
 interface ActivityLineProps {
   engineState: string | null;
+  toolGlyphs?: ToolGlyph[];
 }
 
 /**
  * Shows what the engine is doing — mapped from in-flight tool calls.
  * Hidden when idle (null state).
  * Retry/connection-loss states are handled by ApiErrorModal instead.
+ *
+ * Tool glyphs accumulate as the DM calls tools during a turn,
+ * building a visual impression of compounding effort.
  */
-export const ActivityLine = React.memo(function ActivityLine({ engineState }: ActivityLineProps) {
+export const ActivityLine = React.memo(function ActivityLine({ engineState, toolGlyphs }: ActivityLineProps) {
   const activity = getActivity(engineState);
   if (!activity) return null;
 
   return (
     <Box>
       <Text dimColor>{activity.label}</Text>
+      {toolGlyphs && toolGlyphs.length > 0 && (
+        <Text>
+          {" "}
+          {toolGlyphs.map((tg, i) =>
+            tg.color
+              ? <Text key={i} color={tg.color}>{tg.glyph}</Text>
+              : <Text key={i} dimColor>{tg.glyph}</Text>,
+          )}
+        </Text>
+      )}
     </Box>
   );
 });

--- a/src/tui/components/components.test.tsx
+++ b/src/tui/components/components.test.tsx
@@ -176,6 +176,46 @@ describe("ActivityLine", () => {
     const { lastFrame } = render(<ActivityLine engineState={null} />);
     expect(lastFrame()).toBe("");
   });
+
+  it("renders accumulated tool glyphs after label", () => {
+    const glyphs = [
+      { glyph: "⚄", color: "yellow" },
+      { glyph: "⚔", color: "red" },
+    ];
+    const { lastFrame } = render(
+      <ActivityLine engineState="dm_thinking" toolGlyphs={glyphs} />,
+    );
+    const frame = lastFrame();
+    expect(frame).toContain("DM is thinking");
+    expect(frame).toContain("⚄");
+    expect(frame).toContain("⚔");
+  });
+
+  it("renders no glyphs when array is empty", () => {
+    const { lastFrame } = render(
+      <ActivityLine engineState="dm_thinking" toolGlyphs={[]} />,
+    );
+    const frame = lastFrame();
+    expect(frame).toContain("DM is thinking");
+    // No trailing space from empty glyph list
+    expect(frame).not.toContain("⚄");
+  });
+
+  it("renders duplicate glyphs for repeated tool calls", () => {
+    const glyphs = [
+      { glyph: "⚄", color: "yellow" },
+      { glyph: "⚄", color: "yellow" },
+      { glyph: "◈", color: "blue" },
+    ];
+    const { lastFrame } = render(
+      <ActivityLine engineState="dm_thinking" toolGlyphs={glyphs} />,
+    );
+    const frame = lastFrame();
+    // Both dice glyphs should appear (not deduplicated)
+    const diceCount = (frame.match(/⚄/g) || []).length;
+    expect(diceCount).toBe(2);
+    expect(frame).toContain("◈");
+  });
 });
 
 describe("NarrativeArea", () => {

--- a/src/tui/game-context.test.tsx
+++ b/src/tui/game-context.test.tsx
@@ -31,6 +31,7 @@ export function makeTestContext(overrides: Partial<GameContextValue> = {}): Game
     activePlayerIndex: 0,
     setActivePlayerIndex: vi.fn(),
     engineState: null,
+    toolGlyphs: [],
     resources: [],
     modelines: {},
     activeModal: null,

--- a/src/tui/game-context.ts
+++ b/src/tui/game-context.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react";
 import type Anthropic from "@anthropic-ai/sdk";
 import type { NarrativeLine, ActiveModal, RetryOverlay } from "../types/tui.js";
+import type { ToolGlyph } from "./activity.js";
 import type { ResolvedTheme, StyleVariant } from "./themes/types.js";
 import type { GameEngine } from "../agents/game-engine.js";
 import type { GameState } from "../agents/game-state.js";
@@ -37,6 +38,7 @@ export interface GameContextValue {
   activePlayerIndex: number;
   setActivePlayerIndex: (i: number) => void;
   engineState: string | null;
+  toolGlyphs: ToolGlyph[];
   resources: string[];
   modelines: Record<string, string>;
   // Modal state

--- a/src/tui/hooks/useGameCallbacks.ts
+++ b/src/tui/hooks/useGameCallbacks.ts
@@ -8,6 +8,7 @@ import type { GameState } from "../../agents/game-state.js";
 import type { GameEngine } from "../../agents/game-engine.js";
 import type { FileIO } from "../../agents/scene-manager.js";
 import type { ModeSession } from "../game-context.js";
+import type { ToolGlyph } from "../activity.js";
 
 import { campaignPaths } from "../../tools/filesystem/index.js";
 import { getActivePlayer } from "../../agents/player-manager.js";
@@ -17,6 +18,7 @@ import { CostTracker } from "../../context/cost-tracker.js";
 import { isDevMode } from "../../config/dev-mode.js";
 import type { ToolResult } from "../../agents/tool-registry.js";
 import { appendDelta } from "../narrative-helpers.js";
+import { getToolGlyph } from "../activity.js";
 
 /** All external state/setters the hook needs, passed as a single deps object. */
 export interface GameCallbackDeps {
@@ -33,6 +35,7 @@ export interface GameCallbackDeps {
   setChoiceIndex: React.Dispatch<React.SetStateAction<number>>;
   setActiveSession: (s: ModeSession | null) => void;
   setRetryOverlay: (o: RetryOverlay | null) => void;
+  setToolGlyphs: React.Dispatch<React.SetStateAction<ToolGlyph[]>>;
   // Refs
   gameStateRef: React.RefObject<GameState | null>;
   clientRef: React.RefObject<Anthropic | null>;
@@ -54,7 +57,7 @@ export function useGameCallbacks(deps: GameCallbackDeps): GameCallbackResult {
     setNarrativeLines, setEngineState, setErrorMsg, setModelines,
     setResources, setVariant, setThemeName, setKeyColor,
     setActiveModal, setChoiceIndex,
-    setActiveSession, setRetryOverlay,
+    setActiveSession, setRetryOverlay, setToolGlyphs,
     gameStateRef, clientRef, engineRef, activeModalRef, variantRef, previousVariantRef,
     costTracker, fileIO,
   } = deps;
@@ -174,11 +177,20 @@ export function useGameCallbacks(deps: GameCallbackDeps): GameCallbackResult {
     onStateChange(state: EngineState) {
       setEngineState(state);
       setRetryOverlay(null);
+      // Clear accumulated tool glyphs when the DM turn ends
+      if (state === "waiting_input" || state === "idle") {
+        setToolGlyphs([]);
+      }
     },
     onTuiCommand(cmd: TuiCommand) {
       dispatchTuiCommand(cmd);
     },
     onToolStart(name: string) {
+      // Accumulate a glyph on the activity line for each tool call
+      const tg = getToolGlyph(name);
+      if (tg) {
+        setToolGlyphs((prev) => [...prev, tg]);
+      }
       if (isDevMode()) {
         setNarrativeLines((prev) => [...prev, { kind: "dev", text: `[dev] tool:${name} ...` }]);
       }
@@ -230,7 +242,7 @@ export function useGameCallbacks(deps: GameCallbackDeps): GameCallbackResult {
       setNarrativeLines((prev) => [...prev, { kind: "separator", text: "" }]);
     },
   }), [dispatchTuiCommand, setNarrativeLines, setEngineState,
-       setErrorMsg, setActiveModal, setChoiceIndex, setRetryOverlay,
+       setErrorMsg, setActiveModal, setChoiceIndex, setRetryOverlay, setToolGlyphs,
        gameStateRef, clientRef, activeModalRef, costTracker]);
 
   return { buildCallbacks, dispatchTuiCommand };

--- a/src/tui/layout.tsx
+++ b/src/tui/layout.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Box } from "ink";
 import type { ViewportDimensions, NarrativeLine } from "../types/tui.js";
+import type { ToolGlyph } from "./activity.js";
 import type { ResolvedTheme } from "./themes/types.js";
 import type { PlayerEntry } from "./components/index.js";
 import type { NarrativeAreaHandle } from "./components/index.js";
@@ -56,6 +57,7 @@ export interface LayoutProps {
   // Turn/activity
   turnHolder?: string;
   engineState: string | null;
+  toolGlyphs?: ToolGlyph[];
 
   // Display options
   quoteColor?: string;
@@ -97,6 +99,7 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
     resources,
     turnHolder,
     engineState,
+    toolGlyphs,
     quoteColor,
     playerColor,
     turnIndicatorColor,
@@ -211,7 +214,7 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
           />
 
           {/* Activity Line */}
-          {elements.activityLine && <ActivityLine engineState={engineState} />}
+          {elements.activityLine && <ActivityLine engineState={engineState} toolGlyphs={toolGlyphs} />}
         </Box>
 
         {rightSide}


### PR DESCRIPTION
## Summary
- Adds colored glyphs that accumulate on the activity line as the DM calls tools during a turn (`"The DM is thinking... ⚄ ⚔ ◈ ✎"`), building an impression of compounding effort
- Glyphs are categorized by tool type with distinct colors: yellow dice, red combat, blue map, green scribe, magenta TUI, cyan cards
- Glyphs clear when the DM turn ends — no new screen space allocated

Closes #79

## Test plan
- [x] All 1582 existing tests pass
- [x] 8 new tests: `getToolGlyph()` mapping, `ActivityLine` glyph rendering (empty, populated, duplicates)
- [x] Smoke-tested visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)