### PR TITLE
Use multi-step SEA workflow for signing compatibility (#209)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "esbuild": "^0.27.4",
         "eslint": "^10.0.0",
         "ink-testing-library": "^4.0.0",
+        "postject": "^1.0.0-alpha.6",
         "rcedit": "^5.0.2",
         "react-devtools-core": "^7.0.1",
         "tsx": "^4.7.0",
@@ -2875,6 +2876,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -5619,6 +5630,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "esbuild": "^0.27.4",
     "eslint": "^10.0.0",
     "ink-testing-library": "^4.0.0",
+    "postject": "^1.0.0-alpha.6",
     "rcedit": "^5.0.2",
     "react-devtools-core": "^7.0.1",
     "tsx": "^4.7.0",

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -2,11 +2,14 @@
 /**
  * Build script for Machine Violet distribution.
  *
- * Bundles with esbuild, creates a Node SEA executable, applies Windows
- * metadata via rcedit, and assembles asset directories alongside the binary.
+ * Bundles with esbuild, creates a Node SEA executable via the multi-step
+ * workflow (copy → strip signature → generate blob → inject), applies
+ * Windows metadata via rcedit, and assembles asset directories alongside
+ * the binary.
  *
  * Usage:
- *   node scripts/build-dist.js                  # build for current platform
+ *   node scripts/build-dist.js                          # build for current platform
+ *   node scripts/build-dist.js --version=1.0.0-nightly  # override version
  */
 
 import { build } from "esbuild";
@@ -15,12 +18,13 @@ import {
   cpSync,
   existsSync,
   readFileSync,
+  readdirSync,
   writeFileSync,
   rmSync,
   statSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -34,6 +38,8 @@ const version = versionArg ? versionArg.split("=")[1] : pkg.version;
 
 const isWindows = process.platform === "win32";
 const exeName = isWindows ? "machine-violet.exe" : "machine-violet";
+const exePath = join(DIST, exeName);
+const blobPath = join(DIST, "sea-prep.blob");
 
 console.log(`Building Machine Violet v${version}...`);
 
@@ -65,63 +71,76 @@ await build({
   sourcemap: false,
 });
 
-// --- Step 2: Node SEA ---
-console.log("  Building Node SEA executable...");
+// --- Step 2: Node SEA (multi-step for signing compatibility) ---
+//
+// --build-sea produces a PE binary whose headers confuse signtool (the
+// injected blob invalidates the checksum/signature table). The traditional
+// workflow avoids this by stripping the Authenticode signature from a clean
+// copy of node.exe BEFORE injection, so signtool never sees a corrupt state.
+//
+//   a) Generate the blob
+//   b) Copy node.exe → dist/machine-violet.exe
+//   c) Strip Microsoft's Authenticode signature (Windows only)
+//   d) Inject the blob with postject
+
+console.log("  Generating SEA blob...");
 
 const seaConfig = {
   main: "dist/bundle.js",
-  output: `dist/${exeName}`,
+  output: "dist/sea-prep.blob",
   mainFormat: "module",
   disableExperimentalSEAWarning: true,
 };
-// Write sea-config to dist/ (temp file, cleaned up after build)
 const seaConfigPath = join(DIST, "sea-config.json");
 writeFileSync(seaConfigPath, JSON.stringify(seaConfig, null, 2));
 
-// Remove existing exe to avoid "file busy" errors
-const exePath = join(DIST, exeName);
-if (existsSync(exePath)) rmSync(exePath);
-
-execSync(`node --build-sea dist/sea-config.json`, { stdio: "inherit", cwd: ROOT });
+execSync(`node --experimental-sea-config dist/sea-config.json`, {
+  stdio: "inherit",
+  cwd: ROOT,
+});
 rmSync(seaConfigPath, { force: true });
 
-// Strip the existing Authenticode signature from the SEA binary.
-// node.exe ships pre-signed by Microsoft; --build-sea invalidates that
-// signature by modifying the binary. The stale signature must be removed
-// before re-signing (e.g. via Velopack + Azure Trusted Signing) or
-// signtool will fail with 0x800700C1 (ERROR_BAD_EXE_FORMAT).
+// Copy node binary
+console.log("  Copying node binary...");
+if (existsSync(exePath)) rmSync(exePath);
+cpSync(process.execPath, exePath);
+
+// Strip Authenticode signature on Windows before injection.
+// node.exe ships pre-signed by Microsoft. If we inject the blob first,
+// the stale signature makes the PE unsignable (0x800700C1) and rcedit
+// hangs indefinitely trying to modify a signed PE.
+let signatureStripped = false;
 if (isWindows) {
-  // signtool isn't on PATH by default — search Windows SDK locations
-  let signtool = "signtool";
-  const sdkBin = "C:\\Program Files (x86)\\Windows Kits\\10\\bin";
-  if (existsSync(sdkBin)) {
+  const signtool = findSigntool();
+  if (signtool) {
     try {
-      // Find the latest SDK version directory that contains signtool
-      const { readdirSync } = await import("node:fs");
-      const versions = readdirSync(sdkBin)
-        .filter((d) => d.match(/^10\.\d/))
-        .sort()
-        .reverse();
-      for (const ver of versions) {
-        const candidate = join(sdkBin, ver, "x64", "signtool.exe");
-        if (existsSync(candidate)) {
-          signtool = `"${candidate}"`;
-          break;
-        }
-      }
-    } catch { /* fall through to bare signtool */ }
-  }
-  try {
-    execSync(`${signtool} remove /s "${exePath}"`, { stdio: "inherit" });
-    console.log("  Stripped existing Authenticode signature.");
-  } catch {
-    // signtool not available — skip. Local dev doesn't need signing.
-    // If this fails on CI, Velopack signing will fail with 0x800700C1.
+      execFileSync(signtool, ["remove", "/s", exePath], { stdio: "inherit" });
+      signatureStripped = true;
+      console.log("  Stripped Authenticode signature.");
+    } catch {
+      console.warn("  Warning: signtool not available — skipping signature strip.");
+    }
+  } else {
+    console.warn("  Warning: signtool not found — skipping signature strip.");
   }
 }
 
+// Inject blob with postject
+console.log("  Injecting SEA blob...");
+const postjectBin = join(ROOT, "node_modules", ".bin", isWindows ? "postject.cmd" : "postject");
+execSync(
+  `"${postjectBin}" "${exePath}" NODE_SEA_BLOB "${blobPath}" --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`,
+  { stdio: "inherit", cwd: ROOT },
+);
+
+// Clean up blob
+rmSync(blobPath, { force: true });
+rmSync(join(DIST, "bundle.js"), { force: true });
+
 // --- Step 3: Windows metadata via rcedit ---
-if (isWindows) {
+// Only attempt rcedit if the signature was stripped (or not Windows).
+// rcedit hangs indefinitely on signed PEs — skip rather than block the build.
+if (isWindows && signatureStripped) {
   const icoPath = join(ROOT, "assets", "machine-violet.ico");
   if (existsSync(icoPath)) {
     console.log("  Applying Windows metadata (rcedit)...");
@@ -168,9 +187,34 @@ if (existsSync(licensePath)) {
 // Version file
 writeFileSync(join(DIST, "version.json"), JSON.stringify({ version }, null, 2));
 
-// Clean up bundle (not needed alongside the exe)
-rmSync(join(DIST, "bundle.js"), { force: true });
-
 console.log(`\nDone! Distribution in ${DIST}/`);
 console.log(`  Binary: ${exeName} (${(statSync(exePath).size / 1024 / 1024).toFixed(1)} MB)`);
 console.log(`  Version: ${version}`);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Find signtool.exe in the Windows SDK. Returns path or null. */
+function findSigntool() {
+  // Try PATH first
+  try {
+    execFileSync("signtool", ["/?"], { stdio: "ignore" });
+    return "signtool";
+  } catch { /* not on PATH */ }
+
+  // Search Windows SDK
+  const sdkBin = "C:\\Program Files (x86)\\Windows Kits\\10\\bin";
+  if (!existsSync(sdkBin)) return null;
+  try {
+    const versions = readdirSync(sdkBin)
+      .filter((d) => /^10\.\d/.test(d))
+      .sort()
+      .reverse();
+    for (const ver of versions) {
+      const candidate = join(sdkBin, ver, "x64", "signtool.exe");
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch { /* ignore */ }
+  return null;
+}


### PR DESCRIPTION
## Summary

Follow-up to #214. `--build-sea` produces a PE binary with a corrupted signature table that:
- Makes it unsignable by signtool (0x800700C1)
- Causes rcedit to hang indefinitely trying to modify the PE

Fix: switch to the traditional multi-step SEA workflow where we control the order:

1. **Generate blob** via `--experimental-sea-config` (blob only, no PE modification)
2. **Copy** `node.exe` → `dist/machine-violet.exe`
3. **Strip** Microsoft's Authenticode signature with `signtool remove /s` (clean PE)
4. **Inject** blob with `postject` (into an unsigned binary)

This way the PE is never in a "signed but modified" state. Velopack's Azure Trusted Signing can then sign a clean PE.

Adds `postject` as a dev dependency.

## Test plan
- [x] Local build completes (signtool/rcedit gracefully skipped without Windows SDK)
- [x] SEA exe runs and reports correct version
- [ ] CI signing succeeds on `windows-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)