### PR TITLE
Persist client-side settings across restarts

### DIFF
--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -103,14 +103,22 @@ export function App({ serverUrl, playerId, campaignId }: AppProps) {
   const [discordEnabled, setDiscordEnabled] = useState<boolean | null>(null);
   const [devModeEnabled, setDevModeEnabled] = useState(false);
   const [showVerbose, setShowVerbose] = useState(false);
+  const settingsLoaded = useRef(false);
 
   // Load persisted client settings on mount
   useEffect(() => {
     loadClientSettings().then((s) => {
       setDevModeEnabled(s.devModeEnabled);
       setShowVerbose(s.showVerbose);
-    }).catch(() => { /* use defaults */ });
+      settingsLoaded.current = true;
+    });
   }, []);
+
+  // Persist whenever either setting changes (skip the initial load)
+  useEffect(() => {
+    if (!settingsLoaded.current) return;
+    saveClientSettings({ devModeEnabled, showVerbose }).catch(() => { /* best-effort */ });
+  }, [devModeEnabled, showVerbose]);
   const [archiveStatus, setArchiveStatus] = useState("");
   const [deleteModal, setDeleteModal] = useState<CampaignDeleteInfo | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
@@ -400,17 +408,9 @@ export function App({ serverUrl, playerId, campaignId }: AppProps) {
         theme={theme}
         initialView={phase === "settings_apikeys" ? "api_keys" : undefined}
         devModeEnabled={devModeEnabled}
-        onToggleDevMode={() => setDevModeEnabled((v) => {
-          const next = !v;
-          saveClientSettings({ devModeEnabled: next, showVerbose }).catch(() => { /* best-effort */ });
-          return next;
-        })}
+        onToggleDevMode={() => setDevModeEnabled((v) => !v)}
         showVerbose={showVerbose}
-        onToggleVerbose={() => setShowVerbose((v) => {
-          const next = !v;
-          saveClientSettings({ devModeEnabled, showVerbose: next }).catch(() => { /* best-effort */ });
-          return next;
-        })}
+        onToggleVerbose={() => setShowVerbose((v) => !v)}
         onApiKeys={() => { refreshConnections(); setPhase("api_keys"); }}
         onDiscord={() => {
           apiClientRef.current.getDiscordSettings().then((s) => setDiscordEnabled(s.enabled)).catch(() => { /* ignore */ });

--- a/packages/client-ink/src/config/client-settings.test.ts
+++ b/packages/client-ink/src/config/client-settings.test.ts
@@ -11,11 +11,12 @@ vi.mock("../utils/paths.js", () => ({
   configDir: () => "/tmp/test-config",
 }));
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { loadClientSettings, saveClientSettings } from "./client-settings.js";
 
 const mockReadFile = vi.mocked(readFile);
 const mockWriteFile = vi.mocked(writeFile);
+const mockMkdir = vi.mocked(mkdir);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -45,11 +46,18 @@ describe("loadClientSettings", () => {
     const settings = await loadClientSettings();
     expect(settings).toEqual({ devModeEnabled: true, showVerbose: false });
   });
+
+  it("rejects non-boolean values and falls back to defaults", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ devModeEnabled: "yes", showVerbose: 1 }) as never);
+    const settings = await loadClientSettings();
+    expect(settings).toEqual({ devModeEnabled: false, showVerbose: false });
+  });
 });
 
 describe("saveClientSettings", () => {
-  it("writes JSON to the config directory", async () => {
+  it("creates config directory and writes JSON", async () => {
     await saveClientSettings({ devModeEnabled: true, showVerbose: false });
+    expect(mockMkdir).toHaveBeenCalledWith("/tmp/test-config", { recursive: true });
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining("client-settings.json"),
       expect.stringContaining('"devModeEnabled": true'),

--- a/packages/client-ink/src/config/client-settings.ts
+++ b/packages/client-ink/src/config/client-settings.ts
@@ -1,7 +1,9 @@
 /**
  * Lightweight client-side settings persistence.
  *
- * Reads/writes ~/.machine-violet/client-settings.json (or platform equivalent).
+ * Reads/writes client-settings.json under the client config directory
+ * returned by configDir() (platform config dir in production, or
+ * process.cwd() in dev/non-compiled mode).
  * No server round-trip — these are per-machine preferences.
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
@@ -24,12 +26,22 @@ function settingsPath(): string {
   return join(configDir(), FILENAME);
 }
 
+/** Coerce parsed JSON to valid ClientSettings, falling back to defaults. */
+function sanitize(input: unknown): ClientSettings {
+  const result: ClientSettings = { ...DEFAULTS };
+  if (input && typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    if (typeof obj.devModeEnabled === "boolean") result.devModeEnabled = obj.devModeEnabled;
+    if (typeof obj.showVerbose === "boolean") result.showVerbose = obj.showVerbose;
+  }
+  return result;
+}
+
 /** Load client settings from disk. Returns defaults for missing/corrupt file. */
 export async function loadClientSettings(): Promise<ClientSettings> {
   try {
     const raw = await readFile(settingsPath(), "utf-8");
-    const parsed = JSON.parse(raw) as Partial<ClientSettings>;
-    return { ...DEFAULTS, ...parsed };
+    return sanitize(JSON.parse(raw));
   } catch {
     return { ...DEFAULTS };
   }


### PR DESCRIPTION
## Summary

- Dev Mode and Show Debug Info settings now persist across restarts via `client-settings.json` at the platform config dir (`~/.machine-violet` or equivalent)
- Read on startup, written on toggle — no server round-trip
- Missing or corrupt files gracefully fall back to defaults
- Future client-side preferences (theme overrides, keybindings, etc.) can extend the same file

Closes #286

## Test plan
- [x] `npm run check` passes (1918 tests, lint clean)
- [x] Smoke test: toggle Dev Mode on, restart, setting is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)