### PR TITLE
Fix build workflows: build shared package before esbuild

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,6 +51,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Build shared package
+        run: npm run build -w packages/shared
+
       - name: Build distribution
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Build shared package
+        run: npm run build -w packages/shared
+
       - name: Build distribution
         shell: bash
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -34,6 +34,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Build shared package
+        run: npm run build -w packages/shared
+
       - name: Build distribution
         shell: bash
         run: |
@@ -103,6 +106,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Build shared package
+        run: npm run build -w packages/shared
+
       - name: Build distribution
         run: |
           VERSION=$(node -p "require('./package.json').version")
@@ -129,6 +135,9 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Build shared package
+        run: npm run build -w packages/shared
 
       - name: Build distribution
         run: |


### PR DESCRIPTION
## Summary

- Add `npm run build -w packages/shared` step before `build-dist.js` in nightly, release, and test-build workflows

esbuild resolves `@machine-violet/shared` through the package.json exports map (`dist/*.js`), so the shared package must be TypeScript-compiled first. Without this step, the nightly build fails with "Could not resolve @machine-violet/shared/types/errors.js".

## Test plan

- [ ] Nightly workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)