### PR TITLE
Remove fire-and-forget TUI bail-out from agent loop

### DIFF
--- a/src/agents/agent-session.test.ts
+++ b/src/agents/agent-session.test.ts
@@ -462,11 +462,13 @@ describe("runAgentLoop", () => {
     });
   });
 
-  describe("fire-and-forget TUI bail-out", () => {
-    it("bails out when all tool calls are TUI tools", async () => {
-      // Only one API call — no second round
+  describe("TUI tool handling (no bail-out)", () => {
+    it("continues the loop after TUI-only tool calls", async () => {
+      // Even when all tools are TUI, the loop sends results back for the
+      // next round so the DM can finish its turn properly (#266).
       const client = mockClient([
         textAndToolMessage("The tavern glows warmly.", "update_modeline", { location: "Tavern" }),
+        textMessage("You see a barkeep."),
       ]);
       const toolHandler = vi.fn(() => ({
         content: JSON.stringify({ type: "update_modeline", location: "Tavern" }),
@@ -479,98 +481,34 @@ describe("runAgentLoop", () => {
         baseConfig({ toolHandler, tuiToolNames: new Set(["update_modeline"]) }),
       );
 
-      // Only one API call was made (no round-trip for ack)
-      expect(client.messages.create).toHaveBeenCalledTimes(1);
-      // Text was captured
-      expect(result.text).toBe("The tavern glows warmly.");
-      // TUI command was collected
+      // Two API calls — tool results sent back for the next round
+      expect(client.messages.create).toHaveBeenCalledTimes(2);
+      expect(result.text).toContain("The tavern glows warmly.");
       expect(result.tuiCommands).toHaveLength(1);
     });
 
-    it("keeps tool_use/tool_result pair in roundMessages on bail-out", async () => {
+    it("continues the loop when dm_notes fires with text (#266)", async () => {
+      // Campaign start: DM narrates + writes dm_notes, must continue to
+      // set resources and present choices.
       const client = mockClient([
-        textAndToolMessage("Scene text.", "scribe", { updates: [] }),
-      ]);
-      const toolHandler = vi.fn(() => ({
-        content: JSON.stringify({ type: "scribe", updates: [] }),
-      }));
-
-      const result = await runAgentLoop(
-        client,
-        "System",
-        [{ role: "user", content: "Continue" }],
-        baseConfig({ toolHandler, tuiToolNames: new Set(["scribe"]) }),
-      );
-
-      // roundMessages: assistant(text+tool_use), user(tool_result)
-      expect(result.roundMessages).toHaveLength(2);
-      expect(result.roundMessages[0].role).toBe("assistant");
-      expect(result.roundMessages[1].role).toBe("user");
-
-      // Assistant message retains tool_use blocks
-      const assistantBlocks = result.roundMessages[0].content as Anthropic.ContentBlock[];
-      const types = assistantBlocks.map((b) => b.type);
-      expect(types).toContain("tool_use");
-      expect(types).toContain("text");
-
-      // User message has tool_result
-      const userBlocks = result.roundMessages[1].content as Anthropic.ToolResultBlockParam[];
-      expect(userBlocks[0].type).toBe("tool_result");
-    });
-
-    it("does NOT bail out when some tools are non-TUI", async () => {
-      const msg: Anthropic.Message = {
-        id: "msg_test",
-        type: "message",
-        role: "assistant",
-        model: "claude-haiku-4-5-20251001",
-        content: [
-          { type: "text", text: "Rolling and updating..." },
-          { type: "tool_use", id: "toolu_1", name: "roll_dice", input: { expression: "1d20" } },
-          { type: "tool_use", id: "toolu_2", name: "update_modeline", input: { location: "Arena" } },
-        ],
-        stop_reason: "tool_use",
-        stop_sequence: null,
-        usage: mockUsage(),
-      } as Anthropic.Message;
-
-      const client = mockClient([msg, textMessage("You rolled a 15!")]);
-      const toolHandler = vi.fn((name: string) => {
-        if (name === "roll_dice") return { content: "15" };
-        return { content: JSON.stringify({ type: "update_modeline", location: "Arena" }) };
-      });
-
-      await runAgentLoop(
-        client,
-        "System",
-        [{ role: "user", content: "Attack" }],
-        baseConfig({ toolHandler, tuiToolNames: new Set(["update_modeline"]) }),
-      );
-
-      // Two API calls — results sent back normally
-      expect(client.messages.create).toHaveBeenCalledTimes(2);
-    });
-
-    it("does NOT bail out when TUI tools fire before any text", async () => {
-      // DM calls dm_notes before narrating (e.g. first turn setup).
-      // Should NOT bail out — needs another round to produce text.
-      const client = mockClient([
-        toolUseMessage("dm_notes", { action: "write", notes: "setup" }),
-        textMessage("The rain hammered the window."),
+        textAndToolMessage("Welcome to Warranty Void.", "dm_notes", { action: "write", notes: "secrets" }),
+        textMessage("The neon signs flicker above."),
       ]);
       const toolHandler = vi.fn(() => ({
         content: "DM notes saved.",
+        _tui: { type: "dm_notes", action: "write", notes: "secrets" },
       }));
 
       const result = await runAgentLoop(
         client,
         "System",
-        [{ role: "user", content: "Begin" }],
+        [{ role: "user", content: "[Session begins.]" }],
         baseConfig({ toolHandler, tuiToolNames: new Set(["dm_notes"]) }),
       );
 
       expect(client.messages.create).toHaveBeenCalledTimes(2);
-      expect(result.text).toBe("The rain hammered the window.");
+      expect(result.text).toContain("Welcome to Warranty Void.");
+      expect(result.text).toContain("The neon signs flicker above.");
     });
   });
 });

--- a/src/agents/agent-session.ts
+++ b/src/agents/agent-session.ts
@@ -324,31 +324,6 @@ export async function runAgentLoop(
       break;
     }
 
-    // Fire-and-forget bail-out: if EVERY tool_use in this round was a TUI
-    // tool, skip the next API call. The tool_use/tool_result pair is kept
-    // in conversation history so the DM sees a coherent exchange — we just
-    // don't burn an API call waiting for an acknowledgment.
-    // Only bail out if the DM has already produced text — otherwise the DM
-    // called TUI tools before narrating (e.g. dm_notes on first turn) and
-    // needs another round to actually speak.
-    const toolUseBlocks = assistantContent.filter(
-      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
-    );
-    const allTui = toolUseBlocks.length > 0 &&
-      toolUseBlocks.every((b) => tuiToolNames.has(b.name));
-
-    if (allTui && fullText.length > 0) {
-      // Keep the assistant message as-is (with tool_use blocks) and push
-      // tool_results so conversation history has the complete exchange.
-      workingMessages.push({ role: "user", content: toolResults });
-
-      dumpContext(config.name, params);
-
-      const roundMessages = workingMessages.slice(loopStartIndex);
-      config.onComplete?.(totalUsage);
-      return { text: fullText, tuiCommands, usage: totalUsage, truncated, roundMessages };
-    }
-
     // Append tool results as user message
     workingMessages.push({ role: "user", content: toolResults });
 

--- a/src/agents/game-engine.test.ts
+++ b/src/agents/game-engine.test.ts
@@ -1495,10 +1495,12 @@ describe("GameEngine OOC summary injection", () => {
   });
 });
 
-describe("GameEngine tool ack batching", () => {
-  it("saves API call on TUI-only tool round and keeps history coherent", async () => {
-    // Turn 1: DM responds with text + TUI-only tool call → bail-out
-    const turn1Msg: Anthropic.Message = {
+describe("GameEngine TUI-only tool round (#266)", () => {
+  it("does not bail out on TUI-only rounds — DM gets to continue", async () => {
+    // Turn 1: DM responds with text + TUI-only tool call.
+    // Previously this would bail out; now tool results are sent back and
+    // the DM gets another round to finish its turn.
+    const turn1Round1: Anthropic.Message = {
       id: "msg_1",
       type: "message",
       role: "assistant",
@@ -1512,11 +1514,14 @@ describe("GameEngine tool ack batching", () => {
       usage: mockUsage(),
     } as Anthropic.Message;
 
+    // Turn 1, round 2: DM finishes its turn
+    const turn1Round2 = textMessage("A barkeep polishes a glass.");
+
     // Turn 2: Normal text response
     const turn2Msg = textMessage("The bartender nods.");
 
     let streamCallIdx = 0;
-    const streamResponses = [turn1Msg, turn2Msg];
+    const streamResponses = [turn1Round1, turn1Round2, turn2Msg];
     const streamCalls: unknown[] = [];
 
     const client = {
@@ -1545,18 +1550,18 @@ describe("GameEngine tool ack batching", () => {
       model: "claude-haiku-4-5-20251001",
     });
 
-    // Turn 1: DM bails out — only 1 API call (no ack round-trip)
+    // Turn 1: tool results sent back → 2 API calls (no bail-out)
     await engine.processInput("Aldric", "I enter the tavern.");
-    expect(client.messages.stream).toHaveBeenCalledTimes(1);
+    expect(client.messages.stream).toHaveBeenCalledTimes(2);
 
     // Turn 2: conversation history should include the tool_use/tool_result
     // pair from turn 1 so the DM sees a coherent exchange.
     await engine.processInput("Aldric", "I talk to the bartender.");
-    expect(client.messages.stream).toHaveBeenCalledTimes(2);
+    expect(client.messages.stream).toHaveBeenCalledTimes(3);
 
-    // Verify the second call's messages include the tool_use + tool_result
-    const secondCallParams = streamCalls[1] as { messages: Anthropic.MessageParam[] };
-    const msgs = secondCallParams.messages;
+    // Verify the third call's messages include the tool_use + tool_result
+    const thirdCallParams = streamCalls[2] as { messages: Anthropic.MessageParam[] };
+    const msgs = thirdCallParams.messages;
 
     // Find the assistant message with tool_use from turn 1
     const assistantWithTools = msgs.find((m) =>
@@ -1571,11 +1576,6 @@ describe("GameEngine tool ack batching", () => {
       (m.content as Anthropic.ToolResultBlockParam[]).some((b) => b.type === "tool_result"),
     );
     expect(toolResultMsg).toBeDefined();
-
-    // The new user message should be a plain string (no orphaned tool_results)
-    const userMsgs = msgs.filter((m) => m.role === "user");
-    const lastUserMsg = userMsgs[userMsgs.length - 1];
-    expect(typeof lastUserMsg.content).toBe("string");
   });
 });
 

--- a/src/agents/game-engine.ts
+++ b/src/agents/game-engine.ts
@@ -110,8 +110,7 @@ function stampConversationCache(messages: Anthropic.MessageParam[]): void {
     };
   } else if (Array.isArray(last.content) && last.content.length > 0) {
     // Find the last non-empty text block to stamp cache_control on.
-    // The API rejects cache_control on empty text blocks (e.g. from
-    // fire-and-forget bail-out where tool_use blocks were stripped).
+    // The API rejects cache_control on empty text blocks.
     const blocks = [...last.content] as unknown as Record<string, unknown>[];
     let stampIdx = blocks.length - 1;
     while (stampIdx >= 0) {


### PR DESCRIPTION
## Summary
- Removes the fire-and-forget bail-out optimization from the agent loop that short-circuited the DM's turn when all tool calls were TUI tools
- The bail-out caused the DM to end its turn prematurely during campaign start: after writing `dm_notes` alongside partial narration, it fired before the DM could set resources, theme, choices, or finish narrating
- The DM now always receives tool results and decides for itself when its turn is done via `stop_reason: "end_turn"`

Fixes #266, fixes #269

## Detail
The bail-out (introduced as a cost optimization) saved ~1 Haiku-tier API call per TUI-only tool round by returning early instead of sending tool results back for the next round. But it had a boundary condition: if the DM produced *any* text before calling a TUI tool like `dm_notes`, the optimization treated the turn as complete — even though the DM intended to continue with resource setup, theme, choices, and full narration.

This also root-caused #269 (missing top frame): the DM never reached `set_display_resources` / `set_resource_values` because the turn was cut short.

## Test plan
- [x] `npm run check` passes (2115 tests, lint, coverage)
- [x] Replaced 4 bail-out tests with 2 tests confirming the loop continues after TUI-only rounds
- [x] Updated game-engine integration test to expect 2 API calls per TUI-tool round
- [ ] Manual: start a new campaign and verify the DM completes full setup (narration, resources, choices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)