### PR TITLE
Add id-token permission to cut-release workflow

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   tag:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` to `cut-release.yml` permissions
- Required because the called `release.yml` now needs OIDC tokens for Azure Trusted Signing

## Test plan
- [ ] Run Cut Release workflow (dry run) and verify it validates without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)