### PR TITLE
Sign Windows binary with Azure Trusted Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -80,6 +81,27 @@ jobs:
 
           # License
           if [ -f LICENSE ]; then cp LICENSE dist/; fi
+
+      - name: Sign Windows binary
+        if: matrix.os == 'windows-latest'
+        uses: azure/trusted-signing-action@v0.5.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          endpoint: https://wus2.codesigning.azure.net
+          signing-account-name: mvcodesigning
+          certificate-profile-name: mv-public-trust
+          files: ${{ github.workspace }}/dist/machine-violet.exe
+          exclude-environment-credential: true
+          exclude-workload-identity-credential: false
+          exclude-managed-identity-credential: true
+          exclude-shared-token-cache-credential: true
+          exclude-visual-studio-credential: true
+          exclude-visual-studio-code-credential: true
+          exclude-azure-cli-credential: true
+          exclude-azure-powershell-credential: true
+          exclude-azure-developer-cli-credential: true
+          exclude-interactive-browser-credential: true
 
       - name: Package (zip)
         if: matrix.archive == 'zip'


### PR DESCRIPTION
## Summary
- Adds Authenticode signing step to the Release workflow for the Windows binary
- Uses `azure/trusted-signing-action` with OIDC workload identity federation (passwordless)
- Signing happens before packaging so the zip ships with a signed `machine-violet.exe`
- Adds `id-token: write` permission required for OIDC

## Test plan
- [ ] Trigger a release and verify the Windows zip contains a signed binary
- [ ] Verify macOS and Linux builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)