### PR TITLE
Fix suboption choices silently dropped during setup

### DIFF
--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -268,6 +268,49 @@ describe("createSetupConversation", () => {
     expect(ids).toContain("toolu_choices_2");
   });
 
+  it("load_world in round 1 → present_choices in round 2 is captured as pendingChoices", async () => {
+    // Regression: previously the follow-up round's tool calls were ignored,
+    // so suboption choices (which need load_world's detail before they can
+    // be presented) were silently dropped and the turn ended without a modal.
+    const loadWorldResp: ChatResult = {
+      text: "Let me pull up that world...",
+      toolCalls: [{ id: "toolu_load_1", name: "load_world", input: { slug: "the-shattered-crown" } }],
+      usage: mockUsage(),
+      stopReason: "tool_use",
+      assistantContent: [
+        { type: "text", text: "Let me pull up that world..." },
+        { type: "tool_use", id: "toolu_load_1", name: "load_world", input: { slug: "the-shattered-crown" } },
+      ],
+    };
+    const presentSuboptions: ChatResult = {
+      text: "What kind of story?",
+      toolCalls: [{
+        id: "toolu_subopts",
+        name: "present_choices",
+        input: { prompt: "Pick a tone:", choices: ["Heroic", "Tragic"] },
+      }],
+      usage: mockUsage(),
+      stopReason: "tool_use",
+      assistantContent: [
+        { type: "text", text: "What kind of story?" },
+        { type: "tool_use", id: "toolu_subopts", name: "present_choices", input: { prompt: "Pick a tone:", choices: ["Heroic", "Tragic"] } },
+      ],
+    };
+    const provider = mockProvider([loadWorldResp, presentSuboptions]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+
+    const result = await conv.start(noop);
+
+    expect(provider.stream).toHaveBeenCalledTimes(2);
+    expect(result.pendingChoices).toBeDefined();
+    expect(result.pendingChoices!.prompt).toBe("Pick a tone:");
+    expect(result.pendingChoices!.choices).toEqual(["Heroic", "Tragic"]);
+
+    // Concatenated text from both rounds
+    expect(result.text).toContain("Let me pull up that world...");
+    expect(result.text).toContain("What kind of story?");
+  });
+
   it("send() after dismissed choice includes tool_result", async () => {
     const provider = mockProvider([
       presentChoicesResponse("Pick one:", "Genre:", ["Fantasy", "Sci-Fi"]),

--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -268,6 +268,35 @@ describe("createSetupConversation", () => {
     expect(ids).toContain("toolu_choices_2");
   });
 
+  it("hits MAX_ROUNDS with chained tools → wraps with a tools-disabled call", async () => {
+    // Model keeps calling load_world every round. After MAX_ROUNDS (4) iterations
+    // we must do one final tools-disabled call so the tool_use chain terminates
+    // and the next runTurn doesn't see two consecutive user messages.
+    const loadResp = (n: number): ChatResult => ({
+      text: `chain ${n}`,
+      toolCalls: [{ id: `toolu_load_${n}`, name: "load_world", input: { slug: "the-shattered-crown" } }],
+      usage: mockUsage(),
+      stopReason: "tool_use",
+      assistantContent: [
+        { type: "text", text: `chain ${n}` },
+        { type: "tool_use", id: `toolu_load_${n}`, name: "load_world", input: { slug: "the-shattered-crown" } },
+      ],
+    });
+    // 4 chained load_world responses + 1 wrap-up text response = 5 calls total
+    const provider = mockProvider([loadResp(1), loadResp(2), loadResp(3), loadResp(4), textResponse("OK, ready when you are.")]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+
+    const result = await conv.start(noop);
+
+    expect(provider.stream).toHaveBeenCalledTimes(5);
+    expect(result.text).toContain("OK, ready when you are.");
+
+    // The wrap-up call must have NO tools to prevent the chain from extending
+    const streamCalls = (provider.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const wrapCall = streamCalls[4][0];
+    expect(wrapCall.tools).toBeUndefined();
+  });
+
   it("load_world in round 1 → present_choices in round 2 is captured as pendingChoices", async () => {
     // Regression: previously the follow-up round's tool calls were ignored,
     // so suboption choices (which need load_world's detail before they can

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -521,6 +521,34 @@ export function createSetupConversation(
       messages.push({ role: "user", content: toolResults });
     }
 
+    // Defensive wrap-up: if we exited the loop with the last message being
+    // tool_results (i.e. we hit MAX_ROUNDS while the model was still chaining
+    // tool calls), do one final tools-disabled API call. Otherwise the next
+    // runTurn would push a plain user message on top of an existing one,
+    // breaking the role-alternation contract and 400-ing the next request.
+    const last = messages[messages.length - 1];
+    if (last && last.role === "user" && Array.isArray(last.content)
+      && last.content.some((c) => (c as { type?: string }).type === "tool_result")) {
+      const wrapParams: ChatParams = {
+        model,
+        maxTokens: TOKEN_LIMITS.SUBAGENT_MEDIUM,
+        systemPrompt,
+        messages,
+        // No tools — force a text-only response so the model can't extend the chain.
+        thinking,
+        cacheHints,
+      };
+      const wrap = await streamWithRetry(provider, wrapParams, onDelta, onRetry);
+      totalUsage.inputTokens += wrap.usage.inputTokens;
+      totalUsage.outputTokens += wrap.usage.outputTokens;
+      totalUsage.cacheReadTokens += wrap.usage.cacheReadTokens;
+      totalUsage.cacheCreationTokens += wrap.usage.cacheCreationTokens;
+      totalUsage.reasoningTokens += wrap.usage.reasoningTokens;
+      text += wrap.text;
+      if (wrap.thinkingText) dumpThinking("setup", MAX_ROUNDS, wrap.thinkingText);
+      messages.push({ role: "assistant", content: wrap.assistantContent });
+    }
+
     return {
       text,
       usage: { ...totalUsage },

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -392,13 +392,19 @@ export function createSetupConversation(
   }
 
   /**
-   * Run one API call, stream text, process tool calls.
-   * Returns the result, which may include pendingChoices (needs resolveChoice)
-   * or finalized (setup complete).
+   * Run one player turn. Makes API calls in a loop, processing tool calls
+   * every round, until one of three exit conditions:
+   *   1. Model emits `present_choices` — return early with pendingChoices;
+   *      app resumes via resolveChoice/send.
+   *   2. Round produces no tool calls — turn is done.
+   *   3. Hit MAX_ROUNDS — defensive cap to prevent runaway loops.
    *
-   * Uses deferred tool handling: present_choices pauses the loop and returns
-   * to the app for player input. This pattern doesn't fit runAgentLoop's
-   * immediate-tool-result model, so we handle it manually with retry.
+   * Looping (vs. a single follow-up call) matters because the model legitimately
+   * chains tools across rounds: e.g. call `load_world` to fetch suboptions, then
+   * call `present_choices` in the next round to show them to the player.
+   *
+   * Uses deferred tool handling for present_choices (pauses for player input),
+   * which doesn't fit runAgentLoop's immediate-tool-result model.
    */
   async function runTurn(onDelta: (delta: string) => void): Promise<SetupTurnResult> {
     finalized = undefined;
@@ -415,119 +421,104 @@ export function createSetupConversation(
       { target: "messages" as const },
     ];
 
-    let lastParams: ChatParams = {
-      model,
-      maxTokens: TOKEN_LIMITS.SUBAGENT_LARGE,
-      systemPrompt,
-      messages,
-      tools: TOOLS,
-      thinking,
-      cacheHints,
-    };
+    const MAX_ROUNDS = 4;
+    let text = "";
 
-    const result = await streamWithRetry(provider, lastParams, onDelta, onRetry);
-
-    // Accumulate usage
-    totalUsage.inputTokens += result.usage.inputTokens;
-    totalUsage.outputTokens += result.usage.outputTokens;
-    totalUsage.cacheReadTokens += result.usage.cacheReadTokens;
-    totalUsage.cacheCreationTokens += result.usage.cacheCreationTokens;
-    totalUsage.reasoningTokens += result.usage.reasoningTokens;
-
-    // Process tool calls from normalized result
-    let text = result.text;
-    const toolResults: ContentPart[] = [];
-    let pendingChoices: { prompt: string; choices: string[]; descriptions?: string[] } | undefined;
-
-    for (const tc of result.toolCalls) {
-      if (tc.name === "present_choices") {
-        // Don't resolve immediately — pause and return to the app for player input
-        const input = tc.input as { prompt?: string; choices?: unknown; descriptions?: unknown };
-        const rawChoices = Array.isArray(input.choices) ? input.choices : [];
-        const choices = rawChoices.map((c: unknown) => typeof c === "string" ? c : String(c));
-        const rawDescs = Array.isArray(input.descriptions) ? input.descriptions : [];
-        const descriptions = rawDescs.length > 0
-          ? rawDescs.map((d: unknown) => typeof d === "string" ? d : String(d))
-          : undefined;
-        pendingChoices = { prompt: input.prompt ?? "Choose:", choices, descriptions };
-        pendingToolUseId = tc.id;
-      } else if (tc.name === "load_world") {
-        const slug = (tc.input as { slug?: string }).slug ?? "";
-        const world = loadWorldBySlug(slug);
-        let content: string;
-        if (world) {
-          const parts: string[] = [];
-          if (world.detail) parts.push(`## Detail\n${world.detail}`);
-          if (world.suboptions?.length) {
-            for (const sub of world.suboptions) {
-              parts.push(`## Suboption: ${sub.label}\n` +
-                sub.choices.map((c: { name: string; description: string }) => `- **${c.name}** — ${c.description}`).join("\n"));
-            }
-          }
-          if (world.system) parts.push(`Suggested system: ${world.system}`);
-          if (world.mood) parts.push(`Suggested mood: ${world.mood}`);
-          if (world.difficulty) parts.push(`Suggested difficulty: ${world.difficulty}`);
-          content = parts.length > 0 ? parts.join("\n\n") : "World loaded but has no additional detail.";
-        } else {
-          content = `No world found with slug "${slug}".`;
-        }
-        toolResults.push({
-          type: "tool_result",
-          tool_use_id: tc.id,
-          content,
-        });
-      } else if (tc.name === "finalize_setup") {
-        handleFinalize(tc.input);
-        toolResults.push({
-          type: "tool_result",
-          tool_use_id: tc.id,
-          content: "Setup finalized. Say a brief farewell to the player before the adventure begins.",
-        });
-      }
-    }
-
-    // Dump thinking
-    if (result.thinkingText) dumpThinking("setup", 0, result.thinkingText);
-
-    // Append assistant message (thinking already stripped by provider)
-    messages.push({ role: "assistant", content: result.assistantContent });
-
-    // If we have pending choices, return now — app will call resolveChoice later.
-    // Any tool results produced alongside present_choices (e.g. load_world) are
-    // stashed so they can be flushed with the eventual choice resolution.
-    if (pendingChoices) {
-      pendingExtraToolResults = toolResults;
-      return {
-        text,
-        usage: { ...totalUsage },
-        pendingChoices,
-      };
-    }
-
-    // If any tool produced results, send them back and get the agent's continuation
-    if (toolResults.length > 0) {
-      messages.push({ role: "user", content: toolResults });
-
-      lastParams = {
+    for (let round = 0; round < MAX_ROUNDS; round++) {
+      const params: ChatParams = {
         model,
-        maxTokens: TOKEN_LIMITS.SUBAGENT_MEDIUM,
+        // First round gets a larger budget for the model's main response;
+        // follow-ups (reacting to tool results) are typically shorter.
+        maxTokens: round === 0 ? TOKEN_LIMITS.SUBAGENT_LARGE : TOKEN_LIMITS.SUBAGENT_MEDIUM,
         systemPrompt,
         messages,
         tools: TOOLS,
         thinking,
         cacheHints,
       };
-      const followUp = await streamWithRetry(provider, lastParams, onDelta, onRetry);
 
-      totalUsage.inputTokens += followUp.usage.inputTokens;
-      totalUsage.outputTokens += followUp.usage.outputTokens;
-      totalUsage.cacheReadTokens += followUp.usage.cacheReadTokens;
-      totalUsage.cacheCreationTokens += followUp.usage.cacheCreationTokens;
-      totalUsage.reasoningTokens += followUp.usage.reasoningTokens;
+      const result = await streamWithRetry(provider, params, onDelta, onRetry);
 
-      text += followUp.text;
-      if (followUp.thinkingText) dumpThinking("setup", 1, followUp.thinkingText);
-      messages.push({ role: "assistant", content: followUp.assistantContent });
+      totalUsage.inputTokens += result.usage.inputTokens;
+      totalUsage.outputTokens += result.usage.outputTokens;
+      totalUsage.cacheReadTokens += result.usage.cacheReadTokens;
+      totalUsage.cacheCreationTokens += result.usage.cacheCreationTokens;
+      totalUsage.reasoningTokens += result.usage.reasoningTokens;
+
+      text += result.text;
+      if (result.thinkingText) dumpThinking("setup", round, result.thinkingText);
+
+      // Append assistant message (thinking already stripped by provider)
+      messages.push({ role: "assistant", content: result.assistantContent });
+
+      // Process tool calls from this round
+      const toolResults: ContentPart[] = [];
+      let pendingChoices: { prompt: string; choices: string[]; descriptions?: string[] } | undefined;
+
+      for (const tc of result.toolCalls) {
+        if (tc.name === "present_choices") {
+          // Don't resolve immediately — pause and return to the app for player input
+          const input = tc.input as { prompt?: string; choices?: unknown; descriptions?: unknown };
+          const rawChoices = Array.isArray(input.choices) ? input.choices : [];
+          const choices = rawChoices.map((c: unknown) => typeof c === "string" ? c : String(c));
+          const rawDescs = Array.isArray(input.descriptions) ? input.descriptions : [];
+          const descriptions = rawDescs.length > 0
+            ? rawDescs.map((d: unknown) => typeof d === "string" ? d : String(d))
+            : undefined;
+          pendingChoices = { prompt: input.prompt ?? "Choose:", choices, descriptions };
+          pendingToolUseId = tc.id;
+        } else if (tc.name === "load_world") {
+          const slug = (tc.input as { slug?: string }).slug ?? "";
+          const world = loadWorldBySlug(slug);
+          let content: string;
+          if (world) {
+            const parts: string[] = [];
+            if (world.detail) parts.push(`## Detail\n${world.detail}`);
+            if (world.suboptions?.length) {
+              for (const sub of world.suboptions) {
+                parts.push(`## Suboption: ${sub.label}\n` +
+                  sub.choices.map((c: { name: string; description: string }) => `- **${c.name}** — ${c.description}`).join("\n"));
+              }
+            }
+            if (world.system) parts.push(`Suggested system: ${world.system}`);
+            if (world.mood) parts.push(`Suggested mood: ${world.mood}`);
+            if (world.difficulty) parts.push(`Suggested difficulty: ${world.difficulty}`);
+            content = parts.length > 0 ? parts.join("\n\n") : "World loaded but has no additional detail.";
+          } else {
+            content = `No world found with slug "${slug}".`;
+          }
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: tc.id,
+            content,
+          });
+        } else if (tc.name === "finalize_setup") {
+          handleFinalize(tc.input);
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: tc.id,
+            content: "Setup finalized. Say a brief farewell to the player before the adventure begins.",
+          });
+        }
+      }
+
+      // If we have pending choices, return now — app will call resolveChoice later.
+      // Any tool results produced alongside present_choices (e.g. load_world) are
+      // stashed so they can be flushed with the eventual choice resolution.
+      if (pendingChoices) {
+        pendingExtraToolResults = toolResults;
+        return {
+          text,
+          usage: { ...totalUsage },
+          pendingChoices,
+        };
+      }
+
+      // No tool calls → turn is done
+      if (toolResults.length === 0) break;
+
+      // Send tool results back and loop for the model's continuation
+      messages.push({ role: "user", content: toolResults });
     }
 
     return {


### PR DESCRIPTION
## Summary

When the DM calls \`load_world\` to fetch a seed's full detail (including suboptions like campaign tone/mood) and then wants to offer those suboptions as a \`present_choices\` modal, the modal never appears. The turn ends with an orphaned \`tool_use\` block and the player is left stuck.

**Root cause:** \`runTurn\` in \`setup-conversation.ts\` only processes tool calls from the *first* API call. The follow-up call (triggered after \`load_world\` returns a result) streams text and appends the assistant message, but its \`toolCalls\` are silently discarded. So the \`present_choices\` call in that second round never sets \`pendingChoices\`, no \`choices:presented\` event is emitted, and the suboption modal never appears.

**Fix:** replace the one-shot-follow-up pattern with a bounded loop (4 rounds) that processes tool calls every iteration. \`present_choices\` still returns early as before; other tools push their results and the loop continues picking up whatever the model does next.

This also preserves the earlier co-emission fix from #411 — \`pendingExtraToolResults\` still stashes non-\`present_choices\` results when the model batches them.

## Test plan

- [x] \`npm run check\` (lint + 2298 tests)
- [x] New regression test: \`load_world\` in round 1, \`present_choices\` in round 2 → \`pendingChoices\` is captured and both rounds' text is concatenated
- [ ] Manual smoke test: setup a campaign, pick a seed with suboptions (e.g. The Shattered Crown), verify the suboption modal appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)