### PR TITLE
Fix Velopack shortcut flag in CI workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,7 +109,7 @@ jobs:
             --packDir dist \
             --mainExe machine-violet.exe \
             --icon assets/machine-violet.ico \
-            --noDesktopShortcut \
+            --shortcuts StartMenuRoot \
             --azureTrustedSignFile assets/trusted-signing.json \
             --channel nightly \
             --outputDir velopack-out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
             --packDir dist \
             --mainExe machine-violet.exe \
             --icon assets/machine-violet.ico \
-            --noDesktopShortcut \
+            --shortcuts StartMenuRoot \
             --azureTrustedSignFile assets/trusted-signing.json \
             --outputDir velopack-out
 


### PR DESCRIPTION
## Summary
- Replace invalid `--noDesktopShortcut` flag with `--shortcuts StartMenuRoot` in both `nightly.yml` and `release.yml`
- `--noDesktopShortcut` is not a valid `vpk pack` option, causing nightly CI to fail
- `--shortcuts StartMenuRoot` is the correct way to create only a Start Menu shortcut (no desktop shortcut)

## Test plan
- [ ] Verify nightly workflow passes with the corrected flag
- [ ] Verify release workflow builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)