### PR TITLE
Include discord-settings.json in config migration

### DIFF
--- a/src/config/first-launch.ts
+++ b/src/config/first-launch.ts
@@ -73,7 +73,7 @@ export function getConfigPaths(dir?: string) {
  * Copies files that exist next to the exe but not yet in the config dir.
  * Only runs in compiled mode.
  */
-const CONFIG_FILES = [".env", "config.json", "api-keys.json"] as const;
+const CONFIG_FILES = [".env", "config.json", "api-keys.json", "discord-settings.json"] as const;
 
 const SECRET_FILES = new Set([".env", "api-keys.json"]);
 


### PR DESCRIPTION
## Summary
- `migrateConfigFromExeDir()` copies config files from the old exe-local location to the platform config directory on upgrade, but `discord-settings.json` was missing from the `CONFIG_FILES` list
- This caused the Discord rich presence opt-in setting to be lost after upgrading from a version that stored config next to the executable
- Added `discord-settings.json` to the migration file list

## Test plan
- [ ] Existing `discord.test.ts` tests pass (verified)
- [ ] Place a `discord-settings.json` next to the compiled exe, upgrade, and confirm the file is copied to the platform config dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)