### PR TITLE
Distribution pipeline: Bun compile, install scripts, CI/CD releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "cross-env": "^10.1.0",
         "eslint": "^10.0.0",
         "ink-testing-library": "^4.0.0",
+        "react-devtools-core": "^7.0.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.56.0",
@@ -5641,6 +5642,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-devtools-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-7.0.1.tgz",
+      "integrity": "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
@@ -6008,6 +6042,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cross-env": "^10.1.0",
     "eslint": "^10.0.0",
     "ink-testing-library": "^4.0.0",
+    "react-devtools-core": "^7.0.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.56.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,7 +50,6 @@ import type { ApiKeyStore } from "./config/api-keys.js";
 import { checkKeyHealth, formatHealthStatus } from "./config/api-key-health.js";
 import type { KeyHealthResult } from "./config/api-key-health.js";
 import { formatK } from "./context/cost-tracker.js";
-import { validatePdfs, runIngestPipeline, runPerBookStages, runSharedStages, slugify } from "./content/index.js";
 import type { ValidatedPdf, IngestProgress, ProcessingProgress } from "./content/index.js";
 import { listAvailableSystems, readBundledRuleCard } from "./config/systems.js";
 import type { AvailableSystem } from "./config/systems.js";
@@ -820,6 +819,7 @@ export default function App({ shutdownRef }: AppProps) {
         };
         setContentStatusMsg("Extracting text...");
 
+        const { runIngestPipeline, runPerBookStages, runSharedStages, slugify } = await import("./content/index.js");
         const jobs = await runIngestPipeline(fileIO.current, homeDir, systemSlug, pdfs, onIngestProgress);
 
         // Phase 2: Per-book stages (classifier + extractors) for each PDF
@@ -869,6 +869,7 @@ export default function App({ shutdownRef }: AppProps) {
   }, [getConfigPath, fileIO, loadCampaigns]);
 
   const handleValidatePdf = useCallback(async (path: string): Promise<ValidatedPdf> => {
+    const { validatePdfs } = await import("./content/index.js");
     const results = await validatePdfs([path]);
     return results[0];
   }, []);

--- a/src/config/systems.ts
+++ b/src/config/systems.ts
@@ -8,6 +8,7 @@
 import type { FileIO } from "../agents/scene-manager.js";
 import { join } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
+import { assetDir } from "../utils/paths.js";
 
 export type SystemComplexity = "ultra-light" | "light" | "medium" | "high";
 
@@ -45,9 +46,7 @@ export const KNOWN_SYSTEMS: SystemEntry[] = [
  * Layout: repo-root/systems/<slug>/rule-card.md
  */
 export function getBundledSystemsDir(): string {
-  // src/config/systems.ts → ../../systems/
-  // dist/config/systems.js → ../../systems/
-  return join(import.meta.dirname, "..", "..", "systems");
+  return assetDir("systems");
 }
 
 /**

--- a/src/prompts/load-prompt.ts
+++ b/src/prompts/load-prompt.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { assetDir } from "../utils/paths.js";
 
 const cache = new Map<string, string>();
 
@@ -27,7 +28,7 @@ export function loadPrompt(name: string): string {
   const cached = cache.get(name);
   if (cached !== undefined) return cached;
 
-  const dir = import.meta.dirname;
+  const dir = assetDir("prompts");
   const filePath = join(dir, `${name}.md`);
   const content = stripComments(
     readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n"),

--- a/src/tui/themes/loader.ts
+++ b/src/tui/themes/loader.ts
@@ -6,6 +6,7 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
+import { assetDir } from "../../utils/paths.js";
 import type { ThemeAsset, PlayerPaneFrame, ThemeDefinition } from "./types.js";
 import {
   parseSections,
@@ -23,7 +24,7 @@ const definitionCache = new Map<string, ThemeDefinition>();
 
 /** Directory containing built-in .theme files. */
 function assetsDir(): string {
-  return join(import.meta.dirname, "assets");
+  return assetDir("themes");
 }
 
 /**

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,4 +1,45 @@
+import { dirname, join } from "node:path";
+
 /** Normalize a path to use forward slashes (cross-platform). */
 export function norm(p: string): string {
   return p.replace(/\\/g, "/");
+}
+
+/** True when running inside a Bun-compiled standalone executable. */
+export function isCompiled(): boolean {
+  const meta = import.meta.dirname;
+  return meta.includes("$bunfs") || meta.includes("~BUN");
+}
+
+/**
+ * Resolve the directory for a named asset category.
+ *
+ * Compiled binary layout (next to the exe):
+ *   prompts/  themes/  systems/
+ *
+ * Dev layout (repo root):
+ *   src/prompts/  src/tui/themes/assets/  systems/
+ */
+const _cache = new Map<string, string>();
+const DEV_ASSET_DIRS: Record<string, string> = {
+  prompts: "src/prompts",
+  themes: "src/tui/themes/assets",
+  systems: "systems",
+};
+
+export function assetDir(category: "prompts" | "themes" | "systems"): string {
+  const cached = _cache.get(category);
+  if (cached) return cached;
+
+  let dir: string;
+  if (isCompiled()) {
+    dir = join(dirname(process.execPath), category);
+  } else {
+    // src/utils/paths.ts → repo root is ../..
+    const repoRoot = norm(dirname(dirname(import.meta.dirname)));
+    dir = join(repoRoot, DEV_ASSET_DIRS[category]);
+  }
+
+  _cache.set(category, dir);
+  return dir;
 }


### PR DESCRIPTION
## Summary

Complete distribution pipeline for shipping Machine Violet as a standalone binary via `bun build --compile`. No Node.js installation required.

### Asset path resolution
- `assetDir()` utility resolves prompts/themes/systems correctly in both dev and compiled binary contexts
- Content pipeline imports converted to lazy `await import()` so PDF native deps don't crash at startup

### Build script + version + dotenv
- `scripts/build-dist.ts` — compiles + copies assets, invokable via `npm run dist`
- `--version` / `-v` flag prints version and exits before TUI init
- `loadEnv()` checks exe directory before cwd for `.env`
- Version injected at build time via `--define`

### Install scripts
- `scripts/install.ps1` — Windows: downloads from GitHub, extracts to `%LOCALAPPDATA%`, adds to PATH
- `scripts/install.sh` — macOS/Linux: extracts to `~/.local/lib`, symlinks to `~/.local/bin`
- Both preserve `.env` across upgrades and support `--version` pinning

### Update checker
- `src/config/updater.ts` — queries GitHub releases API, semver comparison, self-update via install scripts
- Windows: spawns detached batch script to work around exe file locking

### CI/CD
- `release.yml` — triggered on `v*` tag push, matrix build (windows-x64, darwin-arm64, linux-x64), publishes GitHub Release
- `cut-release.yml` — manually triggered workflow: pick patch/minor/major, bumps package.json, tags, pushes (triggers release.yml)

Closes #135, #136, #137, #138, #139, #140

## Test plan
- [x] 1884 tests pass
- [x] `bun scripts/build-dist.ts` produces working 115MB exe (40MB zipped)
- [x] `--version` flag works in compiled binary
- [x] Compiled binary loads prompts, themes, systems and initializes Ink
- [ ] Manual: run compiled binary in a real terminal (not subprocess)
- [ ] Manual: test install.ps1 on clean Windows
- [ ] End-to-end: cut a release via workflow and verify builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)