### PR TITLE
Rewrite OOC and Dev Mode prompts for autonomous behavior

### DIFF
--- a/packages/engine/src/prompts/dev-mode.md
+++ b/packages/engine/src/prompts/dev-mode.md
@@ -6,6 +6,7 @@ You are a power-user interface for inspecting and manipulating the running game.
 
 USE TOOLS to look things up — do NOT guess file contents or state values.
 Always inspect before mutating. Read the current state, show what you found, then make changes.
+If tools are unavailable in this session, say so explicitly. Do not pretend to have inspected files or state. Limit yourself to conceptual guidance and step-by-step instructions until tools are provided.
 
 ## How to Handle a Request
 

--- a/packages/engine/src/prompts/ooc-mode.md
+++ b/packages/engine/src/prompts/ooc-mode.md
@@ -15,7 +15,9 @@ You ARE the DM speaking out-of-character. Do NOT narrate game events or advance 
 - "the Gilded Quarter" → `locations/gilded-quarter/index.md`
 - "the Thornwatch" → `factions/thornwatch.md`
 
-**If you're unsure which entity, search first.** Use `find_references` to locate wikilinks pointing at an entity, or read a directory listing. Two tool calls is better than asking the player to navigate their own campaign.
+If file tools aren't available in the current session, say so and answer from your system prompt context only. Suggest Dev Mode if the player needs file access.
+
+**If you're unsure which entity, search first.** Use `find_references` to locate wikilinks pointing at an entity, or try likely path variations with `read_file`. Two tool calls is better than asking the player to navigate their own campaign. If you can't find it, suggest Dev Mode for `search_files` or `list_dir`.
 
 **If the request involves changing data, act on it.** Stat corrections, missing NPCs, data errors — use `scribe` to update entities or `promote_character` for character advancement. Don't ask permission for minor fixes. Only confirm before `rollback` (destructive and irreversible).
 


### PR DESCRIPTION
## Summary

Closes #326.

- **OOC Mode prompt** (65 → ~100 lines): Added prioritized decision heuristics ("check context first → read entity files → search if unsure → act directly → know boundaries"), 3 worked examples, explicit scope boundaries with Dev Mode handoff guidance, and fixed incorrect tool names (`create_entity`/`update_entity` → `scribe`/`promote_character`). Removed redundant tool parameter listings.
- **Dev Mode prompt** (65 → ~90 lines): Added decision heuristics ("read before writing", "dry-run by default", "show raw data", "batch reads"), 3 worked examples, scope boundaries with OOC handoff guidance, and strengthened summary/style guidance. Removed redundant tool parameter listings.

Both prompts now teach the agent *how to think about a request* rather than just listing available tools. The unifying principle: read first, answer second.

No harness or code changes — prompt-only.

## Test plan

- [ ] Verify `npm run check` passes (pre-existing shared package import failures are unrelated)
- [ ] Manual playtest: enter OOC mode, ask a stat question → agent should answer from context without tool calls
- [ ] Manual playtest: enter OOC mode, ask about an NPC → agent should `read_file` proactively
- [ ] Manual playtest: enter Dev Mode, ask to fix a stat → agent should read-then-write, showing before/after
- [ ] Manual playtest: enter Dev Mode, ask to repair links → agent should dry-run first

🤖 Generated with [Claude Code](https://claude.com/claude-code)