### PR TITLE
Fix pre-existing TypeScript type errors (tsc --noEmit)

### DIFF
--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -856,7 +856,7 @@ export class GameEngine {
       const { frontMatter: fm, body: fmBody, changelog: fmChangelog } = parseFrontMatter(currentSheet);
       if (fm.sheet_status === "complete") {
         delete fm.sheet_status;
-        const title = fm._title ?? characterName;
+        const title = String(fm._title ?? characterName);
         await this.fileIO.writeFile(filePath, serializeEntity(title, fm, fmBody, fmChangelog));
         const slug = characterName.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
         this.sceneManager.notifyEntityTouched(filePath, slug);

--- a/src/agents/subagent.test.ts
+++ b/src/agents/subagent.test.ts
@@ -160,7 +160,7 @@ describe("cacheSystemPrompt", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks[0].type).toBe("text");
     expect(blocks[0].text).toBe("You are a summarizer.");
-    expect((blocks[0] as Record<string, unknown>).cache_control).toEqual({
+    expect((blocks[0] as unknown as Record<string, unknown>).cache_control).toEqual({
       type: "ephemeral",
       ttl: "1h",
     });
@@ -191,7 +191,7 @@ describe("oneShot", () => {
     expect(Array.isArray(call.system)).toBe(true);
     const blocks = call.system as Anthropic.TextBlockParam[];
     expect(blocks[0].text).toBe("Test prompt.");
-    expect((blocks[0] as Record<string, unknown>).cache_control).toEqual({
+    expect((blocks[0] as unknown as Record<string, unknown>).cache_control).toEqual({
       type: "ephemeral",
       ttl: "1h",
     });

--- a/src/agents/subagents/dev-mode.test.ts
+++ b/src/agents/subagents/dev-mode.test.ts
@@ -53,7 +53,7 @@ describe("buildDevPrompt", () => {
   it("returns TextBlockParam[] with cache_control on first block", () => {
     const blocks = buildDevPrompt("Test");
     expect(Array.isArray(blocks)).toBe(true);
-    expect((blocks[0] as Record<string, unknown>).cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect((blocks[0] as unknown as Record<string, unknown>).cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   it("includes campaign name", () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Text, Box, useInput } from "ink";
+import type Anthropic from "@anthropic-ai/sdk";
 import { createClient } from "./config/client.js";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { readFile, writeFile, appendFile, mkdir, readdir, stat, unlink, rmdir } from "node:fs/promises";
@@ -260,7 +261,7 @@ async function buildInitialSheet(
       // Mark sheet as complete so the DM doesn't re-promote
       const { frontMatter, body, changelog } = parseFrontMatter(updatedSheet);
       frontMatter.sheet_status = "complete";
-      const title = frontMatter._title ?? result.characterName;
+      const title = String(frontMatter._title ?? result.characterName);
       const tagged = serializeEntity(title, frontMatter, body, changelog);
       await io.writeFile(charPath, tagged);
     }


### PR DESCRIPTION
## Summary
- Add missing `import type Anthropic` in `app.tsx` (TS2304)
- Narrow `fm._title` from `unknown` to `string` via `String()` in `game-engine.ts` and `app.tsx` (TS2345)
- Route `TextBlockParam` test casts through `unknown` first in `subagent.test.ts` and `dev-mode.test.ts` (TS2352)

Fixes 6 of the 9 errors from `tsc --noEmit`. The remaining 3 are unrelated (`fflate` missing module, `SettingsPhase` prop optionality).

Closes #264

## Test plan
- [x] All 2069 tests pass
- [x] `tsc --noEmit` errors reduced from 9 → 3 (remaining are out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)