### PR TITLE
Remove rcedit from SEA build (#209)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "eslint": "^10.0.0",
         "ink-testing-library": "^4.0.0",
         "postject": "^1.0.0-alpha.6",
-        "rcedit": "^5.0.2",
         "react-devtools-core": "^7.0.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3",
@@ -1085,29 +1084,6 @@
     "node_modules/@machine-violet/campaign-explorer": {
       "resolved": "tools/campaign-explorer",
       "link": true
-    },
-    "node_modules/@malept/cross-spawn-promise": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.80",
@@ -3004,31 +2980,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cross-spawn-windows-exe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
-      "integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@malept/cross-spawn-promise": "^1.1.0",
-        "is-wsl": "^2.2.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4197,22 +4148,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4307,19 +4242,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -5737,19 +5659,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rcedit": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-5.0.2.tgz",
-      "integrity": "sha512-dgysxaeXZ4snLpPjn8aVtHvZDCx+aRcvZbaWBgl1poU6OPustMvOkj9a9ZqASQ6i5Y5szJ13LSvglEOwrmgUxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn-windows-exe": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 22.12.0"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint": "^10.0.0",
     "ink-testing-library": "^4.0.0",
     "postject": "^1.0.0-alpha.6",
-    "rcedit": "^5.0.2",
     "react-devtools-core": "^7.0.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -107,18 +107,15 @@ cpSync(process.execPath, exePath);
 
 // Strip Authenticode signature on Windows before injection.
 // node.exe ships pre-signed by Microsoft. If we inject the blob first,
-// the stale signature makes the PE unsignable (0x800700C1) and rcedit
-// hangs indefinitely trying to modify a signed PE.
-let signatureStripped = false;
+// the stale signature makes the PE unsignable (0x800700C1).
 if (isWindows) {
   const signtool = findSigntool();
   if (signtool) {
     try {
       execFileSync(signtool, ["remove", "/s", exePath], { stdio: "inherit" });
-      signatureStripped = true;
       console.log("  Stripped Authenticode signature.");
     } catch {
-      console.warn("  Warning: signtool not available — skipping signature strip.");
+      console.warn("  Warning: signtool remove failed — signing may fail later.");
     }
   } else {
     console.warn("  Warning: signtool not found — skipping signature strip.");
@@ -137,34 +134,7 @@ execSync(
 rmSync(blobPath, { force: true });
 rmSync(join(DIST, "bundle.js"), { force: true });
 
-// --- Step 3: Windows metadata via rcedit ---
-// Only attempt rcedit if the signature was stripped (or not Windows).
-// rcedit hangs indefinitely on signed PEs — skip rather than block the build.
-if (isWindows && signatureStripped) {
-  const icoPath = join(ROOT, "assets", "machine-violet.ico");
-  if (existsSync(icoPath)) {
-    console.log("  Applying Windows metadata (rcedit)...");
-    try {
-      const { rcedit } = await import("rcedit");
-      await rcedit(exePath, {
-        icon: icoPath,
-        "version-string": {
-          ProductName: "Machine Violet",
-          FileDescription: "AI Dungeon Master for tabletop RPGs",
-          CompanyName: "Machine Violet",
-          LegalCopyright: "MIT License",
-        },
-        // file-version must be numeric (X.Y.Z.W) — strip any prerelease suffix
-        "file-version": `${version.replace(/-.*$/, "")}.0`,
-        "product-version": version,
-      });
-    } catch (err) {
-      console.warn(`  Warning: rcedit failed (${err instanceof Error ? err.message : String(err)}). Exe will lack icon/metadata.`);
-    }
-  }
-}
-
-// --- Step 4: Copy assets ---
+// --- Step 3: Copy assets ---
 const assets = [
   { src: "src/prompts", dest: "prompts" },
   { src: "src/tui/themes/assets", dest: "themes" },


### PR DESCRIPTION
## Summary

Follow-up to #215. rcedit hangs indefinitely on the Node SEA binary (even after signature stripping on CI), blocking the build.

Since Velopack already handles the installer icon via `--icon` and the exe Properties metadata is secondary, just remove rcedit entirely. The build pipeline is now: **esbuild → blob → copy node → strip signature → inject**.

Removes `rcedit` dev dependency (-113 lines net).

## Test plan
- [x] Local build completes without hanging
- [x] SEA exe runs correctly
- [ ] CI signing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)