### PR TITLE
Add system selection tiers + initial character sheet building

### DIFF
--- a/src/agents/setup-agent.test.ts
+++ b/src/agents/setup-agent.test.ts
@@ -18,6 +18,7 @@ function makeSetupResult(overrides: Partial<SetupResult> = {}): SetupResult {
     playerName: "Player",
     characterName: "Kael",
     characterDescription: "A wandering sellsword",
+    characterDetails: null,
     themeColor: "#8888aa",
     ...overrides,
   };
@@ -104,6 +105,29 @@ describe("resolveSystemSlug", () => {
 });
 
 describe("buildCampaignWorld", () => {
+  it("includes characterDetails in character file when present", async () => {
+    const files: Record<string, string> = {};
+    const dirs = new Set<string>();
+    const { norm } = await import("../utils/paths.js");
+
+    const fileIO: FileIO = {
+      readFile: vi.fn(async (path) => files[norm(path)] ?? ""),
+      writeFile: vi.fn(async (path, content) => { files[norm(path)] = content; }),
+      appendFile: vi.fn(async (path, content) => { files[norm(path)] = (files[norm(path)] ?? "") + content; }),
+      mkdir: vi.fn(async (path) => { dirs.add(norm(path)); }),
+      exists: vi.fn(async (path) => norm(path) in files || dirs.has(norm(path))),
+      listDir: vi.fn(async () => []),
+    };
+
+    const result = makeSetupResult({ characterDetails: "Fighter, level 1, standard array" });
+    await buildCampaignWorld("/tmp/campaigns", result, fileIO);
+
+    const charFile = Object.keys(files).find((p) => p.includes("/characters/"));
+    expect(charFile).toBeTruthy();
+    expect(files[charFile!]).toContain("Character Details");
+    expect(files[charFile!]).toContain("Fighter, level 1, standard array");
+  });
+
   it("creates campaign directory structure and files", async () => {
     const files: Record<string, string> = {};
     const dirs = new Set<string>();

--- a/src/agents/setup-agent.ts
+++ b/src/agents/setup-agent.ts
@@ -21,6 +21,7 @@ export interface SetupResult {
   playerName: string;
   characterName: string;
   characterDescription: string;
+  characterDetails: string | null;
   themeColor: string;
 }
 

--- a/src/agents/subagents/setup-conversation.test.ts
+++ b/src/agents/subagents/setup-conversation.test.ts
@@ -165,6 +165,21 @@ describe("createSetupConversation", () => {
     expect(result.finalized!.playerName).toBe("Alex");
     expect(result.finalized!.difficulty).toBe("Balanced");
     expect(result.finalized!.personality.name).toBe("The Chronicler");
+    expect(result.finalized!.characterDetails).toBeNull();
+  });
+
+  it("finalize_setup passes through characterDetails", async () => {
+    const input = { ...FINALIZE_INPUT, system: "dnd-5e", character_details: "Human Fighter, level 1, soldier background" };
+    const client = mockClient([
+      finalizeResponse(input),
+      textResponse("May your blade stay sharp!"),
+    ]);
+    const conv = createSetupConversation(client);
+    const result = await conv.start(noop);
+
+    expect(result.finalized).toBeDefined();
+    expect(result.finalized!.characterDetails).toBe("Human Fighter, level 1, soldier background");
+    expect(result.finalized!.system).toBe("dnd-5e");
   });
 
   it("finalize_setup triggers farewell follow-up", async () => {
@@ -202,6 +217,28 @@ describe("createSetupConversation", () => {
     expect(userMsg.content[0].type).toBe("tool_result");
     expect(userMsg.content[0].tool_use_id).toBe("toolu_choices_1");
     expect(userMsg.content[0].content).toContain("I want a pirate adventure");
+  });
+
+  it("system prompt includes complexity tiers and chargen rules", async () => {
+    const client = mockClient([textResponse("Welcome!")]);
+    const conv = createSetupConversation(client);
+    await conv.start(noop);
+
+    const streamCalls = (client.messages.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const systemPrompt = streamCalls[0][0].system as string;
+
+    // Verify tiered system groups
+    expect(systemPrompt).toContain("Light systems");
+    expect(systemPrompt).toContain("Crunchy systems");
+
+    // Verify descriptions are included
+    expect(systemPrompt).toContain("Micro-RPG framework");
+    expect(systemPrompt).toContain("Classic d20 system");
+
+    // Verify chargen rules are injected
+    expect(systemPrompt).toContain("Character creation rules by system");
+    expect(systemPrompt).toContain("High concept");  // from FATE
+    expect(systemPrompt).toContain("Choose race");    // from D&D
   });
 
   it("usage accumulates across turns", async () => {

--- a/src/agents/subagents/setup-conversation.ts
+++ b/src/agents/subagents/setup-conversation.ts
@@ -5,7 +5,8 @@ import type { SetupResult } from "../setup-agent.js";
 import { generateThemeColor } from "../setup-agent.js";
 import { PERSONALITIES } from "../../config/personalities.js";
 import { SEEDS } from "../../config/seeds.js";
-import { KNOWN_SYSTEMS } from "../../config/systems.js";
+import { KNOWN_SYSTEMS, readChargenSection } from "../../config/systems.js";
+import type { SystemComplexity } from "../../config/systems.js";
 import { getModel, getThinkingConfig } from "../../config/models.js";
 import { accumulateUsage as accRawUsage } from "../../context/usage-helpers.js";
 import { TOKEN_LIMITS } from "../../config/tokens.js";
@@ -63,6 +64,7 @@ const FINALIZE_TOOL: Anthropic.Tool = {
       player_name: { type: "string", description: "Player's real name, or 'Player'" },
       character_name: { type: "string", description: "Player character's name" },
       character_description: { type: "string", description: "One-sentence character concept" },
+      character_details: { type: "string", description: "Mechanical character details gathered during setup (class, skills, approaches, etc). Free-form text. Omit or null for pure narrative.", nullable: true },
     },
     required: [
       "genre", "campaign_name", "campaign_premise", "mood",
@@ -106,6 +108,20 @@ const TOOLS = [FINALIZE_TOOL, PRESENT_CHOICES_TOOL];
 
 // --- System prompt ---
 
+/** Group systems by complexity tier label. */
+function groupByTier(systems: typeof KNOWN_SYSTEMS): { light: typeof KNOWN_SYSTEMS; crunchy: typeof KNOWN_SYSTEMS } {
+  const lightComplexities: SystemComplexity[] = ["ultra-light", "light"];
+  return {
+    light: systems.filter((s) => lightComplexities.includes(s.complexity)),
+    crunchy: systems.filter((s) => !lightComplexities.includes(s.complexity)),
+  };
+}
+
+function formatSystemLine(s: typeof KNOWN_SYSTEMS[number]): string {
+  const ruleCard = s.hasRuleCard ? " ✦ full rule card" : "";
+  return `- \`${s.slug}\` — ${s.name}: ${s.description}${ruleCard}`;
+}
+
 function buildSystemPrompt(): string {
   const base = loadPrompt("setup-conversation");
   const seedList = SEEDS.map((s) => {
@@ -116,14 +132,30 @@ function buildSystemPrompt(): string {
     const desc = p.description ? `: ${p.description}` : "";
     return `- **${p.name}**${desc}`;
   }).join("\n");
-  const systemList = KNOWN_SYSTEMS.map((s) => {
-    const ruleCard = s.hasRuleCard ? " (has rule card)" : "";
-    return `- \`${s.slug}\` — ${s.name}${ruleCard}`;
-  }).join("\n");
+
+  const { light, crunchy } = groupByTier(KNOWN_SYSTEMS);
+  const lightList = light.map(formatSystemLine).join("\n");
+  const crunchyList = crunchy.map(formatSystemLine).join("\n");
+
+  let systemSection = "## Available game systems\n\nUse the **slug** (e.g. `dnd-5e`) in `finalize_setup`, not the display name. For pure narrative (no mechanics), pass `null` for system.\n\n";
+  systemSection += "### Light systems (simple rules, fast play)\n" + lightList + "\n\n";
+  if (crunchy.length > 0) {
+    systemSection += "### Crunchy systems (detailed mechanics)\n" + crunchyList + "\n\n";
+  }
+
+  // Inject chargen rules for all systems that have them
+  let chargenSection = "## Character creation rules by system\n\nAfter the player picks a system, use the matching section below to ask smart character questions.\n\n";
+  for (const sys of KNOWN_SYSTEMS) {
+    const section = readChargenSection(sys.slug);
+    if (section) {
+      chargenSection += `### ${sys.name} (\`${sys.slug}\`)\n${section}\n\n`;
+    }
+  }
 
   return base +
-    "\n\n## Available game systems\n\nWhen the player wants mechanics, pick from this list. Use the **slug** (e.g. `dnd-5e`) in `finalize_setup`, not the display name. For pure narrative (no mechanics), pass `null` for system.\n\n" + systemList +
-    "\n\n## Available campaign seeds\n\nUse these when presenting Quick Start options or campaign ideas. Pick seeds that match the player's genre if known. When presenting seeds as choices, use the seed name as the choice label and the premise (or description if available) as the choice description.\n\n" + seedList +
+    "\n\n" + systemSection +
+    chargenSection +
+    "## Available campaign seeds\n\nUse these when presenting Quick Start options or campaign ideas. Pick seeds that match the player's genre if known. When presenting seeds as choices, use the seed name as the choice label and the premise (or description if available) as the choice description.\n\n" + seedList +
     "\n\n## Available DM personalities\n\nWhen presenting personality choices, use the name as the choice label and the description as the choice description. You can also invent new personalities beyond this list — if a campaign calls for a voice that isn't here, or the player asks for something custom, craft a name and prompt fragment in the same style as the examples below.\n\n" + personalityList;
 }
 
@@ -214,6 +246,7 @@ export function createSetupConversation(client: Anthropic): SetupConversation {
       playerName: (input.player_name as string) || "Player",
       characterName,
       characterDescription: (input.character_description as string) || "",
+      characterDetails: (input.character_details as string) || null,
       themeColor: generateThemeColor(characterName),
     };
   }

--- a/src/agents/world-builder.ts
+++ b/src/agents/world-builder.ts
@@ -43,6 +43,10 @@ export async function buildCampaignWorld(
 
   // 3. Write character file
   const charPath = norm(paths.character(slugify(result.characterName)));
+  let charBody = result.characterDescription || "A newly created character. Their story unfolds through play.";
+  if (result.characterDetails) {
+    charBody += "\n\n## Character Details\n" + result.characterDetails;
+  }
   const charContent = serializeEntity(
     result.characterName,
     {
@@ -51,7 +55,7 @@ export async function buildCampaignWorld(
       display_resources: ["HP"],
       theme_color: result.themeColor,
     },
-    result.characterDescription || "A newly created character. Their story unfolds through play.",
+    charBody,
     [],
   );
   await fileIO.writeFile(charPath, charContent);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,7 +21,7 @@ import { listCampaigns } from "./config/main-menu.js";
 import type { CampaignEntry } from "./config/main-menu.js";
 import { buildCampaignConfig } from "./agents/setup-agent.js";
 import type { SetupResult } from "./agents/setup-agent.js";
-import { buildCampaignWorld } from "./agents/world-builder.js";
+import { buildCampaignWorld, slugify as worldSlugify } from "./agents/world-builder.js";
 import { getActivePlayer } from "./agents/player-manager.js";
 import { createClocksState } from "./tools/clocks/index.js";
 import { createCombatState } from "./tools/combat/index.js";
@@ -46,8 +46,11 @@ import { PlayingPhase } from "./phases/PlayingPhase.js";
 import { AddContentPhase } from "./phases/AddContentPhase.js";
 import { validatePdfs, runIngestPipeline, runPerBookStages, runSharedStages, slugify } from "./content/index.js";
 import type { ValidatedPdf, IngestProgress, ProcessingProgress } from "./content/index.js";
-import { listAvailableSystems } from "./config/systems.js";
+import { listAvailableSystems, readBundledRuleCard } from "./config/systems.js";
 import type { AvailableSystem } from "./config/systems.js";
+import { promoteCharacter } from "./agents/subagents/character-promotion.js";
+import { processingPaths } from "./config/processing-paths.js";
+import { norm } from "./utils/paths.js";
 import { GameProvider } from "./tui/game-context.js";
 import type { GameContextValue } from "./tui/game-context.js";
 
@@ -158,6 +161,59 @@ async function loadDisplayHistory(
   return displayLogTail.length > 0
     ? markdownToNarrativeLines(displayLogTail)
     : [];
+}
+
+// --- Post-setup character sheet building ---
+
+/**
+ * Build an initial character sheet using the promoteCharacter subagent.
+ * Called after buildCampaignWorld when we have system + character details.
+ * Silently — no streaming (the "Building your world..." phase covers this).
+ */
+async function buildInitialSheet(
+  campaignRoot: string,
+  result: SetupResult,
+  io: FileIO,
+  homeDir: string,
+): Promise<void> {
+  const charSlug = worldSlugify(result.characterName);
+  const charPath = norm(campaignPaths(campaignRoot).character(charSlug));
+
+  // Read the stub we just wrote
+  let stub: string;
+  try {
+    stub = await io.readFile(charPath);
+  } catch {
+    return; // stub doesn't exist — nothing to promote
+  }
+
+  // Load rule card: prefer user-processed, fall back to bundled
+  let ruleCard: string | null = null;
+  if (result.system) {
+    const sysPaths = processingPaths(homeDir, result.system);
+    try {
+      ruleCard = await io.readFile(norm(sysPaths.ruleCard));
+    } catch {
+      ruleCard = readBundledRuleCard(result.system);
+    }
+  }
+
+  if (!ruleCard) return; // no rule card — can't build a proper sheet
+
+  const client = new Anthropic();
+  try {
+    const { updatedSheet } = await promoteCharacter(client, {
+      characterSheet: stub,
+      systemRules: ruleCard,
+      context: `Build initial character sheet: ${result.characterDetails}`,
+      characterName: result.characterName,
+    });
+    if (updatedSheet) {
+      await io.writeFile(charPath, updatedSheet);
+    }
+  } catch {
+    // Best-effort — the stub is still a valid character file
+  }
 }
 
 // --- App component ---
@@ -513,6 +569,12 @@ export default function App({ shutdownRef }: AppProps) {
 
       const homeDir = getDefaultHomeDir();
       const campaignRoot = await buildCampaignWorld(campaignsDir, result, fileIO.current, homeDir);
+
+      // Build initial character sheet if we have system + details
+      if (result.system && result.characterDetails) {
+        await buildInitialSheet(campaignRoot, result, fileIO.current, homeDir);
+      }
+
       const config = buildCampaignConfig(result);
       await startEngine(config, campaignRoot);
     } catch (e) {

--- a/src/config/systems.test.ts
+++ b/src/config/systems.test.ts
@@ -1,4 +1,4 @@
-import { KNOWN_SYSTEMS, findSystem, listAvailableSystems } from "./systems.js";
+import { KNOWN_SYSTEMS, findSystem, listAvailableSystems, readChargenSection } from "./systems.js";
 import type { FileIO } from "../agents/scene-manager.js";
 
 const norm = (p: string) => p.replace(/\\/g, "/");
@@ -43,6 +43,14 @@ describe("KNOWN_SYSTEMS", () => {
   it("marks all entries as bundled", () => {
     for (const sys of KNOWN_SYSTEMS) {
       expect(sys.bundled).toBe(true);
+    }
+  });
+
+  it("has complexity and description for all entries", () => {
+    const validComplexities = ["ultra-light", "light", "medium", "high"];
+    for (const sys of KNOWN_SYSTEMS) {
+      expect(validComplexities).toContain(sys.complexity);
+      expect(sys.description.length).toBeGreaterThan(0);
     }
   });
 });
@@ -94,5 +102,44 @@ describe("listAvailableSystems", () => {
     const io = mockIO({});
     const systems = await listAvailableSystems(io, "/nonexistent");
     expect(systems.length).toBe(KNOWN_SYSTEMS.length);
+  });
+
+  it("discovered systems get default complexity and description", async () => {
+    const io = mockIO({
+      "/home/systems": ["my-homebrew"],
+    });
+    const systems = await listAvailableSystems(io, "/home");
+    const custom = systems.find((s) => s.slug === "my-homebrew");
+    expect(custom).toBeDefined();
+    expect(custom!.complexity).toBe("medium");
+    expect(custom!.description).toBeTruthy();
+  });
+});
+
+describe("readChargenSection", () => {
+  it("returns chargen content for systems with a character_creation section", () => {
+    const section = readChargenSection("24xx");
+    expect(section).toBeTruthy();
+    expect(section).toContain("skill");
+  });
+
+  it("returns chargen content for dnd-5e", () => {
+    const section = readChargenSection("dnd-5e");
+    expect(section).toBeTruthy();
+    expect(section).toContain("class");
+  });
+
+  it("returns chargen content for fate-accelerated", () => {
+    const section = readChargenSection("fate-accelerated");
+    expect(section).toBeTruthy();
+    expect(section).toContain("High concept");
+  });
+
+  it("returns null for systems without a rule card", () => {
+    expect(readChargenSection("cairn")).toBeNull();
+  });
+
+  it("returns null for unknown systems", () => {
+    expect(readChargenSection("nonexistent")).toBeNull();
   });
 });

--- a/src/config/systems.ts
+++ b/src/config/systems.ts
@@ -9,6 +9,8 @@ import type { FileIO } from "../agents/scene-manager.js";
 import { join } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 
+export type SystemComplexity = "ultra-light" | "light" | "medium" | "high";
+
 export interface SystemEntry {
   slug: string;
   name: string;
@@ -16,6 +18,10 @@ export interface SystemEntry {
   bundled: boolean;
   /** True if a bundled rule-card.md exists. */
   hasRuleCard: boolean;
+  /** Mechanical complexity tier for grouping in system selection. */
+  complexity: SystemComplexity;
+  /** One-liner for choice descriptions in setup. */
+  description: string;
 }
 
 export interface AvailableSystem extends SystemEntry {
@@ -24,13 +30,13 @@ export interface AvailableSystem extends SystemEntry {
 }
 
 export const KNOWN_SYSTEMS: SystemEntry[] = [
-  { slug: "24xx", name: "24XX", bundled: true, hasRuleCard: true },
-  { slug: "fate-accelerated", name: "FATE Accelerated", bundled: true, hasRuleCard: true },
-  { slug: "cairn", name: "Cairn", bundled: true, hasRuleCard: false },
-  { slug: "ironsworn", name: "Ironsworn", bundled: true, hasRuleCard: false },
-  { slug: "breathless", name: "Breathless", bundled: true, hasRuleCard: true },
-  { slug: "charge", name: "Charge RPG", bundled: true, hasRuleCard: true },
-  { slug: "dnd-5e", name: "D&D 5th Edition", bundled: true, hasRuleCard: true },
+  { slug: "24xx", name: "24XX", bundled: true, hasRuleCard: true, complexity: "ultra-light", description: "Micro-RPG framework. 3 skills, d6-d12 ladder." },
+  { slug: "breathless", name: "Breathless", bundled: true, hasRuleCard: true, complexity: "light", description: "Degrading dice pools. Skills deplete as you use them." },
+  { slug: "cairn", name: "Cairn", bundled: true, hasRuleCard: false, complexity: "light", description: "Into the Odd\u2013style. No to-hit rolls, direct damage." },
+  { slug: "charge", name: "Charge RPG", bundled: true, hasRuleCard: true, complexity: "light", description: "Forged in the Dark\u2013lite. Action rolls + momentum." },
+  { slug: "fate-accelerated", name: "FATE Accelerated", bundled: true, hasRuleCard: true, complexity: "light", description: "Approaches, aspects, fate points. Fiction-first." },
+  { slug: "ironsworn", name: "Ironsworn", bundled: true, hasRuleCard: false, complexity: "medium", description: "Solo/co-op PbtA with iron vows and progress tracks." },
+  { slug: "dnd-5e", name: "D&D 5th Edition", bundled: true, hasRuleCard: true, complexity: "high", description: "Classic d20 system. Classes, levels, spells, combat grid." },
 ];
 
 /**
@@ -51,6 +57,17 @@ export function readBundledRuleCard(slug: string): string | null {
   const rcPath = join(getBundledSystemsDir(), slug, "rule-card.md");
   if (!existsSync(rcPath)) return null;
   return readFileSync(rcPath, "utf-8");
+}
+
+/**
+ * Read the <character_creation> section from a system's bundled rule card.
+ * Returns the inner text, or null if the section or rule card doesn't exist.
+ */
+export function readChargenSection(slug: string): string | null {
+  const card = readBundledRuleCard(slug);
+  if (!card) return null;
+  const match = card.match(/<character_creation>([\s\S]*?)<\/character_creation>/);
+  return match ? match[1].trim() : null;
 }
 
 /**
@@ -95,6 +112,8 @@ export async function listAvailableSystems(
         name: dir, // use slug as display name for custom systems
         bundled: false,
         hasRuleCard: false,
+        complexity: "medium",
+        description: "User-processed system.",
         processed: true,
       });
     }

--- a/src/prompts/setup-conversation.md
+++ b/src/prompts/setup-conversation.md
@@ -12,9 +12,24 @@ Start with a dramatic welcome — you're opening the curtain on a new adventure.
    - **Mood** — Heroic, grimdark, whimsical, tense, or a mix
    - **Difficulty** — How forgiving: gentle, balanced, or unforgiving
    - **DM personality** — Who runs the game. Present 5-8 options from the personality list below that fit the campaign's genre and mood, using their names as choice labels and descriptions as choice descriptions. You can also invent new personalities — if the campaign concept calls for a voice not on the list, or if the player asks for something specific, craft a fitting name and prompt fragment for it.
-   - **Character** — Name and a one-sentence concept for the player character
+   - **System selection** (two-tier) — see below
+   - **Character** — Name, one-sentence concept, and system-specific details (see below)
    - **Player name** — The human's real name (or just "Player"). Ask for this AFTER the character — something like "And what should I call *you*, the person behind the character?" Players expect to name their character first; asking for their real name first confuses them.
-   - **Game system** — Pure narrative (no mechanics), or a system from the available systems list below (e.g. D&D 5th Edition, FATE Accelerated, Cairn). Systems with a rule card have full mechanical support.
+
+### System selection (two-tier)
+
+After establishing genre, mood, and campaign concept, guide the player through system selection:
+
+1. Present three play-style choices:
+   - Pure narrative (no dice or mechanics)
+   - Light system (simple rules, fast play)
+   - Crunchy system (detailed mechanics) — only show if crunchy systems are available
+
+2. If not pure narrative, present the matching systems as choices using their descriptions. Systems with a rule card (marked ✦) have full mechanical support — flag this. Include "Show me some more ideas" as the last option.
+
+3. After system selection, ask 1-2 questions about the character's mechanical identity. Use the character creation rules provided below (in the "Character creation rules by system" section) to ask smart, system-appropriate questions. Gather these details naturally — "What class? A spellcaster, a fighter, something else?" not "Please specify your race, class, and level." Store the gathered details in the `character_details` field of `finalize_setup`.
+
+For Quick Start, default to pure narrative (no system) unless the seed implies one.
 
 ## Pre-finalize review (MANDATORY)
 

--- a/systems/dnd-5e/rule-card.md
+++ b/systems/dnd-5e/rule-card.md
@@ -7,6 +7,18 @@ Ability modifier = floor((score - 10) / 2).
 Proficiency bonus scales with level: +2 (1-4), +3 (5-8), +4 (9-12), +5 (13-16), +6 (17-20).
 </core_mechanic>
 
+<character_creation>
+Choose race (human, elf, dwarf, halfling, etc.) — each grants ability bonuses and traits.
+Choose class (fighter, wizard, rogue, cleric, etc.) — determines hit die, proficiencies, features.
+Choose background (soldier, sage, criminal, etc.) — grants 2 skill proficiencies + equipment + a feature.
+Ability scores: use standard array 15/14/13/12/10/8 or roll 4d6-drop-lowest six times, assign to STR/DEX/CON/INT/WIS/CHA.
+HP at level 1 = hit die maximum + CON modifier.
+Proficiency bonus at level 1 = +2.
+Starting equipment: from class + background, or buy with starting gold.
+Armor Class: depends on armor worn + DEX modifier (or class feature).
+Pick spells if a spellcaster (number of cantrips + prepared/known spells per class table).
+</character_creation>
+
 <advantage_disadvantage>
 Advantage: roll 2d20, take higher. Disadvantage: roll 2d20, take lower.
 Multiple sources don't stack — any advantage + any disadvantage = straight roll.

--- a/systems/fate-accelerated/rule-card.md
+++ b/systems/fate-accelerated/rule-card.md
@@ -7,6 +7,16 @@ Fail: total < opposition. Tie: total = opposition. Succeed: total > opposition.
 Succeed with Style: total beats opposition by 3+.
 </core_mechanic>
 
+<character_creation>
+High concept (who you are in a phrase: "Cat Burglar Countess," "Disgraced Paladin").
+Trouble aspect (recurring problem: "Wanted by the Crown," "Can't Resist a Dare").
+One more aspect (optional at start — remaining two can emerge in play).
+Approaches — assign the array +3, +2, +2, +1, +1, +0 across: Careful, Clever, Flashy, Forceful, Quick, Sneaky.
+Up to 3 stunts (each beyond the first reduces refresh by 1; refresh starts at 3).
+Stress: 3 boxes. No consequences yet — they're taken in play.
+Fate points: start each session at refresh (default 3).
+</character_creation>
+
 <approaches>
 Six approaches replace skills. Each rated +0 to +3.
 Starting array: one at +3, two at +2, two at +1, one at +0.


### PR DESCRIPTION
## Summary

Closes #112.

- **Two-tier system selection** in setup: play-style choice (narrative / light / crunchy) then specific system with descriptions and chargen rules
- **System-aware character questions**: after picking a system, the setup agent asks 1-2 targeted questions using `<character_creation>` excerpts from rule cards
- **Post-setup sheet building**: `promoteCharacter` subagent builds a full character sheet from gathered details before the DM's first turn, eliminating the "what class are you?" opener
- `SystemEntry` gains `complexity` and `description` fields; `readChargenSection()` extracts chargen rules from bundled rule cards
- Added `<character_creation>` sections to FATE Accelerated and D&D 5e rule cards
- `finalize_setup` schema gains `character_details` field, flows through `SetupResult` → world-builder stub → `promoteCharacter`

## Test plan

- [x] `npm run check` passes (lint + 1848 tests + coverage)
- [x] Smoke test: new campaign → two-tier system selection works
- [x] Smoke test: system-aware character questions appear after picking a system
- [x] Smoke test: character sheet populated before DM's first turn
- [ ] Verify pure narrative path still works (no chargen questions, no sheet building)
- [ ] Verify Quick Start path defaults to pure narrative

🤖 Generated with [Claude Code](https://claude.com/claude-code)