### PR TITLE
Fix rollback silently undone by endSession's final checkpoint

### DIFF
--- a/packages/engine/src/server/command-handler.test.ts
+++ b/packages/engine/src/server/command-handler.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression guard: /rollback must return endSessionReason: "rollback"
+ * so session-manager.endSession skips its flush+checkpoint block — otherwise
+ * the in-memory ConversationManager (still ahead of the rollback target by
+ * the undone turns) gets persisted back to disk and silently undoes the
+ * rollback for whole-file state like conversation.json and scene.json.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { handleCommand } from "./command-handler.js";
+import type { GameEngine } from "../agents/game-engine.js";
+import type { GameState } from "@machine-violet/shared/types/engine.js";
+
+function makeMockEngine(performRollback = true) {
+  const repo = {
+    isEnabled: () => performRollback,
+    rollback: vi.fn(async () => ({
+      restoredTo: "abc1234",
+      timestamp: 1234567890,
+      summary: "scene: Opening",
+    })),
+  };
+  const sceneManager = {
+    getFileIO: () => ({
+      exists: async () => true,
+      listDir: async () => [],
+      readFile: async () => "",
+      writeFile: async () => {},
+      appendFile: async () => {},
+      mkdir: async () => {},
+    }),
+  };
+  return {
+    getRepo: () => repo,
+    getSceneManager: () => sceneManager,
+  } as unknown as GameEngine;
+}
+
+function makeMockGameState(): GameState {
+  return { campaignRoot: "/tmp/test-campaign" } as unknown as GameState;
+}
+
+describe("handleCommand /rollback", () => {
+  it("returns endSessionReason: 'rollback' so endSession skips persist+checkpoint", async () => {
+    const engine = makeMockEngine();
+    const result = await handleCommand(
+      "rollback",
+      "1",
+      engine,
+      makeMockGameState(),
+      vi.fn(),
+    );
+    expect(result.endSession).toBe(true);
+    expect(result.endSessionReason).toBe("rollback");
+  });
+
+  it("rejects invalid N with a usage error (no endSession)", async () => {
+    const engine = makeMockEngine();
+    const result = await handleCommand(
+      "rollback",
+      "not-a-number",
+      engine,
+      makeMockGameState(),
+      vi.fn(),
+    );
+    expect(result.error).toBe(true);
+    expect(result.endSession).toBeFalsy();
+    expect(result.endSessionReason).toBeUndefined();
+  });
+});

--- a/packages/engine/src/server/command-handler.ts
+++ b/packages/engine/src/server/command-handler.ts
@@ -10,6 +10,7 @@ import type { GameState } from "@machine-violet/shared/types/engine.js";
 import { queryCommitLog, performRollback } from "../tools/git/index.js";
 import { createOOCSession } from "../agents/subagents/ooc-mode.js";
 import { createDevSession, summarizeGameState } from "../agents/subagents/dev-mode.js";
+import type { EndSessionReason } from "./session-manager.js";
 
 export interface CommandResult {
   message?: string;
@@ -18,7 +19,7 @@ export interface CommandResult {
   /** Reason to pass to sessionManager.endSession — e.g. "rollback" skips
    *  the final flush+checkpoint that would otherwise clobber disk with
    *  stale in-memory state. */
-  endSessionReason?: string;
+  endSessionReason?: EndSessionReason;
 }
 
 export async function handleCommand(

--- a/packages/engine/src/server/command-handler.ts
+++ b/packages/engine/src/server/command-handler.ts
@@ -15,6 +15,10 @@ export interface CommandResult {
   message?: string;
   error?: boolean;
   endSession?: boolean;
+  /** Reason to pass to sessionManager.endSession — e.g. "rollback" skips
+   *  the final flush+checkpoint that would otherwise clobber disk with
+   *  stale in-memory state. */
+  endSessionReason?: string;
 }
 
 export async function handleCommand(
@@ -86,7 +90,11 @@ async function handleRollback(args: string, engine: GameEngine, gameState: GameS
   }
   const fileIO = engine.getSceneManager().getFileIO();
   const result = await performRollback(repo, `exchanges_ago:${n}`, gameState.campaignRoot, fileIO);
-  return { message: `Rolled back ${n} exchange(s): ${result.summary}`, endSession: true };
+  return {
+    message: `Rolled back ${n} exchange(s): ${result.summary}`,
+    endSession: true,
+    endSessionReason: "rollback",
+  };
 }
 
 function handleRetry(engine: GameEngine): CommandResult {

--- a/packages/engine/src/server/routes/session.ts
+++ b/packages/engine/src/server/routes/session.ts
@@ -153,7 +153,7 @@ export const sessionRoutes: FastifyPluginAsync = async (server: FastifyInstance)
     }
 
     if (result.endSession) {
-      await sm.endSession();
+      await sm.endSession(result.endSessionReason);
     }
 
     return { ok: !result.error, message: result.message };

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -53,6 +53,14 @@ export interface ConnectedClient {
 
 export type SessionStatus = "idle" | "starting" | "active" | "stopping";
 
+/**
+ * Reasons a session can end. Drives teardown behavior — "rollback" skips
+ * the flush+checkpoint that would otherwise clobber rolled-back disk state
+ * with stale in-memory values. Keep this a closed union so new callsites
+ * can't silently bypass the rollback-safe path with a typo'd string.
+ */
+export type EndSessionReason = "explicit" | "idle_timeout" | "rollback";
+
 export class SessionManager {
   private campaignsDir: string;
   private clients = new Map<WebSocket, ConnectedClient>();
@@ -599,7 +607,7 @@ export class SessionManager {
               type: "narrative:chunk",
               data: { text: `[${err.message}]`, kind: "system" },
             });
-            void this.endSession("rollback");
+            await this.endSession("rollback");
             return;
           }
           throw err;
@@ -619,12 +627,16 @@ export class SessionManager {
       } catch (err) {
         // DM-initiated rollback throws RollbackCompleteError from inside
         // processInput; same handling as the mode-session path above.
+        // Flush any buffered DM deltas with narrative:complete before the
+        // system message so the client doesn't stay stuck in "streaming"
+        // state while teardown runs.
         if (err instanceof RollbackCompleteError) {
+          scopedBroadcast({ type: "narrative:complete", data: { text: "" } });
           scopedBroadcast({
             type: "narrative:chunk",
             data: { text: `[${err.message}]`, kind: "system" },
           });
-          void this.endSession("rollback");
+          await this.endSession("rollback");
           return;
         }
         throw err;
@@ -848,7 +860,7 @@ export class SessionManager {
   }
 
   /** End the current session gracefully. */
-  async endSession(reason = "explicit"): Promise<void> {
+  async endSession(reason: EndSessionReason = "explicit"): Promise<void> {
     if (this.status === "idle" || this.status === "stopping") return;
 
     // If a start is still in progress, wait for it to finish so we can

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -16,6 +16,7 @@ import type {
   GameState,
 } from "@machine-violet/shared";
 import { GameEngine } from "../agents/game-engine.js";
+import { RollbackCompleteError } from "@machine-violet/shared/types/errors.js";
 import type { SceneState } from "../agents/scene-manager.js";
 import { detectSceneState, loadContentBoundaries } from "../agents/scene-manager.js";
 import { buildUIState, type DMSessionState } from "../agents/dm-prompt.js";
@@ -583,9 +584,26 @@ export class SessionManager {
       // If a mode session (OOC/Dev) is active, route to it
       const modeSession = this.engine.getModeSession();
       if (modeSession) {
-        await modeSession.send(text, (delta) => {
-          scopedBroadcast({ type: "narrative:chunk", data: { text: delta, kind: "dm" } });
-        });
+        try {
+          await modeSession.send(text, (delta) => {
+            scopedBroadcast({ type: "narrative:chunk", data: { text: delta, kind: "dm" } });
+          });
+        } catch (err) {
+          // OOC/Dev rollback throws RollbackCompleteError to signal that
+          // teardown should NOT re-persist in-memory state (would undo the
+          // rollback). End the session with the "rollback" reason so
+          // endSession skips its flush+checkpoint.
+          if (err instanceof RollbackCompleteError) {
+            scopedBroadcast({ type: "narrative:complete", data: { text: "" } });
+            scopedBroadcast({
+              type: "narrative:chunk",
+              data: { text: `[${err.message}]`, kind: "system" },
+            });
+            void this.endSession("rollback");
+            return;
+          }
+          throw err;
+        }
         scopedBroadcast({ type: "narrative:complete", data: { text: "" } });
         this.persistTurnState();
         scopedBroadcast({ type: "state:snapshot", data: this.buildStateSnapshot() });
@@ -596,7 +614,21 @@ export class SessionManager {
       // Normal play: send to DM
       const active = getActivePlayer(this.gameState);
       this.syncUIState();
-      await this.engine.processInput(active.characterName, text);
+      try {
+        await this.engine.processInput(active.characterName, text);
+      } catch (err) {
+        // DM-initiated rollback throws RollbackCompleteError from inside
+        // processInput; same handling as the mode-session path above.
+        if (err instanceof RollbackCompleteError) {
+          scopedBroadcast({
+            type: "narrative:chunk",
+            data: { text: `[${err.message}]`, kind: "system" },
+          });
+          void this.endSession("rollback");
+          return;
+        }
+        throw err;
+      }
       this.persistTurnState();
       scopedBroadcast({ type: "state:snapshot", data: this.buildStateSnapshot() });
       this.openNextTurn();
@@ -843,7 +875,14 @@ export class SessionManager {
     try {
       // Flush any pending state, with a timeout so a hanging flush
       // can never permanently brick the session lifecycle.
-      if (this.engine) {
+      //
+      // Skip this block when ending due to a rollback: disk has just been
+      // reset to the target commit, but the engine's in-memory state
+      // (ConversationManager, SceneState) is still ahead by the rolled-back
+      // turns. A flush+checkpoint here would persist that stale state and
+      // silently undo the rollback for whole-file artifacts like
+      // conversation.json and scene.json.
+      if (this.engine && reason !== "rollback") {
         const timeout = (ms: number) => new Promise<void>((_, reject) =>
           setTimeout(() => reject(new Error("endSession flush timeout")), ms));
         const persister = this.engine.getPersister();


### PR DESCRIPTION
## Summary
\`/rollback N\` correctly resets the on-disk state to the target commit, but \`endSession\`'s teardown immediately re-persists stale in-memory state (conversation, scene) as "checkpoint: before Session end", silently undoing the rollback for whole-file artifacts. Display-log.md escaped because it's append-only, which is the smoking-gun mismatch the user spotted.

## Cause
1. \`/rollback 1\` in \`command-handler.handleRollback\` runs \`performRollback\` → \`resetTo(target)\`. Disk is now at target.
2. Returns \`{ endSession: true }\`. Route calls \`sm.endSession()\`.
3. \`endSession\` runs \`persister.flush()\` + \`repo.checkpoint("Session end")\`.
4. \`repo.checkpoint\` fires \`stageAll\` → \`preCommitHook\` → \`persistCurrentScene\` → \`persistConversation(this.conversation.getExchanges())\`. In-memory \`ConversationManager\` still has the rolled-back turns → they get persisted back to disk and committed.

Verified against the reporter's campaign: HEAD was at "checkpoint: before Session end" (69eff6b) carrying an exchange that the rollback target (2cb468c) didn't have.

## Fix
Thread an \`endSessionReason\` through so rollback-triggered teardown skips flush+checkpoint. Disk is already authoritative; in-memory state is stale by design.

- \`CommandResult.endSessionReason\` added; \`handleRollback\` sets it to \`"rollback"\`.
- Route passes the reason into \`sm.endSession(reason)\`.
- \`endSession\` skips flush+checkpoint when \`reason === "rollback"\`.
- Turn commit handler catches \`RollbackCompleteError\` from both the mode-session (OOC/Dev) path and the normal-DM path, ending the session with \`"rollback"\` reason — so DM-initiated and OOC-initiated rollbacks hit the same contract.
- Regression test for \`handleRollback\` returning the reason.

## Test plan
- [x] \`npm run check\` (lint + 2278 tests passing)
- [ ] Manual: play a few turns → \`/rollback 1\` → verify \`conversation.json\` and \`display-log.md\` end on the same turn, no "checkpoint: before Session end" commit undoing the rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)