### PR TITLE
Add Homebrew tap auto-update to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,3 +151,74 @@ jobs:
           tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: machine-violet-*
+
+  update-homebrew:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+
+          # Download tarballs and compute SHA256
+          DARWIN_URL="https://github.com/octopollux/machine-violet/releases/download/${TAG}/machine-violet-${VERSION}-darwin-arm64.tar.gz"
+          LINUX_URL="https://github.com/octopollux/machine-violet/releases/download/${TAG}/machine-violet-${VERSION}-linux-x64.tar.gz"
+
+          DARWIN_SHA=$(curl -fsSL "$DARWIN_URL" | sha256sum | cut -d' ' -f1)
+          LINUX_SHA=$(curl -fsSL "$LINUX_URL" | sha256sum | cut -d' ' -f1)
+
+          # Clone tap repo
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/octopollux/homebrew-mv-tap.git" tap
+          cd tap
+
+          # Generate updated formula
+          cat > Formula/machine-violet.rb << 'FORMULA'
+          class MachineViolet < Formula
+            desc "AI Dungeon Master for tabletop RPGs"
+            homepage "https://github.com/octopollux/machine-violet"
+            version "VERSION_PLACEHOLDER"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/octopollux/machine-violet/releases/download/vVERSION_PLACEHOLDER/machine-violet-VERSION_PLACEHOLDER-darwin-arm64.tar.gz"
+                sha256 "DARWIN_SHA_PLACEHOLDER"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "https://github.com/octopollux/machine-violet/releases/download/vVERSION_PLACEHOLDER/machine-violet-VERSION_PLACEHOLDER-linux-x64.tar.gz"
+                sha256 "LINUX_SHA_PLACEHOLDER"
+              end
+            end
+
+            def install
+              libexec.install "machine-violet"
+              libexec.install "prompts" if Dir.exist?("prompts")
+              libexec.install "themes" if Dir.exist?("themes")
+              libexec.install "systems" if Dir.exist?("systems")
+
+              chmod 0755, libexec/"machine-violet"
+              bin.write_exec_script libexec/"machine-violet"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/machine-violet --version")
+            end
+          end
+          FORMULA
+
+          sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" Formula/machine-violet.rb
+          sed -i "s/DARWIN_SHA_PLACEHOLDER/${DARWIN_SHA}/g" Formula/machine-violet.rb
+          sed -i "s/LINUX_SHA_PLACEHOLDER/${LINUX_SHA}/g" Formula/machine-violet.rb
+          sed -i 's/^          //' Formula/machine-violet.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/machine-violet.rb
+          git commit -m "Update machine-violet to ${VERSION}"
+          git push


### PR DESCRIPTION
## Summary
- Adds `update-homebrew` job to the release workflow, runs after the GitHub Release is created
- Downloads the macOS and Linux tarballs, computes SHA256 hashes, and pushes an updated formula to [octopollux/homebrew-mv-tap](https://github.com/octopollux/homebrew-mv-tap)
- Users can install via: `brew install octopollux/mv-tap/machine-violet`

## Setup required
Create a **GitHub PAT** (fine-grained, scoped to `homebrew-mv-tap` with Contents read/write) and add it as a secret:
```
gh secret set HOMEBREW_TAP_TOKEN --repo octopollux/machine-violet
```

## Test plan
- [ ] Create the PAT and set the secret
- [ ] Cut a release and verify the formula is updated in homebrew-mv-tap
- [ ] `brew tap octopollux/mv-tap && brew install machine-violet` on macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)