### PR TITLE
Fix Windows first-launch experience: config paths + auto-upgrade to Windows Terminal

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Text, Box, useInput } from "ink";
 import Anthropic from "@anthropic-ai/sdk";
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile, appendFile, mkdir, readdir, stat, unlink, rmdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 
@@ -56,7 +56,7 @@ import { listAvailableSystems, readBundledRuleCard } from "./config/systems.js";
 import type { AvailableSystem } from "./config/systems.js";
 import { promoteCharacter } from "./agents/subagents/character-promotion.js";
 import { processingPaths } from "./config/processing-paths.js";
-import { norm } from "./utils/paths.js";
+import { norm, isCompiled } from "./utils/paths.js";
 import { GameProvider } from "./tui/game-context.js";
 import type { GameContextValue } from "./tui/game-context.js";
 
@@ -381,7 +381,9 @@ export default function App({ shutdownRef }: AppProps) {
 
 
   // --- Config paths ---
-  const getAppDir = useCallback(() => process.cwd(), []);
+  // Compiled binaries store config next to the exe (stable location);
+  // dev mode uses cwd (the repo root).
+  const getAppDir = useCallback(() => isCompiled() ? dirname(process.execPath) : process.cwd(), []);
   const getConfigPath = useCallback(() => join(getAppDir(), "config.json"), [getAppDir]);
 
   // --- Load campaigns and systems ---
@@ -443,7 +445,11 @@ export default function App({ shutdownRef }: AppProps) {
   /** Handle store updates from the ApiKeysPhase (or anywhere). */
   const handleUpdateKeyStore = useCallback((updated: ApiKeyStore) => {
     setKeyStore(updated);
-    saveKeyStore(getAppDir(), updated);
+    try {
+      saveKeyStore(getAppDir(), updated);
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : "Failed to save API key store");
+    }
 
     // Sync active key to process.env
     const activeVal = getActiveKeyValue(updated);
@@ -501,9 +507,7 @@ export default function App({ shutdownRef }: AppProps) {
       readFileSync(configPath, "utf-8");
     } catch {
       // First launch — create config.json with defaults
-      const appDir = getAppDir();
       try {
-        mkdirSync(appDir, { recursive: true });
         writeFileSync(configPath, buildAppConfig(getDefaultHomeDir()));
       } catch (e) {
         setErrorMsg(e instanceof Error ? e.message : "Failed to write config");


### PR DESCRIPTION
## Summary

Two fixes for the Windows compiled binary experience, reported by first playtester:

**Config path fix:** `getAppDir()` returned `process.cwd()` for compiled binaries — wherever the user launched from (e.g., Desktop). First-launch `mkdirSync` on Windows special folders failed with EEXIST, and the API key couldn't be saved. Now uses `dirname(process.execPath)` for compiled builds, matching `loadEnv()`'s existing logic.

**Auto-upgrade to Windows Terminal:** When launched in bare cmd.exe/conhost (no emoji, limited formatting), the exe detects this and re-launches itself inside Windows Terminal — either the system `wt.exe` or a bundled portable copy (Windows Terminal 1.24, ~10MB). The original conhost window closes; the user sees a proper WT window. Detection is narrow: only upgrades from cmd.exe, not from PowerShell 7, Git Bash, or other modern terminals. Opt out with `--no-wt`.

## Commits

1. **Fix compiled binary config path** — `dirname(process.execPath)` for compiled builds, remove unnecessary `mkdirSync`, add try/catch on `saveKeyStore`
2. **Auto-upgrade from cmd.exe to Windows Terminal** — detection logic in `terminal-check.ts`, bundled WT portable in nightly/release workflows

## Test plan

- [x] `npm run check` passes (pre-existing flaky tests only)
- [x] Dev mode still uses `process.cwd()` — no behavior change
- [ ] Nightly build: Windows zip includes `terminal/` directory with portable WT
- [ ] Double-click exe from Desktop → opens in Windows Terminal (bundled or system)
- [ ] Run from existing cmd.exe → re-launches in WT, original prompt returns
- [ ] Run from PowerShell 7 / Git Bash → no upgrade, runs directly
- [ ] `--no-wt` flag prevents upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)