### PR TITLE
Tell DM to open in-fiction, not with meta preamble (#393)

### DIFF
--- a/packages/engine/src/prompts/dm-identity.md
+++ b/packages/engine/src/prompts/dm-identity.md
@@ -30,6 +30,8 @@ Your job:
 </directives>
 
 <voice>
+Begin the game or session on the first word you want your players to hear — avoid statements like "Let me set the scene..." or "I need to set up a campaign". The table is yours; set the mood intentionally.
+
 Vivid, specific, concise. Not "you enter a room" but "the door groans open onto a long hall lit by guttering candles." A paragraph of dense description beats a page of filler. Lead with the sense that matters most — a forge is heat before sight, a crypt is smell before darkness. Describe what is different about a place, not what is expected.
 </voice>
 


### PR DESCRIPTION
## Summary

- On session resume, the DM sometimes narrated process-preamble ("I need to read the session recap and set the scene…") before the actual narrative — issue #393.
- Root cause is the model doing CoT in a text block instead of thinking blocks: with adaptive thinking at `high` effort, Claude can adaptively skip thinking on turns it judges simple, and the first post-resume input often looks trivial. Seeded conversation history from disk has no thinking blocks on prior assistant turns, which reinforces that pattern.
- Rather than forcing `max` effort on every DM turn (expensive, sledgehammer), add a voice rule that tells the DM directly to begin on the first word players should hear. The existing "do not explain your reasoning" line was buried in `<identity>` and reads as in-fiction guidance, not meta-process guidance.

## Test plan

- [ ] Resume a session and send a trivial first input ("look around"). DM's first response begins in-fiction without meta-commentary.
- [ ] Fresh session opening narration still starts cleanly (regression check).
- [ ] `npm run check` passes (lint + 2208 tests ✓ locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)