### PR TITLE
Fix DM reasoning in narrative: enable thinking by default

### DIFF
--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -86,7 +86,9 @@ describe("model config", () => {
 
   it("defaults effort with dev-mode high", () => {
     const config = loadModelConfig({ cwd: testDir, reset: true });
-    expect(config.effort).toEqual({ "default": null, "dev-mode": "high" });
+    expect(config.effort).toEqual({
+      "default": null, "dm": "high", "ooc": "high", "setup": "high", "dev-mode": "high",
+    });
   });
 
   it("loads per-agent effort map from dev-config.json", () => {
@@ -107,7 +109,7 @@ describe("model config", () => {
       JSON.stringify({ effort: { dm: "turbo", ooc: "low" } }),
     );
     const config = loadModelConfig({ cwd: testDir, reset: true });
-    expect(config.effort.dm).toBeUndefined();
+    expect(config.effort.dm).toBe("high"); // invalid "turbo" rejected, default preserved
     expect(config.effort.ooc).toBe("low");
   });
 
@@ -127,7 +129,9 @@ describe("model config", () => {
       JSON.stringify({ effort: "high" }),
     );
     const config = loadModelConfig({ cwd: testDir, reset: true });
-    expect(config.effort).toEqual({ "default": null, "dev-mode": "high" });
+    expect(config.effort).toEqual({
+      "default": null, "dm": "high", "ooc": "high", "setup": "high", "dev-mode": "high",
+    });
   });
 
   describe("getEffortConfig", () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -29,7 +29,13 @@ const DEFAULTS: ModelConfig = {
   large: "claude-opus-4-6",
   medium: "claude-sonnet-4-6",
   small: "claude-haiku-4-5-20251001",
-  effort: { "default": null, "dev-mode": "high" },
+  effort: {
+    "default": null,
+    "dm": "high",
+    "ooc": "high",
+    "setup": "high",
+    "dev-mode": "high",
+  },
 };
 
 const VALID_MODELS = new Set<string>([


### PR DESCRIPTION
## Summary
- **Dev lines leaking (#268):** Guard `onDevLog` with `isDevMode()` and add defensive filter in `NarrativeArea` that strips dev lines when dev mode is off
- **DM reasoning inline:** The hardcoded effort defaults only configured the `dev-mode` subagent, not the `dm` agent itself. Production builds (no `dev-config.json`) ran the DM with thinking disabled, causing it to reason inline in its narrative. Add `dm`, `ooc`, and `setup` to the default effort map with `"high"`

Closes #268

## Test plan
- [x] All 2119 tests pass (`npm run check`)
- [x] New tests: dev lines filtered when dev mode off, shown when on
- [ ] Manual: compiled binary — verify no `[dev]` lines in narrative
- [ ] Manual: compiled binary — verify DM does not reason inline (thinking enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)