### PR TITLE
Use "Player" as provisional name during setup

### DIFF
--- a/src/phases/SetupPhase.tsx
+++ b/src/phases/SetupPhase.tsx
@@ -278,13 +278,13 @@ export function SetupPhase({ theme, costTracker, onComplete, onCancel, onError }
           theme={theme}
           narrativeLines={setupConvoLines}
           modelineText="Campaign Setup"
-          activeCharacterName="You"
+          activeCharacterName="Player"
           inputIsDisabled
           players={[{ name: "Player", isAI: false }]}
           activePlayerIndex={0}
           campaignName="New Campaign"
           resources={[]}
-          turnHolder="You"
+          turnHolder="Player"
           engineState={null}
         />
       </Box>
@@ -319,7 +319,7 @@ export function SetupPhase({ theme, costTracker, onComplete, onCancel, onError }
           theme={theme}
           narrativeLines={setupConvoLines}
           modelineText="Campaign Setup"
-          activeCharacterName="You"
+          activeCharacterName="Player"
           inputIsDisabled={textInputDisabled}
           inputResetKey={resetKey}
           onInputSubmit={handleSetupSubmit}
@@ -327,7 +327,7 @@ export function SetupPhase({ theme, costTracker, onComplete, onCancel, onError }
           activePlayerIndex={0}
           campaignName="New Campaign"
           resources={[]}
-          turnHolder="You"
+          turnHolder="Player"
           engineState={setupConvoBusy ? "dm_thinking" : null}
           narrativeRef={narrativeRef}
           hideInputLine={setupHasModal}


### PR DESCRIPTION
## Summary
- Changes the hardcoded provisional name from "You" to "Player" in `SetupPhase.tsx` during game setup, fixing the "You's Turn" grammatical issue in the Player Pane turn indicator.

Closes #63

## Test plan
- [x] `npm run check` passes (lint + tests + coverage)
- [ ] Launch game setup and verify the turn indicator reads "Player's Turn" instead of "You's Turn"

🤖 Generated with [Claude Code](https://claude.com/claude-code)