### PR TITLE
Add theme-editor companion tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "workspaces": [
         "packages/*",
-        "tools/campaign-explorer"
+        "tools/campaign-explorer",
+        "tools/theme-editor"
       ],
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
@@ -1306,6 +1307,10 @@
     },
     "node_modules/@machine-violet/shared": {
       "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/@machine-violet/theme-editor": {
+      "resolved": "tools/theme-editor",
       "link": true
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -9736,6 +9741,585 @@
       }
     },
     "tools/campaign-explorer/node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "tools/theme-editor": {
+      "name": "@machine-violet/theme-editor",
+      "version": "0.1.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "express": "^5.1.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.17",
+        "@types/express": "^5.0.2",
+        "@types/react": "^19.1.6",
+        "@types/react-dom": "^19.1.6",
+        "@vitejs/plugin-react": "^4.5.2",
+        "tsx": "^4.19.4",
+        "typescript": "^5.8.3",
+        "vite": "^6.4.2"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/theme-editor/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "tools/theme-editor/node_modules/vite": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc -b",
     "check": "concurrently -n lint,test --kill-others-on-fail \"npm run lint\" \"npm test\"",
     "dist": "node scripts/build-dist.js",
-    "explorer": "node tools/campaign-explorer/scripts/dev.js"
+    "explorer": "node tools/campaign-explorer/scripts/dev.js",
+    "theme-editor": "node tools/theme-editor/scripts/dev.js"
   },
   "keywords": [
     "rpg",
@@ -60,7 +61,8 @@
   },
   "workspaces": [
     "packages/*",
-    "tools/campaign-explorer"
+    "tools/campaign-explorer",
+    "tools/theme-editor"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/tools/theme-editor/index.html
+++ b/tools/theme-editor/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Theme Editor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client/main.tsx"></script>
+  </body>
+</html>

--- a/tools/theme-editor/package.json
+++ b/tools/theme-editor/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@machine-violet/theme-editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/server/index.ts & vite",
+    "dev:server": "tsx watch src/server/index.ts",
+    "dev:client": "vite",
+    "build": "vite build && tsc -p tsconfig.node.json --noEmit",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.2",
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.5.2",
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3",
+    "vite": "^6.4.2"
+  }
+}

--- a/tools/theme-editor/scripts/dev.js
+++ b/tools/theme-editor/scripts/dev.js
@@ -10,7 +10,10 @@ import { dirname, join } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "..");
 
-const SERVER_PORT = process.env.PORT ?? "3998";
+// Ports are pinned to match the Vite proxy in vite.config.ts — both must
+// change together. If you need to run the backend standalone on a different
+// port, invoke src/server/index.ts directly with PORT set.
+const SERVER_PORT = "3998";
 const CLIENT_PORT = "5198";
 
 const server = spawn("node", ["--import", "tsx/esm", "src/server/index.ts"], {

--- a/tools/theme-editor/scripts/dev.js
+++ b/tools/theme-editor/scripts/dev.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Launch both Theme Editor backend (Express) and frontend (Vite)
+ * in a single terminal session. Cross-platform.
+ */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const SERVER_PORT = process.env.PORT ?? "3998";
+const CLIENT_PORT = "5198";
+
+const server = spawn("node", ["--import", "tsx/esm", "src/server/index.ts"], {
+  cwd: root,
+  stdio: ["ignore", "pipe", "pipe"],
+  env: { ...process.env, PORT: SERVER_PORT },
+  shell: true,
+});
+
+const client = spawn("npx", ["vite", "--port", CLIENT_PORT], {
+  cwd: root,
+  stdio: ["ignore", "pipe", "pipe"],
+  env: process.env,
+  shell: true,
+});
+
+function relay(proc, label) {
+  proc.stdout?.on("data", (data) => {
+    for (const line of data.toString().split("\n").filter(Boolean)) {
+      console.log(`[${label}] ${line}`);
+    }
+  });
+  proc.stderr?.on("data", (data) => {
+    for (const line of data.toString().split("\n").filter(Boolean)) {
+      console.error(`[${label}] ${line}`);
+    }
+  });
+}
+
+relay(server, "server");
+relay(client, "client");
+
+client.stdout?.on("data", (data) => {
+  const text = data.toString();
+  if (text.includes("Local:") || text.includes("localhost")) {
+    console.log(`\n  Theme Editor UI: http://localhost:${CLIENT_PORT}/\n`);
+  }
+});
+
+function cleanup() {
+  server.kill();
+  client.kill();
+}
+
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);
+
+server.on("exit", (code) => {
+  if (code !== null && code !== 0) console.error(`[server] exited with code ${code}`);
+  client.kill();
+});
+
+client.on("exit", (code) => {
+  if (code !== null && code !== 0) console.error(`[client] exited with code ${code}`);
+  server.kill();
+});

--- a/tools/theme-editor/src/client/App.tsx
+++ b/tools/theme-editor/src/client/App.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
 import type { AssetsResponse, ThemeAssetPayload } from "../shared/protocol";
 import type { StyleVariant, ThemeAsset, PlayerPaneFrame } from "@engine-src/tui/themes/types.js";
-import { parseThemeAsset, parsePlayerPaneFrame } from "@engine-src/tui/themes/parser.js";
+import {
+  parseThemeAsset,
+  parsePlayerPaneFrame,
+  parseSections,
+  extractThemeConfig,
+} from "@engine-src/tui/themes/parser.js";
 import { deriveModalTheme } from "@engine-src/tui/themes/color-resolve.js";
 import { buildDefinition } from "./lib/definition";
 import { resolveThemeWithAssets } from "./lib/resolve";
+import { setColorKey } from "./lib/mutate";
 import {
   renderConversationFrame,
   renderModal,
@@ -13,6 +19,7 @@ import {
 } from "./lib/render";
 import { FrameCanvas } from "./components/FrameCanvas";
 import { SourceEditor } from "./components/SourceEditor";
+import { ColorChips } from "./components/ColorChips";
 
 const VARIANTS: StyleVariant[] = ["exploration", "combat", "ooc", "levelup", "dev"];
 
@@ -184,6 +191,32 @@ export function App() {
   const themesList = assets?.themes ?? [];
   const framesList = assets?.playerFrames ?? [];
 
+  // Derive base-section (not variant-merged) values for chip highlighting.
+  const baseColors = useMemo(() => {
+    try {
+      const sections = parseSections(themeSource);
+      const config = extractThemeConfig(sections.metadata, sections.sections);
+      // gradient: null → user wrote "none"; undefined → not written (treat as "none" for UX)
+      const gradientChip =
+        config.gradient === null
+          ? "none"
+          : config.gradient === undefined
+            ? "none"
+            : config.gradient.preset;
+      return {
+        preset: config.swatchConfig?.preset,
+        harmony: config.swatchConfig?.harmony,
+        gradient: gradientChip,
+      };
+    } catch {
+      return { preset: undefined, harmony: undefined, gradient: undefined };
+    }
+  }, [themeSource]);
+
+  const onChipSet = (key: "preset" | "harmony" | "gradient", value: string) => {
+    setThemeSource((prev) => setColorKey(prev, key, value));
+  };
+
   const resetTheme = () => {
     const match = findAsset(themesList, themeName);
     if (match) setThemeSource(match.content);
@@ -246,6 +279,12 @@ export function App() {
               <button onClick={() => copyToClipboard(themeSource)}>Copy .theme</button>
               <button onClick={resetTheme}>Reset to {themeName}</button>
             </div>
+            <ColorChips
+              preset={baseColors.preset}
+              harmony={baseColors.harmony}
+              gradient={baseColors.gradient}
+              onSet={onChipSet}
+            />
             <SourceEditor
               label={`${themeName}.theme`}
               value={themeSource}

--- a/tools/theme-editor/src/client/App.tsx
+++ b/tools/theme-editor/src/client/App.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useMemo, useState } from "react";
+import type { AssetsResponse, ThemeAssetPayload } from "../shared/protocol";
+import type { StyleVariant, ThemeAsset, PlayerPaneFrame } from "@engine-src/tui/themes/types.js";
+import { parseThemeAsset, parsePlayerPaneFrame } from "@engine-src/tui/themes/parser.js";
+import { deriveModalTheme } from "@engine-src/tui/themes/color-resolve.js";
+import { buildDefinition } from "./lib/definition";
+import { resolveThemeWithAssets } from "./lib/resolve";
+import {
+  renderConversationFrame,
+  renderModal,
+  renderPlayerPane,
+  type SegmentRow,
+} from "./lib/render";
+import { FrameCanvas } from "./components/FrameCanvas";
+import { SourceEditor } from "./components/SourceEditor";
+
+const VARIANTS: StyleVariant[] = ["exploration", "combat", "ooc", "levelup", "dev"];
+
+const MAIN_WIDTH = 120;
+const MAIN_HEIGHT = 40;
+const MODAL_WIDTH = 60;
+const MODAL_HEIGHT = 20;
+const PLAYER_WIDTH = 40;
+const PLAYER_HEIGHT = 8;
+
+const SAMPLE_CONTENT = [
+  "  The dragon's shadow falls across the broken temple floor.",
+  "  Faded frescoes show a battle long lost to history.",
+  "",
+  "  > I search the altar for hidden compartments.",
+  "",
+  "  You find a loose stone at the base; behind it, a brass",
+  "  key engraved with a sigil you don't recognize.",
+];
+
+const SAMPLE_MODAL = [
+  "Character: Elowen Briarleaf",
+  "Class:     Druid (Circle of the Moon)",
+  "Level:     5",
+  "",
+  "HP: 42 / 42    AC: 14    Speed: 30 ft",
+];
+
+const SAMPLE_PLAYER = ["Elowen  HP 42/42  AC 14", "Round 3  —  Your turn"];
+
+function copyToClipboard(text: string): void {
+  navigator.clipboard.writeText(text).catch((err) => {
+    console.error("Clipboard write failed:", err);
+  });
+}
+
+function useAssets(): AssetsResponse | null {
+  const [assets, setAssets] = useState<AssetsResponse | null>(null);
+  useEffect(() => {
+    fetch("/api/assets")
+      .then((r) => r.json())
+      .then(setAssets)
+      .catch((err) => console.error("Failed to load assets:", err));
+  }, []);
+  return assets;
+}
+
+function findAsset(list: ThemeAssetPayload[] | undefined, name: string): ThemeAssetPayload | undefined {
+  return list?.find((a) => a.name === name);
+}
+
+export function App() {
+  const assets = useAssets();
+
+  const [themeName, setThemeName] = useState<string>("arcane");
+  const [frameName, setFrameName] = useState<string>("default");
+  const [themeSource, setThemeSource] = useState<string>("");
+  const [frameSource, setFrameSource] = useState<string>("");
+  const [keyColor, setKeyColor] = useState<string>("#8888aa");
+  const [variant, setVariant] = useState<StyleVariant>("exploration");
+
+  // Seed source from selected asset when it loads/changes.
+  useEffect(() => {
+    const match = findAsset(assets?.themes, themeName);
+    if (match) setThemeSource(match.content);
+  }, [assets, themeName]);
+
+  useEffect(() => {
+    const match = findAsset(assets?.playerFrames, frameName);
+    if (match) setFrameSource(match.content);
+  }, [assets, frameName]);
+
+  // Parse theme + frame, catching errors separately so one bad edit doesn't break the other.
+  const parsed = useMemo(() => {
+    let asset: ThemeAsset | null = null;
+    let assetError: string | null = null;
+    let frame: PlayerPaneFrame | null = null;
+    let frameError: string | null = null;
+
+    try {
+      if (themeSource.trim()) asset = parseThemeAsset(themeSource);
+    } catch (err) {
+      assetError = err instanceof Error ? err.message : String(err);
+    }
+    try {
+      if (frameSource.trim()) frame = parsePlayerPaneFrame(frameSource);
+    } catch (err) {
+      frameError = err instanceof Error ? err.message : String(err);
+    }
+
+    return { asset, assetError, frame, frameError };
+  }, [themeSource, frameSource]);
+
+  const definition = useMemo(() => {
+    if (!parsed.asset) return null;
+    try {
+      return buildDefinition(themeName, themeSource);
+    } catch (err) {
+      console.error("buildDefinition failed:", err);
+      return null;
+    }
+  }, [parsed.asset, themeName, themeSource]);
+
+  const resolved = useMemo(() => {
+    if (!definition || !parsed.asset || !parsed.frame) return null;
+    try {
+      return resolveThemeWithAssets(definition, parsed.asset, parsed.frame, variant, keyColor);
+    } catch (err) {
+      console.error("resolveTheme failed:", err);
+      return null;
+    }
+  }, [definition, parsed.asset, parsed.frame, variant, keyColor]);
+
+  const mainRows: SegmentRow[] = useMemo(() => {
+    if (!resolved) return [];
+    const contentHeight = MAIN_HEIGHT - 2 * resolved.asset.height;
+    const rows: string[] = new Array(contentHeight).fill("");
+    for (let i = 0; i < SAMPLE_CONTENT.length && i < contentHeight; i++) {
+      rows[i] = SAMPLE_CONTENT[i];
+    }
+    const turnRow = Math.floor(contentHeight * 0.6);
+    return renderConversationFrame(resolved, {
+      width: MAIN_WIDTH,
+      height: MAIN_HEIGHT,
+      title: "Machine Violet  —  The Silent Spires",
+      turnIndicator: "Round 3 · Elowen's turn",
+      contentRows: rows,
+      turnSeparatorRow: turnRow,
+    }).rows;
+  }, [resolved]);
+
+  const modalRows: SegmentRow[] = useMemo(() => {
+    if (!resolved) return [];
+    const modalTheme = deriveModalTheme(resolved);
+    const contentHeight = MODAL_HEIGHT - 2 * modalTheme.asset.height;
+    const rows: string[] = new Array(contentHeight).fill("");
+    for (let i = 0; i < SAMPLE_MODAL.length && i < contentHeight; i++) rows[i] = SAMPLE_MODAL[i];
+    return renderModal(modalTheme, {
+      width: MODAL_WIDTH,
+      height: MODAL_HEIGHT,
+      title: "Character Sheet",
+      footer: "Enter to close",
+      contentRows: rows,
+    }).rows;
+  }, [resolved]);
+
+  const playerRows: SegmentRow[] = useMemo(() => {
+    if (!resolved) return [];
+    const contentHeight = PLAYER_HEIGHT - 2;
+    const rows: string[] = new Array(contentHeight).fill("");
+    for (let i = 0; i < SAMPLE_PLAYER.length && i < contentHeight; i++) rows[i] = SAMPLE_PLAYER[i];
+    return renderPlayerPane(resolved, {
+      width: PLAYER_WIDTH,
+      height: PLAYER_HEIGHT,
+      contentRows: rows,
+    }).rows;
+  }, [resolved]);
+
+  // Tile period annotations help diagnose whether repeats are landing cleanly.
+  const tileInfo = useMemo(() => {
+    if (!parsed.asset) return null;
+    const { edge_top, edge_left } = parsed.asset.components;
+    return {
+      horizontal: edge_top.width,
+      vertical: edge_left.height,
+    };
+  }, [parsed.asset]);
+
+  const themesList = assets?.themes ?? [];
+  const framesList = assets?.playerFrames ?? [];
+
+  const resetTheme = () => {
+    const match = findAsset(themesList, themeName);
+    if (match) setThemeSource(match.content);
+  };
+  const resetFrame = () => {
+    const match = findAsset(framesList, frameName);
+    if (match) setFrameSource(match.content);
+  };
+
+  return (
+    <>
+      <div className="app-header">
+        <h1>Theme Editor</h1>
+        <div className="controls">
+          <label>
+            Theme
+            <select value={themeName} onChange={(e) => setThemeName(e.target.value)}>
+              {themesList.map((t) => (
+                <option key={t.name} value={t.name}>{t.name}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Player frame
+            <select value={frameName} onChange={(e) => setFrameName(e.target.value)}>
+              {framesList.map((f) => (
+                <option key={f.name} value={f.name}>{f.name}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Variant
+            <select value={variant} onChange={(e) => setVariant(e.target.value as StyleVariant)}>
+              {VARIANTS.map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Key color
+            <input
+              type="color"
+              value={keyColor}
+              onChange={(e) => setKeyColor(e.target.value)}
+            />
+            <input
+              type="text"
+              value={keyColor}
+              onChange={(e) => setKeyColor(e.target.value)}
+              className="hex-input"
+              spellCheck={false}
+            />
+          </label>
+        </div>
+      </div>
+      <div className="app-body">
+        <div className="editors">
+          <div className="editor-section">
+            <div className="editor-actions">
+              <button onClick={() => copyToClipboard(themeSource)}>Copy .theme</button>
+              <button onClick={resetTheme}>Reset to {themeName}</button>
+            </div>
+            <SourceEditor
+              label={`${themeName}.theme`}
+              value={themeSource}
+              onChange={setThemeSource}
+              error={parsed.assetError}
+              rows={26}
+            />
+          </div>
+          <div className="editor-section">
+            <div className="editor-actions">
+              <button onClick={() => copyToClipboard(frameSource)}>Copy .player-frame</button>
+              <button onClick={resetFrame}>Reset to {frameName}</button>
+            </div>
+            <SourceEditor
+              label={`${frameName}.player-frame`}
+              value={frameSource}
+              onChange={setFrameSource}
+              error={parsed.frameError}
+              rows={14}
+            />
+          </div>
+        </div>
+        <div className="previews">
+          {!resolved && (
+            <div className="preview-empty">
+              {parsed.assetError || parsed.frameError
+                ? "Fix parse errors to render a preview."
+                : "Loading theme..."}
+            </div>
+          )}
+          {resolved && (
+            <>
+              <FrameCanvas
+                rows={mainRows}
+                caption={`Conversation pane — ${MAIN_WIDTH}×${MAIN_HEIGHT}${tileInfo ? ` · edge tile H:${tileInfo.horizontal} V:${tileInfo.vertical}` : ""}`}
+              />
+              <FrameCanvas
+                rows={modalRows}
+                caption={`Modal (derived theme) — ${MODAL_WIDTH}×${MODAL_HEIGHT}`}
+              />
+              <FrameCanvas
+                rows={playerRows}
+                caption={`Player pane — ${PLAYER_WIDTH}×${PLAYER_HEIGHT}`}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tools/theme-editor/src/client/components/ColorChips.tsx
+++ b/tools/theme-editor/src/client/components/ColorChips.tsx
@@ -1,0 +1,70 @@
+import type { HarmonyType } from "@engine-src/tui/color/index.js";
+import { listPresets, listGradients } from "@engine-src/tui/color/index.js";
+
+const HARMONIES: HarmonyType[] = [
+  "analogous",
+  "complementary",
+  "split-complementary",
+  "triadic",
+  "tetradic",
+];
+
+interface ColorChipsProps {
+  preset: string | undefined;
+  harmony: string | undefined;
+  gradient: string | "none" | undefined;
+  onSet: (key: "preset" | "harmony" | "gradient", value: string) => void;
+}
+
+interface ChipRowProps {
+  label: string;
+  options: readonly string[];
+  current: string | undefined;
+  onClick: (value: string) => void;
+}
+
+function ChipRow({ label, options, current, onClick }: ChipRowProps) {
+  return (
+    <div className="chip-row">
+      <span className="chip-label">{label}</span>
+      {options.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          className={`chip${opt === current ? " chip-active" : ""}`}
+          onClick={() => onClick(opt)}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function ColorChips({ preset, harmony, gradient, onSet }: ColorChipsProps) {
+  const presets = listPresets();
+  const gradients = [...listGradients(), "none"];
+
+  return (
+    <div className="color-chips">
+      <ChipRow
+        label="preset"
+        options={presets}
+        current={preset}
+        onClick={(v) => onSet("preset", v)}
+      />
+      <ChipRow
+        label="harmony"
+        options={HARMONIES}
+        current={harmony}
+        onClick={(v) => onSet("harmony", v)}
+      />
+      <ChipRow
+        label="gradient"
+        options={gradients}
+        current={gradient}
+        onClick={(v) => onSet("gradient", v)}
+      />
+    </div>
+  );
+}

--- a/tools/theme-editor/src/client/components/FrameCanvas.tsx
+++ b/tools/theme-editor/src/client/components/FrameCanvas.tsx
@@ -1,0 +1,26 @@
+import type { SegmentRow } from "../lib/render";
+
+interface FrameCanvasProps {
+  rows: SegmentRow[];
+  caption?: string;
+}
+
+/** Render colorized rows as a monospace grid of inline-colored spans. */
+export function FrameCanvas({ rows, caption }: FrameCanvasProps) {
+  return (
+    <div className="canvas">
+      {caption && <div className="canvas-caption">{caption}</div>}
+      <div className="canvas-grid">
+        {rows.map((row, i) => (
+          <div key={i} className="canvas-row">
+            {row.map((seg, j) => (
+              <span key={j} style={seg.color ? { color: seg.color } : undefined}>
+                {seg.text}
+              </span>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/tools/theme-editor/src/client/components/SourceEditor.tsx
+++ b/tools/theme-editor/src/client/components/SourceEditor.tsx
@@ -1,0 +1,25 @@
+interface SourceEditorProps {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  error?: string | null;
+  rows?: number;
+}
+
+export function SourceEditor({ label, value, onChange, error, rows = 20 }: SourceEditorProps) {
+  return (
+    <div className="source-editor">
+      <div className="source-editor-header">
+        <label>{label}</label>
+        {error && <span className="source-editor-error">{error}</span>}
+      </div>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={rows}
+        spellCheck={false}
+        className={error ? "has-error" : undefined}
+      />
+    </div>
+  );
+}

--- a/tools/theme-editor/src/client/lib/definition.ts
+++ b/tools/theme-editor/src/client/lib/definition.ts
@@ -1,0 +1,46 @@
+/**
+ * Build a ThemeDefinition from parsed .theme file config.
+ * Mirrors loader.loadThemeDefinition() minus the filesystem read.
+ */
+
+import type { ThemeDefinition, ThemeColorMap } from "@engine-src/tui/themes/types.js";
+import { extractThemeConfig, parseSections } from "@engine-src/tui/themes/parser.js";
+
+const DEFAULT_COLOR_MAP: ThemeColorMap = {
+  border: 2,
+  corner: 3,
+  separator: 4,
+  title: 5,
+  turnIndicator: 6,
+  sideFrame: 1,
+};
+
+export function buildDefinition(themeName: string, themeContent: string): ThemeDefinition {
+  const parsed = parseSections(themeContent);
+  const config = extractThemeConfig(parsed.metadata, parsed.sections);
+
+  const definition: ThemeDefinition = {
+    assetName: themeName,
+    swatchConfig: {
+      preset: config.swatchConfig?.preset ?? "foliage",
+      harmony: config.swatchConfig?.harmony ?? "analogous",
+      ...config.swatchConfig,
+    },
+    colorMap: {
+      ...DEFAULT_COLOR_MAP,
+      ...config.colorMap,
+    },
+  };
+
+  if (config.gradient) {
+    definition.gradient = config.gradient;
+  }
+  if (config.playerFrameName) {
+    definition.playerFrameName = config.playerFrameName;
+  }
+  if (config.variants) {
+    definition.variants = config.variants;
+  }
+
+  return definition;
+}

--- a/tools/theme-editor/src/client/lib/mutate.ts
+++ b/tools/theme-editor/src/client/lib/mutate.ts
@@ -1,0 +1,62 @@
+/**
+ * In-place mutations of a .theme source string.
+ *
+ * Keeps the textarea authoritative: we locate and replace individual
+ * `key: value` lines inside the [colors] section instead of re-serializing
+ * the whole file. Comments, blank lines, and non-target sections are
+ * preserved verbatim.
+ */
+
+const SECTION_RE = /^\s*\[[a-z_]+\]\s*$/;
+
+interface SectionRange {
+  start: number;
+  end: number;
+}
+
+function findSection(lines: string[], name: string): SectionRange | null {
+  const header = `[${name}]`;
+  const startIdx = lines.findIndex((l) => l.trim() === header);
+  if (startIdx === -1) return null;
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (SECTION_RE.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+  return { start: startIdx, end: endIdx };
+}
+
+/**
+ * Set `key: value` within the [colors] section.
+ * Replaces an existing line if present, otherwise inserts before the
+ * section's trailing blank lines.
+ *
+ * If [colors] doesn't exist, returns source unchanged.
+ */
+export function setColorKey(source: string, key: string, value: string): string {
+  const normalized = source.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  const range = findSection(lines, "colors");
+  if (!range) return source;
+
+  const keyRe = new RegExp(`^\\s*${key}\\s*:\\s*.*$`);
+  for (let i = range.start + 1; i < range.end; i++) {
+    if (keyRe.test(lines[i])) {
+      lines[i] = `${key}: ${value}`;
+      return lines.join("\n");
+    }
+  }
+
+  // Insert after the last non-blank line within the section
+  let insertIdx = range.end;
+  for (let i = range.end - 1; i > range.start; i--) {
+    if (lines[i].trim() !== "") {
+      insertIdx = i + 1;
+      break;
+    }
+  }
+  lines.splice(insertIdx, 0, `${key}: ${value}`);
+  return lines.join("\n");
+}

--- a/tools/theme-editor/src/client/lib/render.ts
+++ b/tools/theme-editor/src/client/lib/render.ts
@@ -120,6 +120,9 @@ export function renderConversationFrame(theme: ResolvedTheme, opts: FrameRenderO
   const turnColor = themeColor(theme, "turnIndicator");
   const sideHex = themeColor(theme, "sideFrame");
   const separatorColor = themeColor(theme, "separator");
+  // Match ThemedSideFrame: gradient base falls back to sideFrame so themes
+  // without a border color still get a gradient on the sides.
+  const gradientBaseHex = borderColor ?? sideHex;
 
   const top = composeTopFrame(theme.asset, width, title);
   const bottom = composeBottomFrame(theme.asset, width, turnIndicator);
@@ -140,9 +143,9 @@ export function renderConversationFrame(theme: ResolvedTheme, opts: FrameRenderO
     const rightEdge = rightCol[i] ?? " ";
 
     let sideColor: string | undefined;
-    if (theme.gradient && borderColor) {
+    if (theme.gradient && gradientBaseHex) {
       const t = mirrorT(i, contentHeight);
-      sideColor = applyGradient(theme.gradient, hexToOklch(borderColor), t);
+      sideColor = applyGradient(theme.gradient, hexToOklch(gradientBaseHex), t);
     } else {
       sideColor = sideHex;
     }

--- a/tools/theme-editor/src/client/lib/render.ts
+++ b/tools/theme-editor/src/client/lib/render.ts
@@ -1,0 +1,230 @@
+/**
+ * HTML-ready colorized rows for the preview canvas.
+ *
+ * Mirrors ThemedFrame.tsx but produces arrays of { text, color } segments
+ * instead of Ink <Text> nodes — ready to map to <span style={{color}}>.
+ */
+
+import type { ResolvedTheme } from "@engine-src/tui/themes/types.js";
+import {
+  composeTopFrame,
+  composeBottomFrame,
+  composeSimpleBorder,
+  composeSideColumn,
+  composeTurnSeparator,
+  playerPaneSideColumn,
+} from "@engine-src/tui/themes/composer.js";
+import {
+  colorizeSegments,
+  mirrorT,
+  applyGradient,
+  hexToOklch,
+  type GradientPreset,
+} from "@engine-src/tui/color/index.js";
+import { themeColor } from "@engine-src/tui/themes/color-resolve.js";
+
+export interface Segment {
+  text: string;
+  color: string | undefined;
+}
+
+export type SegmentRow = Segment[];
+
+function pushSegment(row: SegmentRow, text: string, color: string | undefined): void {
+  if (text.length === 0) return;
+  const last = row[row.length - 1];
+  if (last && last.color === color) {
+    last.text += text;
+  } else {
+    row.push({ text, color });
+  }
+}
+
+function gradientSegments(
+  row: string,
+  baseHex: string | undefined,
+  gradient: GradientPreset | undefined,
+  offset: number,
+  totalLength: number,
+): SegmentRow {
+  if (!gradient || !baseHex) return [{ text: row, color: baseHex }];
+  const baseOklch = hexToOklch(baseHex);
+  const segs = colorizeSegments(row, gradient, baseOklch, offset, totalLength);
+  return segs.map((s) => ({ text: s.text, color: s.color }));
+}
+
+/**
+ * Compose a horizontal (top or bottom) border row with optional center text.
+ * When a center text is present and has a distinct color, splits the row so
+ * the title renders in titleColor while the sides flow with the gradient.
+ */
+function composeBorderRows(
+  rows: string[],
+  borderColor: string | undefined,
+  titleColor: string | undefined,
+  gradient: GradientPreset | undefined,
+  centerText: string | undefined,
+): SegmentRow[] {
+  return rows.map((row) => {
+    const segments: SegmentRow = [];
+    if (centerText && titleColor && titleColor !== borderColor) {
+      const needle = ` ${centerText} `;
+      const idx = row.indexOf(needle);
+      if (idx >= 0) {
+        const before = row.slice(0, idx);
+        const after = row.slice(idx + needle.length);
+        for (const s of gradientSegments(before, borderColor, gradient, 0, row.length)) {
+          pushSegment(segments, s.text, s.color);
+        }
+        pushSegment(segments, needle, titleColor);
+        for (const s of gradientSegments(after, borderColor, gradient, idx + needle.length, row.length)) {
+          pushSegment(segments, s.text, s.color);
+        }
+        return segments;
+      }
+    }
+    for (const s of gradientSegments(row, borderColor, gradient, 0, row.length)) {
+      pushSegment(segments, s.text, s.color);
+    }
+    return segments;
+  });
+}
+
+export interface FrameRenderOptions {
+  width: number;
+  height: number;
+  title?: string;
+  turnIndicator?: string;
+  contentRows?: string[];
+  /** Centered turn separator placed on this row of the content area (0-based). */
+  turnSeparatorRow?: number;
+}
+
+export interface FrameRender {
+  rows: SegmentRow[];
+}
+
+/**
+ * Build the full rendered grid for a Conversation Pane.
+ * Rows are returned top-to-bottom, each with its own colorized segments.
+ *
+ * Total height = 2 * asset.height + contentHeight.
+ */
+export function renderConversationFrame(theme: ResolvedTheme, opts: FrameRenderOptions): FrameRender {
+  const { width, height, title, turnIndicator, contentRows, turnSeparatorRow } = opts;
+  const borderHeight = theme.asset.height;
+  const contentHeight = Math.max(0, height - 2 * borderHeight);
+
+  const borderColor = themeColor(theme, "border");
+  const titleColor = themeColor(theme, "title");
+  const turnColor = themeColor(theme, "turnIndicator");
+  const sideHex = themeColor(theme, "sideFrame");
+  const separatorColor = themeColor(theme, "separator");
+
+  const top = composeTopFrame(theme.asset, width, title);
+  const bottom = composeBottomFrame(theme.asset, width, turnIndicator);
+
+  const topRows = composeBorderRows(top.rows, borderColor, titleColor, theme.gradient, title);
+  const bottomRows = composeBorderRows(bottom.rows, borderColor, turnColor, theme.gradient, turnIndicator);
+
+  // Side columns span only the content rows
+  const leftCol = composeSideColumn(theme.asset, "left", contentHeight);
+  const rightCol = composeSideColumn(theme.asset, "right", contentHeight);
+
+  // Content rows: left-edge + content text + right-edge, padded to width.
+  const innerWidth = Math.max(0, width - theme.asset.components.edge_left.width - theme.asset.components.edge_right.width);
+  const contentBody: SegmentRow[] = [];
+  for (let i = 0; i < contentHeight; i++) {
+    const row: SegmentRow = [];
+    const leftEdge = leftCol[i] ?? " ";
+    const rightEdge = rightCol[i] ?? " ";
+
+    let sideColor: string | undefined;
+    if (theme.gradient && borderColor) {
+      const t = mirrorT(i, contentHeight);
+      sideColor = applyGradient(theme.gradient, hexToOklch(borderColor), t);
+    } else {
+      sideColor = sideHex;
+    }
+
+    pushSegment(row, leftEdge, sideColor);
+
+    const bodyText =
+      turnSeparatorRow === i
+        ? composeTurnSeparator(theme.asset, innerWidth)
+        : (contentRows?.[i] ?? "").padEnd(innerWidth).slice(0, innerWidth);
+
+    if (turnSeparatorRow === i) {
+      pushSegment(row, bodyText, separatorColor);
+    } else {
+      pushSegment(row, bodyText, undefined);
+    }
+
+    pushSegment(row, rightEdge, sideColor);
+    contentBody.push(row);
+  }
+
+  return { rows: [...topRows, ...contentBody, ...bottomRows] };
+}
+
+export interface ModalRenderOptions {
+  width: number;
+  height: number;
+  title?: string;
+  footer?: string;
+  contentRows?: string[];
+}
+
+/**
+ * Build a compact modal preview. Uses the passed-in (already modal-derived) theme.
+ * Caller is responsible for applying deriveModalTheme() before calling.
+ */
+export function renderModal(modalTheme: ResolvedTheme, opts: ModalRenderOptions): FrameRender {
+  return renderConversationFrame(modalTheme, {
+    width: opts.width,
+    height: opts.height,
+    title: opts.title,
+    turnIndicator: opts.footer,
+    contentRows: opts.contentRows,
+  });
+}
+
+export interface PlayerPaneRenderOptions {
+  width: number;
+  height: number;
+  contentRows?: string[];
+}
+
+/**
+ * Build a Player Pane preview.
+ * Uses the 1-row simple border + per-row side chars from the player-frame asset.
+ */
+export function renderPlayerPane(theme: ResolvedTheme, opts: PlayerPaneRenderOptions): FrameRender {
+  const { width, height, contentRows } = opts;
+  const borderColor = themeColor(theme, "border");
+
+  const top = composeSimpleBorder(theme.playerPaneFrame, width, "top");
+  const bottom = composeSimpleBorder(theme.playerPaneFrame, width, "bottom");
+
+  const contentHeight = Math.max(0, height - top.height - bottom.height);
+  const leftChars = playerPaneSideColumn(theme.playerPaneFrame, "left", contentHeight);
+  const rightChars = playerPaneSideColumn(theme.playerPaneFrame, "right", contentHeight);
+
+  const topRows: SegmentRow[] = top.rows.map((r) => [{ text: r, color: borderColor }]);
+  const bottomRows: SegmentRow[] = bottom.rows.map((r) => [{ text: r, color: borderColor }]);
+
+  const innerWidth = Math.max(0, width - 2);
+  const body: SegmentRow[] = [];
+  for (let i = 0; i < contentHeight; i++) {
+    const left = leftChars[i] ?? " ";
+    const right = rightChars[i] ?? " ";
+    const content = (contentRows?.[i] ?? "").padEnd(innerWidth).slice(0, innerWidth);
+    const row: SegmentRow = [];
+    pushSegment(row, left, borderColor);
+    pushSegment(row, content, undefined);
+    pushSegment(row, right, borderColor);
+    body.push(row);
+  }
+
+  return { rows: [...topRows, ...body, ...bottomRows] };
+}

--- a/tools/theme-editor/src/client/lib/resolve.ts
+++ b/tools/theme-editor/src/client/lib/resolve.ts
@@ -1,0 +1,79 @@
+/**
+ * Browser-side theme resolver.
+ * Accepts pre-parsed ThemeAsset + PlayerPaneFrame (no filesystem access)
+ * and produces a ResolvedTheme ready for rendering — mirrors the
+ * game-side resolver without importing the Node loader.
+ */
+
+import type {
+  ResolvedTheme,
+  ThemeDefinition,
+  ThemeAsset,
+  PlayerPaneFrame,
+  StyleVariant,
+  SwatchConfig,
+  ThemeColorMap,
+} from "@engine-src/tui/themes/types.js";
+import {
+  generateHarmonySwatch,
+  generateArc,
+  simpleArc,
+  getGradient,
+  type Color,
+  type GradientPreset,
+} from "@engine-src/tui/color/index.js";
+
+const SAFE_DEFAULT_HEX = "#8888aa";
+
+export function resolveThemeWithAssets(
+  definition: ThemeDefinition,
+  asset: ThemeAsset,
+  playerPaneFrame: PlayerPaneFrame,
+  variant: StyleVariant,
+  keyColorHex?: string,
+): ResolvedTheme {
+  const keyColor = keyColorHex && keyColorHex.trim() !== "" ? keyColorHex : SAFE_DEFAULT_HEX;
+
+  const variantOverride = definition.variants?.[variant];
+  const swatchConfig: SwatchConfig = {
+    ...definition.swatchConfig,
+    ...variantOverride?.swatchConfig,
+  };
+  const colorMap: ThemeColorMap = {
+    ...definition.colorMap,
+    ...variantOverride?.colorMap,
+  };
+
+  let harmonySwatch: Color[][];
+  try {
+    harmonySwatch = generateHarmonySwatch(swatchConfig.preset, keyColor, swatchConfig.harmony);
+  } catch {
+    try {
+      harmonySwatch = [generateArc(simpleArc(keyColor))];
+    } catch {
+      harmonySwatch = [generateArc(simpleArc(SAFE_DEFAULT_HEX))];
+    }
+  }
+  const swatch = harmonySwatch[0];
+
+  let gradient: GradientPreset | undefined;
+  const variantGradient = variantOverride?.gradient;
+  if (variantGradient === null) {
+    gradient = undefined;
+  } else if (variantGradient) {
+    gradient = getGradient(variantGradient.preset);
+  } else if (definition.gradient) {
+    gradient = getGradient(definition.gradient.preset);
+  }
+
+  return {
+    asset,
+    playerPaneFrame,
+    swatch,
+    harmonySwatch,
+    colorMap,
+    variant,
+    keyColor,
+    gradient,
+  };
+}

--- a/tools/theme-editor/src/client/main.tsx
+++ b/tools/theme-editor/src/client/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/tools/theme-editor/src/client/styles.css
+++ b/tools/theme-editor/src/client/styles.css
@@ -1,0 +1,234 @@
+:root {
+  --bg-primary: #1a1a2e;
+  --bg-secondary: #16213e;
+  --bg-tertiary: #0f3460;
+  --bg-canvas: #0a0a14;
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a0b0;
+  --text-muted: #6a6a7a;
+  --accent: #4fc3f7;
+  --error: #ff6b6b;
+  --border: #2a2a4e;
+  --scrollbar-thumb: #3a3a5e;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "JetBrains Mono", "Cascadia Code", "Fira Code", monospace;
+  font-size: 13px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  overflow: hidden;
+  height: 100vh;
+}
+
+#root {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 4px;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 10px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.app-header h1 {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.controls {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.controls label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.controls select,
+.controls input[type="text"] {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  padding: 4px 6px;
+  font-family: inherit;
+  font-size: 12px;
+  border-radius: 3px;
+}
+
+.controls input[type="color"] {
+  width: 28px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border);
+  background: transparent;
+  cursor: pointer;
+}
+
+.hex-input {
+  width: 90px;
+}
+
+.app-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.editors {
+  width: 44%;
+  min-width: 420px;
+  max-width: 640px;
+  border-right: 1px solid var(--border);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
+}
+
+.editor-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.editor-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.editor-actions button {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.editor-actions button:hover {
+  background: var(--accent);
+  color: var(--bg-primary);
+}
+
+.source-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.source-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.source-editor-error {
+  color: var(--error);
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 11px;
+}
+
+.source-editor textarea {
+  background: var(--bg-canvas);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 8px;
+  resize: vertical;
+  white-space: pre;
+  overflow-wrap: normal;
+  overflow-x: auto;
+  tab-size: 2;
+}
+
+.source-editor textarea.has-error {
+  border-color: var(--error);
+}
+
+.previews {
+  flex: 1;
+  padding: 16px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: var(--bg-primary);
+}
+
+.preview-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 20px;
+}
+
+.canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.canvas-caption {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.canvas-grid {
+  background: var(--bg-canvas);
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: "JetBrains Mono", "Cascadia Code", "Fira Code", monospace;
+  font-size: 14px;
+  line-height: 1.1;
+  width: fit-content;
+}
+
+.canvas-row {
+  white-space: pre;
+  font-variant-ligatures: none;
+}

--- a/tools/theme-editor/src/client/styles.css
+++ b/tools/theme-editor/src/client/styles.css
@@ -146,6 +146,60 @@ body {
   color: var(--bg-primary);
 }
 
+.color-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  background: var(--bg-canvas);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+}
+
+.chip-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.chip-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  min-width: 60px;
+}
+
+.chip {
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  border-radius: 10px;
+  transition: background 0.1s, color 0.1s;
+}
+
+.chip:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.chip-active {
+  background: var(--accent);
+  color: var(--bg-primary);
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.chip-active:hover {
+  background: var(--accent);
+  color: var(--bg-primary);
+}
+
 .source-editor {
   display: flex;
   flex-direction: column;

--- a/tools/theme-editor/src/server/index.ts
+++ b/tools/theme-editor/src/server/index.ts
@@ -1,0 +1,52 @@
+import express from "express";
+import cors from "cors";
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import type { AssetsResponse, ThemeAssetPayload } from "../shared/protocol.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = parseInt(process.env.PORT ?? "3998", 10);
+
+/** Absolute path to the built-in theme assets directory. */
+const ASSETS_DIR = resolve(__dirname, "../../../../packages/client-ink/src/tui/themes/assets");
+
+async function loadAssets(extension: string): Promise<ThemeAssetPayload[]> {
+  const entries = await readdir(ASSETS_DIR);
+  const matches = entries.filter((e) => e.endsWith(extension));
+  const payloads: ThemeAssetPayload[] = [];
+  for (const filename of matches) {
+    const content = await readFile(join(ASSETS_DIR, filename), "utf-8");
+    payloads.push({ name: filename.slice(0, -extension.length), content });
+  }
+  return payloads.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function main(): Promise<void> {
+  const app = express();
+  app.use(cors());
+
+  app.get("/api/assets", async (_req, res) => {
+    try {
+      const [themes, playerFrames] = await Promise.all([
+        loadAssets(".theme"),
+        loadAssets(".player-frame"),
+      ]);
+      const response: AssetsResponse = { themes, playerFrames };
+      res.json(response);
+    } catch (err) {
+      console.error("Failed to list assets:", err);
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.listen(PORT, () => {
+    console.log(`Theme Editor API listening on http://localhost:${PORT}`);
+    console.log(`Assets dir: ${ASSETS_DIR}`);
+  });
+}
+
+main().catch((err) => {
+  console.error("Failed to start Theme Editor:", err);
+  process.exit(1);
+});

--- a/tools/theme-editor/src/shared/protocol.ts
+++ b/tools/theme-editor/src/shared/protocol.ts
@@ -1,0 +1,11 @@
+/** Shared types between the Theme Editor server and client. */
+
+export interface ThemeAssetPayload {
+  name: string;
+  content: string;
+}
+
+export interface AssetsResponse {
+  themes: ThemeAssetPayload[];
+  playerFrames: ThemeAssetPayload[];
+}

--- a/tools/theme-editor/tsconfig.json
+++ b/tools/theme-editor/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": false,
+    "paths": {
+      "@engine-src/*": ["../../packages/client-ink/src/*"]
+    },
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/client", "src/shared"]
+}

--- a/tools/theme-editor/tsconfig.node.json
+++ b/tools/theme-editor/tsconfig.node.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/server", "src/shared"]
+}

--- a/tools/theme-editor/vite.config.ts
+++ b/tools/theme-editor/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@engine-src": resolve(__dirname, "../../packages/client-ink/src"),
+    },
+  },
+  server: {
+    port: 5198,
+    proxy: {
+      "/api": {
+        target: "http://localhost:3998",
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- New developer-only tool at `tools/theme-editor/`, launched via `npm run theme-editor`. Mirrors the `campaign-explorer` layout (Express API + Vite/React client).
- Edits a `.theme` + `.player-frame` side-by-side and renders live previews of the conversation pane (120×40), a modal (uses `deriveModalTheme`), and a player pane.
- Ink isn't used in the browser — the client imports the engine's pure parser/composer/color modules via a Vite alias to `packages/client-ink/src` and renders composed rows as HTML `<span>`s with inline gradient colors.

## Details
- Server: single `GET /api/assets` that lists built-in `.theme` and `.player-frame` contents. No write endpoint — copy-to-clipboard only for phase 1; the user pastes into the asset file manually.
- Client controls: theme / player-frame / variant dropdowns, key-color picker, and a live tile-period readout so you can tell whether a pattern is landing mid-cycle at the current preview width.
- Main frame size (120×40) is deliberately wider/taller than real gameplay so multi-char edges tile several times.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (tools/ aren't linted)
- [x] `npx vitest run --changed` — no test files changed
- [x] Manually verified dev server boots: `npm run theme-editor`, API returns 4 themes + 1 player frame, client renders all three canvases with correct-width rows and gradient coloring across 80+ segments
- [ ] Reviewer sanity-check the preview in a browser on a wide monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)