### PR TITLE
Add security policy and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Describe the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Start a new campaign with...
+        2. Do this...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - Homebrew
+        - Install script
+        - Built from source
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `machine-violet --version`
+      placeholder: "1.0.1-nightly.20260317"
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal
+      description: Which terminal are you using?
+      placeholder: "Windows Terminal, iTerm2, Alacritty, etc."
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output / logs
+      description: Paste any relevant error messages or terminal output.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord
+    url: https://discord.gg/dDbGZrecvX
+    about: Chat with us on Discord for questions, feedback, and game talk.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest an idea or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like?
+      description: A clear description of the feature or improvement.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why?
+      description: What problem does this solve, or what does it enable?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or considered other approaches?
+    validations:
+      required: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Machine Violet, please report it privately using [GitHub's security advisory feature](https://github.com/octopollux/machine-violet/security/advisories/new).
+
+**Do not open a public issue for security vulnerabilities.**
+
+You should receive an initial response within 72 hours. We'll work with you to understand the issue and coordinate a fix before any public disclosure.
+
+## Scope
+
+Machine Violet runs locally and connects to the Anthropic API. Security concerns we care about include:
+
+- **API key exposure** — leaking the user's Anthropic API key through logs, error messages, or network requests to unintended destinations.
+- **Arbitrary code execution** — ways that game content, campaign files, or crafted input could execute unintended code on the user's machine.
+- **File system access** — reads or writes outside the expected campaign directory or application data paths.
+- **Dependency vulnerabilities** — known CVEs in dependencies that are reachable in our usage.
+
+## Out of Scope
+
+- AI model behavior (prompt injection, jailbreaks) — these are Anthropic API concerns, not application vulnerabilities.
+- Denial of service against the local process.


### PR DESCRIPTION
## Summary
- **SECURITY.md** — private vulnerability reporting via GitHub advisories, scoped to API key exposure, arbitrary code execution, file system access, and dependency CVEs
- **Bug report template** — structured form with platform, install method, version, terminal, and error output fields
- **Feature request template** — description, motivation, alternatives
- **Issue config** — links Discord for general questions, allows blank issues

## Test plan
- [ ] Click "New Issue" on the repo and verify templates appear
- [ ] Verify "Security" tab shows the policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)