### PR TITLE
Add spacing around turn separators in HTML transcript export

### DIFF
--- a/packages/client-ink/src/commands/transcript.ts
+++ b/packages/client-ink/src/commands/transcript.ts
@@ -154,7 +154,7 @@ div {
   min-height: 1.4em;
 }
 .spacer { min-height: 1.4em; }
-.separator { text-align: center; opacity: 0.6; }
+.separator { text-align: center; opacity: 0.6; margin: 1.4em 0; }
 .system { color: #ffff55; }
 .player .prompt { color: inherit; }
 b { font-weight: bold; }


### PR DESCRIPTION
## Summary
- Adds `margin: 1.4em 0` to the `.separator` CSS rule in the HTML transcript export so turn separators are preceded and followed by a full blank line, matching the TUI rendering.

## Test plan
- [x] Existing transcript export tests pass (10/10)
- [ ] Export a transcript and verify separators have blank lines above and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)