### PR TITLE
Wire promote_character as DM and OOC tool (#107)

### DIFF
--- a/src/agents/agent-session.ts
+++ b/src/agents/agent-session.ts
@@ -142,6 +142,7 @@ export const TUI_TOOLS = new Set([
   "context_refresh",
   "scribe",
   "dm_notes",
+  "promote_character",
 ]);
 
 export function isTuiCommand(toolName: string): boolean {

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -23,6 +23,7 @@ import { isAITurn, getActivePlayer } from "./player-manager.js";
 import { aiPlayerTurn } from "./subagents/ai-player.js";
 import { campaignPaths, parseFrontMatter, serializeEntity, formatChangelogEntry } from "../tools/filesystem/index.js";
 import { runScribe } from "./subagents/scribe.js";
+import { promoteCharacter } from "./subagents/character-promotion.js";
 import { searchCampaign } from "./subagents/search-campaign.js";
 import { searchContent } from "./subagents/search-content.js";
 import { norm } from "../utils/paths.js";
@@ -540,6 +541,8 @@ export class GameEngine {
           await this.refreshContext();
         } else if (cmd.type === "scribe") {
           await this.handleScribe(cmd);
+        } else if (cmd.type === "promote_character") {
+          await this.handlePromoteCharacter(cmd);
         } else if (cmd.type === "dm_notes") {
           await this.handleDmNotes(cmd);
         } else if (cmd.type === "style_scene") {
@@ -735,6 +738,53 @@ export class GameEngine {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       this.callbacks.onDevLog?.(`[dev] scribe: failed — ${msg}`);
+    }
+  }
+
+  /** Handle promote_character tool — spawns subagent to update character sheet. */
+  private async handlePromoteCharacter(cmd: TuiCommand): Promise<void> {
+    const characterName = cmd.character as string;
+    const context = cmd.context as string;
+    if (!characterName) return;
+
+    const paths = campaignPaths(this.gameState.campaignRoot);
+    const filePath = norm(paths.character(characterName));
+
+    try {
+      // Read current sheet (may not exist for initial creation)
+      let currentSheet = "";
+      try {
+        currentSheet = await this.fileIO.readFile(filePath);
+      } catch {
+        // New character — start from minimal template
+        currentSheet = `# ${characterName}\n\n**Type:** character\n`;
+      }
+
+      // Load system rules if available
+      const ruleCard = await this.loadRuleCardCombat();
+
+      const result = await promoteCharacter(this.client, {
+        characterName,
+        characterSheet: currentSheet,
+        context,
+        systemRules: ruleCard !== "No rule card available." ? ruleCard : undefined,
+      });
+
+      // Write the updated sheet
+      if (result.updatedSheet) {
+        await this.fileIO.writeFile(filePath, result.updatedSheet);
+      }
+
+      // Notify scene manager
+      const slug = characterName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+      this.sceneManager.notifyEntityTouched(filePath, slug);
+
+      accUsage(this.sessionUsage, result.usage);
+      this.callbacks.onUsageUpdate(this.sessionUsage);
+      this.callbacks.onDevLog?.(`[dev] promote_character: ${characterName} — ${result.changelogEntry}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.callbacks.onDevLog?.(`[dev] promote_character: failed — ${msg}`);
     }
   }
 

--- a/src/agents/phase8.test.ts
+++ b/src/agents/phase8.test.ts
@@ -437,8 +437,13 @@ describe("new Phase 8 tools", () => {
     expect(registry.has("resolve_turn")).toBe(true);
   });
 
-  it("registry has 43 tools total", () => {
+  it("registers promote_character tool", () => {
     const registry = new ToolRegistry();
-    expect(registry.size).toBe(43);
+    expect(registry.has("promote_character")).toBe(true);
+  });
+
+  it("registry has 44 tools total", () => {
+    const registry = new ToolRegistry();
+    expect(registry.size).toBe(44);
   });
 });

--- a/src/agents/subagents/ooc-mode.test.ts
+++ b/src/agents/subagents/ooc-mode.test.ts
@@ -462,9 +462,9 @@ describe("buildOOCTools", () => {
     expect(names).toEqual(["get_commit_log", "read_file", "find_references", "validate_campaign"]);
   });
 
-  it("returns 18 tools when both fileIO and gameState are available", () => {
+  it("returns 19 tools when both fileIO and gameState are available", () => {
     const tools = buildOOCTools(true, true);
-    expect(tools).toHaveLength(18);
+    expect(tools).toHaveLength(19);
     const names = tools.map((t) => t.name);
     expect(names).toContain("roll_dice");
     expect(names).toContain("check_clocks");
@@ -474,9 +474,9 @@ describe("buildOOCTools", () => {
     expect(names).toContain("rollback");
   });
 
-  it("returns 15 tools when gameState but no fileIO", () => {
+  it("returns 16 tools when gameState but no fileIO", () => {
     const tools = buildOOCTools(false, true);
-    expect(tools).toHaveLength(15);
+    expect(tools).toHaveLength(16);
     const names = tools.map((t) => t.name);
     expect(names).toContain("roll_dice");
     expect(names).not.toContain("read_file");
@@ -731,7 +731,7 @@ describe("enterOOC with gameState", () => {
 
     const createCall = (client.messages.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     if (createCall) {
-      expect(createCall.tools).toHaveLength(18);
+      expect(createCall.tools).toHaveLength(19);
       const names = createCall.tools.map((t: { name: string }) => t.name);
       expect(names).toContain("roll_dice");
       expect(names).toContain("scribe");

--- a/src/agents/subagents/ooc-mode.ts
+++ b/src/agents/subagents/ooc-mode.ts
@@ -29,7 +29,7 @@ const OOC_READONLY_TOOLS = [
   "line_of_sight", "tiles_in_range", "find_nearest", "check_clocks",
 ];
 
-const OOC_ENTITY_TOOLS = ["scribe"];
+const OOC_ENTITY_TOOLS = ["scribe", "promote_character"];
 
 const OOC_TUI_TOOLS = ["style_scene", "set_display_resources", "set_resource_values", "show_character_sheet"];
 
@@ -398,6 +398,43 @@ async function dispatchDMTool(
       sceneNumber: 0, // OOC has no scene number
     }, fileIO);
     return { content: scribeResult.summary };
+  }
+
+  // Promote character — read sheet, spawn subagent, write back
+  if (name === "promote_character") {
+    if (!client || !fileIO || !campaignRoot) {
+      return { content: "Client and file I/O required for promote_character", is_error: true };
+    }
+    const result = registry.dispatch(gameState, name, input);
+    if (result.is_error) return result;
+    const cmd = result._tui ?? JSON.parse(result.content);
+    const characterName = (cmd as Record<string, unknown>).character as string;
+    const context = (cmd as Record<string, unknown>).context as string;
+
+    const { campaignPaths } = await import("../../tools/filesystem/index.js");
+    const { norm } = await import("../../utils/paths.js");
+    const paths = campaignPaths(campaignRoot);
+    const filePath = norm(paths.character(characterName));
+
+    let currentSheet: string;
+    try {
+      currentSheet = await fileIO.readFile(filePath);
+    } catch {
+      currentSheet = `# ${characterName}\n\n**Type:** character\n`;
+    }
+
+    const { promoteCharacter } = await import("./character-promotion.js");
+    const promoResult = await promoteCharacter(client, {
+      characterName,
+      characterSheet: currentSheet,
+      context,
+    });
+
+    if (promoResult.updatedSheet) {
+      await fileIO.writeFile(filePath, promoResult.updatedSheet);
+    }
+
+    return { content: `Updated ${characterName}: ${promoResult.changelogEntry}` };
   }
 
   // Rollback — execute via repo (prunes ghost dirs + exits)

--- a/src/agents/tool-registry.ts
+++ b/src/agents/tool-registry.ts
@@ -1037,6 +1037,30 @@ const TOOL_DEFS: RegisteredTool[] = [
       return err("resolve_turn requires async handling. This is a bug.");
     },
   },
+  {
+    definition: {
+      name: "promote_character",
+      description: "Level up, build, or update a character sheet. Use for initial character creation from a player description, level-ups, class feature changes, or stat corrections. Spawns a specialist subagent that reads the current sheet and rules, then produces an updated sheet with changelog.",
+      input_schema: {
+        type: "object" as const,
+        properties: {
+          character: { type: "string", description: "Character name (must match an existing character file, or a new one will be created)" },
+          context: { type: "string", description: "What changed — e.g. 'Build initial sheet: half-orc barbarian level 3', 'Reached level 5 after defeating the dragon', 'Correct AC from 13 to 14'" },
+        },
+        required: ["character", "context"],
+      },
+    },
+    handler: (_state, input) => {
+      const character = input.character as string;
+      const context = input.context as string;
+      if (!character?.trim()) return err("Character name is required.");
+      if (!context?.trim()) return err("Context is required — describe what changed.");
+      return {
+        content: `Promoting ${character}...`,
+        _tui: { type: "promote_character", character: character.trim(), context: context.trim() },
+      };
+    },
+  },
 ];
 
 // --- State change mapping ---


### PR DESCRIPTION
## Summary

The `promoteCharacter` subagent existed but was disconnected — no tool registration, no way for the DM to invoke it. Now wired into three contexts:

- **DM tool** — registered in tool-registry (44 tools). Engine intercepts the TUI command, reads character sheet, loads rule card, spawns subagent, writes updated sheet.
- **OOC tool** — added to `OOC_ENTITY_TOOLS`. Handles inline (same pattern as scribe): reads sheet, calls subagent, writes back. Player can say "I leveled up" in OOC and get their sheet updated.
- **Dev mode** — inherits all DM tools automatically.

Use cases: initial character build ("Build initial sheet: half-orc barbarian level 3"), level-ups ("Reached level 5"), stat corrections ("Correct AC from 13 to 14").

## Test plan

- [x] 1828 tests pass, lint clean
- [x] Tool count: 44 (DM registry), 19 (OOC with fileIO+gameState), 16 (OOC without fileIO)
- [ ] Manual: DM calls promote_character → verify sheet is written/updated
- [ ] Manual: OOC "I leveled up" → verify OOC agent calls promote_character

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)