### PR TITLE
Migrate OpenAI provider to Responses API

### DIFF
--- a/packages/engine/src/providers/openai.test.ts
+++ b/packages/engine/src/providers/openai.test.ts
@@ -358,6 +358,44 @@ describe("Responses API integration", () => {
     });
   });
 
+  it("preserves ordering for interleaved assistant text and tool_use content", async () => {
+    mockResponses.create.mockResolvedValue(fakeResponse());
+
+    const messages: NormalizedMessage[] = [
+      { role: "user", content: "What's the weather and time?" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Checking weather." },
+          { type: "tool_use", id: "call_1", name: "weather", input: { city: "NYC" } },
+          { type: "text", text: "Now checking time." },
+          { type: "tool_use", id: "call_2", name: "time", input: { timezone: "EST" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_1", content: "72°F and sunny" },
+          { type: "tool_result", tool_use_id: "call_2", content: "3:00 PM" },
+        ],
+      },
+    ];
+
+    const provider = createOpenAIProvider({ apiKey: "test-key", providerId: "openai" });
+    await provider.chat(baseChatParams({ messages }));
+
+    const callArgs = mockResponses.create.mock.calls[0][0];
+    const input = callArgs.input;
+
+    expect(input[0]).toEqual({ type: "message", role: "user", content: "What's the weather and time?" });
+    expect(input[1]).toEqual({ type: "message", role: "assistant", content: "Checking weather." });
+    expect(input[2]).toEqual({ type: "function_call", call_id: "call_1", name: "weather", arguments: '{"city":"NYC"}' });
+    expect(input[3]).toEqual({ type: "message", role: "assistant", content: "Now checking time." });
+    expect(input[4]).toEqual({ type: "function_call", call_id: "call_2", name: "time", arguments: '{"timezone":"EST"}' });
+    expect(input[5]).toEqual({ type: "function_call_output", call_id: "call_1", output: "72°F and sunny" });
+    expect(input[6]).toEqual({ type: "function_call_output", call_id: "call_2", output: "3:00 PM" });
+  });
+
   it("sets store: false and max_output_tokens", async () => {
     mockResponses.create.mockResolvedValue(fakeResponse());
 

--- a/packages/engine/src/providers/openai.ts
+++ b/packages/engine/src/providers/openai.ts
@@ -219,17 +219,18 @@ function toResponsesInput(msg: NormalizedMessage): OpenAI.Responses.ResponseInpu
 
   if (msg.role === "assistant") {
     const items: OpenAI.Responses.ResponseInputItem[] = [];
+    let pendingText = "";
 
-    // Collect text parts for a message item
-    const textParts = msg.content.filter((p) => p.type === "text");
-    if (textParts.length > 0) {
-      const text = textParts.map((p) => (p as { text: string }).text).join("");
-      items.push({ type: "message", role: "assistant", content: text });
-    }
-
-    // Each tool_use becomes a top-level function_call item
+    // Iterate in order to preserve text ↔ tool_use interleaving
     for (const part of msg.content) {
-      if (part.type === "tool_use") {
+      if (part.type === "text") {
+        pendingText += part.text;
+      } else if (part.type === "tool_use") {
+        // Flush accumulated text before the function_call
+        if (pendingText) {
+          items.push({ type: "message", role: "assistant", content: pendingText });
+          pendingText = "";
+        }
         items.push({
           type: "function_call",
           call_id: part.id,
@@ -237,6 +238,10 @@ function toResponsesInput(msg: NormalizedMessage): OpenAI.Responses.ResponseInpu
           arguments: JSON.stringify(part.input),
         });
       }
+    }
+    // Flush trailing text
+    if (pendingText) {
+      items.push({ type: "message", role: "assistant", content: pendingText });
     }
 
     return items;
@@ -285,42 +290,42 @@ function fromResponsesResponseWithText(
   const toolCalls: NormalizedToolCall[] = [];
   const assistantContent: ContentPart[] = [];
 
-  // Extract text from output items if not provided
-  let text = accumulatedText;
-  if (text === undefined) {
-    // Prefer the convenience property; fall back to iterating output
-    text = response.output_text ?? "";
-    if (!text) {
-      const textParts: string[] = [];
-      for (const item of response.output) {
-        if (item.type === "message") {
-          for (const part of item.content) {
-            if (part.type === "output_text") {
-              textParts.push(part.text);
-            }
+  // Build text and assistantContent in output order to preserve interleaving
+  const textParts: string[] = [];
+
+  if (accumulatedText !== undefined) {
+    // Streaming path: text was accumulated from deltas, just use it
+    if (accumulatedText) {
+      textParts.push(accumulatedText);
+      assistantContent.push({ type: "text", text: accumulatedText });
+    }
+    // Still need to extract tool calls from output
+    for (const item of response.output) {
+      if (item.type === "function_call") {
+        const input = parseToolArgs(item.arguments);
+        toolCalls.push({ id: item.call_id, name: item.name, input });
+        assistantContent.push({ type: "tool_use", id: item.call_id, name: item.name, input });
+      }
+    }
+  } else {
+    // Non-streaming: iterate output in order to preserve text ↔ tool_call interleaving
+    for (const item of response.output) {
+      if (item.type === "message") {
+        for (const part of item.content) {
+          if (part.type === "output_text" && part.text) {
+            textParts.push(part.text);
+            assistantContent.push({ type: "text", text: part.text });
           }
         }
+      } else if (item.type === "function_call") {
+        const input = parseToolArgs(item.arguments);
+        toolCalls.push({ id: item.call_id, name: item.name, input });
+        assistantContent.push({ type: "tool_use", id: item.call_id, name: item.name, input });
       }
-      text = textParts.join("");
     }
   }
 
-  if (text) {
-    assistantContent.push({ type: "text", text });
-  }
-
-  for (const item of response.output) {
-    if (item.type === "function_call") {
-      let input: Record<string, unknown>;
-      try {
-        input = JSON.parse(item.arguments);
-      } catch {
-        input = { _parse_error: `Malformed JSON in tool arguments: ${item.arguments.slice(0, 200)}` };
-      }
-      toolCalls.push({ id: item.call_id, name: item.name, input });
-      assistantContent.push({ type: "tool_use", id: item.call_id, name: item.name, input });
-    }
-  }
+  const text = textParts.join("");
 
   const stopReason = mapResponsesStatus(response, toolCalls.length > 0);
   const usage = mapResponsesUsage(response.usage);
@@ -331,6 +336,14 @@ function fromResponsesResponseWithText(
 // ---------------------------------------------------------------------------
 // Helpers (Responses API)
 // ---------------------------------------------------------------------------
+
+function parseToolArgs(args: string): Record<string, unknown> {
+  try {
+    return JSON.parse(args);
+  } catch {
+    return { _parse_error: `Malformed JSON in tool arguments: ${args.slice(0, 200)}` };
+  }
+}
 
 function mapResponsesStatus(response: OAIResponse, hasToolCalls: boolean): StopReason {
   if (hasToolCalls) return "tool_use";


### PR DESCRIPTION
## Summary
- Migrate OpenAI provider from Chat Completions API to the Responses API (`client.responses.create()` / `.stream()`) for `openai`, `openai-oauth`, and `openrouter` providers
- Retain Chat Completions as fallback for `custom` endpoints (Ollama, vLLM, etc.)
- Add 23 unit tests covering both API paths

Key mapping changes in the Responses API path:
- System prompt → `instructions` field
- Messages → `input` array with `EasyInputMessage`, `function_call`, `function_call_output` items
- Tools use flat `{ type: "function", name, parameters }` format (not nested under `function`)
- `call_id` instead of `id` for tool call identifiers
- `status`/`incomplete_details` instead of `finish_reason` for stop reason
- Streaming via `client.responses.stream()` + accumulated deltas + `finalResponse()`
- `store: false` to avoid server-side storage

## Test plan
- [x] 23 unit tests (mocked SDK) — both Responses and Chat Completions paths
- [x] Live smoke tests against `gpt-4o-mini`: non-streaming, streaming, tool calls, tool result round-trip, multi-turn, system blocks
- [ ] CI passes

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)