### PR TITLE
Render Markdown horizontal rules as themed separators

### DIFF
--- a/src/prompts/dm-identity.md
+++ b/src/prompts/dm-identity.md
@@ -60,6 +60,7 @@ Do not use Markdown. These HTML-subset tags are available for dramatic effect:
 - <color=#HEX>colored text</color> — thematic color
 - <center>centered text</center> — titles, dramatic reveals, diagetic signs and announcements (auto-adds spacing)
 - <right>right-aligned text</right> (auto-adds spacing)
+- --- — horizontal separator (renders as a themed divider; costs 3 screen lines including spacing)
 
 Color-code notable elements:
 - <color=#20b2aa>notable objects</color> (teal) — items, artifacts, environmental features

--- a/src/tui/formatting.test.ts
+++ b/src/tui/formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseFormatting, toPlainText, stripFormatting, highlightQuotesWithState, markdownToTags, nodeVisibleLength, wrapNodes, processNarrativeLines } from "./formatting.js";
+import { parseFormatting, toPlainText, stripFormatting, highlightQuotesWithState, markdownToTags, nodeVisibleLength, wrapNodes, processNarrativeLines, isHorizontalRule } from "./formatting.js";
 import type { FormattingTag, FormattingNode, NarrativeLine } from "../types/tui.js";
 
 describe("parseFormatting", () => {
@@ -768,6 +768,118 @@ describe("processNarrativeLines", () => {
     const centerLine = result.find((l) => l.alignment === "center");
     expect(centerLine).toBeDefined();
     expect(toPlainText(centerLine!.nodes)).toBe("Title");
+  });
+});
+
+describe("isHorizontalRule", () => {
+  it("matches three dashes", () => {
+    expect(isHorizontalRule("---")).toBe(true);
+  });
+
+  it("matches four or more dashes", () => {
+    expect(isHorizontalRule("----")).toBe(true);
+    expect(isHorizontalRule("----------")).toBe(true);
+  });
+
+  it("matches three asterisks", () => {
+    expect(isHorizontalRule("***")).toBe(true);
+  });
+
+  it("matches three underscores", () => {
+    expect(isHorizontalRule("___")).toBe(true);
+  });
+
+  it("matches spaced variants", () => {
+    expect(isHorizontalRule("- - -")).toBe(true);
+    expect(isHorizontalRule("* * *")).toBe(true);
+    expect(isHorizontalRule("_ _ _")).toBe(true);
+  });
+
+  it("allows leading whitespace (up to 3 spaces)", () => {
+    expect(isHorizontalRule("   ---")).toBe(true);
+    expect(isHorizontalRule(" ---")).toBe(true);
+  });
+
+  it("rejects 4+ leading spaces (code block)", () => {
+    expect(isHorizontalRule("    ---")).toBe(false);
+  });
+
+  it("rejects fewer than 3 characters", () => {
+    expect(isHorizontalRule("--")).toBe(false);
+    expect(isHorizontalRule("-")).toBe(false);
+  });
+
+  it("rejects mixed characters", () => {
+    expect(isHorizontalRule("-*-")).toBe(false);
+    expect(isHorizontalRule("--*")).toBe(false);
+  });
+
+  it("rejects text content", () => {
+    expect(isHorizontalRule("---text")).toBe(false);
+    expect(isHorizontalRule("hello")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isHorizontalRule("")).toBe(false);
+  });
+});
+
+describe("processNarrativeLines — horizontal rule conversion", () => {
+  const dm = (text: string): NarrativeLine => ({ kind: "dm", text });
+
+  it("converts --- DM line to separator kind", () => {
+    const result = processNarrativeLines([dm("---")], 80);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("separator");
+  });
+
+  it("converts *** DM line to separator kind", () => {
+    const result = processNarrativeLines([dm("***")], 80);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("separator");
+  });
+
+  it("converts ___ DM line to separator kind", () => {
+    const result = processNarrativeLines([dm("___")], 80);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("separator");
+  });
+
+  it("preserves surrounding DM lines", () => {
+    const result = processNarrativeLines([
+      dm("Before."),
+      dm("---"),
+      dm("After."),
+    ], 80);
+    expect(result).toHaveLength(3);
+    expect(result[0].kind).toBe("dm");
+    expect(toPlainText(result[0].nodes)).toBe("Before.");
+    expect(result[1].kind).toBe("separator");
+    expect(result[2].kind).toBe("dm");
+    expect(toPlainText(result[2].nodes)).toBe("After.");
+  });
+
+  it("does not convert non-DM separator-like lines", () => {
+    const result = processNarrativeLines([
+      { kind: "player", text: "---" },
+    ], 80);
+    expect(result[0].kind).toBe("player");
+  });
+
+  it("does not affect cross-line healing state", () => {
+    const result = processNarrativeLines([
+      dm("<i>italic start"),
+      dm("---"),
+      dm("still italic</i>"),
+    ], 80);
+    // The separator should break the DM line sequence but italic
+    // should still heal across because separators don't reset the stack
+    const dmLines = result.filter((l) => l.kind === "dm");
+    const lastDM = dmLines[dmLines.length - 1];
+    const hasItalic = lastDM.nodes.some(
+      (n) => typeof n !== "string" && n.type === "italic",
+    );
+    expect(hasItalic).toBe(true);
   });
 });
 

--- a/src/tui/formatting.ts
+++ b/src/tui/formatting.ts
@@ -212,6 +212,14 @@ function flattenToWords(
 }
 
 /**
+ * Test whether a raw text line is a legal Markdown horizontal rule.
+ * Matches 3+ of the same character (-, *, _) with optional spaces.
+ */
+export function isHorizontalRule(text: string): boolean {
+  return /^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/.test(text);
+}
+
+/**
  * Unified processing pipeline for NarrativeLines.
  * Heal → parse → wrap → pad alignment → quote highlight.
  * Returns ProcessedLine[] ready for direct rendering.
@@ -223,12 +231,17 @@ export function processNarrativeLines(
 ): ProcessedLine[] {
   // Phase 0: Split inline <center> and <right> blocks onto their own lines.
   // The rendering pipeline expects these to be the sole content of a line.
+  // Also converts DM horizontal rules (---, ***, ___) into separator lines.
   const expandedLines: NarrativeLine[] = [];
   for (const srcLine of lines) {
     if (srcLine.kind === "dm" && srcLine.text.trim() !== "") {
-      const split = splitAlignmentBlocks(srcLine.text);
-      for (const part of split) {
-        expandedLines.push({ kind: "dm", text: part });
+      if (isHorizontalRule(srcLine.text)) {
+        expandedLines.push({ kind: "separator", text: "" });
+      } else {
+        const split = splitAlignmentBlocks(srcLine.text);
+        for (const part of split) {
+          expandedLines.push({ kind: "dm", text: part });
+        }
       }
     } else {
       expandedLines.push(srcLine);


### PR DESCRIPTION
## Summary
- DM lines matching legal Markdown horizontal rules (`---`, `***`, `___`, spaced variants) are now detected in `processNarrativeLines` Phase 0 and converted to separator kind, rendering them as the themed turn separator
- The DM prompt's `<formatting>` section now officially offers `---` with a note that it costs 3 screen lines (including spacing)
- 17 new tests: 11 for `isHorizontalRule()` edge cases, 6 for pipeline integration

## Test plan
- [x] All 1655 tests pass (`npm run check`)
- [x] Smoke tested in live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)