### PR TITLE
Fix @machine-violet/shared resolution in worktree test runs

### DIFF
--- a/packages/client-ink/vitest.config.ts
+++ b/packages/client-ink/vitest.config.ts
@@ -1,6 +1,13 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    conditions: ["source"],
+    alias: {
+      "@machine-violet/shared": resolve(__dirname, "../shared/src"),
+    },
+  },
   test: {
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -1,6 +1,13 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    conditions: ["source"],
+    alias: {
+      "@machine-violet/shared": resolve(__dirname, "../shared/src"),
+    },
+  },
   test: {
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,9 +6,18 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js",
-    "./*.js": "./dist/*.js",
-    "./types/*.js": "./dist/types/*.js"
+    ".": {
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./*.js": {
+      "source": "./src/*.ts",
+      "default": "./dist/*.js"
+    },
+    "./types/*.js": {
+      "source": "./src/types/*.ts",
+      "default": "./dist/types/*.js"
+    }
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- 26 engine test suites failed at import time because `@machine-violet/shared` subpath exports (e.g. `shared/types/config.js`) mapped to `./dist/*.js`, but `dist/` doesn't exist in fresh worktrees
- Add `resolve.alias` in both engine and client-ink vitest configs to map `@machine-violet/shared` directly to `../shared/src` TypeScript source
- Add `"source"` conditional exports to the shared `package.json` for tools that support the condition

## Test plan
- [x] `npm run check` passes — 109 suites, 2070 tests, 0 failures
- [x] Verified in a worktree without pre-built `dist/`

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)