### PR TITLE
Update trusted-signing-action to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Sign Windows binary
         if: matrix.os == 'windows-latest'
-        uses: azure/trusted-signing-action@v0.5.0
+        uses: azure/trusted-signing-action@v1
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- Bumps `azure/trusted-signing-action` from `v0.5.0` to `v1` (unpinned to major)
- v0.5.0 doesn't have the `signing-account-name` input (it uses `code-signing-account-name`), causing the signing step to fail
- v1 is the current stable release and supports `signing-account-name`

## Test plan
- [ ] Cut a release and verify the signing step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)