### PR TITLE
Fix Windows build flags word-splitting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,15 @@ jobs:
             EXE_NAME="machine-violet.exe"
           fi
 
-          # Windows-specific flags
-          WIN_FLAGS=""
+          # Windows-specific flags (use array to preserve quoting)
+          WIN_FLAGS=()
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            WIN_FLAGS="--windows-icon=assets/machine-violet.ico --windows-title=Machine\ Violet --windows-description=AI\ Dungeon\ Master\ for\ tabletop\ RPGs --windows-version=${VERSION}.0"
+            WIN_FLAGS=(
+              "--windows-icon=assets/machine-violet.ico"
+              "--windows-title=Machine Violet"
+              "--windows-description=AI Dungeon Master for tabletop RPGs"
+              "--windows-version=${VERSION}.0"
+            )
           fi
 
           # Compile
@@ -68,7 +73,7 @@ jobs:
             --target=${{ matrix.target }} \
             --outfile "dist/$EXE_NAME" \
             --define "process.env.MV_VERSION='$VERSION'" \
-            $WIN_FLAGS \
+            "${WIN_FLAGS[@]}" \
             src/index.tsx
 
           # Copy assets


### PR DESCRIPTION
## Summary
- `WIN_FLAGS` was a plain string with backslash-escaped spaces (`Machine\ Violet`)
- On `$WIN_FLAGS` expansion, bash word-splits it — bun receives `Violet`, `Dungeon\`, `Master\`, etc. as separate entry points
- Switches to a bash array + `"${WIN_FLAGS[@]}"` expansion, which preserves spaces in each flag correctly

## Test plan
- [ ] Cut a release and verify the Windows build succeeds
- [ ] Verify the built `.exe` has the correct title/description metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)