### PR TITLE
Fix nightly release notes: timestamp drift, injection, action auth

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -208,6 +208,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.MV_RELEASE_NOTES_ANT_APIKEY }}
+          github_token: ${{ github.token }}
+          claude_args: '--json-schema {"type":"object","properties":{"notes":{"type":"string"}},"required":["notes"]}'
           prompt: |
             Write release notes for a nightly build of Machine Violet, an AI
             Dungeon Master that runs tabletop RPGs in a terminal.
@@ -228,7 +230,7 @@ jobs:
             ${{ steps.commits.outputs.log }}
             ```
 
-            Output ONLY the markdown bullet list — nothing else.
+            Return the notes in the "notes" field of your JSON response.
 
       - name: Create or update nightly release
         env:
@@ -241,7 +243,7 @@ jobs:
           DATE="${{ steps.tags.outputs.date }}"
           NIGHTLY_TAG="${{ steps.tags.outputs.tag }}"
           PREV_TAG="${{ steps.tags.outputs.prev }}"
-          RELEASE_NOTES="${{ steps.changelog.outputs.result }}"
+          RELEASE_NOTES=$(echo '${{ steps.changelog.outputs.structured_output }}' | jq -r '.notes // "Internal improvements and maintenance."')
 
           cat > nightly-body.md << 'BODYEOF'
           ## Download
@@ -296,7 +298,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK }}
         run: |
           NIGHTLY_TAG="${{ steps.tags.outputs.tag }}"
-          RELEASE_NOTES="${{ steps.changelog.outputs.result }}"
+          RELEASE_NOTES=$(echo '${{ steps.changelog.outputs.structured_output }}' | jq -r '.notes // "Internal improvements and maintenance."')
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/nightly"
 
           # Build message, truncating to fit Discord's 2000-char limit


### PR DESCRIPTION
## Summary

Follow-up to #221 (merged). Addresses code review feedback and the failed workflow run.

- **Timestamp drift**: add `prepare` job to compute nightly version once, shared across all matrix runners
- **Tag collision guard**: append `github.run_id` on rerun within the same minute
- **Heredoc injection**: use `printf '%s\n'` for AI-generated content instead of unquoted heredoc
- **Discord safety**: truncate to 2000-char limit, suppress `@everyone`/`@here` with `allowed_mentions: {parse: []}`
- **Action auth**: pass `github_token` to skip Claude GitHub App token exchange
- **Output capture**: use `--json-schema` + `structured_output` since the action has no `result` output

## Test plan

- [ ] Trigger nightly workflow via `workflow_dispatch`
- [ ] Verify `claude-code-action` step succeeds (no 401)
- [ ] Verify release notes appear in the GitHub release body
- [ ] Verify Discord message posts without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)