### PR TITLE
Wire active player into Tier 3 turn-holder so DM stops acting for PCs

### DIFF
--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -379,8 +379,13 @@ export class GameEngine {
       this.sceneManager.appendPlayerInput(characterName, text);
     }
 
-    // Get system prompt (cached Tier 1+2) and volatile context (Tier 3)
-    const { system: systemPrompt, volatile: volatileContext } = this.sceneManager.getSystemPrompt();
+    // Get system prompt (cached Tier 1+2) and volatile context (Tier 3).
+    // Pass the active character so the DM sees an explicit "Turn: {name}"
+    // line in Current State, reinforcing whose decision it is and discouraging
+    // the DM from acting on the PC's behalf.
+    const { system: systemPrompt, volatile: volatileContext } = this.sceneManager.getSystemPrompt({
+      turnHolder: characterName,
+    });
 
     // Build message list
     const messages: NormalizedMessage[] = [...this.conversation.getMessages()];

--- a/packages/engine/src/agents/scene-manager.test.ts
+++ b/packages/engine/src/agents/scene-manager.test.ts
@@ -725,6 +725,35 @@ describe("SceneManager", () => {
     expect(volatile).not.toContain("Entity Registry");
   });
 
+  it("getSystemPrompt surfaces turnHolder as a Turn: line in Current State", () => {
+    const sessionState = mockSessionState();
+    const mgr = new SceneManager(
+      mockState(),
+      mockScene(),
+      new ConversationManager({ retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 }),
+      sessionState,
+      mockFileIO(),
+    );
+
+    const { volatile } = mgr.getSystemPrompt({ turnHolder: "Adam James" });
+    expect(volatile).toContain("## Current State");
+    expect(volatile).toContain("Turn: Adam James");
+  });
+
+  it("getSystemPrompt omits Turn: line when no turnHolder is passed", () => {
+    const sessionState = mockSessionState();
+    const mgr = new SceneManager(
+      mockState(),
+      mockScene(),
+      new ConversationManager({ retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 }),
+      sessionState,
+      mockFileIO(),
+    );
+
+    const { volatile } = mgr.getSystemPrompt();
+    expect(volatile).not.toContain("Turn:");
+  });
+
   it("mid-scene upserts update the tree but not the DM snapshot", () => {
     const sessionState = mockSessionState();
     const mgr = new SceneManager(

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -137,12 +137,12 @@ export class SceneManager {
   }
 
   /** Get the current system prompt (cached prefix) and volatile context. */
-  getSystemPrompt(): CachedPrefixResult {
+  getSystemPrompt(opts?: { turnHolder?: string }): CachedPrefixResult {
     this.state.objectives.current_scene = this.scene.sceneNumber;
     this.sessionState.activeState = buildActiveState({
       pcSummaries: this.pcSummaries,
       pendingAlarms: [],
-      turnHolder: undefined,
+      turnHolder: opts?.turnHolder,
       resourceValues: this.state.resourceValues,
       activeObjectives: this.getActiveObjectives(),
     });


### PR DESCRIPTION
## Summary

The DM frequently runs whole turns on behalf of the player despite the lengthy "Never act for a PC" rule in `dm-identity.md`. Investigating, the volatile context (Tier 3, injected per turn) already had a `turnHolder` field plumbed through `buildActiveState()` that renders as a `Turn: {name}` line at the top of `## Current State` — but `scene-manager.getSystemPrompt()` always passed `turnHolder: undefined`. The DM only ever saw the active PC's name as a `[Adam James]` tag at the start of the user message, which is clearly too subtle.

This PR pipes the active character (already in scope in `processInput`) into `getSystemPrompt()`. Every DM turn now has a structured, labeled `Turn: Adam James` line in the same block where it reads PCs, resources, and objectives — much harder to drift past than prose buried in the cached identity prompt.

Total: 9 lines added, 4 removed across 2 files.

## Test plan

- [x] `npm run check` — lint clean, 2276 tests pass.
- [ ] Play a few turns and confirm the DM ends narration at the active PC's decision point more reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)