### PR TITLE
Fix OOC summary extraction: skip filler, handle end-of-string (#108)

### DIFF
--- a/src/agents/subagents/ooc-mode.test.ts
+++ b/src/agents/subagents/ooc-mode.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Anthropic from "@anthropic-ai/sdk";
-import { buildOOCPrompt, buildOOCTools, buildOOCToolHandler, enterOOC, parseEndOOCSignal } from "./ooc-mode.js";
+import { buildOOCPrompt, buildOOCTools, buildOOCToolHandler, enterOOC, parseEndOOCSignal, extractSummary } from "./ooc-mode.js";
 import type { DMSessionState } from "../dm-prompt.js";
 import type { FileIO } from "../scene-manager.js";
 import type { GameState } from "../game-state.js";
@@ -861,5 +861,44 @@ describe("enterOOC END_OOC integration", () => {
     });
     expect(result.endSession).toBeUndefined();
     expect(result.playerAction).toBeUndefined();
+  });
+});
+
+describe("extractSummary", () => {
+  it("extracts first substantive sentence", () => {
+    expect(extractSummary("Grappling lets you restrain foes. You need a STR check."))
+      .toBe("Grappling lets you restrain foes.");
+  });
+
+  it("skips filler phrases and takes second sentence", () => {
+    expect(extractSummary("No worries. Clarified the grappling rules for the player."))
+      .toBe("Clarified the grappling rules for the player.");
+  });
+
+  it("handles end-of-string without trailing space", () => {
+    expect(extractSummary("Corrected HP from 12 to 18."))
+      .toBe("Corrected HP from 12 to 18.");
+  });
+
+  it("returns fallback for empty text", () => {
+    expect(extractSummary("")).toBe("OOC discussion.");
+    expect(extractSummary("   ")).toBe("OOC discussion.");
+  });
+
+  it("truncates over 100 chars", () => {
+    const long = "A".repeat(110) + ".";
+    const result = extractSummary(long);
+    expect(result).toHaveLength(100);
+    expect(result).toMatch(/\.\.\.$/);
+  });
+
+  it("uses first sentence when all sentences are short filler", () => {
+    // All sentences under 15 chars — falls back to first
+    expect(extractSummary("Got it. OK. Done.")).toBe("Got it.");
+  });
+
+  it("adds period if sentence lacks punctuation", () => {
+    expect(extractSummary("Explained the combat rules to the player"))
+      .toBe("Explained the combat rules to the player.");
   });
 });

--- a/src/agents/subagents/ooc-mode.ts
+++ b/src/agents/subagents/ooc-mode.ts
@@ -544,14 +544,27 @@ export function parseEndOOCSignal(text: string): EndOOCSignal {
 }
 
 /**
- * Extract a terse summary from OOC text — first sentence, max 100 chars.
+ * Extract a terse summary from OOC text.
+ * Takes the first substantive sentence (skips filler phrases < 15 chars).
+ * Falls back to first 100 chars if no sentence boundary found.
  */
-function extractSummary(text: string): string {
-  const firstSentence = text.split(/[.!?]\s/)[0];
-  if (!firstSentence) return "OOC discussion.";
-  const trimmed = firstSentence.trim();
+export function extractSummary(text: string): string {
+  if (!text.trim()) return "OOC discussion.";
+
+  // Split on sentence boundaries (period/exclaim/question followed by space or end-of-string)
+  const sentences = text.split(/(?<=[.!?])(?:\s|$)/).filter((s) => s.trim());
+
+  // Find first substantive sentence (skip filler like "No worries", "Sure thing")
+  const substantive = sentences.find((s) => s.trim().length >= 15);
+  const best = substantive ?? sentences[0];
+
+  if (!best) return "OOC discussion.";
+
+  let trimmed = best.trim();
+  // Ensure it ends with punctuation
+  if (!/[.!?]$/.test(trimmed)) trimmed += ".";
   if (trimmed.length > 100) return trimmed.slice(0, 97) + "...";
-  return trimmed + ".";
+  return trimmed;
 }
 
 /**

--- a/src/prompts/ooc-mode.md
+++ b/src/prompts/ooc-mode.md
@@ -60,6 +60,6 @@ Roll back game state to a previous checkpoint. Targets: `last`, `scene:Title`, `
 
 ## Summary
 
-Your response text is automatically summarized (first sentence) for the DM's context. Make your opening sentence a terse summary of what was discussed or resolved — the DM won't see the full OOC conversation, only this summary.
+Your response text is automatically summarized (first substantive sentence) for the DM's context. Your FIRST SENTENCE must describe what was discussed or resolved — not a filler phrase like "No worries" or "Sure thing". Example: "Clarified grappling rules: contested Athletics check, target can use Athletics or Acrobatics." The DM won't see the full OOC conversation, only this summary.
 
 For AI-related mistakes: lead with a description of the reported mistake and the correct approach.


### PR DESCRIPTION
## Summary

- Fix sentence-boundary regex to handle end-of-string (was requiring trailing space)
- Skip filler phrases under 15 chars ("No worries.", "Sure thing.") and take the first substantive sentence
- Strengthen OOC prompt: first sentence must describe what was discussed, with example
- Export `extractSummary()` for direct testing

Before: `"OOC discussion. No worries."`
After: `"Clarified the grappling rules for the player."`

## Test plan

- [x] 7 new `extractSummary` unit tests (filler skip, end-of-string, truncation, empty, punctuation)
- [x] All 1827 tests pass

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)