### PR TITLE
Wire up retry/backoff for transient API errors

### DIFF
--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -572,7 +572,10 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
       activeModal,
       setActiveModal,
       retryOverlay: clientState.lastError?.recoverable
-        ? { status: 0, delaySec: 5 }
+        ? {
+            status: clientState.lastError.status ?? 0,
+            delaySec: Math.ceil((clientState.lastError.delayMs ?? 5000) / 1000),
+          }
         : null,
       mode: clientState.mode,
       stateSnapshot,

--- a/packages/client-ink/src/event-handler.test.ts
+++ b/packages/client-ink/src/event-handler.test.ts
@@ -338,14 +338,61 @@ describe("event-handler", () => {
   });
 
   describe("errors", () => {
-    it("stores error", () => {
+    it("stores error with status and delayMs", () => {
       const h = makeHarness();
       h.dispatch({
         type: "error",
-        data: { message: "API retry", recoverable: true, status: 529, delayMs: 5000 },
+        data: { message: "API retry (status 529)", recoverable: true, status: 529, delayMs: 2000 },
       });
 
-      expect(h.state.lastError).toEqual({ message: "API retry", recoverable: true });
+      expect(h.state.lastError).toEqual({
+        message: "API retry (status 529)",
+        recoverable: true,
+        status: 529,
+        delayMs: 2000,
+      });
+    });
+
+    it("stores non-recoverable error without status/delayMs", () => {
+      const h = makeHarness();
+      h.dispatch({
+        type: "error",
+        data: { message: "Something broke", recoverable: false },
+      });
+
+      expect(h.state.lastError).toEqual({
+        message: "Something broke",
+        recoverable: false,
+        status: undefined,
+        delayMs: undefined,
+      });
+    });
+
+    it("clears recoverable lastError on narrative:chunk", () => {
+      const h = makeHarness();
+      // Set a recoverable error (retry in progress)
+      h.dispatch({
+        type: "error",
+        data: { message: "API retry (status 429)", recoverable: true, status: 429, delayMs: 1000 },
+      });
+      expect(h.state.lastError).not.toBeNull();
+
+      // Narrative chunk arrives → retry succeeded
+      h.dispatch({ type: "narrative:chunk", data: { text: "The door opens.", kind: "dm" } });
+      expect(h.state.lastError).toBeNull();
+    });
+
+    it("preserves non-recoverable lastError on narrative:chunk", () => {
+      const h = makeHarness();
+      h.dispatch({
+        type: "error",
+        data: { message: "Something broke", recoverable: false },
+      });
+
+      h.dispatch({ type: "narrative:chunk", data: { text: "Hello", kind: "dm" } });
+      // Non-recoverable error should persist
+      expect(h.state.lastError).not.toBeNull();
+      expect(h.state.lastError!.recoverable).toBe(false);
     });
   });
 

--- a/packages/client-ink/src/event-handler.ts
+++ b/packages/client-ink/src/event-handler.ts
@@ -50,7 +50,7 @@ export interface ClientState {
   transitionCampaignId: string | null;
   /** Human-readable campaign name from the transition event. */
   transitionCampaignName: string | null;
-  lastError: { message: string; recoverable: boolean } | null;
+  lastError: { message: string; recoverable: boolean; status?: number; delayMs?: number } | null;
   /** Per-character modeline text (character name → status string). */
   modelines: Record<string, string>;
   /** Per-character resource display keys. */
@@ -190,6 +190,8 @@ function handleNarrativeChunk(event: NarrativeChunkEvent, update: StateUpdater):
     return {
       ...prev,
       narrativeLines: appendDelta(lines, text, lineKind),
+      // Clear any retry error — arriving data proves the retry succeeded
+      lastError: prev.lastError?.recoverable ? null : prev.lastError,
     };
   });
 }
@@ -372,6 +374,11 @@ function handleSessionEnded(_event: SessionEndedEvent, update: StateUpdater): vo
 function handleError(event: ErrorEvent, update: StateUpdater): void {
   update((prev) => ({
     ...prev,
-    lastError: { message: event.data.message, recoverable: event.data.recoverable },
+    lastError: {
+      message: event.data.message,
+      recoverable: event.data.recoverable,
+      status: event.data.status,
+      delayMs: event.data.delayMs,
+    },
   }));
 }

--- a/packages/engine/src/agents/agent-loop.ts
+++ b/packages/engine/src/agents/agent-loop.ts
@@ -55,6 +55,8 @@ export interface AgentLoopConfig {
   onComplete?: (usage: UsageStats) => void;
   /** Called on error */
   onError?: (error: Error) => void;
+  /** Called when a retryable API error triggers a backoff wait */
+  onRetry?: (status: number, delayMs: number) => void;
 }
 
 import type { UsageStats, TuiCommand } from "@machine-violet/shared/types/engine.js";
@@ -144,6 +146,7 @@ async function runAgentLoopInternal(
     onToolEnd: config.onToolEnd,
     onComplete: config.onComplete,
     onError: config.onError,
+    onRetry: config.onRetry,
   });
 
   return {

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -1174,6 +1174,7 @@ export class GameEngine {
         // visual updates appear mid-narration instead of after the turn.
         this.callbacks.onTuiCommand(cmd);
       },
+      onRetry: (status, delayMs) => this.callbacks.onRetry(status, delayMs),
     };
   }
 

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -228,6 +228,7 @@ async function streamWithRetry(
   provider: LLMProvider,
   params: ChatParams,
   onDelta: (delta: string) => void,
+  onRetry?: (status: number, delayMs: number) => void,
 ): Promise<ChatResult> {
   for (let attempt = 0; ; attempt++) {
     try {
@@ -244,7 +245,9 @@ async function streamWithRetry(
       if (status === null || !RETRYABLE_STATUS.has(status)) {
         throw e instanceof Error ? e : new Error(String(e));
       }
-      await sleep(retryDelay(attempt));
+      const delay = retryDelay(attempt);
+      onRetry?.(status, delay);
+      await sleep(delay);
     }
   }
 }
@@ -275,6 +278,7 @@ export function createSetupConversation(
   provider: LLMProvider,
   model: string,
   existingPlayers?: KnownPlayer[],
+  onRetry?: (status: number, delayMs: number) => void,
 ): SetupConversation {
   // Build per-session system prompt (randomizes seed/personality order).
   // Known players are injected right after the base prompt (before seeds/personalities)
@@ -369,7 +373,7 @@ export function createSetupConversation(
       thinking,
     };
 
-    const result = await streamWithRetry(provider, lastParams, onDelta);
+    const result = await streamWithRetry(provider, lastParams, onDelta, onRetry);
 
     // Accumulate usage
     totalUsage.inputTokens += result.usage.inputTokens;
@@ -457,7 +461,7 @@ export function createSetupConversation(
         tools: TOOLS,
         thinking,
       };
-      const followUp = await streamWithRetry(provider, lastParams, onDelta);
+      const followUp = await streamWithRetry(provider, lastParams, onDelta, onRetry);
 
       totalUsage.inputTokens += followUp.usage.inputTokens;
       totalUsage.outputTokens += followUp.usage.outputTokens;

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from "vitest";
+import type { LLMProvider, ChatResult, NormalizedUsage } from "./types.js";
+import { runProviderLoop } from "./agent-loop-bridge.js";
+
+function mockUsage(): NormalizedUsage {
+  return { inputTokens: 50, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 };
+}
+
+function textResult(text: string): ChatResult {
+  return {
+    text,
+    toolCalls: [],
+    usage: mockUsage(),
+    stopReason: "end",
+    assistantContent: [{ type: "text", text }],
+  };
+}
+
+function apiError(status: number, message = "error"): Error {
+  const err = new Error(message);
+  (err as unknown as Record<string, unknown>).status = status;
+  return err;
+}
+
+function networkError(): Error {
+  const err = new Error("fetch failed");
+  err.name = "TypeError";
+  return err;
+}
+
+describe("runProviderLoop retry", () => {
+  it("retries on 429 and succeeds on second attempt", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) throw apiError(429, "Rate limited");
+        return textResult("Success after retry");
+      }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      onRetry,
+    });
+
+    expect(result.text).toBe("Success after retry");
+    expect(callCount).toBe(2);
+    expect(onRetry).toHaveBeenCalledOnce();
+    expect(onRetry).toHaveBeenCalledWith(429, expect.any(Number));
+  });
+
+  it("retries on 529 (overloaded)", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) throw apiError(529, "Overloaded");
+        return textResult("OK");
+      }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      onRetry,
+    });
+
+    expect(result.text).toBe("OK");
+    expect(onRetry).toHaveBeenCalledWith(529, expect.any(Number));
+  });
+
+  it("retries on network errors (status 0)", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) throw networkError();
+        return textResult("Reconnected");
+      }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      onRetry,
+    });
+
+    expect(result.text).toBe("Reconnected");
+    expect(onRetry).toHaveBeenCalledWith(0, expect.any(Number));
+  });
+
+  it("throws after maxRetries exhausted", async () => {
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => { throw apiError(429, "Always rate limited"); }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    await expect(runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      maxRetries: 2,
+      onRetry,
+    })).rejects.toThrow("Always rate limited");
+
+    // Should have retried exactly maxRetries times (attempts 0, 1, 2 — fail on attempt 2 with attempt < maxRetries false)
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-retryable errors (400)", async () => {
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => { throw apiError(400, "Bad request"); }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    await expect(runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      onRetry,
+    })).rejects.toThrow("Bad request");
+
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(provider.chat).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry errors without HTTP status (e.g. ContentRefusalError)", async () => {
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => { throw new Error("Content refusal"); }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    await expect(runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      onRetry,
+    })).rejects.toThrow("Content refusal");
+
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("works without onRetry callback (silent retry for subagents)", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) throw apiError(503, "Service unavailable");
+        return textResult("OK");
+      }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    // No onRetry callback — subagents and resolve-session don't pass one
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+    });
+
+    expect(result.text).toBe("OK");
+    expect(callCount).toBe(2);
+  });
+
+  it("retries streaming calls", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) throw apiError(502, "Bad gateway");
+        const result = textResult("Streamed OK");
+        onDelta(result.text);
+        return result;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    const onTextDelta = vi.fn();
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta,
+      onRetry,
+    });
+
+    expect(result.text).toBe("Streamed OK");
+    expect(onRetry).toHaveBeenCalledWith(502, expect.any(Number));
+  });
+});

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { LLMProvider, ChatResult, NormalizedUsage } from "./types.js";
 import { runProviderLoop } from "./agent-loop-bridge.js";
 
@@ -29,6 +29,9 @@ function networkError(): Error {
 }
 
 describe("runProviderLoop retry", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
   it("retries on 429 and succeeds on second attempt", async () => {
     let callCount = 0;
     const provider: LLMProvider = {
@@ -43,7 +46,7 @@ describe("runProviderLoop retry", () => {
     };
 
     const onRetry = vi.fn();
-    const result = await runProviderLoop(provider, "system", [
+    const promise = runProviderLoop(provider, "system", [
       { role: "user", content: "hello" },
     ], {
       name: "test",
@@ -52,6 +55,9 @@ describe("runProviderLoop retry", () => {
       stream: false,
       onRetry,
     });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
 
     expect(result.text).toBe("Success after retry");
     expect(callCount).toBe(2);
@@ -73,7 +79,7 @@ describe("runProviderLoop retry", () => {
     };
 
     const onRetry = vi.fn();
-    const result = await runProviderLoop(provider, "system", [
+    const promise = runProviderLoop(provider, "system", [
       { role: "user", content: "hello" },
     ], {
       name: "test",
@@ -82,6 +88,9 @@ describe("runProviderLoop retry", () => {
       stream: false,
       onRetry,
     });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
 
     expect(result.text).toBe("OK");
     expect(onRetry).toHaveBeenCalledWith(529, expect.any(Number));
@@ -101,7 +110,7 @@ describe("runProviderLoop retry", () => {
     };
 
     const onRetry = vi.fn();
-    const result = await runProviderLoop(provider, "system", [
+    const promise = runProviderLoop(provider, "system", [
       { role: "user", content: "hello" },
     ], {
       name: "test",
@@ -110,6 +119,9 @@ describe("runProviderLoop retry", () => {
       stream: false,
       onRetry,
     });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
 
     expect(result.text).toBe("Reconnected");
     expect(onRetry).toHaveBeenCalledWith(0, expect.any(Number));
@@ -124,7 +136,7 @@ describe("runProviderLoop retry", () => {
     };
 
     const onRetry = vi.fn();
-    await expect(runProviderLoop(provider, "system", [
+    const promise = runProviderLoop(provider, "system", [
       { role: "user", content: "hello" },
     ], {
       name: "test",
@@ -133,9 +145,23 @@ describe("runProviderLoop retry", () => {
       stream: false,
       maxRetries: 2,
       onRetry,
-    })).rejects.toThrow("Always rate limited");
+    });
 
-    // Should have retried exactly maxRetries times (attempts 0, 1, 2 — fail on attempt 2 with attempt < maxRetries false)
+    // Catch the rejection early to avoid unhandled rejection warning,
+    // then advance timers and assert the error.
+    let caughtError: Error | undefined;
+    promise.catch((e: Error) => { caughtError = e; });
+
+    // Advance through both retry delays (1s + 2s)
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
+    // Let the final rejection settle
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError!.message).toBe("Always rate limited");
+
+    // 2 retries (attempts 0 and 1 trigger onRetry; attempt 2 exceeds maxRetries and throws)
     expect(onRetry).toHaveBeenCalledTimes(2);
   });
 
@@ -198,7 +224,7 @@ describe("runProviderLoop retry", () => {
     };
 
     // No onRetry callback — subagents and resolve-session don't pass one
-    const result = await runProviderLoop(provider, "system", [
+    const promise = runProviderLoop(provider, "system", [
       { role: "user", content: "hello" },
     ], {
       name: "test",
@@ -206,6 +232,9 @@ describe("runProviderLoop retry", () => {
       maxTokens: 100,
       stream: false,
     });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
 
     expect(result.text).toBe("OK");
     expect(callCount).toBe(2);
@@ -228,7 +257,7 @@ describe("runProviderLoop retry", () => {
 
     const onRetry = vi.fn();
     const onTextDelta = vi.fn();
-    const result = await runProviderLoop(provider, "system", [
+    const promise = runProviderLoop(provider, "system", [
       { role: "user", content: "hello" },
     ], {
       name: "test",
@@ -238,6 +267,9 @@ describe("runProviderLoop retry", () => {
       onTextDelta,
       onRetry,
     });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
 
     expect(result.text).toBe("Streamed OK");
     expect(onRetry).toHaveBeenCalledWith(502, expect.any(Number));

--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -16,6 +16,9 @@ import type {
 } from "./types.js";
 import type { ToolResult } from "../agents/tool-registry.js";
 import type { TuiCommand } from "../agents/agent-loop.js";
+import {
+  extractStatus, RETRYABLE_STATUS, retryDelay, sleep,
+} from "../utils/retry.js";
 
 /**
  * TUI command types that require engine-side processing (scene transitions,
@@ -68,6 +71,10 @@ export interface ProviderLoopConfig {
   onToolEnd?: (name: string, result: ToolResult) => void;
   onComplete?: (usage: NormalizedUsage) => void;
   onError?: (error: Error) => void;
+  /** Called when a retryable API error triggers a backoff wait. */
+  onRetry?: (status: number, delayMs: number) => void;
+  /** Max retry attempts per API call (default 5 → ~27s total backoff). */
+  maxRetries?: number;
 }
 
 export interface ProviderLoopResult {
@@ -89,6 +96,7 @@ export async function runProviderLoop(
   config: ProviderLoopConfig,
 ): Promise<ProviderLoopResult> {
   const maxToolRounds = config.maxToolRounds ?? 3;
+  const maxRetries = config.maxRetries ?? 5;
   const shouldStream = config.stream !== false && !!config.onTextDelta;
 
   // Only enable thinking for models that support it (per model registry).
@@ -148,22 +156,40 @@ export async function runProviderLoop(
 
     let result: ChatResult;
     const apiStart = Date.now();
-    try {
-      if (shouldStream) {
-        result = await provider.stream(chatParams, (delta) => config.onTextDelta?.(delta));
-      } else {
-        result = await provider.chat(chatParams);
-        // In non-streaming mode, emit the full text
-        if (result.text) config.onTextDelta?.(result.text);
+    for (let attempt = 0; ; attempt++) {
+      try {
+        if (shouldStream) {
+          result = await provider.stream(chatParams, (delta) => config.onTextDelta?.(delta));
+        } else {
+          result = await provider.chat(chatParams);
+          // In non-streaming mode, emit the full text
+          if (result.text) config.onTextDelta?.(result.text);
+        }
+        break; // success — exit retry loop
+      } catch (apiErr) {
+        const status = extractStatus(apiErr);
+        const retryable = status !== null
+          && RETRYABLE_STATUS.has(status)
+          && attempt < maxRetries;
+
+        logEvent("api:error", {
+          agent: config.name,
+          model: config.model,
+          durationMs: Date.now() - apiStart,
+          message: apiErr instanceof Error ? apiErr.message : String(apiErr),
+          status,
+          attempt,
+          willRetry: retryable,
+        });
+
+        if (!retryable) {
+          throw apiErr;
+        }
+
+        const delay = retryDelay(attempt);
+        config.onRetry?.(status, delay);
+        await sleep(delay);
       }
-    } catch (apiErr) {
-      logEvent("api:error", {
-        agent: config.name,
-        model: config.model,
-        durationMs: Date.now() - apiStart,
-        message: apiErr instanceof Error ? apiErr.message : String(apiErr),
-      });
-      throw apiErr;
     }
 
     logEvent("api:call", {

--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -73,7 +73,7 @@ export interface ProviderLoopConfig {
   onError?: (error: Error) => void;
   /** Called when a retryable API error triggers a backoff wait. */
   onRetry?: (status: number, delayMs: number) => void;
-  /** Max retry attempts per API call (default 5 → ~27s total backoff). */
+  /** Max retries after the initial attempt (default 5 → up to 6 total attempts, ~27s backoff). */
   maxRetries?: number;
 }
 

--- a/packages/engine/src/server/setup-session.ts
+++ b/packages/engine/src/server/setup-session.ts
@@ -98,7 +98,12 @@ export class SetupSession {
   /** Start the setup conversation. Streams opening narrative to clients. */
   async start(): Promise<void> {
     const knownPlayers = await this.scanKnownPlayers();
-    this.conversation = createSetupConversation(this.provider, this.model, knownPlayers);
+    this.conversation = createSetupConversation(this.provider, this.model, knownPlayers, (status, delayMs) => {
+      this.broadcast({
+        type: "error",
+        data: { message: `API retry (status ${status})`, recoverable: true, status, delayMs },
+      });
+    });
     this.started = true;
 
     this.emitThinking();


### PR DESCRIPTION
## Summary

- Retry/backoff was completely nonfunctional after the multi-provider refactor and client-server split
- Added retry loop in `runProviderLoop` (the single API call site) with exponential backoff: 1s→2s→4s→8s→12s, max 5 attempts
- Wired `onRetry` callback through `AgentLoopConfig` → `ProviderLoopConfig` → `game-engine.buildAgentConfig()` → bridge
- Fixed client to propagate real `status`/`delayMs` from error events (was being dropped)
- Fixed `app.tsx` to use real values for retry overlay (was hardcoded `{status: 0, delaySec: 5}`)
- Clear recoverable errors when narrative data arrives (proves retry succeeded → modal auto-dismisses)

Subagents and resolve-session get silent retry for free since they call `runProviderLoop` without an `onRetry` callback.

## What was broken (4 breaks in the chain)

1. No retry loop anywhere in the main game flow
2. `onRetry` callback defined in bridge but never called (not wired through agent loop config)
3. Client `event-handler.ts` dropped `status`/`delayMs` from error events
4. `app.tsx` hardcoded `{status: 0, delaySec: 5}` for retry overlay regardless of actual error

## Files changed

| File | Change |
|------|--------|
| `agent-loop-bridge.ts` | Retry loop around `provider.chat()`/`stream()`, `onRetry`/`maxRetries` on config |
| `agent-loop.ts` | Pass `onRetry` through `AgentLoopConfig` → `ProviderLoopConfig` |
| `game-engine.ts` | Wire `onRetry` in `buildAgentConfig()` |
| `event-handler.ts` | Propagate `status`/`delayMs`, clear recoverable errors on narrative chunk |
| `app.tsx` | Derive `retryOverlay` from real error data |

## Test plan

- [x] 8 new retry tests in `agent-loop-bridge.test.ts` (429/529/network retry, max retries, non-retryable passthrough, silent retry, streaming)
- [x] 3 new error tests in `event-handler.test.ts` (status/delayMs propagation, recoverable error clearing, non-recoverable preservation)
- [x] Full `npm run check` passes (2205 tests, lint clean)
- [ ] Manual: trigger 429 during gameplay and verify countdown modal shows real status/delay, auto-dismisses on retry success

🤖 Generated with [Claude Code](https://claude.com/claude-code)