### PR TITLE
Add animated starfield to main menu

### DIFF
--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -275,7 +275,7 @@ export function MainMenuPhase({
 
   return (
     <>
-      <FullScreenFrame theme={theme} columns={cols} rows={termRows} title="Machine Violet" contentRows={totalRows}>
+      <FullScreenFrame theme={theme} columns={cols} rows={termRows} title="Machine Violet" contentRows={totalRows} starfield>
         {menuLines}
         {errorMsg && (
           <Box marginTop={1}>

--- a/packages/client-ink/src/tui/components/FullScreenFrame.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Box } from "ink";
 import type { ResolvedTheme } from "../themes/types.js";
 import { ThemedHorizontalBorder, ThemedSideFrame } from "./ThemedFrame.js";
+import { useStarfield, StarfieldRows } from "./Starfield.js";
+import type { StarfieldConfig } from "./Starfield.js";
 
 export interface FullScreenFrameProps {
   theme: ResolvedTheme;
@@ -11,6 +13,8 @@ export interface FullScreenFrameProps {
   title?: string;
   /** Number of content rows the children occupy (used for vertical centering). */
   contentRows: number;
+  /** Enable an animated starfield in the padding areas around content. */
+  starfield?: boolean | StarfieldConfig;
   children: React.ReactNode;
 }
 
@@ -25,6 +29,7 @@ export function FullScreenFrame({
   rows,
   title,
   contentRows,
+  starfield,
   children,
 }: FullScreenFrameProps) {
   const sideWidth = theme.asset.components.edge_left.width;
@@ -35,6 +40,15 @@ export function FullScreenFrame({
 
   const topPad = Math.max(0, Math.floor((contentHeight - contentRows) / 2));
   const bottomPad = Math.max(0, contentHeight - contentRows - topPad);
+
+  const sfEnabled = !!starfield;
+  const sfConfig: StarfieldConfig = {
+    ...(typeof starfield === "object" ? starfield : undefined),
+    isActive: sfEnabled,
+  };
+
+  // Hook is called unconditionally (Rules of Hooks); isActive gates animation.
+  const grid = useStarfield(contentWidth, contentHeight, sfConfig);
 
   return (
     <Box flexDirection="column" width={columns} height={rows}>
@@ -48,13 +62,21 @@ export function FullScreenFrame({
       <Box flexDirection="row" height={contentHeight}>
         <ThemedSideFrame theme={theme} side="left" height={contentHeight} />
         <Box flexDirection="column" width={contentWidth} alignItems="center">
-          {topPad > 0 && <Box height={topPad} />}
+          {topPad > 0 && (
+            sfEnabled
+              ? <StarfieldRows grid={grid} startRow={0} rowCount={topPad} />
+              : <Box height={topPad} />
+          )}
 
           <Box flexDirection="column" alignItems="flex-start">
             {children}
           </Box>
 
-          {bottomPad > 0 && <Box height={bottomPad} />}
+          {bottomPad > 0 && (
+            sfEnabled
+              ? <StarfieldRows grid={grid} startRow={topPad + contentRows} rowCount={bottomPad} />
+              : <Box height={bottomPad} />
+          )}
         </Box>
         <ThemedSideFrame theme={theme} side="right" height={contentHeight} />
       </Box>

--- a/packages/client-ink/src/tui/components/Starfield.test.ts
+++ b/packages/client-ink/src/tui/components/Starfield.test.ts
@@ -53,6 +53,15 @@ describe("fadeCurve", () => {
     expect(fadeCurve(-1, 60)).toBe(0);
     expect(fadeCurve(61, 60)).toBe(0);
   });
+
+  it("spends most of its life below half brightness (cubic sharpening)", () => {
+    let aboveHalf = 0;
+    for (let age = 0; age < 60; age++) {
+      if (fadeCurve(age, 60) > 0.5) aboveHalf++;
+    }
+    // With sin³, only ~1/3 of frames are above 0.5 brightness
+    expect(aboveHalf).toBeLessThanOrEqual(25);
+  });
 });
 
 describe("glyphForBrightness", () => {
@@ -74,6 +83,15 @@ describe("glyphForBrightness", () => {
   it("returns bright glyph for high brightness", () => {
     expect(glyphForBrightness(0.75)).toBe("★");
     expect(glyphForBrightness(1.0)).toBe("★");
+  });
+
+  it("respects maxTier cap", () => {
+    // At full brightness, maxTier=1 caps at ∗
+    expect(glyphForBrightness(1.0, 1)).toBe("∗");
+    // maxTier=2 caps at ✦
+    expect(glyphForBrightness(1.0, 2)).toBe("✦");
+    // maxTier=0 caps at ·
+    expect(glyphForBrightness(1.0, 0)).toBe("·");
   });
 });
 

--- a/packages/client-ink/src/tui/components/Starfield.test.ts
+++ b/packages/client-ink/src/tui/components/Starfield.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  createRng,
+  fadeCurve,
+  glyphForBrightness,
+  buildGrid,
+} from "./Starfield.js";
+
+describe("createRng", () => {
+  it("produces deterministic values from same seed", () => {
+    const a = createRng(42);
+    const b = createRng(42);
+    const valuesA = Array.from({ length: 10 }, () => a());
+    const valuesB = Array.from({ length: 10 }, () => b());
+    expect(valuesA).toEqual(valuesB);
+  });
+
+  it("produces values in [0, 1)", () => {
+    const rng = createRng(123);
+    for (let i = 0; i < 1000; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("produces different sequences for different seeds", () => {
+    const a = createRng(1);
+    const b = createRng(2);
+    const va = Array.from({ length: 5 }, () => a());
+    const vb = Array.from({ length: 5 }, () => b());
+    expect(va).not.toEqual(vb);
+  });
+});
+
+describe("fadeCurve", () => {
+  it("returns 0 at birth and death", () => {
+    expect(fadeCurve(0, 60)).toBeCloseTo(0, 5);
+    expect(fadeCurve(60, 60)).toBe(0);
+  });
+
+  it("peaks at midpoint", () => {
+    const peak = fadeCurve(30, 60);
+    expect(peak).toBeCloseTo(1.0, 5);
+  });
+
+  it("is symmetric around midpoint", () => {
+    expect(fadeCurve(10, 60)).toBeCloseTo(fadeCurve(50, 60), 5);
+    expect(fadeCurve(15, 60)).toBeCloseTo(fadeCurve(45, 60), 5);
+  });
+
+  it("returns 0 for out-of-range ages", () => {
+    expect(fadeCurve(-1, 60)).toBe(0);
+    expect(fadeCurve(61, 60)).toBe(0);
+  });
+});
+
+describe("glyphForBrightness", () => {
+  it("returns dim glyph for low brightness", () => {
+    expect(glyphForBrightness(0.05)).toBe("·");
+    expect(glyphForBrightness(0.19)).toBe("·");
+  });
+
+  it("returns medium-dim glyph for mid-low brightness", () => {
+    expect(glyphForBrightness(0.25)).toBe("∗");
+    expect(glyphForBrightness(0.44)).toBe("∗");
+  });
+
+  it("returns medium-bright glyph", () => {
+    expect(glyphForBrightness(0.50)).toBe("✦");
+    expect(glyphForBrightness(0.69)).toBe("✦");
+  });
+
+  it("returns bright glyph for high brightness", () => {
+    expect(glyphForBrightness(0.75)).toBe("★");
+    expect(glyphForBrightness(1.0)).toBe("★");
+  });
+});
+
+describe("buildGrid", () => {
+  it("returns grid of correct dimensions", () => {
+    const grid = buildGrid([], 10, 5, 0);
+    expect(grid.length).toBe(5);
+    for (const row of grid) {
+      expect(row.length).toBe(10);
+    }
+  });
+
+  it("returns all-null grid when there are no stars", () => {
+    const grid = buildGrid([], 10, 5, 0);
+    for (const row of grid) {
+      for (const cell of row) {
+        expect(cell).toBeNull();
+      }
+    }
+  });
+
+  it("places a star at its position", () => {
+    const star = {
+      x: 3,
+      y: 2,
+      birthFrame: 0,
+      lifetime: 60,
+      palette: { peakL: 0.9, C: 0, H: 0 },
+      isQuasar: false,
+    };
+    const grid = buildGrid([star], 10, 5, 30); // frame 30 = peak brightness
+    const cell = grid[2]![3];
+    expect(cell).not.toBeNull();
+    expect(cell!.glyph).toBe("★"); // peak brightness -> bright glyph
+    expect(cell!.color).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it("does not place dead stars", () => {
+    const star = {
+      x: 3,
+      y: 2,
+      birthFrame: 0,
+      lifetime: 60,
+      palette: { peakL: 0.9, C: 0, H: 0 },
+      isQuasar: false,
+    };
+    const grid = buildGrid([star], 10, 5, 70); // past lifetime
+    expect(grid[2]![3]).toBeNull();
+  });
+
+  it("places quasar arms", () => {
+    const star = {
+      x: 5,
+      y: 3,
+      birthFrame: 0,
+      lifetime: 60,
+      palette: { peakL: 0.9, C: 0, H: 0 },
+      isQuasar: true,
+    };
+    const grid = buildGrid([star], 10, 7, 30);
+    // Center
+    expect(grid[3]![5]).not.toBeNull();
+    expect(grid[3]![5]!.glyph).toBe("╋");
+    // Cardinal arms
+    expect(grid[2]![5]!.glyph).toBe("│"); // up
+    expect(grid[4]![5]!.glyph).toBe("│"); // down
+    expect(grid[3]![4]!.glyph).toBe("─"); // left
+    expect(grid[3]![6]!.glyph).toBe("─"); // right
+    // Outer tips
+    expect(grid[1]![5]!.glyph).toBe("·"); // up-2
+    expect(grid[5]![5]!.glyph).toBe("·"); // down-2
+  });
+
+  it("clips quasar arms at grid boundaries", () => {
+    const star = {
+      x: 0,
+      y: 0,
+      birthFrame: 0,
+      lifetime: 60,
+      palette: { peakL: 0.9, C: 0, H: 0 },
+      isQuasar: true,
+    };
+    // Should not throw; arms extending off-grid are simply clipped
+    const grid = buildGrid([star], 3, 3, 30);
+    expect(grid[0]![0]!.glyph).toBe("╋");
+    expect(grid[0]![1]!.glyph).toBe("─"); // right arm fits
+  });
+
+  it("produces colored stars (orange)", () => {
+    const star = {
+      x: 2,
+      y: 1,
+      birthFrame: 0,
+      lifetime: 60,
+      palette: { peakL: 0.75, C: 0.14, H: 65 }, // orange
+      isQuasar: false,
+    };
+    const grid = buildGrid([star], 5, 3, 30);
+    const cell = grid[1]![2]!;
+    // Orange star at peak: should produce a warm hex color, not pure grey
+    const r = parseInt(cell.color.slice(1, 3), 16);
+    const g = parseInt(cell.color.slice(3, 5), 16);
+    const b = parseInt(cell.color.slice(5, 7), 16);
+    expect(r).toBeGreaterThan(g); // orange has more red than green
+    expect(r).toBeGreaterThan(b); // and more red than blue
+  });
+});

--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -277,6 +277,18 @@ export function buildGrid(
 }
 
 // ---------------------------------------------------------------------------
+// Module-level cache so the starfield survives mount/unmount cycles
+// (e.g. navigating to Settings and back).
+// ---------------------------------------------------------------------------
+
+const stateCache = new Map<string, SimState>();
+
+/** Clear the cached starfield (useful in tests). */
+export function resetStarfieldCache(): void {
+  stateCache.clear();
+}
+
+// ---------------------------------------------------------------------------
 // Hook: useStarfield
 // ---------------------------------------------------------------------------
 
@@ -294,21 +306,31 @@ export function useStarfield(
   const { frame } = useAnimation({ interval, isActive });
 
   const stateRef = useRef<SimState | null>(null);
+  const frameOffsetRef = useRef(0);
 
   const dimKey = `${width}x${height}`;
   const area = width * height;
   const targetCount = Math.max(1, Math.round(area * density));
 
-  // (Re-)initialize when dimensions change — start empty and let stars
-  // fade in gradually via the per-frame spawn cap in advanceFrame.
+  // (Re-)initialize when dimensions change.
+  // Check module-level cache first so stars survive mount/unmount.
   if (!stateRef.current || stateRef.current.dimKey !== dimKey) {
-    stateRef.current = { stars: [], rng: createRng(42), lastFrame: -1, dimKey };
+    const cached = stateCache.get(dimKey);
+    if (cached) {
+      stateRef.current = cached;
+      // Resume: map animation frame 0 → the simulation frame after where we paused
+      frameOffsetRef.current = cached.lastFrame + 1;
+    } else {
+      stateRef.current = { stars: [], rng: createRng(42), lastFrame: -1, dimKey };
+      frameOffsetRef.current = 0;
+    }
   }
 
   const state = stateRef.current;
+  const simFrame = frame + frameOffsetRef.current;
 
   // Advance simulation to current frame (idempotent for same frame)
-  while (state.lastFrame < frame) {
+  while (state.lastFrame < simFrame) {
     state.lastFrame++;
     advanceFrame(
       state,
@@ -321,7 +343,10 @@ export function useStarfield(
     );
   }
 
-  return buildGrid(state.stars, width, height, frame);
+  // Persist to cache so state survives unmount
+  stateCache.set(dimKey, state);
+
+  return buildGrid(state.stars, width, height, simFrame);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -16,7 +16,7 @@ import { oklchToHex } from "../color/oklch.js";
 // ---------------------------------------------------------------------------
 
 export interface StarfieldConfig {
-  /** Stars per addressable cell (0–1). Default 0.05 */
+  /** Stars per addressable cell (0–1). Default 0.025 */
   density?: number;
   /** Frames for a full fade-in + fade-out cycle. Default 60 */
   lifetime?: number;
@@ -37,7 +37,7 @@ const DEFAULT_INTERVAL = 1000;
 // Star color palette (OKLCH)
 // ---------------------------------------------------------------------------
 
-interface StarPalette {
+export interface StarPalette {
   peakL: number;
   C: number;
   H: number;
@@ -114,14 +114,14 @@ const QUASAR_SHAPE: QuasarArm[] = [
 // Star data
 // ---------------------------------------------------------------------------
 
-interface Star {
+export interface Star {
   x: number;
   y: number;
   birthFrame: number;
   lifetime: number;
   palette: StarPalette;
   isQuasar: boolean;
-  /** Highest glyph tier this star can reach (0=·, 1=∗, 2=✦, 3=★). */
+  /** Highest glyph tier this star can reach (1=∗, 2=✦, 3=★). */
   maxGlyphTier: number;
 }
 
@@ -158,6 +158,12 @@ export function fadeCurve(age: number, lifetime: number): number {
 // Cell grid
 // ---------------------------------------------------------------------------
 
+function emptyGrid(width: number, height: number): (StarfieldCell | null)[][] {
+  return Array.from({ length: height }, () =>
+    Array.from<StarfieldCell | null>({ length: width }).fill(null),
+  );
+}
+
 export interface StarfieldCell {
   glyph: string;
   color: string; // hex
@@ -182,7 +188,7 @@ function spawnStar(
   lifetime: number,
   quasarChance: number,
 ): Star {
-  // 60% of stars cap at tier 0–2 (never reach ★), 40% can reach tier 3
+  // 60% of stars cap at tier 1–2 (never reach ★), 40% can reach tier 3
   const tierRoll = rng();
   const maxGlyphTier = tierRoll < 0.25 ? 1 : tierRoll < 0.60 ? 2 : 3;
 
@@ -311,6 +317,12 @@ export function useStarfield(
   const dimKey = `${width}x${height}`;
   const area = width * height;
   const targetCount = Math.max(1, Math.round(area * density));
+
+  // When inactive (starfield disabled), skip simulation and cache entirely.
+  // Return an empty grid so other screens don't seed/pollute the cache.
+  if (!isActive) {
+    return emptyGrid(width, height);
+  }
 
   // (Re-)initialize when dimensions change.
   // Check module-level cache first so stars survive mount/unmount.

--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -28,7 +28,7 @@ export interface StarfieldConfig {
   isActive?: boolean;
 }
 
-const DEFAULT_DENSITY = 0.05;
+const DEFAULT_DENSITY = 0.025;
 const DEFAULT_LIFETIME = 60;
 const DEFAULT_QUASAR_CHANCE = 0.03;
 const DEFAULT_INTERVAL = 1000;
@@ -45,10 +45,10 @@ interface StarPalette {
 }
 
 const PALETTE: StarPalette[] = [
-  { peakL: 0.30, C: 0,    H: 0,   weight: 3 }, // dark/black
-  { peakL: 0.90, C: 0,    H: 0,   weight: 4 }, // white
-  { peakL: 0.75, C: 0.14, H: 65,  weight: 2 }, // orange
-  { peakL: 0.65, C: 0.18, H: 300, weight: 2 }, // violet
+  { peakL: 0.30, C: 0,    H: 0,   weight: 3 },   // dark/black
+  { peakL: 0.90, C: 0,    H: 0,   weight: 4 },   // white
+  { peakL: 0.75, C: 0.14, H: 65,  weight: 0.4 }, // orange (rare)
+  { peakL: 0.65, C: 0.18, H: 300, weight: 2 },   // violet
 ];
 
 const TOTAL_WEIGHT = PALETTE.reduce((s, p) => s + p.weight, 0);
@@ -68,12 +68,19 @@ function pickColor(rng: () => number): StarPalette {
 // Glyph selection by brightness
 // ---------------------------------------------------------------------------
 
-/** Map normalized brightness (0–1) to a glyph that conveys intensity. */
-export function glyphForBrightness(t: number): string {
-  if (t < 0.20) return "·";
-  if (t < 0.45) return "∗";
-  if (t < 0.70) return "✦";
-  return "★";
+const GLYPH_TIERS = ["·", "∗", "✦", "★"] as const;
+const GLYPH_THRESHOLDS = [0.20, 0.45, 0.70];
+
+/**
+ * Map normalized brightness (0–1) to a glyph that conveys intensity.
+ * `maxTier` caps the brightest glyph (0 = ·, 3 = ★). Default 3.
+ */
+export function glyphForBrightness(t: number, maxTier = 3): string {
+  let tier = 0;
+  for (let i = 0; i < GLYPH_THRESHOLDS.length; i++) {
+    if (t >= GLYPH_THRESHOLDS[i]) tier = i + 1;
+  }
+  return GLYPH_TIERS[Math.min(tier, maxTier)];
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +120,8 @@ interface Star {
   lifetime: number;
   palette: StarPalette;
   isQuasar: boolean;
+  /** Highest glyph tier this star can reach (0=·, 1=∗, 2=✦, 3=★). */
+  maxGlyphTier: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -133,10 +142,15 @@ export function createRng(seed: number): () => number {
 // Luminance curve
 // ---------------------------------------------------------------------------
 
-/** Sine fade: 0 → 1 → 0 over a normalized lifetime [0, 1]. */
+/**
+ * Sine-cubed fade: 0 → 1 → 0 over a normalized lifetime [0, 1].
+ * The cubic sharpens the peak so stars spend most of their life dim
+ * and only briefly reach full brightness.
+ */
 export function fadeCurve(age: number, lifetime: number): number {
   if (age < 0 || age >= lifetime) return 0;
-  return Math.sin((age / lifetime) * Math.PI);
+  const s = Math.sin((age / lifetime) * Math.PI);
+  return s * s * s;
 }
 
 // ---------------------------------------------------------------------------
@@ -167,6 +181,10 @@ function spawnStar(
   lifetime: number,
   quasarChance: number,
 ): Star {
+  // 60% of stars cap at tier 0–2 (never reach ★), 40% can reach tier 3
+  const tierRoll = rng();
+  const maxGlyphTier = tierRoll < 0.25 ? 1 : tierRoll < 0.60 ? 2 : 3;
+
   return {
     x: Math.floor(rng() * width),
     y: Math.floor(rng() * height),
@@ -174,6 +192,7 @@ function spawnStar(
     lifetime: Math.round(lifetime * (0.7 + rng() * 0.6)), // ±30% variation
     palette: pickColor(rng),
     isQuasar: rng() < quasarChance,
+    maxGlyphTier,
   };
 }
 
@@ -242,7 +261,7 @@ export function buildGrid(
           const L = brightness * star.palette.peakL;
           const C = brightness * star.palette.C;
           row[star.x] = {
-            glyph: glyphForBrightness(brightness),
+            glyph: glyphForBrightness(brightness, star.maxGlyphTier),
             color: oklchToHex({ L, C, H: star.palette.H }),
           };
         }

--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -1,0 +1,382 @@
+/**
+ * Animated starfield background for the main menu.
+ *
+ * Stars fade in and out at random positions using OKLCH lightness animation.
+ * Occasionally a "quasar" appears — a larger plus-shaped burst.
+ *
+ * Designed to run at 1 FPS for a slow, atmospheric effect.
+ */
+
+import React, { useRef } from "react";
+import { Text, Box, useAnimation } from "ink";
+import { oklchToHex } from "../color/oklch.js";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface StarfieldConfig {
+  /** Stars per addressable cell (0–1). Default 0.05 */
+  density?: number;
+  /** Frames for a full fade-in + fade-out cycle. Default 60 */
+  lifetime?: number;
+  /** Probability that a new star is a quasar. Default 0.03 */
+  quasarChance?: number;
+  /** Animation interval in ms. Default 1000 (1 FPS) */
+  interval?: number;
+  /** Whether the animation is active. Default true */
+  isActive?: boolean;
+}
+
+const DEFAULT_DENSITY = 0.05;
+const DEFAULT_LIFETIME = 60;
+const DEFAULT_QUASAR_CHANCE = 0.03;
+const DEFAULT_INTERVAL = 1000;
+
+// ---------------------------------------------------------------------------
+// Star color palette (OKLCH)
+// ---------------------------------------------------------------------------
+
+interface StarPalette {
+  peakL: number;
+  C: number;
+  H: number;
+  weight: number; // relative spawn probability
+}
+
+const PALETTE: StarPalette[] = [
+  { peakL: 0.30, C: 0,    H: 0,   weight: 3 }, // dark/black
+  { peakL: 0.90, C: 0,    H: 0,   weight: 4 }, // white
+  { peakL: 0.75, C: 0.14, H: 65,  weight: 2 }, // orange
+  { peakL: 0.65, C: 0.18, H: 300, weight: 2 }, // violet
+];
+
+const TOTAL_WEIGHT = PALETTE.reduce((s, p) => s + p.weight, 0);
+
+function pickColor(rng: () => number): StarPalette {
+  let r = rng() * TOTAL_WEIGHT;
+  for (const p of PALETTE) {
+    r -= p.weight;
+    if (r <= 0) return p;
+  }
+  // Unreachable: r starts ≤ TOTAL_WEIGHT so the loop always returns.
+  // Fallback satisfies the type checker.
+  return PALETTE[PALETTE.length - 1] as StarPalette;
+}
+
+// ---------------------------------------------------------------------------
+// Glyph selection by brightness
+// ---------------------------------------------------------------------------
+
+/** Map normalized brightness (0–1) to a glyph that conveys intensity. */
+export function glyphForBrightness(t: number): string {
+  if (t < 0.20) return "·";
+  if (t < 0.45) return "∗";
+  if (t < 0.70) return "✦";
+  return "★";
+}
+
+// ---------------------------------------------------------------------------
+// Quasar shape
+// ---------------------------------------------------------------------------
+
+interface QuasarArm {
+  dx: number;
+  dy: number;
+  glyph: string;
+  /** Brightness multiplier relative to center. */
+  bright: number;
+}
+
+const QUASAR_SHAPE: QuasarArm[] = [
+  // Inner arms
+  { dx: 0, dy: -1, glyph: "│", bright: 0.7 },
+  { dx: -1, dy: 0, glyph: "─", bright: 0.7 },
+  { dx: 0,  dy: 0, glyph: "╋", bright: 1.0 },
+  { dx: 1,  dy: 0, glyph: "─", bright: 0.7 },
+  { dx: 0,  dy: 1, glyph: "│", bright: 0.7 },
+  // Outer tips
+  { dx: 0, dy: -2, glyph: "·", bright: 0.35 },
+  { dx: -2, dy: 0, glyph: "·", bright: 0.35 },
+  { dx: 2,  dy: 0, glyph: "·", bright: 0.35 },
+  { dx: 0,  dy: 2, glyph: "·", bright: 0.35 },
+];
+
+// ---------------------------------------------------------------------------
+// Star data
+// ---------------------------------------------------------------------------
+
+interface Star {
+  x: number;
+  y: number;
+  birthFrame: number;
+  lifetime: number;
+  palette: StarPalette;
+  isQuasar: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Simple PRNG (mulberry32)
+// ---------------------------------------------------------------------------
+
+export function createRng(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Luminance curve
+// ---------------------------------------------------------------------------
+
+/** Sine fade: 0 → 1 → 0 over a normalized lifetime [0, 1]. */
+export function fadeCurve(age: number, lifetime: number): number {
+  if (age < 0 || age >= lifetime) return 0;
+  return Math.sin((age / lifetime) * Math.PI);
+}
+
+// ---------------------------------------------------------------------------
+// Cell grid
+// ---------------------------------------------------------------------------
+
+export interface StarfieldCell {
+  glyph: string;
+  color: string; // hex
+}
+
+// ---------------------------------------------------------------------------
+// Mutable simulation state (lives in useRef)
+// ---------------------------------------------------------------------------
+
+interface SimState {
+  stars: Star[];
+  rng: () => number;
+  lastFrame: number;
+  dimKey: string;
+}
+
+function spawnStar(
+  rng: () => number,
+  frame: number,
+  width: number,
+  height: number,
+  lifetime: number,
+  quasarChance: number,
+): Star {
+  return {
+    x: Math.floor(rng() * width),
+    y: Math.floor(rng() * height),
+    birthFrame: frame,
+    lifetime: Math.round(lifetime * (0.7 + rng() * 0.6)), // ±30% variation
+    palette: pickColor(rng),
+    isQuasar: rng() < quasarChance,
+  };
+}
+
+function advanceFrame(
+  state: SimState,
+  frame: number,
+  width: number,
+  height: number,
+  lifetime: number,
+  quasarChance: number,
+  targetCount: number,
+): void {
+  // Expire dead stars
+  state.stars = state.stars.filter(
+    (s) => frame - s.birthFrame < s.lifetime,
+  );
+
+  // Spawn new stars to maintain target density
+  const deficit = targetCount - state.stars.length;
+  for (let i = 0; i < deficit; i++) {
+    state.stars.push(
+      spawnStar(state.rng, frame, width, height, lifetime, quasarChance),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Grid builder
+// ---------------------------------------------------------------------------
+
+export function buildGrid(
+  stars: Star[],
+  width: number,
+  height: number,
+  frame: number,
+): (StarfieldCell | null)[][] {
+  // Allocate grid
+  const grid: (StarfieldCell | null)[][] = Array.from({ length: height }, () =>
+    Array.from<StarfieldCell | null>({ length: width }).fill(null),
+  );
+
+  for (const star of stars) {
+    const age = frame - star.birthFrame;
+    const brightness = fadeCurve(age, star.lifetime);
+    if (brightness <= 0) continue;
+
+    if (star.isQuasar) {
+      for (const arm of QUASAR_SHAPE) {
+        const cx = star.x + arm.dx;
+        const cy = star.y + arm.dy;
+        if (cx < 0 || cx >= width || cy < 0 || cy >= height) continue;
+        const row = grid[cy];
+        if (!row || row[cx] !== null) continue; // don't overwrite
+        const b = brightness * arm.bright;
+        const L = b * star.palette.peakL;
+        const C = b * star.palette.C;
+        row[cx] = {
+          glyph: arm.glyph,
+          color: oklchToHex({ L, C, H: star.palette.H }),
+        };
+      }
+    } else {
+      if (star.x >= 0 && star.x < width && star.y >= 0 && star.y < height) {
+        const row = grid[star.y];
+        if (row && row[star.x] === null) {
+          const L = brightness * star.palette.peakL;
+          const C = brightness * star.palette.C;
+          row[star.x] = {
+            glyph: glyphForBrightness(brightness),
+            color: oklchToHex({ L, C, H: star.palette.H }),
+          };
+        }
+      }
+    }
+  }
+
+  return grid;
+}
+
+// ---------------------------------------------------------------------------
+// Hook: useStarfield
+// ---------------------------------------------------------------------------
+
+export function useStarfield(
+  width: number,
+  height: number,
+  config: StarfieldConfig = {},
+): (StarfieldCell | null)[][] {
+  const density = config.density ?? DEFAULT_DENSITY;
+  const lifetime = config.lifetime ?? DEFAULT_LIFETIME;
+  const quasarChance = config.quasarChance ?? DEFAULT_QUASAR_CHANCE;
+  const interval = config.interval ?? DEFAULT_INTERVAL;
+  const isActive = config.isActive ?? true;
+
+  const { frame } = useAnimation({ interval, isActive });
+
+  const stateRef = useRef<SimState | null>(null);
+
+  const dimKey = `${width}x${height}`;
+  const area = width * height;
+  const targetCount = Math.max(1, Math.round(area * density));
+
+  // (Re-)initialize when dimensions change
+  if (!stateRef.current || stateRef.current.dimKey !== dimKey) {
+    const rng = createRng(42);
+    const stars: Star[] = [];
+    // Pre-seed stars at random lifecycle phases so the field isn't empty at start
+    for (let i = 0; i < targetCount; i++) {
+      const s = spawnStar(rng, 0, width, height, lifetime, quasarChance);
+      // Backdate birth so stars are at various ages on frame 0
+      s.birthFrame = -Math.floor(rng() * s.lifetime);
+      stars.push(s);
+    }
+    stateRef.current = { stars, rng, lastFrame: -1, dimKey };
+  }
+
+  const state = stateRef.current;
+
+  // Advance simulation to current frame (idempotent for same frame)
+  while (state.lastFrame < frame) {
+    state.lastFrame++;
+    advanceFrame(
+      state,
+      state.lastFrame,
+      width,
+      height,
+      lifetime,
+      quasarChance,
+      targetCount,
+    );
+  }
+
+  return buildGrid(state.stars, width, height, frame);
+}
+
+// ---------------------------------------------------------------------------
+// Component: StarfieldRow
+// ---------------------------------------------------------------------------
+
+interface StarfieldRowProps {
+  cells: (StarfieldCell | null)[];
+}
+
+/**
+ * Renders a single row of the starfield as batched colored spans.
+ * Consecutive spaces are merged; consecutive same-color stars are merged.
+ */
+function StarfieldRow({ cells }: StarfieldRowProps) {
+  const segments: React.ReactNode[] = [];
+  let spaces = 0;
+
+  const flushSpaces = () => {
+    if (spaces > 0) {
+      segments.push(" ".repeat(spaces));
+      spaces = 0;
+    }
+  };
+
+  for (let i = 0; i < cells.length; i++) {
+    const cell = cells[i];
+    if (!cell) {
+      spaces++;
+      continue;
+    }
+    flushSpaces();
+
+    // Batch consecutive cells with the same color
+    let run = cell.glyph;
+    while (i + 1 < cells.length && cells[i + 1]?.color === cell.color) {
+      i++;
+      run += (cells[i] as StarfieldCell).glyph;
+    }
+    segments.push(
+      <Text key={i} color={cell.color}>
+        {run}
+      </Text>,
+    );
+  }
+  flushSpaces();
+
+  // Wrap in a single Text so segments lay out inline
+  return <Text>{segments}</Text>;
+}
+
+// ---------------------------------------------------------------------------
+// Component: StarfieldRows
+// ---------------------------------------------------------------------------
+
+export interface StarfieldRowsProps {
+  grid: (StarfieldCell | null)[][];
+  startRow: number;
+  rowCount: number;
+}
+
+/**
+ * Renders a slice of the starfield grid as a vertical stack of rows.
+ */
+export function StarfieldRows({ grid, startRow, rowCount }: StarfieldRowsProps) {
+  const rows: React.ReactNode[] = [];
+  for (let r = 0; r < rowCount; r++) {
+    const gridRow = grid[startRow + r];
+    if (!gridRow) continue;
+    rows.push(<StarfieldRow key={r} cells={gridRow} />);
+  }
+  return <Box flexDirection="column">{rows}</Box>;
+}

--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -48,6 +48,7 @@ const PALETTE: StarPalette[] = [
   { peakL: 0.30, C: 0,    H: 0,   weight: 3 },   // dark/black
   { peakL: 0.90, C: 0,    H: 0,   weight: 4 },   // white
   { peakL: 0.75, C: 0.14, H: 65,  weight: 0.4 }, // orange (rare)
+  { peakL: 0.55, C: 0.18, H: 25,  weight: 3 },   // red
   { peakL: 0.65, C: 0.18, H: 300, weight: 2 },   // violet
 ];
 
@@ -210,9 +211,12 @@ function advanceFrame(
     (s) => frame - s.birthFrame < s.lifetime,
   );
 
-  // Spawn new stars to maintain target density
+  // Spawn new stars toward target density, capped at the steady-state
+  // replacement rate so the field fills in gradually from empty.
+  const maxSpawnsPerFrame = Math.max(1, Math.ceil(targetCount / lifetime));
   const deficit = targetCount - state.stars.length;
-  for (let i = 0; i < deficit; i++) {
+  const toSpawn = Math.min(deficit, maxSpawnsPerFrame);
+  for (let i = 0; i < toSpawn; i++) {
     state.stars.push(
       spawnStar(state.rng, frame, width, height, lifetime, quasarChance),
     );
@@ -295,18 +299,10 @@ export function useStarfield(
   const area = width * height;
   const targetCount = Math.max(1, Math.round(area * density));
 
-  // (Re-)initialize when dimensions change
+  // (Re-)initialize when dimensions change — start empty and let stars
+  // fade in gradually via the per-frame spawn cap in advanceFrame.
   if (!stateRef.current || stateRef.current.dimKey !== dimKey) {
-    const rng = createRng(42);
-    const stars: Star[] = [];
-    // Pre-seed stars at random lifecycle phases so the field isn't empty at start
-    for (let i = 0; i < targetCount; i++) {
-      const s = spawnStar(rng, 0, width, height, lifetime, quasarChance);
-      // Backdate birth so stars are at various ages on frame 0
-      s.birthFrame = -Math.floor(rng() * s.lifetime);
-      stars.push(s);
-    }
-    stateRef.current = { stars, rng, lastFrame: -1, dimKey };
+    stateRef.current = { stars: [], rng: createRng(42), lastFrame: -1, dimKey };
   }
 
   const state = stateRef.current;

--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -48,7 +48,7 @@ const PALETTE: StarPalette[] = [
   { peakL: 0.30, C: 0,    H: 0,   weight: 3 },   // dark/black
   { peakL: 0.90, C: 0,    H: 0,   weight: 4 },   // white
   { peakL: 0.75, C: 0.14, H: 65,  weight: 0.4 }, // orange (rare)
-  { peakL: 0.55, C: 0.18, H: 25,  weight: 3 },   // red
+  { peakL: 0.55, C: 0.18, H: 25,  weight: 0.4 }, // red (rare)
   { peakL: 0.65, C: 0.18, H: 300, weight: 2 },   // violet
 ];
 

--- a/packages/client-ink/src/tui/components/index.ts
+++ b/packages/client-ink/src/tui/components/index.ts
@@ -12,3 +12,5 @@ export type { KeyHint } from "./KeyHints.js";
 export { TerminalTooSmall } from "./TerminalTooSmall.js";
 export { FullScreenFrame } from "./FullScreenFrame.js";
 export type { FullScreenFrameProps } from "./FullScreenFrame.js";
+export { useStarfield, StarfieldRows } from "./Starfield.js";
+export type { StarfieldConfig, StarfieldCell } from "./Starfield.js";

--- a/packages/client-ink/src/tui/components/index.ts
+++ b/packages/client-ink/src/tui/components/index.ts
@@ -12,5 +12,5 @@ export type { KeyHint } from "./KeyHints.js";
 export { TerminalTooSmall } from "./TerminalTooSmall.js";
 export { FullScreenFrame } from "./FullScreenFrame.js";
 export type { FullScreenFrameProps } from "./FullScreenFrame.js";
-export { useStarfield, StarfieldRows } from "./Starfield.js";
+export { useStarfield, StarfieldRows, resetStarfieldCache } from "./Starfield.js";
 export type { StarfieldConfig, StarfieldCell } from "./Starfield.js";


### PR DESCRIPTION
## Summary

- Slow atmospheric starfield (1 FPS) fills the padding areas above and below the centered menu content
- Stars fade in/out over ~60 frames using OKLCH lightness with a sin³ curve (mostly dim, briefly bright)
- Five-color palette: dark, white, orange (rare), red (rare), violet
- ~3% of stars are quasars — box-drawing plus shapes with fading arms
- 60% of stars never reach the brightest glyph tier
- Field starts empty and fills gradually over ~60 seconds
- Simulation state persists across menu navigation (Settings → back) via module-level cache with frame offset for seamless resume
- `FullScreenFrame` gains optional `starfield` prop (boolean or config object)
- Uses Ink 7's `useAnimation` hook (from #369)

## Test plan

- [x] 783 client-ink tests pass (20 new starfield tests)
- [x] 1315 engine tests pass
- [x] Visual verification of density, color mix, fade curve, quasars
- [ ] Manual test: navigate to Settings and back, verify stars persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)