### PR TITLE
Strip stale Authenticode signature from Node SEA binary (#209)

### DIFF
--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -85,6 +85,21 @@ if (existsSync(exePath)) rmSync(exePath);
 execSync(`node --build-sea dist/sea-config.json`, { stdio: "inherit", cwd: ROOT });
 rmSync(seaConfigPath, { force: true });
 
+// Strip the existing Authenticode signature from the SEA binary.
+// node.exe ships pre-signed by Microsoft; --build-sea invalidates that
+// signature by modifying the binary. The stale signature must be removed
+// before re-signing (e.g. via Velopack + Azure Trusted Signing) or
+// signtool will fail with 0x800700C1 (ERROR_BAD_EXE_FORMAT).
+if (isWindows) {
+  try {
+    execSync(`signtool remove /s "${exePath}"`, { stdio: "inherit" });
+    console.log("  Stripped existing Authenticode signature.");
+  } catch {
+    // signtool not on PATH (local dev without Windows SDK) — skip silently.
+    // CI runners have it; local builds don't need signing.
+  }
+}
+
 // --- Step 3: Windows metadata via rcedit ---
 if (isWindows) {
   const icoPath = join(ROOT, "assets", "machine-violet.ico");


### PR DESCRIPTION
## Summary

Follow-up to #212. Fixes the signing failure (`0x800700C1 ERROR_BAD_EXE_FORMAT`) in the release/nightly workflows.

- `node.exe` ships pre-signed by Microsoft. `--build-sea` injects the app blob, invalidating that signature.
- Azure Trusted Signing (via Velopack) then fails trying to sign over the corrupted old signature.
- Fix: call `signtool remove /s` after `--build-sea` to strip the stale signature before any downstream signing or PE modification (rcedit).
- Silently skipped when signtool isn't on PATH (local dev without Windows SDK).

## Test plan
- [ ] Nightly workflow signing succeeds
- [x] Local build completes (signtool skip is silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)