### PR TITLE
Cut repeat-run CPU for parallel agent workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,16 @@ All documentation lives in `docs/`. Start at `docs/index.md` for navigation, `do
 - Vitest `globals: true` — `describe`/`it`/`expect` available without import.
 - Anthropic client mocked via `vi.fn()`. FileIO mocked with in-memory `Record<string, string>`.
 
+### CPU-efficient iteration
+
+Multiple agents often run in parallel against this repo; `npm test` is ~80s CPU/run and dominates total check cost. Lint (with `--cache`) and typecheck (`tsc -b` incremental) are already cheap to re-run.
+
+For mid-iteration validation, prefer targeted vitest over the full suite:
+- **`npx vitest run --changed`** — only tests for files changed since HEAD. ~3s CPU on a clean tree.
+- **`npx vitest run related <files>`** — only tests reachable from the given files.
+
+Reserve `npm run check` for the pre-commit / pre-PR gate. Use your judgement: full suite for risk-sensitive or cross-cutting changes, targeted for routine iteration.
+
 ## Cost Awareness
 
 Live API key in `.env` with limited credit. Default dev override uses Sonnet for DM. Don't make unnecessary API calls in manual testing.

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "lint": "eslint packages/shared/src/ packages/engine/src/ packages/client-ink/src/",
-    "typecheck": "npm run -w packages/shared build && npm run -w packages/engine typecheck && npm run -w packages/client-ink typecheck",
+    "lint": "eslint --cache --cache-location node_modules/.cache/eslint packages/shared/src/ packages/engine/src/ packages/client-ink/src/",
+    "typecheck": "tsc -b",
     "check": "concurrently -n lint,test --kill-others-on-fail \"npm run lint\" \"npm test\"",
     "dist": "node scripts/build-dist.js",
     "explorer": "node tools/campaign-explorer/scripts/dev.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/shared" },
+    { "path": "./packages/engine" },
+    { "path": "./packages/client-ink" }
+  ]
+}


### PR DESCRIPTION
## Summary

When multiple Claude sessions run in parallel, each iterates lint / typecheck / tests almost continuously before committing. This PR trims per-invocation CPU on the cheap commands and points agents at a targeted vitest flow for mid-iteration validation, where the real savings live.

## Measured impact (median of 3 runs, CPU = user + kernel across all descendant processes)

| Command | Before | After | Δ |
|---|---|---|---|
| `npm run lint` (warm) | 5.77s | 1.23s | **−79% (4.7×)** |
| `npm run typecheck` (warm)* | 3.92s | 2.72s | −31% |
| `npm test` | 78.66s | 76.22s | ~flat |

\* The typecheck baseline short-circuits at a pre-existing engine TS error in `packages/engine/src/content/test-helpers.ts:28`, so it skips client-ink entirely. The "after" number runs all three packages and is still 31% cheaper; real win will be larger once that error is fixed.

## The larger lever

`npx vitest run --changed` on a clean tree measured at **3.23s CPU — 24× cheaper than the full 78.66s suite**. CLAUDE.md now recommends it (and `vitest run related <files>`) for mid-iteration validation, reserving `npm run check` for the pre-commit gate. Framed as judgement, not a rule.

## Changes

- `package.json` — lint now uses `--cache --cache-location node_modules/.cache/eslint`; typecheck is `tsc -b`
- `tsconfig.json` — new root file with composite references to `shared`, `engine`, `client-ink`
- `CLAUDE.md` — added `CPU-efficient iteration` subsection under Testing

## Behavior note for reviewer

`tsc -b` respects each project's tsconfig, so engine and client-ink now **emit** to their (gitignored) `dist/` during typecheck, instead of running with the `--noEmit` CLI override that the old per-workspace scripts used. The incremental `.tsbuildinfo` cache makes repeat runs cheap. If you'd rather preserve the strict no-emit behavior, we can add a `tsconfig.typecheck.json` per leaf with `noEmit: true` (~10 lines).

## Test plan

- [ ] `npm run lint` — passes, writes cache to `node_modules/.cache/eslint`
- [ ] `npm run lint` (second run) — near-instant via cache
- [ ] `npm run typecheck` — same exit status as before (still fails at pre-existing engine error; unrelated to this PR)
- [ ] `npm test` — unchanged
- [ ] `npx vitest run --changed` on a clean tree — completes in ~2s wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)