### PR TITLE
Long-lived accumulating session for the choice generator

### DIFF
--- a/docs/subagents-catalog.md
+++ b/docs/subagents-catalog.md
@@ -79,13 +79,22 @@ Sandboxed conversation for out-of-character discussion. Receives the DM's curren
 | **Trigger** | Engine auto-triggers based on frequency config, or DM calls `present_choices({})` with no params |
 | **Source doc** | [tui-design.md](tui-design.md) |
 
-Reads the last few exchanges of DM narration and generates 3-6 reasonable player options. Each choice is prepended with a Unicode bullet glyph (e.g. ◆, ▸, ◇) chosen to suit the scene's tone. Does not need to be brilliant — freeform input is always available as a fallback.
+Generates 3-6 reasonable player options for the next turn. Each choice is prepended with a Unicode bullet glyph (e.g. ◆, ▸, ◇) chosen to suit the scene's tone. Does not need to be brilliant — freeform input is always available as a fallback.
 
 The prompt gently asks the subagent to stretch across tones where it fits the scene — thoughtful, passive, bold/aggressive, playful/funny, chaotic — but does **not** force any mood. If a tone would break fiction, it's omitted. Frequency is a 5-step probability (never / rarely / sometimes / often / always) set in `config.choices.campaign_default`, with optional per-character overrides. Default is `never` (opt-in).
 
-**Context**: Last 3-5 exchanges of DM narration + player input. ~500-1K tokens.
+**Session model.** Unlike most subagents, the choice generator runs as a **long-lived accumulating session** (`createChoiceGeneratorSession` in `packages/engine/src/agents/subagents/choice-generator.ts`), mirroring the DM's main conversation loop rather than one-shot inference. The shape matches the DM tiers:
 
-**Returns**: A prompt string and 3-6 bullet-prefixed choice strings. ~50-100 tokens.
+- **Tier 1** — `choice-generator.md` system prompt (1h cache).
+- **Tier 2** — party character sheets loaded at session construction (1h cache). Not refreshed mid-session: promotions are rare and any resulting changes show up in narration anyway, which isn't worth invalidating the cache for.
+- **Tier 3** — accumulating user/assistant pairs. Each turn's `user` is the plain `Player action + DM narration` body; each `assistant` is the prior set of generated choices. Messages use ephemeral cache hints so the turn-N+1 call reads the turn-N prefix from cache.
+- **Tier 4 (volatile)** — an XML `<context>` block with scene precis, open threads, NPC intents, and the active turn-holder. Prepended to the current user message only and discarded afterward (mirrors the DM's `<context>` pattern — the stored conversation never contains it).
+
+The session is reset on scene transitions with a synthetic seed exchange carrying the condensed campaign-log entry, so Haiku keeps long-range continuity across cuts without dragging a full scene's conversation tokens forward.
+
+**Context per turn**: ~500 input tokens of volatile + growing prefix (usually cached). Even a long scene stays well under 30K tokens of accumulated history.
+
+**Returns**: 3-6 bullet-prefixed choice strings, possibly with inline `<color=…>` tags for chaotic (orange), aggressive (red), or funny (pink) tones. ~50-200 tokens.
 
 ---
 

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -40,7 +40,8 @@ import { TOKEN_LIMITS } from "../config/tokens.js";
 import type { ToolRegistry } from "./tool-registry.js";
 import { isAITurn, getActivePlayer, getCombatActivePlayer } from "./player-manager.js";
 import { aiPlayerTurn } from "./subagents/ai-player.js";
-import { generateChoices, shouldGenerateChoices } from "./subagents/choice-generator.js";
+import { createChoiceGeneratorSession, shouldGenerateChoices } from "./subagents/choice-generator.js";
+import type { ChoiceGeneratorSession } from "./subagents/choice-generator.js";
 import { campaignPaths, parseFrontMatter, serializeEntity, formatChangelogEntry } from "../tools/filesystem/index.js";
 import { runScribe } from "./subagents/scribe.js";
 import { promoteCharacter } from "./subagents/character-promotion.js";
@@ -95,6 +96,10 @@ export class GameEngine {
   /** Set while the DM turn is running if the DM called `present_choices` itself.
    *  Used to suppress auto-generated choices for that turn. */
   private dmProvidedChoicesThisTurn = false;
+
+  /** Long-lived Haiku session for generating suggested responses.
+   *  Lazy-initialized on first use, reset on scene transitions. */
+  private choiceSession: ChoiceGeneratorSession | null = null;
 
   constructor(params: {
     provider: LLMProvider;
@@ -702,12 +707,13 @@ export class GameEngine {
     if (!shouldGenerateChoices(frequency, this.dmProvidedChoicesThisTurn)) return;
 
     try {
-      const generated = await generateChoices(
-        this.provider,
+      const session = await this.getOrCreateChoiceSession();
+      const generated = await session.generate({
         narration,
-        active.characterName,
-        playerAction || undefined,
-      );
+        playerAction,
+        volatileContext: this.buildChoiceVolatileContext(active.characterName),
+        activeCharacterName: active.characterName,
+      });
       accUsage(this.sessionUsage, generated.usage);
       this.callbacks.onUsageUpdate(generated.usage, "small");
 
@@ -723,6 +729,52 @@ export class GameEngine {
         `[dev] choice-generator failed: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
+  }
+
+  /**
+   * Lazy-init the long-lived Haiku choice session. Character sheets are loaded
+   * once and baked into the cached system prompt prefix — we intentionally do
+   * NOT refresh mid-session (character promotions show up in narration anyway,
+   * and blowing away the cache on every tweak is not worth it).
+   */
+  private async getOrCreateChoiceSession(): Promise<ChoiceGeneratorSession> {
+    if (this.choiceSession) return this.choiceSession;
+
+    const sheets: string[] = [];
+    for (const player of this.gameState.config.players) {
+      const name = player.character;
+      try {
+        const sheetPath = campaignPaths(this.gameState.campaignRoot).character(name);
+        const content = await this.fileIO.readFile(sheetPath);
+        if (content && content.trim().length > 0) {
+          sheets.push(content);
+        }
+      } catch {
+        // Missing sheet is fine — systemless or freshly-created characters.
+      }
+    }
+
+    this.choiceSession = createChoiceGeneratorSession({
+      provider: this.provider,
+      characterSheets: sheets.join("\n\n---\n\n"),
+      onRetry: (status, delayMs) => this.callbacks.onRetry(status, delayMs),
+    });
+    return this.choiceSession;
+  }
+
+  /**
+   * Build the per-turn volatile `<context>` block for the choice generator.
+   * Mirrors the DM's volatile-context pattern: ephemeral scene snapshot that
+   * is injected into the API message but not persisted into the conversation.
+   */
+  private buildChoiceVolatileContext(activeCharacterName: string): string {
+    const scene = this.sceneManager.getScene();
+    const parts: string[] = [];
+    if (scene.precis?.trim()) parts.push(`<scene_precis>\n${scene.precis.trim()}\n</scene_precis>`);
+    if (scene.openThreads?.trim()) parts.push(`<open_threads>${scene.openThreads.trim()}</open_threads>`);
+    if (scene.npcIntents?.trim()) parts.push(`<npc_intents>${scene.npcIntents.trim()}</npc_intents>`);
+    parts.push(`<active_turn>${activeCharacterName}</active_turn>`);
+    return `<context>\n${parts.join("\n")}\n</context>`;
   }
 
   /**
@@ -750,6 +802,11 @@ export class GameEngine {
 
       // Auto-apply theme from location entity if it has theme metadata
       await this.applyLocationTheme(title);
+
+      // Reset the choice session so Haiku doesn't drag a full scene's worth of
+      // user/assistant pairs across the cut. Reseed with the condensed campaign
+      // log entry so cross-scene threads still carry forward.
+      this.choiceSession?.reset(result.campaignLogEntry);
 
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -749,8 +749,15 @@ export class GameEngine {
         if (content && content.trim().length > 0) {
           sheets.push(content);
         }
-      } catch {
-        // Missing sheet is fine — systemless or freshly-created characters.
+      } catch (e) {
+        // Missing sheet is fine (systemless play, freshly-created characters).
+        // Anything else (permissions, I/O error) should surface in the dev log
+        // instead of being swallowed silently.
+        if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") {
+          this.callbacks.onDevLog?.(
+            `[dev] choice-session: failed to read ${name} sheet: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
       }
     }
 
@@ -1221,8 +1228,15 @@ export class GameEngine {
       const sheetPath = campaignPaths(this.gameState.campaignRoot).character(characterName);
       const content = await this.fileIO.readFile(sheetPath);
       if (content) characterSheet = content;
-    } catch {
-      // Fallback to name-only — fine for systemless play
+    } catch (e) {
+      // Missing sheet is fine — systemless or freshly-created characters.
+      // Other errors (permissions, I/O) surface in the dev log rather than
+      // vanishing silently.
+      if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        this.callbacks.onDevLog?.(
+          `[dev] ai-player: failed to read ${characterName} sheet: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
     }
 
     // Gather recent narration from conversation

--- a/packages/engine/src/agents/subagents/choice-generator-session.test.ts
+++ b/packages/engine/src/agents/subagents/choice-generator-session.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ChatParams, ChatResult, LLMProvider } from "../../providers/types.js";
+import { createChoiceGeneratorSession } from "./choice-generator.js";
+
+function mockUsage() {
+  return { inputTokens: 50, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 };
+}
+
+function mockResponse(text: string): ChatResult {
+  return {
+    text,
+    toolCalls: [],
+    usage: mockUsage(),
+    stopReason: "end",
+    assistantContent: [{ type: "text", text }],
+  };
+}
+
+/**
+ * Provider mock that records every ChatParams call so tests can assert on
+ * message history, system prompt shape, and cache hints.
+ */
+function recordingProvider(responses: ChatResult[]) {
+  let i = 0;
+  const calls: ChatParams[] = [];
+  const provider = {
+    providerId: "mock",
+    chat: vi.fn(async (params: ChatParams) => {
+      calls.push(params);
+      const r = responses[i++];
+      if (!r) throw new Error(`mock exhausted (call #${i})`);
+      return r;
+    }),
+    stream: vi.fn(),
+    healthCheck: vi.fn(async () => ({ ok: true })),
+  } as unknown as LLMProvider;
+  return { provider, calls };
+}
+
+const baseOpts = (provider: LLMProvider) => ({
+  provider,
+  model: "claude-haiku-mock",
+  characterSheets: "# Aldric\n**Class:** Rogue\n**Inventory:** poisoned dagger",
+});
+
+const turn = (narration: string, playerAction = "I do a thing") => ({
+  narration,
+  playerAction,
+  volatileContext: "<context><active_turn>Aldric</active_turn></context>",
+  activeCharacterName: "Aldric",
+});
+
+describe("createChoiceGeneratorSession", () => {
+  it("returns parsed choices from the first turn", async () => {
+    const { provider } = recordingProvider([
+      mockResponse("◆ Listen\n◆ Leave\n◆ <color=#cc4444>Strike</color>"),
+    ]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    const result = await session.generate(turn("You see a dusty shop."));
+
+    expect(result.choices).toEqual([
+      "◆ Listen",
+      "◆ Leave",
+      "◆ <color=#cc4444>Strike</color>",
+    ]);
+    expect(result.usage.inputTokens).toBe(50);
+  });
+
+  it("accumulates stored history across turns (but no volatile context)", async () => {
+    const { provider, calls } = recordingProvider([
+      mockResponse("◆ Ask"),
+      mockResponse("◆ Follow"),
+      mockResponse("◆ Hide"),
+    ]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    await session.generate(turn("Scene 1", "approach"));
+    await session.generate(turn("Scene 2", "speak"));
+    await session.generate(turn("Scene 3", "watch"));
+
+    // Turn 3 should have sent: turn-1 user, turn-1 assistant, turn-2 user,
+    // turn-2 assistant, turn-3 user (with volatile). 5 messages total.
+    const turn3 = calls[2];
+    expect(turn3.messages).toHaveLength(5);
+    // Prior messages are persisted WITHOUT the volatile `<context>` block.
+    expect(turn3.messages[0].role).toBe("user");
+    expect(turn3.messages[0].content).not.toContain("<context>");
+    expect(turn3.messages[1].role).toBe("assistant");
+    expect(turn3.messages[2].role).toBe("user");
+    expect(turn3.messages[2].content).not.toContain("<context>");
+    // Current turn's user message DOES include volatile context.
+    expect(turn3.messages[4].role).toBe("user");
+    expect(turn3.messages[4].content).toContain("<context>");
+
+    expect(session.getExchangeCount()).toBe(3);
+  });
+
+  it("places character sheets in the cached system prompt (Tier 2)", async () => {
+    const { provider, calls } = recordingProvider([mockResponse("◆ Look")]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    await session.generate(turn("Something happens."));
+
+    const sys = calls[0].systemPrompt;
+    expect(Array.isArray(sys)).toBe(true);
+    if (Array.isArray(sys)) {
+      // Tier 1: core instructions (with 1h cache)
+      expect(sys[0].cacheControl).toEqual({ ttl: "1h" });
+      // Tier 2: character sheets (also 1h)
+      expect(sys[1].cacheControl).toEqual({ ttl: "1h" });
+      expect(sys[1].text).toContain("poisoned dagger");
+    }
+  });
+
+  it("embeds the player action and DM narration into the current user message", async () => {
+    const { provider, calls } = recordingProvider([mockResponse("◆ Wait")]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    await session.generate(turn("The merchant scowls at you.", "I clear my throat"));
+
+    const last = calls[0].messages[calls[0].messages.length - 1];
+    expect(typeof last.content).toBe("string");
+    expect(last.content as string).toContain("I clear my throat");
+    expect(last.content as string).toContain("The merchant scowls at you.");
+    expect(last.content as string).toContain("Aldric");
+  });
+
+  it("reset() clears history by default", async () => {
+    const { provider } = recordingProvider([
+      mockResponse("◆ A"),
+      mockResponse("◆ B"),
+    ]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    await session.generate(turn("Scene 1"));
+    expect(session.getExchangeCount()).toBe(1);
+
+    session.reset();
+    expect(session.getExchangeCount()).toBe(0);
+
+    await session.generate(turn("Scene 2"));
+    expect(session.getExchangeCount()).toBe(1);
+  });
+
+  it("reset(precis) seeds a synthetic exchange for cross-scene continuity", async () => {
+    const { provider, calls } = recordingProvider([
+      mockResponse("◆ A"),
+      mockResponse("◆ B"),
+    ]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    await session.generate(turn("First scene narration."));
+    session.reset("The previous scene: you freed the prisoner and the jailor knows your face.");
+    expect(session.getExchangeCount()).toBe(1); // the synthetic seed pair
+
+    await session.generate(turn("Second scene narration."));
+    // The second turn's messages should include the synthetic seed + the new turn.
+    const turn2 = calls[1];
+    expect(turn2.messages).toHaveLength(3);
+    expect(turn2.messages[0].role).toBe("user");
+    expect(turn2.messages[0].content).toContain("freed the prisoner");
+    expect(turn2.messages[1].role).toBe("assistant");
+  });
+
+  it("parses choices even when the model returns markdown-style bullets", async () => {
+    const { provider } = recordingProvider([
+      mockResponse("- Climb the wall\n• Wait in the shadows\n1. Bluff the guard"),
+    ]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    const result = await session.generate(turn("..."));
+    expect(result.choices).toEqual([
+      "Climb the wall",
+      "Wait in the shadows",
+      "Bluff the guard",
+    ]);
+  });
+
+  it("caps choices at 6 even if the model returns more", async () => {
+    const { provider } = recordingProvider([
+      mockResponse("◆ 1\n◆ 2\n◆ 3\n◆ 4\n◆ 5\n◆ 6\n◆ 7\n◆ 8"),
+    ]);
+    const session = createChoiceGeneratorSession(baseOpts(provider));
+    const result = await session.generate(turn("..."));
+    expect(result.choices).toHaveLength(6);
+  });
+
+  it("omits the sheet block when no character sheets are supplied", async () => {
+    const { provider, calls } = recordingProvider([mockResponse("◆ Wait")]);
+    const session = createChoiceGeneratorSession({
+      provider,
+      model: "claude-haiku-mock",
+      characterSheets: "",
+    });
+    await session.generate(turn("..."));
+
+    const sys = calls[0].systemPrompt;
+    if (Array.isArray(sys)) {
+      expect(sys[1].text.trim()).toBe("");
+    }
+  });
+});

--- a/packages/engine/src/agents/subagents/choice-generator.ts
+++ b/packages/engine/src/agents/subagents/choice-generator.ts
@@ -1,20 +1,35 @@
 /**
  * Auto-generates player choices after DM narration.
- * Fires a Haiku subagent with recent context to suggest 3-6 options.
- * Explicit DM choices (via present_choices tool) take precedence.
+ *
+ * Historically this was a stateless one-shot Haiku call with just the latest
+ * DM narration + character name. The session variant ({@link createChoiceGeneratorSession})
+ * mirrors the DM main loop: a cached system-prompt prefix (instructions +
+ * character sheets), an accumulating user/assistant conversation of prior
+ * turns, and a per-turn volatile `<context>` block that is injected into the
+ * API message but NOT persisted in the stored conversation. This gives Haiku
+ * real continuity across a scene at roughly cache-read prices.
+ *
+ * The legacy stateless {@link generateChoices} helper is retained for tests
+ * and simple one-off use.
+ *
+ * Explicit DM choices (via the `present_choices` tool) always take precedence
+ * over auto-generation — see {@link shouldGenerateChoices}.
  */
-import type { LLMProvider } from "../../providers/types.js";
+import type { LLMProvider, NormalizedMessage, SystemBlock, ChatParams, ChatResult } from "../../providers/types.js";
 import type { ChoiceFrequency } from "@machine-violet/shared/types/config.js";
 import { oneShot } from "../subagent.js";
 import type { SubagentResult } from "../subagent.js";
+import type { UsageStats, ModelId } from "../agent-loop.js";
 import { getModel } from "../../config/models.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
+import { TOKEN_LIMITS } from "../../config/tokens.js";
 
 export interface GeneratedChoices extends SubagentResult {
   choices: string[];
 }
 
 const SYSTEM_PROMPT = loadPrompt("choice-generator");
+const MAX_OUTPUT_TOKENS = 400;
 
 /**
  * Should we auto-generate choices for this turn?
@@ -43,8 +58,23 @@ export function shouldGenerateChoices(
   return false;
 }
 
+/** Parse the Haiku response into a trimmed, capped choice list. */
+function parseChoices(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/^[-•*\d.)\s]+/, "").trim())
+    .filter((line) => line.length > 0)
+    .slice(0, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Stateless helper (kept for tests and simple one-off callers)
+// ---------------------------------------------------------------------------
+
 /**
- * Generate player choices from recent DM narration.
+ * Generate player choices from recent DM narration. Stateless — each call
+ * starts from scratch with no cross-turn memory. Prefer
+ * {@link createChoiceGeneratorSession} for live gameplay.
  */
 export async function generateChoices(
   provider: LLMProvider,
@@ -64,11 +94,186 @@ export async function generateChoices(
     "choice-generator",
   );
 
-  const choices = result.text
-    .split("\n")
-    .map((line) => line.replace(/^[-•*\d.)\s]+/, "").trim())
-    .filter((line) => line.length > 0)
-    .slice(0, 6);
+  return { ...result, choices: parseChoices(result.text) };
+}
 
-  return { ...result, choices };
+// ---------------------------------------------------------------------------
+// Accumulating session (the real implementation used in gameplay)
+// ---------------------------------------------------------------------------
+
+export interface ChoiceGeneratorSession {
+  /**
+   * Generate choices for the current turn. The user message sent to Haiku
+   * includes a volatile `<context>` block; the stored conversation records
+   * only the plain `Player action / DM narration` body (context is ephemeral).
+   */
+  generate(params: {
+    narration: string;
+    playerAction: string;
+    /** Pre-rendered `<context>…</context>` block; pass an empty string to skip. */
+    volatileContext: string;
+    activeCharacterName: string;
+  }): Promise<GeneratedChoices>;
+
+  /**
+   * Reset conversation history — intended for scene transitions. If a prior
+   * scene precis is supplied, a single synthetic exchange is seeded so Haiku
+   * retains long-range context across the cut.
+   */
+  reset(priorScenePrecis?: string): void;
+
+  /** Number of accumulated user/assistant exchange pairs. Exposed for tests. */
+  getExchangeCount(): number;
+}
+
+export interface ChoiceGeneratorSessionOptions {
+  provider: LLMProvider;
+  /** Haiku (or equivalent small-tier) model id. */
+  model?: ModelId;
+  /** Character sheets (one or more, concatenated markdown). Goes in the cached Tier-2 prefix. */
+  characterSheets: string;
+  /** Bubbled up from the session manager for transient-retry notifications. */
+  onRetry?: (status: number, delayMs: number) => void;
+}
+
+/**
+ * Build the system prompt as three SystemBlocks:
+ *   1. Core instructions from `choice-generator.md`         (1h cache)
+ *   2. Party/character sheets                                (1h cache)
+ *
+ * Tier 3 (volatile context) lives on the current user message, not here.
+ */
+function buildSystemBlocks(characterSheets: string): SystemBlock[] {
+  const trimmed = characterSheets.trim();
+  const sheetBlock = trimmed
+    ? `\n\n## Character sheets\n\nThese are the PCs whose choices you generate. Refer to their stats, abilities, inventory, and relationships when suggesting actions — their toolkit shapes what's plausible.\n\n${trimmed}`
+    : "";
+
+  return [
+    { text: SYSTEM_PROMPT, cacheControl: { ttl: "1h" } },
+    { text: sheetBlock, cacheControl: { ttl: "1h" } },
+  ];
+}
+
+/** Compose the plain (persisted) user-message body for a turn. */
+function plainTurnBody(activeCharacter: string, playerAction: string, narration: string): string {
+  const actionLine = playerAction ? `Player action (${activeCharacter}): ${playerAction}` : `Active character: ${activeCharacter}`;
+  return `${actionLine}\n\nDM narration:\n${narration}`;
+}
+
+/**
+ * Create a long-lived choice-generator session. The returned object
+ * accumulates history across `generate()` calls and resets on scene
+ * transition.
+ */
+export function createChoiceGeneratorSession(
+  opts: ChoiceGeneratorSessionOptions,
+): ChoiceGeneratorSession {
+  const provider = opts.provider;
+  const model = opts.model ?? getModel("small");
+  const systemBlocks = buildSystemBlocks(opts.characterSheets);
+
+  // Stored conversation — plain user/assistant pairs with NO volatile context.
+  // Volatile context is added only to the API message, not to what we persist.
+  const stored: NormalizedMessage[] = [];
+
+  async function callHaiku(apiMessages: NormalizedMessage[]): Promise<ChatResult> {
+    const params: ChatParams = {
+      model,
+      systemPrompt: systemBlocks,
+      messages: apiMessages,
+      maxTokens: Math.min(MAX_OUTPUT_TOKENS, TOKEN_LIMITS.SUBAGENT_LARGE),
+      // Cache hints: system prompt blocks are stamped with 1h cache above.
+      // On messages, ephemeral ("messages" target) means each call refreshes
+      // the last-message breakpoint — subsequent calls hit cached history.
+      cacheHints: [{ target: "messages" as const }],
+    };
+
+    // Retry on transient provider errors the caller knows how to signal.
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await provider.chat(params);
+      } catch (e) {
+        const status = extractStatus(e);
+        if (status === null || !RETRYABLE.has(status) || attempt >= 4) {
+          throw e instanceof Error ? e : new Error(String(e));
+        }
+        const delay = Math.min(1000 * 2 ** attempt, 8000);
+        opts.onRetry?.(status, delay);
+        await sleep(delay);
+      }
+    }
+  }
+
+  return {
+    async generate({ narration, playerAction, volatileContext, activeCharacterName }) {
+      const plainBody = plainTurnBody(activeCharacterName, playerAction, narration);
+      const apiBody = volatileContext
+        ? `${volatileContext}\n\n${plainBody}`
+        : plainBody;
+
+      // Send = stored history + current turn (API-only body with context)
+      const apiMessages: NormalizedMessage[] = [
+        ...stored,
+        { role: "user", content: apiBody },
+      ];
+
+      const result = await callHaiku(apiMessages);
+
+      // On success, persist the plain body (no volatile) + the assistant reply.
+      stored.push({ role: "user", content: plainBody });
+      stored.push({ role: "assistant", content: result.text });
+
+      const usage: UsageStats = {
+        inputTokens: result.usage.inputTokens,
+        outputTokens: result.usage.outputTokens,
+        cacheReadTokens: result.usage.cacheReadTokens,
+        cacheCreationTokens: result.usage.cacheCreationTokens,
+      };
+
+      return { text: result.text, usage, choices: parseChoices(result.text) };
+    },
+
+    reset(priorScenePrecis?: string) {
+      stored.length = 0;
+      const precis = priorScenePrecis?.trim();
+      if (precis) {
+        // Seed a synthetic exchange so cross-scene threads carry forward without
+        // paying for the full prior-scene history. The assistant ack is cheap
+        // (~10 tokens) and keeps the conversation in user/assistant alternation.
+        stored.push({
+          role: "user",
+          content: `[Scene transition. Summary of the prior scene for continuity:]\n${precis}`,
+        });
+        stored.push({
+          role: "assistant",
+          content: "Acknowledged. Ready to generate choices for the new scene.",
+        });
+      }
+    },
+
+    getExchangeCount() {
+      // Each exchange is a user+assistant pair.
+      return Math.floor(stored.length / 2);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retry internals (match the modest retry profile used elsewhere)
+// ---------------------------------------------------------------------------
+
+const RETRYABLE = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
+
+function extractStatus(err: unknown): number | null {
+  if (err && typeof err === "object") {
+    const e = err as { status?: unknown; response?: { status?: unknown } };
+    if (typeof e.status === "number") return e.status;
+    if (e.response && typeof e.response.status === "number") return e.response.status;
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/engine/src/agents/subagents/choice-generator.ts
+++ b/packages/engine/src/agents/subagents/choice-generator.ts
@@ -23,13 +23,19 @@ import type { UsageStats, ModelId } from "../agent-loop.js";
 import { getModel } from "../../config/models.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
 import { TOKEN_LIMITS } from "../../config/tokens.js";
+import { extractStatus, retryDelay, RETRYABLE_STATUS, sleep } from "../../utils/retry.js";
 
 export interface GeneratedChoices extends SubagentResult {
   choices: string[];
 }
 
 const SYSTEM_PROMPT = loadPrompt("choice-generator");
-const MAX_OUTPUT_TOKENS = 400;
+
+/** Per small-tier convention: 6 bullet-prefixed choice lines with room for
+ *  bullets, color tags, and a short action phrase fits comfortably here.
+ *  Extreme colored outputs might graze the edge; freeform input is always
+ *  available as a fallback if a set gets truncated. */
+const MAX_OUTPUT_TOKENS = TOKEN_LIMITS.SUBAGENT_SMALL;
 
 /**
  * Should we auto-generate choices for this turn?
@@ -182,23 +188,26 @@ export function createChoiceGeneratorSession(
       model,
       systemPrompt: systemBlocks,
       messages: apiMessages,
-      maxTokens: Math.min(MAX_OUTPUT_TOKENS, TOKEN_LIMITS.SUBAGENT_LARGE),
+      maxTokens: MAX_OUTPUT_TOKENS,
       // Cache hints: system prompt blocks are stamped with 1h cache above.
       // On messages, ephemeral ("messages" target) means each call refreshes
       // the last-message breakpoint — subsequent calls hit cached history.
       cacheHints: [{ target: "messages" as const }],
     };
 
-    // Retry on transient provider errors the caller knows how to signal.
+    // Retry on transient provider errors. Uses the same `extractStatus` /
+    // `RETRYABLE_STATUS` / `retryDelay` / `sleep` helpers as the main provider
+    // loop so network-level failures (status 0) and overload strings (→ 529)
+    // get retried consistently with the rest of the engine.
     for (let attempt = 0; ; attempt++) {
       try {
         return await provider.chat(params);
       } catch (e) {
         const status = extractStatus(e);
-        if (status === null || !RETRYABLE.has(status) || attempt >= 4) {
+        if (status === null || !RETRYABLE_STATUS.has(status) || attempt >= 4) {
           throw e instanceof Error ? e : new Error(String(e));
         }
-        const delay = Math.min(1000 * 2 ** attempt, 8000);
+        const delay = retryDelay(attempt);
         opts.onRetry?.(status, delay);
         await sleep(delay);
       }
@@ -259,21 +268,3 @@ export function createChoiceGeneratorSession(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Retry internals (match the modest retry profile used elsewhere)
-// ---------------------------------------------------------------------------
-
-const RETRYABLE = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
-
-function extractStatus(err: unknown): number | null {
-  if (err && typeof err === "object") {
-    const e = err as { status?: unknown; response?: { status?: unknown } };
-    if (typeof e.status === "number") return e.status;
-    if (e.response && typeof e.response.status === "number") return e.response.status;
-  }
-  return null;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
## Summary
The choice generator now runs as a long-lived accumulating session instead of a one-shot Haiku call. It mirrors the DM main loop's four-tier architecture so Haiku sees the character sheets, the full scene's prior narration + its own prior suggestions, and a volatile scene snapshot — at roughly cache-read prices per turn.

- **Tier 1 (1h cache)** — core `choice-generator.md` instructions
- **Tier 2 (1h cache)** — party character sheets, loaded once at session construction
- **Tier 3 (ephemeral messages cache)** — accumulating `user`/`assistant` pairs (plain body only; no volatile context)
- **Tier 4 (volatile, not persisted)** — `<context>` block with scene precis, open threads, NPC intents, active turn-holder; prepended only to the current API message

Scene transitions reset the session and reseed with the condensed campaign-log entry so cross-scene threads carry forward without token-dragging a whole scene of prior conversation.

Per user direction: one session (not per-PC), reseed on scene-transition (not hard-clear), and **don't** refresh character sheets mid-session — promotions show up in narration, and blowing away the cache for every tweak isn't worth it.

## Test plan
- [x] `npm run check` — 2322/2322 tests pass (9 new session tests), lint clean
- [x] New tests cover: parsed choices, history accumulation across turns, volatile-context-not-persisted, character-sheet placement in system prompt, bullet-strip parsing, 6-choice cap, `reset()` clearing, `reset(precis)` seeding a synthetic exchange, empty-sheet handling
- [ ] Smoke test in live session: suggestions remain coherent across a multi-turn scene, and still feel scene-appropriate after a scene transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)