### PR TITLE
Make hp_change deltas system-agnostic (#181)

### DIFF
--- a/src/agents/game-engine.test.ts
+++ b/src/agents/game-engine.test.ts
@@ -1626,3 +1626,58 @@ describe("cross-mode resource dispatch: Engine + Dev Mode share singleton", () =
     // not via the registry callback. The TUI command triggers setResources → effect → persist.
   });
 });
+
+describe("applyResolutionDeltas — system-agnostic hp_change", () => {
+  it("uses resource key from delta when present", async () => {
+    const state = mockState();
+    state.displayResources["Goblin"] = ["Hull Integrity"];
+    state.resourceValues["Goblin"] = { "Hull Integrity": "50" };
+
+    const client = mockClient([textMessage("ok")]);
+    const { callbacks } = mockCallbacks();
+    const engine = new GameEngine({
+      client, gameState: state, scene: mockScene(),
+      sessionState: mockSessionState(), fileIO: mockFileIO(), callbacks,
+    });
+
+    const applyDeltas = (engine as unknown as { applyResolutionDeltas: (d: unknown[]) => void }).applyResolutionDeltas.bind(engine);
+    applyDeltas([{ type: "hp_change", target: "Goblin", details: { resource: "Hull Integrity", amount: -15 } }]);
+
+    expect(state.resourceValues["Goblin"]["Hull Integrity"]).toBe("35");
+  });
+
+  it("falls back to first displayResource key when delta has no resource", async () => {
+    const state = mockState();
+    state.displayResources["Kael"] = ["Vitality", "Mana"];
+    state.resourceValues["Kael"] = { Vitality: "100", Mana: "50" };
+
+    const client = mockClient([textMessage("ok")]);
+    const { callbacks } = mockCallbacks();
+    const engine = new GameEngine({
+      client, gameState: state, scene: mockScene(),
+      sessionState: mockSessionState(), fileIO: mockFileIO(), callbacks,
+    });
+
+    const applyDeltas = (engine as unknown as { applyResolutionDeltas: (d: unknown[]) => void }).applyResolutionDeltas.bind(engine);
+    applyDeltas([{ type: "hp_change", target: "Kael", details: { amount: -20 } }]);
+
+    expect(state.resourceValues["Kael"]["Vitality"]).toBe("80");
+    expect(state.resourceValues["Kael"]["Mana"]).toBe("50"); // untouched
+  });
+
+  it("falls back to 'hp' when no displayResources and no resource in delta", async () => {
+    const state = mockState();
+    const client = mockClient([textMessage("ok")]);
+    const { callbacks } = mockCallbacks();
+    const engine = new GameEngine({
+      client, gameState: state, scene: mockScene(),
+      sessionState: mockSessionState(), fileIO: mockFileIO(), callbacks,
+    });
+
+    const applyDeltas = (engine as unknown as { applyResolutionDeltas: (d: unknown[]) => void }).applyResolutionDeltas.bind(engine);
+    applyDeltas([{ type: "hp_change", target: "Goblin", details: { amount: -5 } }]);
+
+    // No displayResources, no resource in delta → falls back to "hp"
+    expect(state.resourceValues["Goblin"]["hp"]).toBe("-5");
+  });
+});

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -1334,9 +1334,14 @@ export class GameEngine {
           const values = this.gameState.resourceValues[target];
           if (delta.type === "hp_change") {
             const amount = delta.details.amount as number;
-            const currentStr = values.hp ?? "0";
+            // Use the resource key from the delta (system-agnostic), or fall back
+            // to the first display resource for backward compat with old deltas.
+            const key = (delta.details.resource as string | undefined)
+              ?? this.gameState.displayResources[target]?.[0]
+              ?? "hp";
+            const currentStr = values[key] ?? "0";
             const current = parseInt(currentStr, 10) || 0;
-            values.hp = String(current + amount);
+            values[key] = String(current + amount);
           } else {
             const resource = delta.details.resource as string;
             if (delta.details.remaining !== undefined) {
@@ -1395,7 +1400,8 @@ export class GameEngine {
       if (delta.type === "hp_change") {
         const amt = delta.details.amount as number;
         const sign = amt >= 0 ? "+" : "";
-        lines.push(`<color=${muteColor}>${delta.target} HP ${sign}${amt}</color>`);
+        const key = (delta.details.resource as string | undefined) ?? "HP";
+        lines.push(`<color=${muteColor}>${delta.target} ${key} ${sign}${amt}</color>`);
       } else if (delta.type === "condition_add") {
         lines.push(`<color=${muteColor}>${delta.target}: +${delta.details.condition}</color>`);
       } else if (delta.type === "condition_remove") {

--- a/src/agents/resolve-xml.test.ts
+++ b/src/agents/resolve-xml.test.ts
@@ -13,7 +13,7 @@ describe("parseResolutionXml", () => {
     <roll expr="2d8" reason="Divine Smite (2nd level)" result="11" detail="[6,5]=11"/>
   </rolls>
   <deltas>
-    <delta type="hp_change" target="dragon" amount="-24" damage_type="slashing+radiant"/>
+    <delta type="hp_change" target="dragon" resource="HP" amount="-24" damage_type="slashing+radiant"/>
     <delta type="resource_spend" target="Kael" resource="spell_slots_2nd" spent="1" remaining="2"/>
   </deltas>
 </resolution>`;
@@ -38,7 +38,7 @@ describe("parseResolutionXml", () => {
     expect(result!.deltas[0]).toEqual({
       type: "hp_change",
       target: "dragon",
-      details: { amount: -24, damage_type: "slashing+radiant" },
+      details: { resource: "HP", amount: -24, damage_type: "slashing+radiant" },
     });
     expect(result!.deltas[1]).toEqual({
       type: "resource_spend",

--- a/src/prompts/resolve-session.md
+++ b/src/prompts/resolve-session.md
@@ -31,7 +31,7 @@ After resolving, end your response with a `<resolution>` XML block:
     <roll expr="1d20+7" reason="Attack roll" result="23" detail="[16]+7=23"/>
   </rolls>
   <deltas>
-    <delta type="hp_change" target="goblin" amount="-12" damage_type="slashing"/>
+    <delta type="hp_change" target="goblin" resource="HP" amount="-12" damage_type="slashing"/>
     <delta type="resource_spend" target="Kael" resource="spell_slots_2nd" spent="1" remaining="2"/>
     <delta type="condition_add" target="goblin" condition="prone" duration="until end of next turn"/>
     <delta type="condition_remove" target="Kael" condition="frightened"/>
@@ -41,7 +41,7 @@ After resolving, end your response with a `<resolution>` XML block:
 ```
 
 ### Delta types
-- `hp_change`: `amount` (negative=damage, positive=healing), optional `damage_type`, `current`, `max`
+- `hp_change`: `resource` (the health resource key from the character's tracked resources, e.g. "HP", "Hull Integrity"), `amount` (negative=damage, positive=healing), optional `damage_type`, `current`, `max`
 - `condition_add`: `condition`, optional `duration`, `source`
 - `condition_remove`: `condition`
 - `resource_spend`: `resource`, `spent`, optional `remaining`


### PR DESCRIPTION
## Summary

- `hp_change` deltas hardcoded the resource key `"hp"`, but the DM sets arbitrary names per game system (e.g., "HP", "Hull Integrity", "Vitality")
- The resolve subagent prompt now includes a `resource` attribute on `hp_change` deltas
- `applyResolutionDeltas` uses a three-level fallback: `delta.details.resource` → first `displayResources` key → `"hp"`
- `emitResolutionToPlayer` displays the actual resource name instead of hardcoded "HP"

## Test plan

- [x] `npm run check` passes (pre-existing flaky tests only)
- [x] New test: `hp_change` with explicit resource key updates correct value
- [x] New test: fallback to first `displayResources` key when delta has no resource
- [x] New test: ultimate fallback to `"hp"` when no display resources exist
- [x] Updated resolve-xml parsing test to include `resource` attribute

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)