### PR TITLE
Dev mode defaults to ON from source, OFF in builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Anthropic API Key for Claude SDK
 ANTHROPIC_API_KEY=your_api_key_here
 
-# Dev Mode — shows tool calls, subagent activity, and file I/O in the narrative
+# Dev Mode — shows tool calls, subagent activity, and file I/O in the narrative.
+# Defaults to ON when running from source, OFF in compiled binaries.
+# Set explicitly to override: DEV_MODE=true or DEV_MODE=false
 # DEV_MODE=true

--- a/src/config/context-dump.test.ts
+++ b/src/config/context-dump.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 describe("dumpContext", () => {
   it("is a no-op when dev mode is off", async () => {
     const { writeFile } = await import("node:fs/promises");
-    delete process.env.DEV_MODE;
+    process.env.DEV_MODE = "false";
     resetDevMode();
     setContextDumpDir("/tmp/test-dump");
 
@@ -124,7 +124,7 @@ describe("dumpThinking", () => {
   it("is a no-op when dev mode is off", async () => {
     const { writeFile } = await import("node:fs/promises");
     (writeFile as ReturnType<typeof vi.fn>).mockClear();
-    delete process.env.DEV_MODE;
+    process.env.DEV_MODE = "false";
     resetDevMode();
     setContextDumpDir("/tmp/test-dump");
 

--- a/src/config/dev-mode.test.ts
+++ b/src/config/dev-mode.test.ts
@@ -1,17 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { isDevMode, resetDevMode, wrapFileIOWithDevLog } from "./dev-mode.js";
 import type { FileIO } from "../agents/scene-manager.js";
+import * as paths from "../utils/paths.js";
 
 describe("isDevMode", () => {
   beforeEach(() => resetDevMode());
   afterEach(() => {
     delete process.env.DEV_MODE;
     resetDevMode();
-  });
-
-  it("returns false when DEV_MODE is not set", () => {
-    delete process.env.DEV_MODE;
-    expect(isDevMode()).toBe(false);
+    vi.restoreAllMocks();
   });
 
   it("returns true when DEV_MODE is 'true'", () => {
@@ -19,9 +16,34 @@ describe("isDevMode", () => {
     expect(isDevMode()).toBe(true);
   });
 
-  it("returns false for other values", () => {
-    process.env.DEV_MODE = "1";
+  it("returns false when DEV_MODE is 'false'", () => {
+    process.env.DEV_MODE = "false";
     expect(isDevMode()).toBe(false);
+  });
+
+  it("returns false for non-boolean values like '1'", () => {
+    process.env.DEV_MODE = "1";
+    // Not "true" or "false", so falls through to isCompiled() check
+    vi.spyOn(paths, "isCompiled").mockReturnValue(true);
+    expect(isDevMode()).toBe(false);
+  });
+
+  it("defaults to true when running from source (not compiled)", () => {
+    delete process.env.DEV_MODE;
+    vi.spyOn(paths, "isCompiled").mockReturnValue(false);
+    expect(isDevMode()).toBe(true);
+  });
+
+  it("defaults to false when running as compiled binary", () => {
+    delete process.env.DEV_MODE;
+    vi.spyOn(paths, "isCompiled").mockReturnValue(true);
+    expect(isDevMode()).toBe(false);
+  });
+
+  it("explicit env var overrides compiled status", () => {
+    process.env.DEV_MODE = "true";
+    vi.spyOn(paths, "isCompiled").mockReturnValue(true);
+    expect(isDevMode()).toBe(true);
   });
 
   it("caches the result", () => {

--- a/src/config/dev-mode.ts
+++ b/src/config/dev-mode.ts
@@ -1,14 +1,23 @@
 import type { FileIO } from "../agents/scene-manager.js";
+import { isCompiled } from "../utils/paths.js";
 
 let cached: boolean | null = null;
 
 /**
- * Check if dev mode is active (DEV_MODE=true in .env).
+ * Check if dev mode is active.
+ *
+ * Priority:
+ * 1. Explicit `DEV_MODE=true` or `DEV_MODE=false` env var wins.
+ * 2. Otherwise, dev mode is ON when running from source, OFF in compiled binaries.
+ *
  * Result is cached after first call.
  */
 export function isDevMode(): boolean {
   if (cached !== null) return cached;
-  cached = process.env.DEV_MODE === "true";
+  const env = process.env.DEV_MODE;
+  if (env === "true") cached = true;
+  else if (env === "false") cached = false;
+  else cached = !isCompiled();
   return cached;
 }
 


### PR DESCRIPTION
## Summary
- `isDevMode()` now defaults to `!isCompiled()` — ON when running from source (tsx/node), OFF in bun-compiled binaries
- Explicit `DEV_MODE=true` or `DEV_MODE=false` env var overrides in either direction
- Playtesters get clean builds without dev tooling; devs keep it automatically

## Test plan
- [x] `dev-mode.test.ts` updated with cases for compiled vs source defaults and explicit overrides
- [x] `context-dump.test.ts` fixed to use explicit `DEV_MODE=false` instead of relying on unset default
- [x] Full test suite passes (1975/1976 — 1 pre-existing flaky Ink render test)
- [ ] Smoke test: `npm run dev` shows dev mode active
- [ ] Smoke test: `npm run dist` binary does not show dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)