### PR TITLE
Flush co-emitted tool_results when present_choices is pending

### DIFF
--- a/packages/client-ink/tsconfig.json
+++ b/packages/client-ink/tsconfig.json
@@ -14,7 +14,6 @@
     "node_modules", "dist",
     "src/**/*.test.ts", "src/**/*.test.tsx",
     "src/phases/index.ts",
-    "src/phases/SetupPhase.tsx",
     "src/phases/ApiKeysPhase.tsx",
     "src/phases/AddContentPhase.tsx",
     "src/phases/UpdatePhase.tsx",

--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -194,6 +194,80 @@ describe("createSetupConversation", () => {
     expect(result.text).toContain("May your blade stay sharp!");
   });
 
+  it("co-emitted load_world + present_choices: both tool_results flushed on resolveChoice", async () => {
+    // Model emits load_world AND present_choices in the same assistant turn.
+    // Regression: previously the load_world tool_result was discarded on early-return,
+    // leaving its tool_use orphaned — Anthropic 400s on the next request.
+    const coEmitted: ChatResult = {
+      text: "Let me check that world...",
+      toolCalls: [
+        { id: "toolu_load_1", name: "load_world", input: { slug: "the-shattered-crown" } },
+        { id: "toolu_choices_1", name: "present_choices", input: { prompt: "Pick one:", choices: ["A", "B"] } },
+      ],
+      usage: mockUsage(),
+      stopReason: "tool_use",
+      assistantContent: [
+        { type: "text", text: "Let me check that world..." },
+        { type: "tool_use", id: "toolu_load_1", name: "load_world", input: { slug: "the-shattered-crown" } },
+        { type: "tool_use", id: "toolu_choices_1", name: "present_choices", input: { prompt: "Pick one:", choices: ["A", "B"] } },
+      ],
+    };
+    const provider = mockProvider([coEmitted, textResponse("Good pick!")]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+
+    const first = await conv.start(noop);
+    expect(first.pendingChoices).toBeDefined();
+
+    await conv.resolveChoice("A", noop);
+
+    // Second API call's user message must satisfy BOTH tool_uses
+    const streamCalls = (provider.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const secondCall = streamCalls[1][0];
+    const userMsg = secondCall.messages.find(
+      (m: { role: string; content?: unknown }) => m.role === "user" && Array.isArray(m.content),
+    );
+    expect(userMsg).toBeDefined();
+    const ids = (userMsg.content as { type: string; tool_use_id: string }[])
+      .filter((c) => c.type === "tool_result")
+      .map((c) => c.tool_use_id);
+    expect(ids).toContain("toolu_load_1");
+    expect(ids).toContain("toolu_choices_1");
+  });
+
+  it("co-emitted load_world + present_choices: both tool_results flushed on dismissal", async () => {
+    // Same scenario but the user dismisses the modal (send instead of resolveChoice).
+    const coEmitted: ChatResult = {
+      text: "",
+      toolCalls: [
+        { id: "toolu_load_2", name: "load_world", input: { slug: "the-shattered-crown" } },
+        { id: "toolu_choices_2", name: "present_choices", input: { prompt: "Pick one:", choices: ["A", "B"] } },
+      ],
+      usage: mockUsage(),
+      stopReason: "tool_use",
+      assistantContent: [
+        { type: "tool_use", id: "toolu_load_2", name: "load_world", input: { slug: "the-shattered-crown" } },
+        { type: "tool_use", id: "toolu_choices_2", name: "present_choices", input: { prompt: "Pick one:", choices: ["A", "B"] } },
+      ],
+    };
+    const provider = mockProvider([coEmitted, textResponse("Got it.")]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+
+    await conv.start(noop);
+    await conv.send("never mind, let's do something else", noop);
+
+    const streamCalls = (provider.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const secondCall = streamCalls[1][0];
+    const userMsg = secondCall.messages.find(
+      (m: { role: string; content?: unknown }) => m.role === "user" && Array.isArray(m.content),
+    );
+    expect(userMsg).toBeDefined();
+    const ids = (userMsg.content as { type: string; tool_use_id: string }[])
+      .filter((c) => c.type === "tool_result")
+      .map((c) => c.tool_use_id);
+    expect(ids).toContain("toolu_load_2");
+    expect(ids).toContain("toolu_choices_2");
+  });
+
   it("send() after dismissed choice includes tool_result", async () => {
     const provider = mockProvider([
       presentChoicesResponse("Pick one:", "Genre:", ["Fantasy", "Sci-Fi"]),

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -18,7 +18,7 @@ import {
 import type {
   LLMProvider, ChatParams, ChatResult,
   NormalizedMessage, NormalizedTool, NormalizedUsage,
-  SystemBlock,
+  SystemBlock, ContentPart,
 } from "../../providers/types.js";
 
 // --- Types ---
@@ -334,7 +334,7 @@ export function createSetupConversation(
   // Tool results for tools that ran alongside present_choices (e.g. load_world).
   // They must be flushed with the choice resolution — otherwise their tool_use
   // blocks are left orphaned and Anthropic 400s on the next request.
-  let pendingExtraToolResults: NormalizedMessage["content"] = [];
+  let pendingExtraToolResults: ContentPart[] = [];
 
   function handleFinalize(input: Record<string, unknown>): void {
     const personalityName = (input.dm_personality as string) || "The Chronicler";
@@ -436,7 +436,7 @@ export function createSetupConversation(
 
     // Process tool calls from normalized result
     let text = result.text;
-    const toolResults: NormalizedMessage["content"] = [];
+    const toolResults: ContentPart[] = [];
     let pendingChoices: { prompt: string; choices: string[]; descriptions?: string[] } | undefined;
 
     for (const tc of result.toolCalls) {
@@ -471,14 +471,14 @@ export function createSetupConversation(
         } else {
           content = `No world found with slug "${slug}".`;
         }
-        (toolResults as { type: "tool_result"; tool_use_id: string; content: string }[]).push({
+        toolResults.push({
           type: "tool_result",
           tool_use_id: tc.id,
           content,
         });
       } else if (tc.name === "finalize_setup") {
         handleFinalize(tc.input);
-        (toolResults as { type: "tool_result"; tool_use_id: string; content: string }[]).push({
+        toolResults.push({
           type: "tool_result",
           tool_use_id: tc.id,
           content: "Setup finalized. Say a brief farewell to the player before the adventure begins.",
@@ -505,7 +505,7 @@ export function createSetupConversation(
     }
 
     // If any tool produced results, send them back and get the agent's continuation
-    if ((toolResults as unknown[]).length > 0) {
+    if (toolResults.length > 0) {
       messages.push({ role: "user", content: toolResults });
 
       lastParams = {

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -331,6 +331,10 @@ export function createSetupConversation(
   let finalized: SetupResult | undefined;
   // Pending state when present_choices is called — stores tool_use_id so we can send the result back
   let pendingToolUseId: string | null = null;
+  // Tool results for tools that ran alongside present_choices (e.g. load_world).
+  // They must be flushed with the choice resolution — otherwise their tool_use
+  // blocks are left orphaned and Anthropic 400s on the next request.
+  let pendingExtraToolResults: NormalizedMessage["content"] = [];
 
   function handleFinalize(input: Record<string, unknown>): void {
     const personalityName = (input.dm_personality as string) || "The Chronicler";
@@ -488,8 +492,11 @@ export function createSetupConversation(
     // Append assistant message (thinking already stripped by provider)
     messages.push({ role: "assistant", content: result.assistantContent });
 
-    // If we have pending choices, return now — app will call resolveChoice later
+    // If we have pending choices, return now — app will call resolveChoice later.
+    // Any tool results produced alongside present_choices (e.g. load_world) are
+    // stashed so they can be flushed with the eventual choice resolution.
     if (pendingChoices) {
+      pendingExtraToolResults = toolResults;
       return {
         text,
         usage: { ...totalUsage },
@@ -539,16 +546,22 @@ export function createSetupConversation(
     async send(text, onDelta) {
       if (pendingToolUseId) {
         // User dismissed the choice modal and typed a free-form response.
-        // Still must send a tool_result to satisfy the API contract.
+        // Still must send a tool_result to satisfy the API contract — and
+        // flush any tool_results stashed from co-emitted tools (e.g. load_world)
+        // so their tool_use blocks are not orphaned.
         messages.push({
           role: "user",
-          content: [{
-            type: "tool_result" as const,
-            tool_use_id: pendingToolUseId,
-            content: `The player dismissed the choices and instead wrote: "${text}"`,
-          }],
+          content: [
+            ...pendingExtraToolResults,
+            {
+              type: "tool_result" as const,
+              tool_use_id: pendingToolUseId,
+              content: `The player dismissed the choices and instead wrote: "${text}"`,
+            },
+          ],
         });
         pendingToolUseId = null;
+        pendingExtraToolResults = [];
       } else {
         messages.push({ role: "user", content: text });
       }
@@ -560,16 +573,21 @@ export function createSetupConversation(
         throw new Error("No pending choice to resolve");
       }
 
-      // Send the player's selection as the tool result
+      // Send the player's selection as the tool result, along with any stashed
+      // tool_results from tools that ran alongside present_choices.
       messages.push({
         role: "user",
-        content: [{
-          type: "tool_result" as const,
-          tool_use_id: pendingToolUseId,
-          content: `The player selected: "${selectedText}"`,
-        }],
+        content: [
+          ...pendingExtraToolResults,
+          {
+            type: "tool_result" as const,
+            tool_use_id: pendingToolUseId,
+            content: `The player selected: "${selectedText}"`,
+          },
+        ],
       });
       pendingToolUseId = null;
+      pendingExtraToolResults = [];
 
       return runTurn(onDelta);
     },


### PR DESCRIPTION
## Summary

- Fixes a latent bug in `setup-conversation.ts` where `load_world` (or any other tool) co-emitted with `present_choices` in the same assistant turn had its `tool_result` discarded on early-return, leaving the `tool_use` orphaned. Anthropic 400s on the next request when that happens.
- Drops a stale `SetupPhase.tsx` tsconfig exclude left behind when setup moved into `PlayingPhase` (#311).

The fix stashes extra tool_results in closure state and flushes them alongside the choice resolution or dismissal on the next user turn.

## Context

Started as an investigation of #384 (migrate setup-conversation to `runProviderLoop`). On analysis, most of that issue's listed risks were non-issues — `runProviderLoop` already handles retry, usage accumulation, context dumping, and multi-round tool dispatch identically. But the issue's proposed blocking-promise approach doesn't fit `SetupSession`'s request/response shape: `send()`/`resolveChoice()` must return to the route so it can decide whether to `transitionToGame`. Closing #384 with analysis; landing the in-place fix instead.

## Test plan

- [x] `npm run check` (lint + 2297 tests passing)
- [x] Two new regression tests for co-emission (resolution path and dismissal path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)