### PR TITLE
Pass secrets to release workflow from cut-release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -78,5 +78,6 @@ jobs:
     needs: tag
     if: ${{ !inputs.dry_run }}
     uses: ./.github/workflows/release.yml
+    secrets: inherit
     with:
       tag: ${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
## Summary
- Adds `secrets: inherit` to the `workflow_call` invocation in `cut-release.yml`
- Without this, `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` are empty in the called workflow, causing `WorkloadIdentityCredential authentication unavailable`

## Test plan
- [ ] Run Cut Release and verify the signing step authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)