### PR TITLE
Flush transcript to disk at end of every DM turn

### DIFF
--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -128,9 +128,10 @@ export class GameEngine {
     if (this.repo) {
       const persister = this.persister;
       this.repo.preCommitHook = async () => {
-        // Snapshot current scene to disk so the commit captures the
-        // true in-memory state. Display log is already append-flushed.
+        // Snapshot current scene + transcript to disk so the commit
+        // captures the true in-memory state.
         this.persistCurrentScene();
+        await this.sceneManager.flushTranscript();
         await persister.flush();
       };
     }
@@ -519,6 +520,11 @@ export class GameEngine {
         });
         this.persister.persistConversation(this.conversation.getExchanges());
       }
+
+      // Write transcript to disk so on-disk state always reflects the
+      // completed DM turn. Without this, transcript.md is only written
+      // during scene transitions, leaving it stale during normal play.
+      await this.sceneManager.flushTranscript();
 
       // Track exchange for git auto-commit
       await this.repo?.trackExchange();


### PR DESCRIPTION
## Summary

- Scene transcript (`campaign/scenes/*/transcript.md`) was only written to disk during scene transitions — during normal play it lived entirely in memory
- On-disk state was always stale, and if the DM's first turn was interrupted the campaign had no transcript and could not resume
- Now `flushTranscript()` is called after every completed DM exchange in `processInput`, and in the git `preCommitHook` so checkpoints always capture current state

## Test plan
- [x] `npm run check` passes (1918 tests, lint clean)
- [ ] Play a turn, check `campaign/scenes/001-*/transcript.md` on disk — should include the latest exchange
- [ ] Interrupt a first DM turn (Ctrl+C), restart — campaign should resume with transcript intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)