### PR TITLE
Multi-provider support + Anthropic SDK decoupling

### DIFF
--- a/packages/engine/src/agents/agent-loop.ts
+++ b/packages/engine/src/agents/agent-loop.ts
@@ -133,7 +133,7 @@ async function runAgentLoopInternal(
     stream,
     tools: registry.getDefinitions(),
     toolHandler,
-    cacheHints: [{ target: "tools", ttl: "1h" }],
+    cacheHints: [{ target: "tools", ttl: "1h" }, { target: "messages" }],
     tuiToolNames: TUI_TOOLS,
     onTextDelta: config.onTextDelta,
     onToolStart: config.onToolStart,

--- a/packages/engine/src/config/connections.ts
+++ b/packages/engine/src/config/connections.ts
@@ -137,8 +137,9 @@ export function buildEffectiveConnections(stored: ConnectionStore, configDir?: s
     });
   }
 
-  // Manual connections — auto-populate models if empty
+  // Manual connections — auto-populate models if empty or missing
   for (const conn of stored.connections.filter((c) => c.source !== "env")) {
+    if (!conn.models) conn.models = [];
     if (conn.models.length === 0) {
       const knownModels = getModelsForProvider(conn.provider, configDir);
       conn.models = Object.entries(knownModels).map(([id, m]) => ({

--- a/packages/engine/src/providers/anthropic.ts
+++ b/packages/engine/src/providers/anthropic.ts
@@ -128,6 +128,35 @@ function toAnthropicParams(params: ChatParams): {
     maxTokens = Math.max(maxTokens, modelMax);
   }
 
+  // Apply cache hint to last conversation message (BP4) if requested
+  const msgCacheHint = params.cacheHints?.find((h) => h.target === "messages");
+  if (msgCacheHint && messages.length > 0) {
+    const last = messages[messages.length - 1];
+    if (typeof last.content === "string") {
+      if (last.content) {
+        messages[messages.length - 1] = {
+          role: last.role,
+          content: [{
+            type: "text" as const,
+            text: last.content,
+            cache_control: { type: "ephemeral" },
+          } as Anthropic.TextBlockParam],
+        };
+      }
+    } else if (Array.isArray(last.content) && last.content.length > 0) {
+      const blocks = [...last.content] as unknown as Record<string, unknown>[];
+      // Find last non-empty text block
+      let stampIdx = blocks.length - 1;
+      while (stampIdx >= 0 && blocks[stampIdx].type === "text" && !(blocks[stampIdx].text as string)) {
+        stampIdx--;
+      }
+      if (stampIdx >= 0) {
+        blocks[stampIdx] = { ...blocks[stampIdx], cache_control: { type: "ephemeral" } };
+        messages[messages.length - 1] = { role: last.role, content: blocks as unknown as Anthropic.MessageParam["content"] };
+      }
+    }
+  }
+
   return {
     model: params.model,
     max_tokens: maxTokens,

--- a/packages/engine/src/providers/openai.ts
+++ b/packages/engine/src/providers/openai.ts
@@ -23,7 +23,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 export interface OpenAIProviderOptions {
-  apiKey: string | (() => Promise<string>);
+  apiKey: string;
   baseURL?: string;
   /** Extra default headers (e.g., OpenRouter's HTTP-Referer, X-Title). */
   defaultHeaders?: Record<string, string>;

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -38,7 +38,7 @@ import {
   addConnection, removeConnection, setTierAssignment, updateConnectionModels,
   maskKey,
 } from "../../config/connections.js";
-import type { ConnectionStore, TierAssignment } from "../../config/connections.js";
+import type { ConnectionStore, TierAssignment, ProviderType } from "../../config/connections.js";
 import { createProviderFromConnection } from "../../providers/index.js";
 import { loadModelRegistry, getModelsForProvider } from "../../config/model-registry.js";
 import {
@@ -87,14 +87,19 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
   });
 
   /** Add a connection. */
+  const VALID_PROVIDERS = new Set<string>(["anthropic", "openai", "openai-oauth", "openrouter", "custom"]);
+
   server.post<{ Body: { provider: string; apiKey: string; label?: string; baseUrl?: string } }>("/connections", async (request, reply) => {
     const { provider, apiKey, label, baseUrl } = request.body ?? {};
     if (!provider || !apiKey) {
       return reply.status(400).send({ error: "Missing provider or apiKey." });
     }
+    if (!VALID_PROVIDERS.has(provider)) {
+      return reply.status(400).send({ error: `Unknown provider: ${provider}. Valid: ${[...VALID_PROVIDERS].join(", ")}` });
+    }
 
     let store = getConnections();
-    store = addConnection(store, provider as "anthropic" | "openai" | "openrouter" | "custom", apiKey, label ?? "", baseUrl);
+    store = addConnection(store, provider as ProviderType, apiKey, label ?? "", baseUrl);
 
     // Auto-discover known models for this provider
     const knownModels = getModelsForProvider(provider, server.configDir);

--- a/packages/engine/src/server/routes/session.ts
+++ b/packages/engine/src/server/routes/session.ts
@@ -132,7 +132,6 @@ export const sessionRoutes: FastifyPluginAsync = async (server: FastifyInstance)
       // (which handles turn lifecycle + game transition)
       const sm = server.sessionManager;
       const setup = sm.getSetupSession();
-      console.log(`[modal] id=${id}, hasSetup=${!!setup}, value=${String(value).slice(0, 50)}`);
       if (setup && id === "setup-choice") {
         await sm.resolveSetupChoice(String(value));
         return { ok: true };

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -212,14 +212,11 @@ export class SessionManager {
   /** Resolve a choice during setup. */
   async resolveSetupChoice(selectedText: string): Promise<{ finalized?: string }> {
     if (!this.setupSession) throw new Error("No setup session.");
-    console.log(`[setup] resolveSetupChoice: "${selectedText.slice(0, 50)}"`);
     const result = await this.setupSession.resolveChoice(selectedText);
-    console.log(`[setup] resolveChoice returned: finalized=${!!result.finalized}`);
     if (result.finalized) {
       await this.transitionToGame(result.finalized);
       return { finalized: result.finalized };
     }
-    console.log(`[setup] opening next turn after choice resolution`);
     this.openNextTurn();
     return {};
   }


### PR DESCRIPTION
## Summary

- **Provider abstraction layer**: `LLMProvider` interface with Anthropic and OpenAI-compatible adapters, model registry, connection management
- **Connection management UI**: New `ConnectionsPhase` replaces `ApiKeysPhase` — multi-screen navigation for managing API connections and tier assignments (large/medium/small)
- **Anthropic SDK decoupled from engine**: All 30+ files that imported `@anthropic-ai/sdk` now use provider-agnostic normalized types (`NormalizedMessage`, `NormalizedTool`, `SystemBlock`, etc.). Only `providers/anthropic.ts` and two config utilities retain the SDK import.
- **Setup conversation wired through providers**: Setup was bypassing the tier system entirely — now resolves the medium tier from `connections.json` like gameplay does
- **Agent loop consolidated**: Legacy Anthropic path removed from `agent-loop.ts`; everything routes through `runProviderLoop`. Retry utilities extracted to `utils/retry.ts`.
- **All cache breakpoints preserved**: BP1-BP3 via `SystemBlock.cacheControl` and `CacheHint` on tools; BP4 (conversation) reintroduced via `{ target: "messages" }` hint handled in the Anthropic adapter
- **Misc fixes**: DM truncation with thinking enabled, setup turn lifecycle bugs, dev-mode context dumps, `npm run dev` now builds shared package first

### Review feedback addressed (from #282)

- Validate provider type on POST /connections — reject unknown providers with 400
- Remove debug console.logs that leaked player input into server logs
- Reintroduce BP4 conversation cache via normalized CacheHint
- Restrict OpenAI `apiKey` option to `string` (async getter was declared but never supported)
- Null-safe `conn.models` in `buildEffectiveConnections`

## Test plan

- [x] `npm run check` — lint clean, 1915 tests pass (102 suites)
- [x] Manual smoke test: setup → game session with OpenAI provider — correct models used per tier
- [x] DM status text ("The DM is thinking...") confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)