### PR TITLE
Fix shared subpath exports and missing player path

### DIFF
--- a/packages/engine/src/server/routes/data.ts
+++ b/packages/engine/src/server/routes/data.ts
@@ -11,7 +11,7 @@ import {
   NotesResponse, NotesUpdateRequest, OkResponse,
   SettingsResponse, SettingsPatch, CostResponse, ErrorResponse,
 } from "@machine-violet/shared";
-import { campaignPaths } from "../../tools/filesystem/scaffold.js";
+import { campaignPaths, machinePaths } from "../../tools/filesystem/scaffold.js";
 
 export const dataRoutes: FastifyPluginAsync = async (server: FastifyInstance) => {
 
@@ -45,7 +45,8 @@ export const dataRoutes: FastifyPluginAsync = async (server: FastifyInstance) =>
 
     // Try characters/<name>.md first, then players/<name>.md
     const paths = campaignPaths(gs.campaignRoot);
-    for (const pathFn of [paths.character, paths.player]) {
+    const mPaths = machinePaths(gs.homeDir);
+    for (const pathFn of [paths.character, mPaths.player]) {
       const path = pathFn(name);
       try {
         if (await fileIO.exists(path)) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
-    "./*.js": "./dist/*.js"
+    "./*.js": "./dist/*.js",
+    "./types/*.js": "./dist/types/*.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- Add `./types/*.js` export mapping to `packages/shared/package.json` so nested type imports resolve correctly — fixes #330
- Use `machinePaths().player` instead of non-existent `campaignPaths().player` in the character GET route — fixes #321

## Test plan
- [x] `npm run check` passes (lint + 104 test suites, 1986 tests)
- [x] `MainMenuPhase.test.tsx` and `CompendiumModal.test.tsx` no longer error at import time
- [x] `npx tsc --noEmit --project packages/engine/tsconfig.json` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)