### PR TITLE
Fix SEA binary crash from Scalar API docs plugin

### DIFF
--- a/packages/engine/src/server/server.ts
+++ b/packages/engine/src/server/server.ts
@@ -11,7 +11,6 @@ import Fastify, { type FastifyInstance } from "fastify";
 import fastifyWebSocket from "@fastify/websocket";
 import fastifyCors from "@fastify/cors";
 import fastifySwagger from "@fastify/swagger";
-import scalarReference from "@scalar/fastify-api-reference";
 import { campaignRoutes } from "./routes/campaigns.js";
 import { sessionRoutes } from "./routes/session.js";
 import { dataRoutes } from "./routes/data.js";
@@ -19,6 +18,7 @@ import { managementRoutes } from "./routes/management.js";
 import { wsHandler } from "./ws.js";
 import { SessionManager } from "./session-manager.js";
 import { initEngineLog, logEvent, closeEngineLog } from "../context/engine-log.js";
+import { isCompiled } from "../utils/paths.js";
 
 export interface ServerConfig {
   /** Port to listen on. Default 7200. */
@@ -145,10 +145,15 @@ export async function createServer(
       ],
     },
   });
-  await server.register(scalarReference, {
-    routePrefix: "/docs",
-    configuration: { title: "Machine Violet API", agent: { disabled: true } },
-  });
+  // Scalar API docs — dev only. The plugin serves a static JS file from
+  // node_modules which doesn't exist inside a compiled SEA binary.
+  if (!isCompiled()) {
+    const { default: scalarReference } = await import("@scalar/fastify-api-reference");
+    await server.register(scalarReference, {
+      routePrefix: "/docs",
+      configuration: { title: "Machine Violet API", agent: { disabled: true } },
+    });
+  }
 
   // --- Session manager (one active session per process) ---
 


### PR DESCRIPTION
## Summary
- `@scalar/fastify-api-reference` crashes the SEA binary on startup because it tries to serve `js/standalone.js` from its package directory, which doesn't exist inside a compiled Node SEA
- Skip Scalar registration when `isCompiled()` is true — API docs are dev-only
- Dynamic import so the module isn't eagerly loaded in production builds

## Root cause
```
Error: JavaScript file not found: C:\Users\quant\AppData\Local\MachineViolet\current\js\standalone.js
    at getJavaScriptFile (file:///...MachineViolet.exe:152261:11)
    at fastifyApiReference.name (file:///...MachineViolet.exe:152320:23)
    at Plugin.exec (file:///...MachineViolet.exe:799:32)
```

## Test plan
- [x] All 2070 tests pass, lint clean
- [ ] Rebuild SEA binary and verify it starts without error
- [ ] Verify `/docs` endpoint still works in dev mode (`npm run dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)