### PR TITLE
Split SEA build: --build-sea for macOS/Linux, postject for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "isomorphic-git": "^1.37.1",
         "pdf-lib": "^1.17.1",
         "pdf-parse": "^2.4.5",
+        "postject": "^1.0.0-alpha.6",
         "react": "^19.0.0"
       },
       "devDependencies": {
@@ -2945,6 +2946,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/content-disposition": {
@@ -5938,6 +5948,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/powershell-utils": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "isomorphic-git": "^1.37.1",
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^2.4.5",
+    "postject": "^1.0.0-alpha.6",
     "react": "^19.0.0"
   },
   "devDependencies": {

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -2,9 +2,12 @@
 /**
  * Build script for Machine Violet distribution.
  *
- * Bundles with esbuild, creates a Node SEA executable via --build-sea,
- * applies Windows metadata via rcedit, and assembles asset directories
- * alongside the binary.
+ * Bundles with esbuild, creates a Node SEA executable, applies Windows
+ * metadata via rcedit, and assembles asset directories alongside the binary.
+ *
+ * SEA creation is platform-split: macOS/Linux use --build-sea (postject
+ * corrupts Node 25's Mach-O layout); Windows uses the postject workflow
+ * (--build-sea breaks Velopack/Authenticode signing).
  *
  * Usage:
  *   node scripts/build-dist.js                          # build for current platform
@@ -17,12 +20,13 @@ import {
   cpSync,
   existsSync,
   readFileSync,
+  readdirSync,
   writeFileSync,
   rmSync,
   statSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -68,33 +72,61 @@ await build({
   sourcemap: false,
 });
 
-// --- Step 2: Node SEA via --build-sea ---
+// --- Step 2: Node SEA ---
 //
-// Node 25's --build-sea produces a complete single-executable binary in one
-// step (copies node, injects blob, sets fuse). This replaces the old
-// multi-step postject workflow which broke on Node 25's Mach-O layout,
-// causing segfaults on macOS ARM64.
+// Two paths:
+//   macOS/Linux — Node 25's --build-sea produces a correct binary in one step.
+//                 postject 1.0.0-alpha.6 corrupts Node 25's Mach-O layout,
+//                 causing an immediate segfault on ARM64.
+//   Windows    — The battle-tested postject workflow: generate blob → copy
+//                node.exe → strip Authenticode sig → set icon → inject blob.
+//                --build-sea produces a PE whose signature state breaks
+//                Velopack/signtool downstream.
 
-console.log("  Building single executable...");
-
-const seaConfig = {
-  main: "dist/bundle.js",
-  output: `dist/${exeName}`,
-  mainFormat: "module",
-  disableExperimentalSEAWarning: true,
-};
 const seaConfigPath = join(DIST, "sea-config.json");
-writeFileSync(seaConfigPath, JSON.stringify(seaConfig, null, 2));
 
-if (existsSync(exePath)) rmSync(exePath);
-execSync(`node --build-sea=dist/sea-config.json`, {
-  stdio: "inherit",
-  cwd: ROOT,
-});
-rmSync(seaConfigPath, { force: true });
-
-// Set Windows exe icon via rcedit (after SEA build, before Velopack signing).
 if (isWindows) {
+  // --- Windows: postject workflow ---
+  console.log("  Generating SEA blob...");
+
+  const blobPath = join(DIST, "sea-prep.blob");
+  const seaConfig = {
+    main: "dist/bundle.js",
+    output: "dist/sea-prep.blob",
+    mainFormat: "module",
+    disableExperimentalSEAWarning: true,
+  };
+  writeFileSync(seaConfigPath, JSON.stringify(seaConfig, null, 2));
+
+  execSync(`node --experimental-sea-config dist/sea-config.json`, {
+    stdio: "inherit",
+    cwd: ROOT,
+  });
+  rmSync(seaConfigPath, { force: true });
+
+  // Copy node binary
+  console.log("  Copying node binary...");
+  if (existsSync(exePath)) rmSync(exePath);
+  cpSync(process.execPath, exePath);
+
+  // Strip Authenticode signature before injection.
+  // node.exe ships pre-signed by Microsoft. If we inject the blob first,
+  // the stale signature makes the PE unsignable (0x800700C1).
+  const signtool = findSigntool();
+  if (signtool) {
+    try {
+      execFileSync(signtool, ["remove", "/s", exePath], { stdio: "inherit" });
+      console.log("  Stripped Authenticode signature.");
+    } catch {
+      console.warn("  Warning: signtool remove failed — signing may fail later.");
+    }
+  } else {
+    console.warn("  Warning: signtool not found — skipping signature strip.");
+  }
+
+  // Set exe icon (after sig strip, before blob injection).
+  // The PE is clean and unsigned at this point so rcedit won't hang.
+  // postject only touches the blob section — icon resources survive injection.
   const icoPath = join(ROOT, "assets", "machine-violet.ico");
   if (existsSync(icoPath)) {
     console.log("  Setting exe icon (rcedit)...");
@@ -105,14 +137,42 @@ if (isWindows) {
       console.warn(`  Warning: rcedit failed (${err instanceof Error ? err.message : String(err)}). Exe will have Node icon.`);
     }
   }
-}
 
-// Re-sign on macOS — --build-sea inherits the ad-hoc signature from the
-// source node binary, but the injected blob invalidates it. Apple Silicon
-// kills binaries with broken signatures.
-if (process.platform === "darwin") {
-  console.log("  Re-signing binary (ad-hoc)...");
-  execSync(`codesign --sign - --force "${exePath}"`, { stdio: "inherit" });
+  // Inject blob with postject
+  console.log("  Injecting SEA blob...");
+  const postjectBin = join(ROOT, "node_modules", ".bin", "postject.cmd");
+  execSync(
+    `"${postjectBin}" "${exePath}" NODE_SEA_BLOB "${blobPath}" --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`,
+    { stdio: "inherit", cwd: ROOT },
+  );
+
+  rmSync(blobPath, { force: true });
+} else {
+  // --- macOS/Linux: --build-sea ---
+  console.log("  Building single executable...");
+
+  const seaConfig = {
+    main: "dist/bundle.js",
+    output: `dist/${exeName}`,
+    mainFormat: "module",
+    disableExperimentalSEAWarning: true,
+  };
+  writeFileSync(seaConfigPath, JSON.stringify(seaConfig, null, 2));
+
+  if (existsSync(exePath)) rmSync(exePath);
+  execSync(`node --build-sea=dist/sea-config.json`, {
+    stdio: "inherit",
+    cwd: ROOT,
+  });
+  rmSync(seaConfigPath, { force: true });
+
+  // Re-sign on macOS — --build-sea inherits the ad-hoc signature from the
+  // source node binary, but the injected blob invalidates it. Apple Silicon
+  // kills binaries with broken signatures.
+  if (process.platform === "darwin") {
+    console.log("  Re-signing binary (ad-hoc)...");
+    execSync(`codesign --sign - --force "${exePath}"`, { stdio: "inherit" });
+  }
 }
 
 // Clean up intermediate bundle
@@ -144,4 +204,32 @@ writeFileSync(join(DIST, "version.json"), JSON.stringify({ version }, null, 2));
 console.log(`\nDone! Distribution in ${DIST}/`);
 console.log(`  Binary: ${exeName} (${(statSync(exePath).size / 1024 / 1024).toFixed(1)} MB)`);
 console.log(`  Version: ${version}`);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Find signtool.exe in the Windows SDK. Returns path or null. */
+function findSigntool() {
+  // Try PATH first
+  try {
+    execFileSync("signtool", ["/?"], { stdio: "ignore" });
+    return "signtool";
+  } catch { /* not on PATH */ }
+
+  // Search Windows SDK
+  const sdkBin = "C:\\Program Files (x86)\\Windows Kits\\10\\bin";
+  if (!existsSync(sdkBin)) return null;
+  try {
+    const versions = readdirSync(sdkBin)
+      .filter((d) => /^10\.\d/.test(d))
+      .sort()
+      .reverse();
+    for (const ver of versions) {
+      const candidate = join(sdkBin, ver, "x64", "signtool.exe");
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
 


### PR DESCRIPTION
## Summary
- Fixes the macOS ARM64 segfault from #251 while restoring the working Windows signing pipeline.
- **macOS/Linux**: Use Node 25's `--build-sea` (one step, correct Mach-O injection) + ad-hoc re-sign on macOS.
- **Windows**: Restore the original postject workflow (blob → copy node.exe → strip Authenticode sig → rcedit icon → inject blob). This is the flow that works with Velopack/signtool downstream.

## Test plan
- [x] Local macOS ARM64 build: `./dist/machine-violet --version` works, no segfault
- [ ] CI Windows build: Velopack packaging and signing succeeds
- [ ] CI macOS build: binary launches correctly
- [ ] CI Linux build: binary launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)