### PR TITLE
Fix Campaign Explorer rendering empty system prompt

### DIFF
--- a/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
+++ b/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
@@ -37,7 +37,9 @@ interface ContextDump {
   agent: string;
   timestamp: string;
   model?: string;
-  system?: string | Array<{ type: string; text?: string }>;
+  // Engine SystemBlocks are `{ text, cacheControl? }` — no `type` field —
+  // but older dumps from the Anthropic SDK shape include `{ type: "text", text }`.
+  system?: string | Array<{ type?: string; text?: string }>;
   messages?: Message[];
   tools?: ToolDef[];
   _thinking_trace?: ThinkingTrace[];
@@ -170,11 +172,13 @@ function ToolsList({ tools }: { tools: ToolDef[] }) {
   );
 }
 
-function SystemPrompt({ system }: { system: string | Array<{ type: string; text?: string }> }) {
+function SystemPrompt({ system }: { system: string | Array<{ type?: string; text?: string }> }) {
+  // Engine blocks have no `type` field; accept any block with `text`.
+  // Keep the optional `type === "text"` path so SDK-shaped blocks still render.
   const text = typeof system === "string"
     ? system
     : system
-        .filter((b) => b.type === "text" && b.text)
+        .filter((b) => b.text && (b.type === undefined || b.type === "text"))
         .map((b) => b.text)
         .join("\n\n");
 

--- a/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
+++ b/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
@@ -39,7 +39,7 @@ interface ContextDump {
   model?: string;
   // Engine SystemBlocks are `{ text, cacheControl? }` — no `type` field —
   // but older dumps from the Anthropic SDK shape include `{ type: "text", text }`.
-  system?: string | Array<{ type?: string; text?: string }>;
+  system?: string | Array<{ type?: string; text?: string; cacheControl?: { ttl: "5m" | "1h" } }>;
   messages?: Message[];
   tools?: ToolDef[];
   _thinking_trace?: ThinkingTrace[];
@@ -172,15 +172,24 @@ function ToolsList({ tools }: { tools: ToolDef[] }) {
   );
 }
 
-function SystemPrompt({ system }: { system: string | Array<{ type?: string; text?: string }> }) {
-  // Engine blocks have no `type` field; accept any block with `text`.
-  // Keep the optional `type === "text"` path so SDK-shaped blocks still render.
-  const text = typeof system === "string"
-    ? system
-    : system
-        .filter((b) => b.text && (b.type === undefined || b.type === "text"))
-        .map((b) => b.text)
-        .join("\n\n");
+type SystemBlockLike = { type?: string; text?: string; cacheControl?: { ttl: "5m" | "1h" } };
+
+/**
+ * Flatten a dumped system-prompt field into plain text.
+ * Engine blocks have no `type` field; accept any block with `text`.
+ * Keep the optional `type === "text"` path so SDK-shaped blocks still render.
+ * Exported for contract-test coverage against regressions like #403.
+ */
+export function systemPromptToText(system: string | SystemBlockLike[]): string {
+  if (typeof system === "string") return system;
+  return system
+    .filter((b) => b.text && (b.type === undefined || b.type === "text"))
+    .map((b) => b.text)
+    .join("\n\n");
+}
+
+function SystemPrompt({ system }: { system: string | SystemBlockLike[] }) {
+  const text = systemPromptToText(system);
 
   return (
     <div className="markdown-viewer">

--- a/tools/campaign-explorer/tests/contract/system-prompt-render.contract.test.ts
+++ b/tools/campaign-explorer/tests/contract/system-prompt-render.contract.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression guard for #403: the Campaign Explorer must flatten system-prompt
+ * dumps that use the engine's SystemBlock shape ({ text, cacheControl? }),
+ * which has no `type` field. The older Anthropic SDK shape with
+ * `{ type: "text", text }` must also still render.
+ */
+import { describe, it, expect } from "vitest";
+import { systemPromptToText } from "../../src/client/components/ContextDumpViewer.js";
+
+describe("systemPromptToText", () => {
+  it("renders engine SystemBlock dumps (no type field)", () => {
+    const text = systemPromptToText([
+      { text: "DM identity" },
+      { text: "\n\nPersonality", cacheControl: { ttl: "1h" } },
+    ]);
+    expect(text).toContain("DM identity");
+    expect(text).toContain("Personality");
+  });
+
+  it("renders SDK-shaped blocks with type: 'text'", () => {
+    const text = systemPromptToText([
+      { type: "text", text: "SDK block one" },
+      { type: "text", text: "SDK block two" },
+    ]);
+    expect(text).toContain("SDK block one");
+    expect(text).toContain("SDK block two");
+  });
+
+  it("passes plain-string system prompts through unchanged", () => {
+    expect(systemPromptToText("already plain")).toBe("already plain");
+  });
+
+  it("skips blocks with a non-text type (defensive)", () => {
+    const text = systemPromptToText([
+      { text: "kept" },
+      { type: "image", text: "dropped" } as { type?: string; text?: string },
+    ]);
+    expect(text).toContain("kept");
+    expect(text).not.toContain("dropped");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     projects: [
       "packages/engine",
       "packages/client-ink",
+      "tools/campaign-explorer",
     ],
   },
 });


### PR DESCRIPTION
## Summary
- \`ContextDumpViewer\` filtered system blocks with \`b.type === \"text\"\`, but the engine's \`SystemBlock\` is \`{ text, cacheControl? }\` — no \`type\` field. Every block failed the filter, so the System Prompt panel rendered empty even though the dumped JSON had a full prompt.
- Accept any block with a \`text\` field; keep the optional \`type === \"text\"\` branch so SDK-shaped dumps still render.

## Test plan
- [x] \`npm run check\` + \`cd tools/campaign-explorer && npx tsc --noEmit\`
- [ ] Manual: open the explorer against a campaign with a recent DM call, confirm the system prompt now renders with all Tier 1+2 blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)