### PR TITLE
Fix macOS Apple Silicon binary killed on launch

### DIFF
--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -146,6 +146,14 @@ execSync(
   { stdio: "inherit", cwd: ROOT },
 );
 
+// Re-sign on macOS — the injected blob invalidates the ad-hoc signature
+// that ships with the node binary. Without this, Apple Silicon kills the
+// binary on launch ("Zsh: Killed").
+if (process.platform === "darwin") {
+  console.log("  Re-signing binary (ad-hoc)...");
+  execSync(`codesign --sign - --force "${exePath}"`, { stdio: "inherit" });
+}
+
 // Clean up blob
 rmSync(blobPath, { force: true });
 rmSync(join(DIST, "bundle.js"), { force: true });


### PR DESCRIPTION
## Summary
- The Node binary on macOS ARM64 ships with an ad-hoc code signature. `postject` blob injection invalidates it, causing the kernel to kill the binary immediately ("Zsh: Killed").
- Add `codesign --sign - --force` after injection to re-sign with a fresh ad-hoc signature, mirroring the existing Windows signature handling flow.

## Test plan
- [ ] Build locally on Apple Silicon Mac with `node scripts/build-dist.js` and verify `dist/machine-violet` launches
- [ ] Verify `codesign -v dist/machine-violet` passes after build
- [ ] Confirm CI release workflow still succeeds on macOS runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)