### PR TITLE
Fix release workflow: chain via workflow_call

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -61,13 +64,18 @@ jobs:
           git push origin main
           git push origin "v${{ steps.bump.outputs.new }}"
           echo ""
-          echo "✅ Tagged v${{ steps.bump.outputs.new }}"
-          echo "   Release workflow will build and publish automatically."
+          echo "Tagged v${{ steps.bump.outputs.new }} — release build starting."
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}
         run: |
-          echo "🔍 Dry run — no push."
-          echo "   Would have tagged: v${{ steps.bump.outputs.new }}"
-          echo "   Commit:"
+          echo "Dry run — no push."
+          echo "Would have tagged: v${{ steps.bump.outputs.new }}"
           git log --oneline -1
+
+  build-and-release:
+    needs: tag
+    if: ${{ !inputs.dry_run }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -29,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: oven-sh/setup-bun@v2
 
@@ -42,7 +49,8 @@ jobs:
       - name: Build distribution
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
           EXE_NAME="machine-violet"
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             EXE_NAME="machine-violet.exe"
@@ -70,7 +78,8 @@ jobs:
         if: matrix.archive == 'zip'
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
           cd dist
           7z a "../machine-violet-${VERSION}-${{ matrix.asset_suffix }}.zip" .
 
@@ -78,7 +87,8 @@ jobs:
         if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
           tar -czf "machine-violet-${VERSION}-${{ matrix.asset_suffix }}.tar.gz" -C dist .
 
       - name: Upload artifact
@@ -98,5 +108,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: machine-violet-*


### PR DESCRIPTION
## Summary
The Cut Release workflow pushed a tag, but the Release workflow never triggered. This is a [known GitHub Actions limitation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow): events from the default `GITHUB_TOKEN` don't trigger other workflows.

**Fix:** Release now accepts `workflow_call` with a `tag` input. Cut Release chains directly into it after pushing the tag — the build runs in the same pipeline.

Release also still triggers on manual `git push --tags` as a fallback (`push: tags: v*`).

## Test plan
- [ ] Run Cut Release workflow and verify build + GitHub Release are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)