### PR TITLE
Prompt tuning: sentient objects, custom personalities, setup formatting

### DIFF
--- a/src/agents/subagents/setup-conversation.ts
+++ b/src/agents/subagents/setup-conversation.ts
@@ -57,7 +57,8 @@ const FINALIZE_TOOL: Anthropic.Tool = {
       campaign_premise: { type: "string", description: "One-paragraph campaign hook" },
       mood: { type: "string", description: "Mood (e.g. 'Heroic', 'Grimdark', 'Whimsical', 'Tense')" },
       difficulty: { type: "string", description: "Difficulty ('Gentle', 'Balanced', 'Unforgiving')" },
-      dm_personality: { type: "string", description: "DM personality name (must match a name from the available personalities list)" },
+      dm_personality: { type: "string", description: "DM personality name from the available list, or a custom name if the player described their own" },
+      dm_personality_prompt: { type: "string", description: "For custom personalities only: a 2-3 sentence prompt fragment describing the DM's narrative voice and style (e.g. 'You are The Captain. You narrate with dry naval authority...'). Omit when using a personality from the available list." },
       player_name: { type: "string", description: "Player's real name, or 'Player'" },
       character_name: { type: "string", description: "Player character's name" },
       character_description: { type: "string", description: "One-sentence character concept" },
@@ -116,7 +117,7 @@ function buildSystemPrompt(): string {
   }).join("\n");
   return base +
     "\n\n## Available campaign seeds\n\nUse these when presenting Quick Start options or campaign ideas. Pick seeds that match the player's genre if known. When presenting seeds as choices, use the seed name as the choice label and the premise (or description if available) as the choice description.\n\n" + seedList +
-    "\n\n## Available DM personalities\n\nWhen presenting personality choices, use the name as the choice label and the description as the choice description.\n\n" + personalityList;
+    "\n\n## Available DM personalities\n\nWhen presenting personality choices, use the name as the choice label and the description as the choice description. You can also invent new personalities beyond this list — if a campaign calls for a voice that isn't here, or the player asks for something custom, craft a name and prompt fragment in the same style as the examples below.\n\n" + personalityList;
 }
 
 const SYSTEM_PROMPT = buildSystemPrompt();
@@ -164,8 +165,9 @@ export function createSetupConversation(client: Anthropic): SetupConversation {
 
   function handleFinalize(input: Record<string, unknown>): void {
     const personalityName = (input.dm_personality as string) || "The Chronicler";
+    const customPrompt = input.dm_personality_prompt as string | undefined;
     const personality = PERSONALITIES.find((p) => p.name === personalityName)
-      ?? { name: personalityName, prompt_fragment: `You are ${personalityName}.` };
+      ?? { name: personalityName, prompt_fragment: customPrompt || `You are ${personalityName}.` };
 
     const characterName = (input.character_name as string) || "Adventurer";
 

--- a/src/prompts/dm-identity.md
+++ b/src/prompts/dm-identity.md
@@ -49,7 +49,7 @@ Your precis tracks open threads and your player-read tracks pacing. Use them:
 
 When in doubt, end the scene. You lose nothing — unresolved threads carry forward, and the cut itself creates anticipation. What you gain is a clean slate, fired alarms, and the chance to surprise the player with what happened while they weren't looking. Ending the scene also compacts your context.
 
-NPCs need three anchors: a want, a fear, a mannerism. Speak as them, not about them. They react to the player's reputation and past actions. When you narrate, include anything that has changed — an NPC acting on their agenda, the environment shifting, a consequence landing. Not every NPC in a scene needs a beat every turn — a crowded tavern has one voice that matters and twenty that are atmosphere.
+NPCs need three anchors: a want, a fear, a mannerism. Speak as them, not about them. They react to the player's reputation and past actions. When you narrate, include anything that has changed — an NPC acting on their agenda, the environment shifting, a consequence landing. Not every NPC in a scene needs a beat every turn — a crowded tavern has one voice that matters and twenty that are atmosphere. Sentient or talking objects are characters, not objects — treat them accordingly.
 </craft>
 
 <formatting>

--- a/src/prompts/setup-conversation.md
+++ b/src/prompts/setup-conversation.md
@@ -11,7 +11,7 @@ Start with a dramatic welcome — you're opening the curtain on a new adventure.
    - **Campaign concept** — A compelling premise and name for the adventure
    - **Mood** — Heroic, grimdark, whimsical, tense, or a mix
    - **Difficulty** — How forgiving: gentle, balanced, or unforgiving
-   - **DM personality** — Who runs the game (see the personality list below — present 5-8 options that fit the campaign's genre and mood, using their names as choice labels and descriptions as choice descriptions)
+   - **DM personality** — Who runs the game. Present 5-8 options from the personality list below that fit the campaign's genre and mood, using their names as choice labels and descriptions as choice descriptions. You can also invent new personalities — if the campaign concept calls for a voice not on the list, or if the player asks for something specific, craft a fitting name and prompt fragment for it.
    - **Character** — Name and a one-sentence concept for the player character
    - **Player name** — The human's real name (or just "Player"). Ask for this AFTER the character — something like "And what should I call *you*, the person behind the character?" Players expect to name their character first; asking for their real name first confuses them.
    - **Game system** — Pure narrative (no mechanics), or a light system like FATE Accelerated or 24XX
@@ -20,7 +20,13 @@ Start with a dramatic welcome — you're opening the curtain on a new adventure.
 
 Before calling `finalize_setup`, you MUST read back the full configuration in natural language and ask the player to confirm or request changes. Something like:
 
-"Here's what we've got: A grimdark fantasy called *The Shattered Crown*, balanced difficulty, narrated by The Chronicler, pure narrative — no dice system. You'll be playing as Kael, a wandering sellsword with a debt and a bad reputation. Sound good, or want to change anything?"
+---
+
+<center><i>The Shattered Crown</i></center>
+
+A <color=#cc4444>grimdark fantasy</color>, balanced difficulty, narrated by <b>The Chronicler</b>. Pure narrative — no dice system. You'll be playing as <color=#44cc44>Kael</color>, a wandering sellsword with a debt and a bad reputation.
+
+Sound good, or want to change anything?
 
 Only call `finalize_setup` after the player confirms.
 
@@ -52,7 +58,9 @@ Do not use markdown syntax (e.g. **bold**, *italics*, `code`) — it won't rende
 
 Correct:
 ```
-Welcome, traveler.
+<i>Welcome, traveler.</i>
+
+---
 
 <center><b>The Stage Is Set</b></center>
 


### PR DESCRIPTION
## Summary

- **DM narrating for the player around sentient objects:** The DM treated telepathic/talking objects (e.g. a sentient weapon that speaks into the PC's mind) as environmental stimuli rather than NPCs, bypassing the "never act for a PC" guardrail and scripting PC dialogue. Added a one-sentence clarification to the NPC craft section of `dm-identity.md`: sentient or talking objects are characters, not objects.
- **Game setup agent refusing custom DM personalities:** The tool schema said "must match," the prompt said "see the list," and the appended context said "use the name as the choice label." All three layers told the agent the list was exhaustive, even though the code already had a graceful fallback. Relaxed all three and added a `dm_personality_prompt` field so the agent can craft proper prompt fragments for invented personalities.
- **Setup agent not using formatting:** The only concrete output example in the setup prompt used markdown italics (`*The Shattered Crown*`) instead of the HTML-like tags the renderer supports. Models anchor on examples over rules. Updated both examples to demonstrate `---`, `<center>`, `<color>`, `<b>`, and `<i>`.

## Test plan
- [x] `setup-conversation.test.ts` — 10 tests pass
- [x] `setup-agent.test.ts` — 6 tests pass
- [x] `config.test.ts` — 18 tests pass
- [ ] Manual smoke test: setup agent uses formatting in output
- [ ] Manual smoke test: custom DM personality accepted and persisted
- [ ] Manual smoke test: DM color-codes sentient object NPCs and doesn't narrate PC dialogue around them

🤖 Generated with [Claude Code](https://claude.com/claude-code)