### PR TITLE
Add retry UX for API errors: enter-to-retry + /retry command

### DIFF
--- a/docs/error-recovery.md
+++ b/docs/error-recovery.md
@@ -60,6 +60,26 @@ Retry with exponential backoff (1s, 2s, 4s, 8s, capped at 12s) **indefinitely** 
 
 Retryable statuses: 429, 500, 502, 503, 529, plus synthetic status 0 for connection-level errors. No state has changed — the API call didn't complete — so there's nothing to roll back.
 
+### Non-retryable API errors (manual retry)
+
+When an API call fails with an error that exhausts automatic retries or isn't in the retryable set, the engine stores the failed input and prompts the player:
+
+```
+[Error: 401 Unauthorized]
+[Debug info saved to .debug/ folder]
+[Press Enter to retry]
+```
+
+Pressing Enter with an empty input replays the last DM turn (`processInput` with `skipTranscript: true`, since the transcript was already written). The pending retry is cleared on the next successful turn.
+
+### `/retry` slash command
+
+The `/retry` command retries the last DM turn at any time — useful for recovering from garbled output, tool loops, or any unsatisfying response:
+
+- If there's a pending error retry, `/retry` replays that failed input.
+- Otherwise, it pops the last exchange from conversation history and replays the original player input (with `skipTranscript: true`).
+- Both paths log a `dev` narrative line when dev mode is active.
+
 ### Subagent failures
 
 If a Haiku/Sonnet subagent call fails (during `resolve_action`, OOC, chargen, etc.), the engine retries the subagent call. The parent (Opus DM) doesn't see the failure unless retries are exhausted, in which case it receives an error result: "Resolution failed — resolve manually or retry." The DM can narrate around it or ask the player to wait.

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -156,6 +156,9 @@ export class GameEngine {
   private terminalDims: TerminalDims | undefined;
   private resolveSession: ResolveSession | null = null;
 
+  /** Tracks the last failed input so the player can press Enter to retry. */
+  private lastFailedInput: { characterName: string; text: string; opts?: { fromAI?: boolean; skipTranscript?: boolean } } | null = null;
+
   constructor(params: {
     client: Anthropic;
     gameState: GameState;
@@ -306,6 +309,49 @@ export class GameEngine {
   /** Update terminal dimensions for length steering (called from TUI layer on resize). */
   setTerminalDims(dims: TerminalDims): void {
     this.terminalDims = dims;
+  }
+
+  /** Whether the engine has a failed input that can be retried with Enter. */
+  hasPendingRetry(): boolean {
+    return this.lastFailedInput !== null;
+  }
+
+  /**
+   * Retry the last failed DM turn.
+   * Used by the "Press Enter to retry" prompt after API errors.
+   * Since the error occurred before the exchange was added to conversation,
+   * we just replay processInput with the same arguments.
+   */
+  retryLastTurn(): void {
+    const pending = this.lastFailedInput;
+    if (!pending) return;
+    // skipTranscript: true — transcript was already written on the original attempt
+    this.processInput(pending.characterName, pending.text, { ...pending.opts, skipTranscript: true });
+  }
+
+  /**
+   * Pop the last exchange from conversation and replay it.
+   * Used by /retry to discard a bad DM response and try again.
+   * Returns false if there's nothing to retry.
+   */
+  retryLastExchange(): boolean {
+    const popped = this.conversation.popLastExchange();
+    if (!popped) return false;
+    // Extract character name and text from the stored user message
+    const content = typeof popped.user.content === "string"
+      ? popped.user.content
+      : (popped.user.content as Anthropic.TextBlock[])
+          .filter((b): b is Anthropic.TextBlock => b.type === "text")
+          .map((b) => b.text)
+          .join("");
+    // Tagged format is "[CharName] text" — optionally with OOC prefix
+    const match = content.match(/(?:<ooc_summary>[\s\S]*?<\/ooc_summary>\s*)?(?:\[([^\]]+)\]\s*)([\s\S]*)/);
+    if (!match) return false;
+    const characterName = match[1];
+    const text = match[2];
+    // skipTranscript: true — the original transcript entry is already written
+    this.processInput(characterName, text, { skipTranscript: true });
+    return true;
   }
 
   /** Store a pending OOC summary to inject into the next DM turn (called from TUI layer on OOC exit). */
@@ -567,11 +613,16 @@ export class GameEngine {
       this.callbacks.onNarrativeComplete(result.text, text || undefined);
       this.callbacks.onTurnEnd(dmTurn);
 
+      // Clear any pending retry on success
+      this.lastFailedInput = null;
+
     } catch (e) {
       // Restore consumed OOC summary so it retries on the next turn
       if (consumedOOCSummary) {
         this.pendingOOCSummary = consumedOOCSummary;
       }
+      // Store the failed input so the player can press Enter to retry
+      this.lastFailedInput = { characterName, text, opts };
       const error = e instanceof Error ? e : new Error(String(e));
       await this.dumpDebugInfo(error);
       this.callbacks.onError(error);

--- a/src/commands/slash-commands.test.ts
+++ b/src/commands/slash-commands.test.ts
@@ -381,6 +381,48 @@ describe("trySlashCommand", () => {
     });
   });
 
+  describe("/retry", () => {
+    it("shows unavailable when no engine", () => {
+      const ctx = mockCtx({ engine: null });
+      trySlashCommand("/retry", ctx);
+      expect(lastAppended(ctx).text).toContain("unavailable");
+    });
+
+    it("retries last failed turn when pending retry exists", () => {
+      const retryLastTurn = vi.fn();
+      const hasPendingRetry = vi.fn().mockReturnValue(true);
+      const ctx = mockCtx();
+      Object.assign(ctx.engine, { retryLastTurn, hasPendingRetry });
+      trySlashCommand("/retry", ctx);
+      expect(retryLastTurn).toHaveBeenCalled();
+    });
+
+    it("pops last exchange and retries when no pending error", () => {
+      const retryLastExchange = vi.fn().mockReturnValue(true);
+      const hasPendingRetry = vi.fn().mockReturnValue(false);
+      const ctx = mockCtx();
+      Object.assign(ctx.engine, { retryLastExchange, hasPendingRetry });
+      trySlashCommand("/retry", ctx);
+      expect(retryLastExchange).toHaveBeenCalled();
+      expect(lastAppended(ctx).text).toContain("Retrying last turn");
+    });
+
+    it("shows nothing-to-retry when no history", () => {
+      const retryLastExchange = vi.fn().mockReturnValue(false);
+      const hasPendingRetry = vi.fn().mockReturnValue(false);
+      const ctx = mockCtx();
+      Object.assign(ctx.engine, { retryLastExchange, hasPendingRetry });
+      trySlashCommand("/retry", ctx);
+      expect(lastAppended(ctx).text).toContain("Nothing to retry");
+    });
+
+    it("appears in /help output", () => {
+      const ctx = mockCtx();
+      trySlashCommand("/help", ctx);
+      expect(lastAppended(ctx).text).toContain("/retry");
+    });
+  });
+
   describe("/swatch", () => {
     it("invokes setActiveModal with swatch kind", () => {
       const setActiveModal = vi.fn();

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -232,6 +232,31 @@ const snapshotCommand: SlashCommand = {
   },
 };
 
+const retryCommand: SlashCommand = {
+  name: "retry",
+  usage: "/retry",
+  description: "Retry the last DM turn (discards current response)",
+  execute(_args, ctx) {
+    if (!ctx.engine) {
+      ctx.appendLine({ kind: "system", text: "[Retry unavailable — no active engine]" });
+      return;
+    }
+    // If there's a pending error retry, just replay that
+    if (ctx.engine.hasPendingRetry()) {
+      ctx.appendLine({ kind: "dev", text: "[dev] retrying last failed turn" });
+      ctx.engine.retryLastTurn();
+      return;
+    }
+    // Otherwise pop the last exchange and replay
+    const ok = ctx.engine.retryLastExchange();
+    if (!ok) {
+      ctx.appendLine({ kind: "system", text: "[Nothing to retry — no conversation history]" });
+      return;
+    }
+    ctx.appendLine({ kind: "system", text: "[Retrying last turn...]" });
+  },
+};
+
 const swatchCommand: SlashCommand = {
   name: "swatch",
   usage: "/swatch",
@@ -252,6 +277,7 @@ const commands: SlashCommand[] = [
   saveCommand,
   logCommand,
   rollbackCommand,
+  retryCommand,
   sceneCommand,
   oocCommand,
   devCommand,

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -228,6 +228,26 @@ describe("ConversationManager", () => {
     expect(content[0].content).toBe("1d20: [15]→20");
   });
 
+  it("popLastExchange removes and returns last exchange", () => {
+    const mgr = new ConversationManager(defaultContextConfig);
+    mgr.addExchange(userMsg("First"), assistantMsg("Resp 1"));
+    mgr.addExchange(userMsg("Second"), assistantMsg("Resp 2"));
+
+    const popped = mgr.popLastExchange();
+    expect(popped).not.toBeNull();
+    expect(popped!.user.content).toBe("Second");
+    expect(popped!.assistant.content).toBe("Resp 2");
+    expect(mgr.size).toBe(1);
+    // Remaining exchange is the first one
+    const messages = mgr.getMessages();
+    expect(messages[0].content).toBe("First");
+  });
+
+  it("popLastExchange returns null when empty", () => {
+    const mgr = new ConversationManager(defaultContextConfig);
+    expect(mgr.popLastExchange()).toBeNull();
+  });
+
   it("seeded exchanges participate in normal retention", () => {
     const config: ContextConfig = { ...defaultContextConfig, retention_exchanges: 2 };
     const mgr = new ConversationManager(config);

--- a/src/context/conversation.ts
+++ b/src/context/conversation.ts
@@ -69,6 +69,11 @@ export class ConversationManager {
     return this.exchanges.length;
   }
 
+  /** Remove and return the last exchange (for /retry). Returns null if empty. */
+  popLastExchange(): ConversationExchange | null {
+    return this.exchanges.pop() ?? null;
+  }
+
   /** Clear all exchanges (e.g. on scene transition) */
   clear(): void {
     this.exchanges = [];

--- a/src/phases/PlayingPhase.tsx
+++ b/src/phases/PlayingPhase.tsx
@@ -106,7 +106,14 @@ export function PlayingPhase() {
 
   // --- Submit handler for TextInput ---
   const handleSubmit = useCallback((value: string) => {
-    if (!value.trim()) return;
+    // Empty Enter retries the last failed DM turn (if one is pending)
+    if (!value.trim()) {
+      if (engineRef.current?.hasPendingRetry()) {
+        engineRef.current.retryLastTurn();
+        clearInput();
+      }
+      return;
+    }
     const text = value.trim();
 
     if (trySlashCommand(text, {

--- a/src/tui/hooks/useGameCallbacks.ts
+++ b/src/tui/hooks/useGameCallbacks.ts
@@ -263,11 +263,15 @@ export function useGameCallbacks(deps: GameCallbackDeps): GameCallbackResult {
       // Rollback-complete errors are handled via TUI command — not a real error
       if (error instanceof RollbackCompleteError) return;
       setErrorMsg(error.message);
-      setNarrativeLines((prev) => [
-        ...prev,
+      const lines: NarrativeLine[] = [
         { kind: "system", text: `[Error: ${error.message}]` },
         { kind: "system", text: "[Debug info saved to .debug/ folder]" },
-      ]);
+      ];
+      // If the engine stored the failed input, prompt the player to retry
+      if (engineRef.current?.hasPendingRetry()) {
+        lines.push({ kind: "system", text: "[Press Enter to retry]" });
+      }
+      setNarrativeLines((prev) => [...prev, ...lines]);
     },
     onRetry(status: number, delayMs: number) {
       const delaySec = Math.ceil(delayMs / 1000);


### PR DESCRIPTION
## Summary

- When a non-retryable API error occurs, the engine stores the failed input and shows `[Press Enter to retry]` — empty Enter replays the last DM turn
- Adds `/retry` slash command: pops the last exchange from conversation history and replays it, useful for recovering from garbled output or tool loops
- Adds `ConversationManager.popLastExchange()` and `GameEngine.hasPendingRetry()` / `retryLastTurn()` / `retryLastExchange()` public methods

## Test plan

- [x] `npm run check` passes (lint + 1923 tests + coverage)
- [ ] Verify enter-to-retry: trigger a non-retryable API error (e.g. invalid key), confirm `[Press Enter to retry]` appears, press Enter, confirm turn replays
- [ ] Verify `/retry` during normal play: after a DM response, type `/retry`, confirm last exchange is popped and replayed
- [ ] Verify `/retry` after error: confirm it retries the failed input (same as Enter)
- [ ] Verify `/retry` with empty history: confirm `[Nothing to retry]` message

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)