### PR TITLE
Fix compendium modal crash on missing category arrays

### DIFF
--- a/packages/client-ink/src/tui/modals/CompendiumModal.test.tsx
+++ b/packages/client-ink/src/tui/modals/CompendiumModal.test.tsx
@@ -101,6 +101,35 @@ describe("CompendiumModal", () => {
     expect(frame).toContain("Objectives (1)");
   });
 
+  it("handles compendium with missing category arrays", () => {
+    // Legacy compendiums may lack newer categories (e.g. items)
+    const legacy = {
+      version: 1 as const,
+      lastUpdatedScene: 3,
+      characters: [entry({ name: "Oros", slug: "oros", summary: "A PC." })],
+      places: [],
+      storyline: [],
+      lore: [],
+      objectives: [],
+      // items intentionally missing
+    } as unknown as Compendium;
+
+    const { lastFrame } = render(
+      <Box width={60} height={24}>
+        <CompendiumModal
+          theme={theme}
+          width={60}
+          height={24}
+          data={legacy}
+          onClose={() => {}}
+        />
+      </Box>,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain("Characters (1)");
+    expect(frame).toContain("Items (0)");
+  });
+
   it("renders title as Compendium", () => {
     const { lastFrame } = render(
       <Box width={60} height={24}>

--- a/packages/client-ink/src/tui/modals/CompendiumModal.tsx
+++ b/packages/client-ink/src/tui/modals/CompendiumModal.tsx
@@ -55,7 +55,7 @@ export function CompendiumModal({
   const rows: TreeRow[] = useMemo(() => {
     const result: TreeRow[] = [];
     for (const cat of COMPENDIUM_CATEGORIES) {
-      const entries = data[cat];
+      const entries = data[cat] ?? [];
       const isExpanded = expanded.has(cat);
       result.push({
         type: "category",
@@ -164,7 +164,7 @@ export function CompendiumModal({
   }
 
   // --- Tree view ---
-  const isEmpty = COMPENDIUM_CATEGORIES.every((cat) => data[cat].length === 0);
+  const isEmpty = COMPENDIUM_CATEGORIES.every((cat) => (data[cat] ?? []).length === 0);
 
   if (isEmpty) {
     return (


### PR DESCRIPTION
## Summary

- Opening the compendium modal crashes with `TypeError: Cannot read properties of undefined (reading 'length')` when a category array (e.g. `items`) is missing from the compendium JSON.
- This happens with legacy compendiums created before newer categories were added.
- Added `?? []` fallback on both access sites (row building and empty check).

## Test plan

- [x] All 2194 tests pass
- [x] Lint clean
- [x] New test: compendium with missing `items` array renders without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)