### PR TITLE
Fix compendium crash and server 500s from schema mismatches

### DIFF
--- a/packages/client-ink/src/tui/modals/CompendiumModal.tsx
+++ b/packages/client-ink/src/tui/modals/CompendiumModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import React, { useState, useMemo, useCallback, useEffect } from "react";
 import { useInput } from "ink";
 import type { ResolvedTheme } from "../themes/types.js";
 import type { FormattingNode } from "@machine-violet/shared/types/tui.js";

--- a/packages/shared/src/protocol/rest.ts
+++ b/packages/shared/src/protocol/rest.ts
@@ -167,8 +167,19 @@ export const AddConnectionRequest = Type.Object({
 
 export const HealthCheckResponse = Type.Object({
   id: Type.String(),
-  status: Type.Union([Type.Literal("ok"), Type.Literal("error")]),
-  message: Type.Optional(Type.String()),
+  status: Type.Union([
+    Type.Literal("valid"),
+    Type.Literal("invalid"),
+    Type.Literal("error"),
+    Type.Literal("rate_limited"),
+  ]),
+  message: Type.String(),
+  rateLimits: Type.Optional(Type.Object({
+    requestsRemaining: Type.Number(),
+    requestsLimit: Type.Number(),
+    tokensRemaining: Type.Number(),
+    tokensLimit: Type.Number(),
+  })),
 });
 
 export const UpdateModelsRequest = Type.Object({
@@ -212,9 +223,9 @@ export const KeysListResponse = Type.Object({
 });
 
 export const DeleteInfoResponse = Type.Object({
-  name: Type.String(),
-  sceneCount: Type.Optional(Type.Number()),
-  lastPlayed: Type.Optional(Type.String()),
+  campaignName: Type.String(),
+  characterNames: Type.Array(Type.String()),
+  dmTurnCount: Type.Number(),
 });
 
 // --- Static types ---


### PR DESCRIPTION
## Summary

- **CompendiumModal** missing `React` default import — caused "React is not defined" crash when opening the compendium
- **HealthCheckResponse** TypeBox schema had `"ok"|"error"` but providers return `"valid"|"invalid"|"error"|"rate_limited"` — Fastify rejected the response as a 500
- **DeleteInfoResponse** TypeBox schema had wrong field names (`name`, `sceneCount`, `lastPlayed`) vs what `getCampaignDeleteInfo` actually returns (`campaignName`, `characterNames`, `dmTurnCount`) — also 500

## Test plan
- [x] `npm run check` passes (1913 tests, lint clean)
- [ ] Launch dev, open compendium on first turn — should render empty-state modal without crash
- [ ] Connection health check returns proper status values without 500
- [ ] Delete campaign info dialog loads without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)