### PR TITLE
UX polish: no desktop shortcut, release download links (#209)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,6 +109,7 @@ jobs:
             --packDir dist \
             --mainExe machine-violet.exe \
             --icon assets/machine-violet.ico \
+            --noDesktopShortcut \
             --azureTrustedSignFile assets/trusted-signing.json \
             --channel nightly \
             --outputDir velopack-out
@@ -152,10 +153,38 @@ jobs:
           git push --delete origin nightly 2>/dev/null || true
 
           # Create fresh nightly release
+          DATE=$(date -u +%Y-%m-%d)
+          cat > nightly-body.md << 'BODYEOF'
+          ## Download
+
+          ### Windows
+          | | File |
+          |---|---|
+          | **Installer** (recommended) | [`MachineViolet-nightly-Setup.exe`](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Setup.exe) |
+          | Portable (no install) | [`MachineViolet-nightly-Portable.zip`](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Portable.zip) |
+
+          ### macOS (Apple Silicon)
+          | | File |
+          |---|---|
+          | Tarball | [`machine-violet-nightly-darwin-arm64.tar.gz`](https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-darwin-arm64.tar.gz) |
+
+          ### Linux (x64)
+          | | File |
+          |---|---|
+          | Tarball | [`machine-violet-nightly-linux-x64.tar.gz`](https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-linux-x64.tar.gz) |
+
+          Also available via Homebrew: `brew install octopollux/mv-tap/machine-violet`
+
+          ---
+
+          Automated nightly build from `main`. **Not a stable release.**
+          BODYEOF
+          sed -i 's/^          //' nightly-body.md
+
           gh release create nightly \
             --repo ${{ github.repository }} \
-            --title "Nightly ($(date -u +%Y-%m-%d))" \
-            --notes "Automated nightly build from \`main\` at $(date -u +%Y-%m-%d). **Not a stable release.**" \
+            --title "Nightly ($DATE)" \
+            --notes-file nightly-body.md \
             --prerelease \
             --target main \
             MachineViolet-* \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
             --packDir dist \
             --mainExe machine-violet.exe \
             --icon assets/machine-violet.ico \
+            --noDesktopShortcut \
             --azureTrustedSignFile assets/trusted-signing.json \
             --outputDir velopack-out
 
@@ -147,11 +148,47 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
-          generate_release_notes: true
-          files: |
-            MachineViolet-*
-            machine-violet-*
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+
+          # Generate changelog from GitHub
+          CHANGELOG=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="$TAG" --jq '.body' 2>/dev/null || echo "")
+
+          cat > release-body.md << BODYEOF
+          ## Download
+
+          ### Windows
+          | | File |
+          |---|---|
+          | **Installer** (recommended) | [\`MachineViolet-Setup.exe\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Setup.exe) |
+          | Portable (no install) | [\`MachineViolet-Portable.zip\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Portable.zip) |
+
+          ### macOS (Apple Silicon)
+          | | File |
+          |---|---|
+          | Tarball | [\`machine-violet-${VERSION}-darwin-arm64.tar.gz\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/machine-violet-${VERSION}-darwin-arm64.tar.gz) |
+
+          ### Linux (x64)
+          | | File |
+          |---|---|
+          | Tarball | [\`machine-violet-${VERSION}-linux-x64.tar.gz\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/machine-violet-${VERSION}-linux-x64.tar.gz) |
+
+          Also available via Homebrew: \`brew install octopollux/mv-tap/machine-violet\`
+
+          ---
+
+          ${CHANGELOG}
+          BODYEOF
+          sed -i 's/^          //' release-body.md
+
+          gh release create "$TAG" \
+            --repo ${{ github.repository }} \
+            --title "Machine Violet ${VERSION}" \
+            --notes-file release-body.md \
+            MachineViolet-* \
+            machine-violet-* \
             releases.win.json


### PR DESCRIPTION
## Summary

Two installer UX improvements:

- **No desktop shortcut**: Adds `--noDesktopShortcut` to `vpk pack` in both release and nightly workflows. Start Menu shortcut is still created.
- **Download links in release notes**: Both release and nightly GitHub releases now include a structured download section with direct links organized by platform (Windows installer first, marked as recommended), plus Homebrew instructions. Release workflow switched from `softprops/action-gh-release` to `gh` CLI to combine the download section with auto-generated changelog.

## Test plan
- [ ] Nightly release body renders correctly with download table
- [ ] Next stable release includes changelog below the download section
- [ ] Fresh install does not create a desktop shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)