### PR TITLE
Add world_slug field to finalize_setup tool

### DIFF
--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
 import type { LLMProvider, ChatResult, NormalizedUsage, SystemBlock } from "../../providers/types.js";
+
+// Mock loadWorldBySlug so we can test world_slug resolution without real .mvworld files
+vi.mock("../../config/world-loader.js", async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    loadWorldBySlug: vi.fn((slug: string) => {
+      if (slug === "the-shattered-crown") {
+        return { name: "The Shattered Crown", summary: "A kingdom torn apart", genres: ["fantasy"], detail: "Secret detail about the crown." };
+      }
+      return undefined;
+    }),
+  };
+});
+
 import { createSetupConversation } from "./setup-conversation.js";
 
 /** Flatten SystemBlock[] | string to a single string for content assertions. */
@@ -412,5 +427,61 @@ describe("createSetupConversation", () => {
     expect(params.cacheHints).toBeDefined();
     expect(params.cacheHints).toContainEqual({ target: "tools", ttl: "1h" });
     expect(params.cacheHints).toContainEqual({ target: "messages" });
+  });
+
+  it("finalize_setup uses world_slug for detail lookup when campaign_name differs", async () => {
+    // Agent renamed campaign from "The Shattered Crown" to "Crownfall" but passed world_slug
+    const input = {
+      ...FINALIZE_INPUT,
+      campaign_name: "Crownfall",
+      world_slug: "the-shattered-crown",
+      // campaign_detail omitted — should fall back to world file lookup via world_slug
+    };
+    const provider = mockProvider([
+      finalizeResponse(input),
+      textResponse("Your adventure begins!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized).toBeDefined();
+    expect(result.finalized!.campaignName).toBe("Crownfall");
+    expect(result.finalized!.campaignDetail).toBe("Secret detail about the crown.");
+  });
+
+  it("finalize_setup falls back to campaign_name slug when world_slug is absent", async () => {
+    // Campaign name matches the world slug directly
+    const input = {
+      ...FINALIZE_INPUT,
+      campaign_name: "The Shattered Crown",
+      // no world_slug, no campaign_detail — should derive slug from campaign_name
+    };
+    const provider = mockProvider([
+      finalizeResponse(input),
+      textResponse("Your adventure begins!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized).toBeDefined();
+    expect(result.finalized!.campaignDetail).toBe("Secret detail about the crown.");
+  });
+
+  it("finalize_setup sanitizes world_slug (path traversal prevention)", async () => {
+    const input = {
+      ...FINALIZE_INPUT,
+      campaign_name: "Evil Campaign",
+      world_slug: "../../../etc/passwd",
+      // Should be sanitized to "etc-passwd" which won't match any world
+    };
+    const provider = mockProvider([
+      finalizeResponse(input),
+      textResponse("Your adventure begins!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized).toBeDefined();
+    expect(result.finalized!.campaignDetail).toBeNull();
   });
 });

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -359,7 +359,9 @@ export function createSetupConversation(
     if (rawDetail === undefined || rawDetail === null) {
       // Primary: use world_slug if the agent passed it (reliable — came from load_world)
       // Fallback: derive slug from campaign_name (fragile — agent may rename the campaign)
-      const worldSlug = typeof input.world_slug === "string" ? input.world_slug.trim() : "";
+      // Sanitize world_slug to prevent path traversal (strip non-slug chars)
+      const rawWorldSlug = typeof input.world_slug === "string" ? input.world_slug.trim().toLowerCase() : "";
+      const worldSlug = rawWorldSlug.replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
       const fallbackSlug = campaignName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
       const slug = worldSlug || fallbackSlug;
       const world = loadWorldBySlug(slug);

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -68,6 +68,7 @@ const FINALIZE_TOOL: NormalizedTool = {
       character_description: { type: "string", description: "One-sentence character concept" },
       character_details: { type: "string", description: "Mechanical character details gathered during setup (class, skills, approaches, etc). Free-form text. Omit or null for pure narrative.", nullable: true },
       campaign_detail: { type: "string", description: "The world's hidden detail block (from load_world), passed through verbatim for the DM. Omit if the chosen world has no detail or the campaign is fully custom.", nullable: true },
+      world_slug: { type: "string", description: "Slug of the world file used (from load_world). Omit for fully custom campaigns.", nullable: true },
       age_group: { type: "string", enum: ["child", "teenager", "adult"], description: "Player's age group. Set to 'child' or 'teenager' if the player clearly indicates so. Otherwise — including when age is not discussed or the player declines — set to 'adult'. Always include this field." },
       content_preferences: { type: "string", description: "Any content preferences or sensitivities the player mentioned during setup (one per line). Only include if the player volunteered them — never prompt for these.", nullable: true },
     },
@@ -356,8 +357,11 @@ export function createSetupConversation(
     let campaignDetail: string | null = typeof rawDetail === "string" && rawDetail.trim()
       ? rawDetail : null;
     if (rawDetail === undefined || rawDetail === null) {
-      // Try to find matching world by slug derived from campaign name
-      const slug = campaignName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+      // Primary: use world_slug if the agent passed it (reliable — came from load_world)
+      // Fallback: derive slug from campaign_name (fragile — agent may rename the campaign)
+      const worldSlug = typeof input.world_slug === "string" ? input.world_slug.trim() : "";
+      const fallbackSlug = campaignName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+      const slug = worldSlug || fallbackSlug;
       const world = loadWorldBySlug(slug);
       if (world?.detail) campaignDetail = world.detail;
     }

--- a/packages/engine/src/prompts/setup-conversation.md
+++ b/packages/engine/src/prompts/setup-conversation.md
@@ -111,7 +111,7 @@ When `load_world` returns suboptions:
 4. If the player doesn't like any suboption, let them describe their own — that's fine.
 5. For Quick Start, you may auto-pick suboptions (roll for them in your head) rather than adding extra steps.
 
-When the player picks a world that has detail, pass the detail through verbatim in `campaign_detail` on `finalize_setup`. The detail will be injected into the DM's system prompt at game start — you don't need to summarize or transform it. If the player picks a world without detail, or builds a fully custom campaign, omit the field.
+When the player picks a world that has detail, pass the detail through verbatim in `campaign_detail` on `finalize_setup`, and include the world's slug in `world_slug`. The detail will be injected into the DM's system prompt at game start — you don't need to summarize or transform it. If the player picks a world without detail, or builds a fully custom campaign, omit both fields.
 
 For DM personalities with detail blocks: the detail is automatically included when the personality is resolved by name. You don't need to pass it explicitly — just use the personality name in `dm_personality`.
 


### PR DESCRIPTION
## Summary

- Added optional `world_slug` field to `finalize_setup` tool schema
- Used as primary lookup key in `handleFinalize` when `campaign_detail` is missing, falling back to the `campaign_name`-derived slug for backward compatibility
- Updated setup prompt to instruct the agent to pass the slug when a world was selected

## Problem

The `handleFinalize` fallback derived a slug from `campaign_name` to look up the world file's detail block. But `campaign_name` is free-form — if the agent named the campaign differently from the world file (e.g., "Crownfall" instead of "The Shattered Crown"), the lookup failed silently and the DM lost the detail block.

Closes #374

## Test plan

- [x] `npm run check` passes (2208 tests, lint clean)
- [ ] Manual: select a world with detail, verify the DM receives the detail block even if the campaign is renamed

🤖 Generated with [Claude Code](https://claude.com/claude-code)