### PR TITLE
Emit resolve_turn results to player and fix setup streaming

### DIFF
--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -1058,6 +1058,10 @@ export class GameEngine {
         accUsage(this.sessionUsage, result.usage);
         this.callbacks.onUsageUpdate(this.sessionUsage);
         this.callbacks.onDevLog?.(`[dev] resolve_turn: ${action.actor} — ${result.narrative.slice(0, 80)}`);
+        // Emit resolution to the player so they always see the mechanical outcome,
+        // regardless of whether the DM narrates it. This is visible in the TUI
+        // as formatted text before the DM's narrative response.
+        this.emitResolutionToPlayer(action.actor, result);
         return { content: this.formatResolutionForDM(result) };
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -1245,6 +1249,47 @@ export class GameEngine {
           // existing GameState fields. The DM reads them from the tool result.
           break;
       }
+    }
+  }
+
+  /**
+   * Emit the resolution result to the player via onNarrativeDelta.
+   * Shows rolls and outcome so the player always sees what happened mechanically.
+   */
+  private emitResolutionToPlayer(
+    actor: string,
+    result: import("../types/resolve-session.js").ResolutionResult,
+  ): void {
+    const lines: string[] = [];
+
+    // Rolls — formatted as "⚔ reason: detail = result"
+    for (const roll of result.rolls) {
+      lines.push(`<color=#888888>⚔ ${roll.reason}: ${roll.detail}</color>`);
+    }
+
+    // Outcome narrative
+    if (result.narrative) {
+      lines.push(`<i>${result.narrative}</i>`);
+    }
+
+    // State changes summary (HP, conditions)
+    for (const delta of result.deltas) {
+      if (delta.type === "hp_change") {
+        const amt = delta.details.amount as number;
+        const sign = amt >= 0 ? "+" : "";
+        lines.push(`<color=#888888>${delta.target} HP ${sign}${amt}</color>`);
+      } else if (delta.type === "condition_add") {
+        lines.push(`<color=#888888>${delta.target}: +${delta.details.condition}</color>`);
+      } else if (delta.type === "condition_remove") {
+        lines.push(`<color=#888888>${delta.target}: -${delta.details.condition}</color>`);
+      } else if (delta.type === "resource_spend") {
+        lines.push(`<color=#888888>${delta.target}: ${delta.details.resource} -${delta.details.spent}</color>`);
+      }
+    }
+
+    if (lines.length > 0) {
+      const block = `\n<color=#666666>───── ${actor} ─────</color>\n${lines.join("\n")}\n`;
+      this.callbacks.onNarrativeDelta(block);
     }
   }
 

--- a/src/agents/subagents/setup-conversation.ts
+++ b/src/agents/subagents/setup-conversation.ts
@@ -136,13 +136,13 @@ const SYSTEM_PROMPT = buildSystemPrompt();
  */
 async function streamWithRetry(
   client: Anthropic,
-  params: Anthropic.MessageCreateParamsNonStreaming,
+  params: Omit<Anthropic.MessageCreateParams, "stream">,
   onDelta: (delta: string) => void,
 ): Promise<Anthropic.Message> {
   for (let attempt = 0; ; attempt++) {
     try {
       dumpContext("setup", params);
-      const stream = client.messages.stream({ ...params });
+      const stream = client.messages.stream(params);
       stream.on("text", (delta) => { onDelta(delta); });
       return await stream.finalMessage();
     } catch (e) {
@@ -233,12 +233,11 @@ export function createSetupConversation(client: Anthropic): SetupConversation {
 
     const tc = getThinkingConfig("setup");
 
-    let lastParams: Anthropic.MessageCreateParamsNonStreaming = {
+    let lastParams = {
       model: getModel("medium"),
       max_tokens: TOKEN_LIMITS.SUBAGENT_LARGE + tc.budgetTokens,
       system: SYSTEM_PROMPT,
       messages,
-      stream: false,
       tools: TOOLS,
       thinking: tc.param,
     };
@@ -306,7 +305,6 @@ export function createSetupConversation(client: Anthropic): SetupConversation {
         max_tokens: TOKEN_LIMITS.SUBAGENT_MEDIUM + tc.budgetTokens,
         system: SYSTEM_PROMPT,
         messages,
-        stream: false,
         tools: TOOLS,
         thinking: tc.param,
       };


### PR DESCRIPTION
## Summary

Two fixes for missing/incomplete player-visible output:

- **resolve_turn results now emit to narrative view** (#109): After each resolve_turn, the engine emits a formatted block to the player via onNarrativeDelta showing rolls, outcome narrative, and state changes (HP, conditions, resources). The player always sees what happened mechanically, regardless of whether the DM narrates it. Format:
  ```
  ───── Kael ─────
  ⚔ Attack roll: [16]+5=21
  ⚔ Longsword damage: [4,3]+3=10
  Kael's blade bites deep into the goblin's side.
  Goblin HP -10
  ```

- **Setup streaming fix** (#111): Removed `stream: false` from params that were being spread into `client.messages.stream()`. The type/implementation mismatch could cause silent streaming failures mid-turn.

## Test plan

- [x] 1820 tests pass, lint clean
- [ ] Manual: start combat, call resolve_turn → verify rolls/outcome appear in narrative
- [ ] Manual: run setup conversation → verify streaming doesn't stop mid-turn

Closes #109, closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)