### PR TITLE
Seed starfield RNG with current time, not constant 42

### DIFF
--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -333,6 +333,9 @@ export function useStarfield(
       // Resume: map animation frame 0 → the simulation frame after where we paused
       frameOffsetRef.current = cached.lastFrame + 1;
     } else {
+      // stateCache persists across mount/unmount within a session, so the stars
+      // survive menu navigation. A fresh seed is drawn only on first sight of a
+      // given dim (or after resetStarfieldCache / app restart).
       stateRef.current = { stars: [], rng: createRng(Date.now() | 0), lastFrame: -1, dimKey };
       frameOffsetRef.current = 0;
     }

--- a/packages/client-ink/src/tui/components/Starfield.tsx
+++ b/packages/client-ink/src/tui/components/Starfield.tsx
@@ -333,7 +333,7 @@ export function useStarfield(
       // Resume: map animation frame 0 → the simulation frame after where we paused
       frameOffsetRef.current = cached.lastFrame + 1;
     } else {
-      stateRef.current = { stars: [], rng: createRng(42), lastFrame: -1, dimKey };
+      stateRef.current = { stars: [], rng: createRng(Date.now() | 0), lastFrame: -1, dimKey };
       frameOffsetRef.current = 0;
     }
   }


### PR DESCRIPTION
## Summary

The main-menu starfield's per-dimension cache initialized its RNG with a hardcoded seed of `42` (Starfield.tsx:336). Every fresh *process* at a given terminal size played the identical star sequence. Seed with `Date.now() | 0` instead so each session gets a different starscape.

By design, `stateCache` is module-level and persists stars across mount/unmount within a single process, so a new seed is only drawn on first sight of a given dim (or after `resetStarfieldCache()` / app restart). Added an inline comment to make that intent explicit after Copilot flagged the ambiguity.

Tests still pass `createRng(42)` directly to verify determinism — that's about the RNG function itself, not the renderer's seeding choice, so no test changes needed.

## Test plan

- [x] `npm run check` — 2174 tests pass.
- [ ] Restart the app twice — starfields should differ. Within a single session, stars persist across menu navigation as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)