### PR TITLE
Warn when user world files are skipped (#376)

### DIFF
--- a/packages/engine/src/config/world-loader.test.ts
+++ b/packages/engine/src/config/world-loader.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { readdirSync, readFileSync } from "node:fs";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { worldSummaries } from "./world-loader.js";
+import { loadAllWorlds, worldSummaries } from "./world-loader.js";
 import type { WorldFile } from "@machine-violet/shared/types/world.js";
 
 // --- Bundled seed validation (uses real filesystem, no mocks) ---
@@ -74,6 +75,64 @@ function makeWorld(overrides?: Partial<WorldFile>): WorldFile {
     ...overrides,
   };
 }
+
+describe("loadAllWorlds — user world warnings", () => {
+  const tempDirs: string[] = [];
+  afterEach(() => {
+    vi.restoreAllMocks();
+    while (tempDirs.length) {
+      const d = tempDirs.pop()!;
+      try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  function makeUserDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "mv-worlds-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it("warns and skips user world files with unparseable JSON", () => {
+    const userDir = makeUserDir();
+    writeFileSync(join(userDir, "broken.mvworld"), "{ not valid json", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const worlds = loadAllWorlds(userDir);
+
+    expect(worlds.find((w) => w.slug === "broken")).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0][0] as string;
+    expect(msg).toContain("broken.mvworld");
+    expect(msg).toContain("[worlds]");
+  });
+
+  it("warns and skips user world files that fail schema validation", () => {
+    const userDir = makeUserDir();
+    // Valid JSON but missing required fields (e.g. wrong format string).
+    writeFileSync(join(userDir, "bad-schema.mvworld"), JSON.stringify({ format: "not-a-world", version: 1 }), "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const worlds = loadAllWorlds(userDir);
+
+    expect(worlds.find((w) => w.slug === "bad-schema")).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0][0] as string;
+    expect(msg).toContain("bad-schema.mvworld");
+    expect(msg).toContain("schema validation");
+  });
+
+  it("does not warn on valid user world files", () => {
+    const userDir = makeUserDir();
+    const good = makeWorld({ name: "Custom", summary: "Custom world." });
+    writeFileSync(join(userDir, "custom.mvworld"), JSON.stringify(good), "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const worlds = loadAllWorlds(userDir);
+
+    expect(worlds.find((w) => w.slug === "custom")).toBeDefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
 
 describe("worldSummaries", () => {
   it("builds summaries from loaded worlds", () => {

--- a/packages/engine/src/config/world-loader.ts
+++ b/packages/engine/src/config/world-loader.ts
@@ -67,12 +67,14 @@ function scanDir(dir: string, strict: boolean): LoadedWorld[] {
         if (strict) {
           throw new Error(`Invalid world file: ${filePath} (failed schema validation)`);
         }
+        console.warn(`[worlds] Skipping user world ${filePath}: failed schema validation.`);
         continue;
       }
       results.push({ slug, world: data });
     } catch (e) {
       if (strict) throw e;
-      // User worlds: skip silently (or log in future)
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[worlds] Skipping user world ${filePath}: ${msg}`);
     }
   }
   return results;


### PR DESCRIPTION
## Summary
- `scanDir()` in `world-loader.ts` silently skipped malformed `.mvworld` files in `~/.machine-violet/worlds/`, so users had no indication their file was rejected.
- Emit `console.warn` identifying the file path plus the reason (parse error or schema validation) when a user world is dropped. Bundled worlds still throw in strict mode, unchanged.
- Added three tests: unparseable JSON, failed schema validation, and valid world (no warning).

Closes #376.

## Test plan
- [x] `npm run check` passes (lint + 2298 tests)
- [ ] Drop a bad `.mvworld` into `~/.machine-violet/worlds/` and confirm the `[worlds] Skipping user world …` warning appears at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)