### PR TITLE
Harden setup → DM handoff with postcard, git snapshot, and canonical entity paths

### DIFF
--- a/docs/error-recovery.md
+++ b/docs/error-recovery.md
@@ -41,7 +41,7 @@ After rollback completes, a `RollbackSummaryModal` displays what was restored an
 // config.json (partial)
 {
   "recovery": {
-    "auto_commit_interval": 3,     // commit every N exchanges
+    "auto_commit_interval": 1,     // commit every N exchanges (default 1 — every turn)
     "max_commits": 500,            // prune oldest auto-commits beyond this (keep scene/session commits)
     "enable_git": true             // can be disabled if the user doesn't want it
   }

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -175,7 +175,7 @@ Everything else is created during play.
 
   // Git recovery
   "recovery": {
-    "auto_commit_interval": 3,            // Exchanges between auto-commits.
+    "auto_commit_interval": 1,            // Exchanges between auto-commits. 1 = commit every turn (default).
     "max_commits": 100,                   // Pruning threshold.
     "enable_git": true                    // Whether git snapshots are active.
   },

--- a/packages/engine/src/agents/resolve-session.test.ts
+++ b/packages/engine/src/agents/resolve-session.test.ts
@@ -298,9 +298,10 @@ describe("ResolveSession", () => {
     const result = await session.resolve({ actor: "Kael", action: "Check stats" });
     expect(result.narrative).toBe("Checked sheet.");
 
-    // Verify the character sheet was read
+    // Verify the character sheet was read. campaignPaths.character slugifies
+    // the name defensively, so "Kael" → "kael.md" on disk.
     expect(fileIO.readFile).toHaveBeenCalledWith(
-      expect.stringContaining("Kael.md"),
+      expect.stringContaining("kael.md"),
     );
   });
 });

--- a/packages/engine/src/agents/setup-agent.test.ts
+++ b/packages/engine/src/agents/setup-agent.test.ts
@@ -51,6 +51,18 @@ describe("buildCampaignConfig", () => {
     expect(config.campaign_detail).toBeUndefined();
   });
 
+  it("passes handoffNote through as setup_handoff", () => {
+    const result = makeSetupResult({ handoffNote: "Player leans noir-burnout. Wants ensemble scenes." });
+    const config = buildCampaignConfig(result);
+    expect(config.setup_handoff).toBe("Player leans noir-burnout. Wants ensemble scenes.");
+  });
+
+  it("omits setup_handoff when handoffNote is undefined", () => {
+    const result = makeSetupResult();
+    const config = buildCampaignConfig(result);
+    expect(config.setup_handoff).toBeUndefined();
+  });
+
   it("passes personality detail through to config", () => {
     const result = makeSetupResult({
       personality: { name: "Test", prompt_fragment: "Terse.", detail: "Use callbacks." },

--- a/packages/engine/src/agents/setup-agent.ts
+++ b/packages/engine/src/agents/setup-agent.ts
@@ -28,6 +28,15 @@ export interface SetupResult {
   ageGroup?: "child" | "teenager" | "adult";
   /** Freeform content preferences captured during setup (one per line). */
   contentPreferences?: string;
+  /**
+   * Handoff postcard for the DM's first turn. Written by the setup agent
+   * as free-form prose summarising what the player actually said (character
+   * in their own words, freeform world/tone notes, anything else useful),
+   * plus anything the setup agent wants to pass along. Injected once into
+   * the DM's first-turn priming message; persisted in CampaignConfig so it
+   * survives a mid-first-turn crash and restart.
+   */
+  handoffNote?: string;
 }
 
 /**
@@ -52,6 +61,7 @@ export function buildCampaignConfig(result: SetupResult): CampaignConfig {
     difficulty: result.difficulty,
     premise: result.campaignPremise,
     campaign_detail: result.campaignDetail ?? undefined,
+    setup_handoff: result.handoffNote ?? undefined,
     dm_personality: result.personality,
     players: [player],
     combat: defaultCombatConfig(),
@@ -61,7 +71,12 @@ export function buildCampaignConfig(result: SetupResult): CampaignConfig {
       tool_result_stub_after: 5,
     },
     recovery: {
-      auto_commit_interval: 3,
+      // Commit every exchange. Git commits on a fresh campaign are tiny and
+      // cheap; the downside of bundling exchanges is that a crash drops work
+      // back to the last commit, and losing even a single DM turn is painful
+      // because DM turns frequently produce rich content (full dm-notes, NPCs,
+      // scene prep). One commit per exchange is the crash-safety floor.
+      auto_commit_interval: 1,
       max_commits: 500,
       enable_git: true,
     },

--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -183,6 +183,46 @@ describe("createSetupConversation", () => {
     expect(result.finalized!.characterDetails).toBeNull();
   });
 
+  it("finalize_setup passes through handoff_note", async () => {
+    const note = "Player leans noir-burnout. Wants ensemble scenes, not solo monologues.";
+    const input = { ...FINALIZE_INPUT, handoff_note: note };
+    const provider = mockProvider([
+      finalizeResponse(input),
+      textResponse("Onward!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized).toBeDefined();
+    expect(result.finalized!.handoffNote).toBe(note);
+  });
+
+  it("finalize_setup leaves handoffNote undefined when the model omits it", async () => {
+    // Defensive: the schema marks handoff_note required, but handleFinalize
+    // must not crash if the model misbehaves.
+    const provider = mockProvider([
+      finalizeResponse(FINALIZE_INPUT),
+      textResponse("Onward!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized).toBeDefined();
+    expect(result.finalized!.handoffNote).toBeUndefined();
+  });
+
+  it("finalize_setup trims whitespace-only handoff_note to undefined", async () => {
+    const input = { ...FINALIZE_INPUT, handoff_note: "   \n  \t  " };
+    const provider = mockProvider([
+      finalizeResponse(input),
+      textResponse("Onward!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized!.handoffNote).toBeUndefined();
+  });
+
   it("finalize_setup passes through characterDetails", async () => {
     const input = { ...FINALIZE_INPUT, system: "dnd-5e", character_details: "Human Fighter, level 1, soldier background" };
     const provider = mockProvider([

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -74,11 +74,12 @@ const FINALIZE_TOOL: NormalizedTool = {
       world_slug: { type: "string", description: "Slug of the world file used (from load_world). Omit for fully custom campaigns.", nullable: true },
       age_group: { type: "string", enum: ["child", "teenager", "adult"], description: "Player's age group. Set to 'child' or 'teenager' if the player clearly indicates so. Otherwise — including when age is not discussed or the player declines — set to 'adult'. Always include this field." },
       content_preferences: { type: "string", description: "Any content preferences or sensitivities the player mentioned during setup (one per line). Only include if the player volunteered them — never prompt for these.", nullable: true },
+      handoff_note: { type: "string", description: "Handoff postcard for the DM's first turn. Free-form prose — the DM sees this once as priming for the opening scene. Include: what the player said about their character IN THEIR OWN WORDS (quote or paraphrase closely, don't sanitize), any freeform remarks they made about the world / tone / things they want or don't want, and anything you (the setup agent) want to pass along to the DM — hooks you promised, tone cues the structured fields don't capture, unresolved ambiguities. Write it as a direct note to the DM, not as narration. A paragraph or two is usually right. Always include this field." },
     },
     required: [
       "genre", "campaign_name", "campaign_premise", "mood",
       "difficulty", "dm_personality", "player_name",
-      "character_name", "character_description",
+      "character_name", "character_description", "handoff_note",
     ],
   },
 };
@@ -391,6 +392,8 @@ export function createSetupConversation(
       themeColor: generateThemeColor(characterName),
       ageGroup: (input.age_group as "child" | "teenager" | "adult" | undefined) ?? undefined,
       contentPreferences: (input.content_preferences as string) || undefined,
+      handoffNote: (typeof input.handoff_note === "string" && input.handoff_note.trim())
+        ? input.handoff_note.trim() : undefined,
     };
   }
 

--- a/packages/engine/src/agents/world-builder.ts
+++ b/packages/engine/src/agents/world-builder.ts
@@ -4,6 +4,7 @@ import { buildCampaignConfig } from "./setup-agent.js";
 import { campaignDirs, campaignPaths, machineDirs, machinePaths } from "../tools/filesystem/index.js";
 import { serializeEntity, parseFrontMatter, extractSection } from "../tools/filesystem/index.js";
 import { norm } from "../utils/paths.js";
+import { slugify } from "../utils/slug.js";
 import { findSystem, readBundledRuleCard } from "../config/systems.js";
 import { processingPaths } from "../config/processing-paths.js";
 
@@ -190,15 +191,9 @@ function buildInitialContentBoundaries(
 }
 
 /**
- * Convert a name to a filesystem-safe slug.
- * Strips leading articles (the, a, an) so "The Black Coin" and "Black Coin"
- * produce the same slug, preventing accidental duplicate entities.
+ * Re-exported from utils/slug for backwards compatibility.
+ * The canonical entity-name → slug function lives in `../utils/slug.js` so
+ * the filesystem path helpers can defensively slugify without creating a
+ * circular dependency through this file.
  */
-export function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/^(the|a|an)\s+/i, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, 50);
-}
+export { slugify };

--- a/packages/engine/src/prompts/setup-conversation.md
+++ b/packages/engine/src/prompts/setup-conversation.md
@@ -138,6 +138,24 @@ After the player gives their name — and only if they are NOT a returning playe
 
 Do NOT proactively ask about content limits, phobias, or sensitivities. If the player volunteers any during the conversation ("I have arachnophobia", "please avoid gore"), note them in `content_preferences` when finalizing. Otherwise omit the field entirely.
 
+## Handoff note (MANDATORY)
+
+When you call `finalize_setup`, you MUST include a `handoff_note` — a short free-form letter to the DM who is about to run this campaign. The DM reads this **once**, at the top of the first turn, as priming for the opening scene. After that it's gone from their working context.
+
+Structured fields (`genre`, `premise`, `campaign_detail`, `character_description`, etc.) already reach the DM. The handoff note is for everything else: the things a player said that *don't* fit those fields cleanly.
+
+Include:
+- **The character in the player's own words** — quote or closely paraphrase how *they* described their PC (voice, backstory flavor, why they picked this concept). Don't sanitize into third-person sheet prose.
+- **Freeform world and tone remarks** — anything the player said about what they want, what they don't want, vibes, touchstones, references, "don't make it too ___", "I'd love it if ___".
+- **Your notes to the DM** — hooks you promised the player, ambiguities you resolved arbitrarily, tone cues that aren't captured by mood/genre, anything the DM would benefit from knowing that isn't in the structured fields.
+
+Write it as a direct note to the DM, not as narration. Plain prose, no HTML tags. A paragraph or two is the usual size — not a bullet list, not a sheet. Never reveal its contents to the player.
+
+Example:
+```
+handoff_note: "Player calls her character 'basically a tired ex-cop who's seen too much' — she's leaning noir-burnout, not stoic-tough. She mentioned she loves ensemble scenes and doesn't love long solo brooding monologues, so keep NPC beats moving. I promised her there'd be at least one talking cat somewhere in the first session — deliver on that when it feels right. She was ambivalent about Balanced vs. Gentle; I picked Balanced because she said 'I want to feel stakes.' The campaign_detail covers the cult; she doesn't know about the mayor's involvement yet."
+```
+
 ## Start
 
 Your very first message must:

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -28,7 +28,8 @@ import { createProviderFromConnection } from "../providers/index.js";
 import { configDir } from "../utils/paths.js";
 import { sandboxFileIO } from "../tools/filesystem/sandbox.js";
 import { campaignPaths } from "../tools/filesystem/scaffold.js";
-import { buildEntityTree } from "../tools/filesystem/entity-tree.js";
+import { buildEntityTree, renderEntityTree } from "../tools/filesystem/entity-tree.js";
+import type { EntityTree } from "@machine-violet/shared/types/entities.js";
 import { createGitIO } from "../tools/git/isogit-adapter.js";
 import { createClocksState } from "../tools/clocks/index.js";
 import { createCombatState } from "../tools/combat/index.js";
@@ -646,7 +647,7 @@ export class SessionManager {
     if (isResume) {
       await this.resumeSession(engine, config, gs, scene);
     } else {
-      await this.startNewGame(engine, config, gs);
+      await this.startNewGame(engine, config, gs, entityTree);
     }
   }
 
@@ -781,19 +782,43 @@ export class SessionManager {
     engine: GameEngine,
     config: CampaignConfig,
     gs: GameState,
+    entityTree: EntityTree,
   ): Promise<void> {
     // Trigger opening scene — TUI commands (theme, resources, modelines)
     // stream live to the client as activity:update events during this call.
+    //
+    // Priming message layout:
+    //   1. Bracketed stage direction: "[Session begins. Set the scene. <premise>. <PC>.]"
+    //      This is the cue the DM is trained to react to.
+    //   2. If the setup agent wrote a handoff note, a blank line + the note verbatim.
+    //      The note carries the player's own words and any setup-agent notes that
+    //      don't survive into structured config. It's a one-shot read; after the
+    //      opening turn succeeds it remains in config.json purely for resume.
+    //   3. A "Pre-existing entities" block listing every entity file already on
+    //      disk after setup scaffolding. This is the "chain of custody" the DM
+    //      relies on to avoid creating duplicate files (e.g. writing a fresh
+    //      character sheet at `Janey Bruce.md` when `janey-bruce.md` already
+    //      exists). Always included when the tree is non-empty.
     const active = getActivePlayer(gs);
     const openingParts = ["[Session begins. Set the scene."];
     if (config.premise) openingParts.push(`Campaign premise: ${config.premise}`);
     const pc = config.players[0];
     if (pc) openingParts.push(`The player character is ${pc.character}.`);
+    let priming = openingParts.join(" ") + "]";
+    if (config.setup_handoff && config.setup_handoff.trim()) {
+      priming += "\n\nSetup agent's handoff note:\n" + config.setup_handoff.trim();
+    }
+    const entityListing = renderEntityTree(entityTree);
+    if (entityListing) {
+      priming += "\n\nPre-existing entities (created during setup — write to these paths,"
+        + " do not create duplicates under alternate names):\n"
+        + entityListing;
+    }
 
     this.syncUIState();
     await engine.processInput(
       active.characterName,
-      openingParts.join(" ") + "]",
+      priming,
       { skipTranscript: true },
     );
 

--- a/packages/engine/src/server/setup-session.ts
+++ b/packages/engine/src/server/setup-session.ts
@@ -28,7 +28,7 @@ import { createProviderFromConnection, createAnthropicProvider } from "../provid
 import type { LLMProvider } from "../providers/types.js";
 import { getModel } from "../config/models.js";
 import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { CampaignRepo } from "../tools/git/campaign-repo.js";
 import { createGitIO } from "../tools/git/isogit-adapter.js";
@@ -242,7 +242,7 @@ export class SetupSession {
   private async commitHandoff(campaignRoot: string): Promise<void> {
     let config: CampaignConfig;
     try {
-      const raw = readFileSync(join(campaignRoot, "config.json"), "utf-8");
+      const raw = await readFile(join(campaignRoot, "config.json"), "utf-8");
       config = JSON.parse(raw) as CampaignConfig;
     } catch (err) {
       logEvent("setup:handoff_commit_error", {

--- a/packages/engine/src/server/setup-session.ts
+++ b/packages/engine/src/server/setup-session.ts
@@ -27,6 +27,12 @@ import { loadConnectionStore, buildEffectiveConnections, getTierProvider } from 
 import { createProviderFromConnection, createAnthropicProvider } from "../providers/index.js";
 import type { LLMProvider } from "../providers/types.js";
 import { getModel } from "../config/models.js";
+import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { CampaignRepo } from "../tools/git/campaign-repo.js";
+import { createGitIO } from "../tools/git/isogit-adapter.js";
+import { logEvent } from "../context/engine-log.js";
 
 export class SetupSession {
   private conversation: SetupConversation | null = null;
@@ -48,18 +54,21 @@ export class SetupSession {
     this.broadcast = broadcast;
     this.fileIO = createBaseFileIO();
 
-    // Resolve medium tier from connections (same path as gameplay uses for large)
+    // Setup runs on the large tier — the conversation is short and
+    // cache-friendly (stable system prompt with BP1 1h caching), so the
+    // incremental cost over medium is small and the quality of the handoff
+    // note + world framing benefits meaningfully.
     const appConfigDir = configDir();
     const connStore = buildEffectiveConnections(loadConnectionStore(appConfigDir), appConfigDir);
-    const mediumTier = getTierProvider(connStore, "medium");
+    const largeTier = getTierProvider(connStore, "large");
 
-    if (mediumTier) {
-      this.provider = createProviderFromConnection(mediumTier.connection);
-      this.model = mediumTier.modelId;
+    if (largeTier) {
+      this.provider = createProviderFromConnection(largeTier.connection);
+      this.model = largeTier.modelId;
     } else {
-      // Fallback: Anthropic from env key with default medium model
+      // Fallback: Anthropic from env key with default large model
       this.provider = createAnthropicProvider();
-      this.model = getModel("medium");
+      this.model = getModel("large");
     }
   }
 
@@ -209,9 +218,56 @@ export class SetupSession {
       await this.buildInitialSheet(campaignRoot, result);
     }
 
+    // Handoff commit — the campaign directory becomes a git repo and all
+    // scaffolded files (config.json, character sheet, party.md, etc.) land
+    // in a single commit BEFORE the DM's first turn runs. If the first turn
+    // crashes mid-flight, reloading from disk restores this exact state and
+    // the DM is re-primed with the same handoff note. Without this commit,
+    // a crash would leave us with scaffolded-but-unsnapshot files and a lazy
+    // "auto: initial state" commit baked into the first-turn critical path.
+    await this.commitHandoff(campaignRoot);
+
     // Return the campaign directory name as the ID
     const parts = norm(campaignRoot).split("/");
     return parts[parts.length - 1];
+  }
+
+  /**
+   * Initialize git + write the handoff commit for a freshly scaffolded campaign.
+   *
+   * Reads the just-written config.json to honour `recovery.enable_git` — if the
+   * player opted out of git, this is a no-op. Failures here are logged but never
+   * throw: git is recovery infrastructure, not a hard dependency of setup.
+   */
+  private async commitHandoff(campaignRoot: string): Promise<void> {
+    let config: CampaignConfig;
+    try {
+      const raw = readFileSync(join(campaignRoot, "config.json"), "utf-8");
+      config = JSON.parse(raw) as CampaignConfig;
+    } catch (err) {
+      logEvent("setup:handoff_commit_error", {
+        phase: "read_config",
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    if (!config.recovery?.enable_git) return;
+
+    try {
+      const repo = new CampaignRepo({
+        dir: campaignRoot,
+        git: createGitIO(),
+        enabled: true,
+        autoCommitInterval: config.recovery.auto_commit_interval,
+        maxCommits: config.recovery.max_commits,
+      });
+      await repo.init("handoff: campaign scaffolded from setup");
+    } catch (err) {
+      logEvent("setup:handoff_commit_error", {
+        phase: "commit",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private async buildInitialSheet(campaignRoot: string, result: SetupResult): Promise<void> {

--- a/packages/engine/src/tools/filesystem/config.ts
+++ b/packages/engine/src/tools/filesystem/config.ts
@@ -135,7 +135,7 @@ export function createDefaultCampaignConfig(
       tool_result_stub_after: 5,
     },
     recovery: {
-      auto_commit_interval: 3,
+      auto_commit_interval: 1,
       max_commits: 100,
       enable_git: true,
     },

--- a/packages/engine/src/tools/filesystem/filesystem.test.ts
+++ b/packages/engine/src/tools/filesystem/filesystem.test.ts
@@ -400,6 +400,33 @@ describe("campaignPaths", () => {
     expect(norm(paths.sceneTranscript(1, "tavern"))).toContain("001-tavern/transcript.md");
     expect(norm(paths.sceneDmNotes(1, "tavern"))).toContain("001-tavern/dm-notes.md");
   });
+
+  it("slugifies display names defensively across entity helpers", () => {
+    const paths = campaignPaths("/root");
+    // Display names with spaces/casing collapse to slugged filenames. This is
+    // the invariant that keeps the DM's lazy codepaths (promote_character,
+    // read_character_sheet, combatant sheet loading) from creating parallel
+    // entity files under the raw display name.
+    expect(norm(paths.character("Janey Bruce"))).toContain("characters/janey-bruce.md");
+    expect(norm(paths.location("The Goblin Caves"))).toContain("locations/goblin-caves/index.md");
+    expect(norm(paths.locationMap("Maren Crossing", "level-1")))
+      .toContain("locations/maren-crossing/level-1.json");
+    expect(norm(paths.faction("The Silver Hand"))).toContain("factions/silver-hand.md");
+    expect(norm(paths.lore("Ancient Sword"))).toContain("lore/ancient-sword.md");
+    expect(norm(paths.item("Ring of Power"))).toContain("items/ring-of-power.md");
+    expect(norm(paths.rule("Combat Basics"))).toContain("rules/combat-basics.md");
+  });
+
+  it("is idempotent for already-slugified names", () => {
+    const paths = campaignPaths("/root");
+    // Callers that already pass slugs must land on the same path either way —
+    // otherwise introducing the defensive slugify would break every correct
+    // existing callsite (world-builder, scribe).
+    expect(norm(paths.character("janey-bruce"))).toContain("characters/janey-bruce.md");
+    expect(norm(paths.location("starting-location")))
+      .toContain("locations/starting-location/index.md");
+    expect(norm(paths.faction("silver-hand"))).toContain("factions/silver-hand.md");
+  });
 });
 
 // --- Changelog ---

--- a/packages/engine/src/tools/filesystem/scaffold.ts
+++ b/packages/engine/src/tools/filesystem/scaffold.ts
@@ -38,12 +38,20 @@ export function sceneDir(
  * Standard file paths within a campaign.
  *
  * The entity-type helpers (`character`, `location`, `faction`, `lore`, `item`,
- * `rule`) defensively slugify the name. Callers can pass either a raw display
- * name ("Janey Bruce") or an already-slugified id ("janey-bruce") and land on
- * the same canonical path. This is belt-and-suspenders against a class of
- * bugs where a DM-side codepath reads/writes an entity file under its display
- * name while a sibling path (setup, scribe) uses the slug — producing two
- * parallel files for the same entity.
+ * `rule`) defensively slugify the name via the canonical `slugify` in
+ * `utils/slug.ts`. Callers can pass either a raw display name ("Janey Bruce")
+ * or a slug already produced by that same canonical slugify ("janey-bruce")
+ * and land on the same path. Ad-hoc slugs produced by other transformations
+ * are NOT guaranteed to round-trip — e.g. a hand-written "the-goblin-caves"
+ * stays "the-goblin-caves" here (article-stripping only triggers on whitespace)
+ * and would not collide with the canonical "goblin-caves". Everything
+ * campaign-internal routes through `slugify()`, so this only matters if a
+ * caller is constructing slugs manually — don't.
+ *
+ * This is belt-and-suspenders against a class of bugs where a DM-side
+ * codepath reads/writes an entity file under its display name while a
+ * sibling path (setup, scribe) uses the slug — producing two parallel files
+ * for the same entity.
  */
 export function campaignPaths(root: string) {
   return {

--- a/packages/engine/src/tools/filesystem/scaffold.ts
+++ b/packages/engine/src/tools/filesystem/scaffold.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { slugify } from "../../utils/slug.js";
 
 /**
  * The deterministic campaign directory structure.
@@ -35,6 +36,14 @@ export function sceneDir(
 
 /**
  * Standard file paths within a campaign.
+ *
+ * The entity-type helpers (`character`, `location`, `faction`, `lore`, `item`,
+ * `rule`) defensively slugify the name. Callers can pass either a raw display
+ * name ("Janey Bruce") or an already-slugified id ("janey-bruce") and land on
+ * the same canonical path. This is belt-and-suspenders against a class of
+ * bugs where a DM-side codepath reads/writes an entity file under its display
+ * name while a sibling path (setup, scribe) uses the slug — producing two
+ * parallel files for the same entity.
  */
 export function campaignPaths(root: string) {
   return {
@@ -43,15 +52,15 @@ export function campaignPaths(root: string) {
     legacyLog: join(root, "campaign", "log.md"),
     sceneSummary: (n: number, slug: string) =>
       join(sceneDir(root, n, slug), "summary.md"),
-    character: (name: string) => join(root, "characters", `${name}.md`),
-    location: (name: string) => join(root, "locations", name, "index.md"),
+    character: (name: string) => join(root, "characters", `${slugify(name)}.md`),
+    location: (name: string) => join(root, "locations", slugify(name), "index.md"),
     locationMap: (name: string, mapId: string) =>
-      join(root, "locations", name, `${mapId}.json`),
+      join(root, "locations", slugify(name), `${mapId}.json`),
     party: join(root, "characters", "party.md"),
-    faction: (name: string) => join(root, "factions", `${name}.md`),
-    lore: (name: string) => join(root, "lore", `${name}.md`),
-    item: (name: string) => join(root, "items", `${name}.md`),
-    rule: (name: string) => join(root, "rules", `${name}.md`),
+    faction: (name: string) => join(root, "factions", `${slugify(name)}.md`),
+    lore: (name: string) => join(root, "lore", `${slugify(name)}.md`),
+    item: (name: string) => join(root, "items", `${slugify(name)}.md`),
+    rule: (name: string) => join(root, "rules", `${slugify(name)}.md`),
     sessionRecap: (n: number) =>
       join(root, "campaign", "session-recaps", `session-${String(n).padStart(3, "0")}.md`),
     sessionRecapNarrative: (n: number) =>

--- a/packages/engine/src/tools/git/campaign-repo.ts
+++ b/packages/engine/src/tools/git/campaign-repo.ts
@@ -79,13 +79,34 @@ export class CampaignRepo {
     this.maxCommits = params.maxCommits ?? 500;
   }
 
-  /** Initialize git repo in campaign directory. No-op if already initialized. */
-  async init(): Promise<void> {
+  /**
+   * Initialize git repo in campaign directory.
+   *
+   * Idempotent in two senses:
+   *   1. In-process: no-op if `init()` has already succeeded on this instance.
+   *   2. Cross-process: if `.git` already has a commit (e.g. a handoff commit
+   *      written during setup), skip the "initial state" commit rather than
+   *      writing a duplicate. This lets the setup handoff own the first commit
+   *      and the engine's first `trackExchange` quietly attach to the existing
+   *      repo without polluting history.
+   *
+   * The initial commit message is configurable so the setup handoff can use
+   * a descriptive label; the engine's lazy fallback still uses "auto: initial state".
+   */
+  async init(initialMessage = "auto: initial state"): Promise<void> {
     if (!this.enabled) return;
     await this.git.init(this.dir);
-    // Initial commit with all existing files
-    await this.stageAll();
-    await this.commitIfDirty("auto: initial state");
+    let hasCommits = false;
+    try {
+      const existing = await this.git.log(this.dir, 1);
+      hasCommits = existing.length > 0;
+    } catch {
+      // No HEAD yet — fresh repo.
+    }
+    if (!hasCommits) {
+      await this.stageAll();
+      await this.commitIfDirty(initialMessage);
+    }
     this.initialized = true;
   }
 

--- a/packages/engine/src/tools/git/campaign-repo.ts
+++ b/packages/engine/src/tools/git/campaign-repo.ts
@@ -95,6 +95,21 @@ export class CampaignRepo {
    */
   async init(initialMessage = "auto: initial state"): Promise<void> {
     if (!this.enabled) return;
+    // In-process idempotence: subsequent init() calls on the same instance
+    // are no-ops. Matches the docstring contract and avoids redundant
+    // git.init/git.log I/O if a caller wires init() into a retry path.
+    if (this.initialized) return;
+    if (this.initPromise) {
+      await this.initPromise;
+      return;
+    }
+    this.initPromise = this.runInit(initialMessage).finally(() => {
+      this.initPromise = null;
+    });
+    await this.initPromise;
+  }
+
+  private async runInit(initialMessage: string): Promise<void> {
     await this.git.init(this.dir);
     let hasCommits = false;
     try {
@@ -110,15 +125,11 @@ export class CampaignRepo {
     this.initialized = true;
   }
 
-  /** Ensure init() has been called. Safe to call multiple times. */
+  /** Ensure init() has been called. Safe to call multiple times —
+   *  init() itself is idempotent and handles concurrent callers via
+   *  initPromise. */
   private async ensureInit(): Promise<void> {
-    if (this.initialized) return;
-    if (!this.initPromise) {
-      this.initPromise = this.init().finally(() => {
-        this.initPromise = null;
-      });
-    }
-    await this.initPromise;
+    await this.init();
   }
 
   /**

--- a/packages/engine/src/tools/git/git.test.ts
+++ b/packages/engine/src/tools/git/git.test.ts
@@ -101,6 +101,33 @@ describe("CampaignRepo", () => {
     expect(git.commits[0].message).toBe("auto: initial state");
   });
 
+  it("uses a custom initial commit message when one is passed to init", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
+
+    await repo.init("handoff: campaign scaffolded from setup");
+
+    expect(git.commits).toHaveLength(1);
+    expect(git.commits[0].message).toBe("handoff: campaign scaffolded from setup");
+  });
+
+  it("skips the initial commit when the repo already has a commit", async () => {
+    const git = mockGitIO();
+
+    // First process: setup's handoff commit
+    const setupRepo = new CampaignRepo({ dir: "/tmp/campaign", git });
+    await setupRepo.init("handoff: campaign scaffolded from setup");
+    expect(git.commits).toHaveLength(1);
+
+    // Second process: engine's CampaignRepo attaching to the same repo.
+    // Its lazy init must not write a duplicate "auto: initial state" commit.
+    const engineRepo = new CampaignRepo({ dir: "/tmp/campaign", git });
+    await engineRepo.init();
+
+    expect(git.commits).toHaveLength(1);
+    expect(git.commits[0].message).toBe("handoff: campaign scaffolded from setup");
+  });
+
   it("tracks exchanges and auto-commits at interval", async () => {
     const git = mockGitIO();
     const repo = new CampaignRepo({ dir: "/tmp/campaign", git, autoCommitInterval: 3 });

--- a/packages/engine/src/tools/git/git.test.ts
+++ b/packages/engine/src/tools/git/git.test.ts
@@ -111,6 +111,22 @@ describe("CampaignRepo", () => {
     expect(git.commits[0].message).toBe("handoff: campaign scaffolded from setup");
   });
 
+  it("is a no-op on repeat init() calls against the same instance", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
+
+    await repo.init("handoff: campaign scaffolded from setup");
+    await repo.init("handoff: campaign scaffolded from setup");
+    await repo.init();
+
+    // git.init must fire exactly once despite three calls — the documented
+    // in-process idempotence contract. Without it, a caller that wires init()
+    // into a retry path would thrash git.init and git.log each time.
+    expect((git.init as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    expect(git.commits).toHaveLength(1);
+    expect(git.commits[0].message).toBe("handoff: campaign scaffolded from setup");
+  });
+
   it("skips the initial commit when the repo already has a commit", async () => {
     const git = mockGitIO();
 

--- a/packages/engine/src/utils/slug.test.ts
+++ b/packages/engine/src/utils/slug.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { slugify } from "./slug.js";
+
+describe("slugify", () => {
+  it("lowercases and collapses non-alnum runs to single hyphens", () => {
+    expect(slugify("Janey Bruce")).toBe("janey-bruce");
+    expect(slugify("Hello  World!")).toBe("hello-world");
+    expect(slugify("Multi___under---score")).toBe("multi-under-score");
+  });
+
+  it("strips a single leading English article followed by whitespace", () => {
+    expect(slugify("The Black Coin")).toBe("black-coin");
+    expect(slugify("Black Coin")).toBe("black-coin");
+    expect(slugify("A Hooded Figure")).toBe("hooded-figure");
+    expect(slugify("An Old Tower")).toBe("old-tower");
+  });
+
+  it("does NOT strip 'the-' when no whitespace follows the article", () => {
+    // This is deliberate — slugs that already contain "the-" as part of the
+    // canonical slug (e.g. produced from "The-ory" or from a name where the
+    // article wasn't at the start) must not be further mangled. Article
+    // stripping is a display-name-only transform.
+    expect(slugify("the-goblin-caves")).toBe("the-goblin-caves");
+    expect(slugify("theory-of-everything")).toBe("theory-of-everything");
+  });
+
+  it("is idempotent on outputs produced by itself", () => {
+    const inputs = ["Janey Bruce", "The Black Coin", "ring-of-power", "maren-crossing"];
+    for (const input of inputs) {
+      const once = slugify(input);
+      expect(slugify(once)).toBe(once);
+    }
+  });
+
+  it("caps at 50 characters", () => {
+    const long = slugify("A Very Long Name That Exceeds Fifty Characters In Total Length Here");
+    expect(long.length).toBeLessThanOrEqual(50);
+  });
+
+  it("falls back to entity-{hash} when the input has no ASCII alnum", () => {
+    // Without the fallback these would produce "", and campaignPaths.character
+    // would create hidden `.md` files that collide with each other.
+    const whitespace = slugify("   ");
+    expect(whitespace).toMatch(/^entity-[0-9a-f]{8}$/);
+
+    const punct = slugify("!!!???");
+    expect(punct).toMatch(/^entity-[0-9a-f]{8}$/);
+
+    const nonAscii = slugify("花子");
+    expect(nonAscii).toMatch(/^entity-[0-9a-f]{8}$/);
+  });
+
+  it("the fallback is deterministic — same input yields same slug", () => {
+    expect(slugify("!!!")).toBe(slugify("!!!"));
+    expect(slugify("花子")).toBe(slugify("花子"));
+  });
+
+  it("distinct empty-slug inputs map to distinct fallbacks", () => {
+    // Not cryptographic, but any two distinct short strings should hash apart.
+    expect(slugify("!!!")).not.toBe(slugify("???"));
+    expect(slugify("花子")).not.toBe(slugify("太郎"));
+  });
+
+  it("the fallback itself slugifies to itself (idempotent)", () => {
+    const fallback = slugify("!!!");
+    expect(slugify(fallback)).toBe(fallback);
+  });
+});

--- a/packages/engine/src/utils/slug.ts
+++ b/packages/engine/src/utils/slug.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical entity-name → filesystem-slug function for the game engine.
+ *
+ * Rules:
+ *   1. Lowercase
+ *   2. Strip a single leading article (the / a / an + whitespace) — so
+ *      "The Black Coin" and "Black Coin" produce the same slug.
+ *   3. Collapse any run of non-alnum characters to a single hyphen.
+ *   4. Trim leading/trailing hyphens.
+ *   5. Cap at 50 characters.
+ *
+ * Idempotent: slugify(slugify(x)) === slugify(x) for any input.
+ *
+ * This is the function all entity files must be named with. Setup (world
+ * builder, character file creation), the DM's scribe tool, and any direct
+ * filesystem helper that takes an entity display name must all route through
+ * this. Divergent slugification has been the root cause of duplicate entity
+ * files (e.g. `Janey Bruce.md` alongside `janey-bruce.md`).
+ *
+ * Unrelated: `packages/engine/src/content/job-manager.ts` has its own
+ * `slugify` for content-pipeline directory names — that pipeline is isolated
+ * by design and does not share this function.
+ */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/^(the|a|an)\s+/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+}

--- a/packages/engine/src/utils/slug.ts
+++ b/packages/engine/src/utils/slug.ts
@@ -8,8 +8,15 @@
  *   3. Collapse any run of non-alnum characters to a single hyphen.
  *   4. Trim leading/trailing hyphens.
  *   5. Cap at 50 characters.
+ *   6. Inputs that reduce to the empty string (whitespace-only, punctuation-
+ *      only, pure non-ASCII) fall back to `entity-{hash}` with a short
+ *      deterministic hash of the original input. Never returns "" — that
+ *      would produce hidden `.md` files and collisions.
  *
- * Idempotent: slugify(slugify(x)) === slugify(x) for any input.
+ * Idempotent: slugify(slugify(x)) === slugify(x) for any input that already
+ * produces a non-empty ASCII slug. The empty-input fallback is deterministic
+ * per input (same input → same `entity-{hash}`), but slugify of that
+ * fallback just returns it unchanged (it's already a valid slug).
  *
  * This is the function all entity files must be named with. Setup (world
  * builder, character file creation), the DM's scribe tool, and any direct
@@ -22,10 +29,26 @@
  * by design and does not share this function.
  */
 export function slugify(name: string): string {
-  return name
+  const slug = name
     .toLowerCase()
     .replace(/^(the|a|an)\s+/i, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 50);
+  if (slug) return slug;
+  // Empty result: the input had no ASCII alnum after lowercasing.
+  // Emit a deterministic fallback so the caller gets a valid, non-hidden
+  // filename. The hash is short (8 hex) and keyed on the raw input so
+  // distinct weird inputs don't collide onto the same file.
+  return `entity-${shortHash(name)}`;
+}
+
+function shortHash(input: string): string {
+  // Simple djb2-style hash, truncated. Not cryptographic — just needs to
+  // spread distinct inputs across distinct slugs with high probability.
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5) + h + input.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16).padStart(8, "0").slice(0, 8);
 }

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -68,6 +68,15 @@ export interface CampaignConfig {
   premise?: string;
   /** Hidden campaign detail — DM-only instructions (variants, secrets, pacing notes). */
   campaign_detail?: string;
+  /**
+   * Handoff postcard written by the setup agent for the DM's first turn.
+   * Free-form prose: player's words about their character, any freeform intent
+   * captured in setup, setup-agent notes to the DM. Injected once into the
+   * first-turn priming message; persists here for resume-from-disk after a
+   * mid-first-turn crash. Never re-injected after the DM's opening narration
+   * succeeds.
+   */
+  setup_handoff?: string;
   dm_personality: DMPersonality;
   players: PlayerConfig[];
   combat: CombatConfig;


### PR DESCRIPTION
## Summary

- **Handoff postcard.** Setup agent now writes a free-form `handoff_note` (required on `finalize_setup`) that rides in `config.setup_handoff` and is injected into the DM's first-turn priming message — character in the player's own words, freeform tone/world remarks, setup-agent notes. Reloads cleanly after a mid-first-turn crash.
- **Handoff commit.** The campaign directory becomes a git repo with a `handoff: campaign scaffolded from setup` commit *before* the DM runs, not lazily inside first-turn `trackExchange`. `CampaignRepo.init()` is now idempotent across processes. `auto_commit_interval` default drops from 3 to 1 so every DM turn is snapshotted.
- **Canonical entity paths.** `campaignPaths.character/location/faction/lore/item/rule` slugify defensively, fixing a duplicate-file bug where DM-side codepaths (`handlePromoteCharacter`, `read_character_sheet`, etc.) passed raw display names. The priming message also now carries a "Pre-existing entities" listing so the DM doesn't create parallel files under alternate names.
- **Setup on `large` tier.** Short, fully cached conversation — quality upside on the postcard + world framing outweighs the small cost delta.

## Test plan

- [ ] `npm run check` passes (135 files, 2355 tests, lint clean)
- [ ] Create a new campaign with setup's free-form path and verify `config.json` contains a non-empty `setup_handoff` capturing the player's own words
- [ ] Verify `git log` in the fresh campaign shows `handoff: campaign scaffolded from setup` as the first commit, before the DM's first turn has run
- [ ] Verify the DM's first turn does not write a non-slugified duplicate character file (e.g. `characters/Janey Bruce.md` alongside `characters/janey-bruce.md`)
- [ ] Verify every subsequent DM turn produces a commit (exchange interval = 1)
- [ ] Verify interrupting the DM's first turn and reloading presents the same postcard to the DM again, with transcript empty and campaign dir restored to the handoff snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)