### PR TITLE
Use azure/login for OIDC before signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,23 +87,29 @@ jobs:
           # License
           if [ -f LICENSE ]; then cp LICENSE dist/; fi
 
+      - name: Azure login (OIDC)
+        if: matrix.os == 'windows-latest'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Sign Windows binary
         if: matrix.os == 'windows-latest'
         uses: azure/trusted-signing-action@v1
         with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           endpoint: https://wus2.codesigning.azure.net
           signing-account-name: mvcodesigning
           certificate-profile-name: mv-public-trust
           files: ${{ github.workspace }}/dist/machine-violet.exe
           exclude-environment-credential: true
-          exclude-workload-identity-credential: false
+          exclude-workload-identity-credential: true
           exclude-managed-identity-credential: true
           exclude-shared-token-cache-credential: true
           exclude-visual-studio-credential: true
           exclude-visual-studio-code-credential: true
-          exclude-azure-cli-credential: true
+          exclude-azure-cli-credential: false
           exclude-azure-powershell-credential: true
           exclude-azure-developer-cli-credential: true
           exclude-interactive-browser-credential: true


### PR DESCRIPTION
## Summary
- Adds `azure/login@v2` step before `trusted-signing-action` to handle the OIDC token exchange explicitly
- Switches the signing action from `WorkloadIdentityCredential` to `AzureCliCredential` (which picks up the session from `azure/login`)
- Removes `azure-tenant-id`/`azure-client-id` from the signing action inputs (no longer needed — `az` is already authenticated)

The `WorkloadIdentityCredential` path requires `ACTIONS_ID_TOKEN_REQUEST_URL` to be injected into the composite action's environment, which wasn't happening reliably. `azure/login` handles the OIDC exchange at the job step level where `id-token: write` is effective, then the signing action just uses the authenticated `az` session.

## Test plan
- [ ] Cut a release and verify the signing step authenticates and signs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)