### PR TITLE
Loosen scene-pacing advisory thresholds

### DIFF
--- a/packages/engine/src/agents/scene-manager.test.ts
+++ b/packages/engine/src/agents/scene-manager.test.ts
@@ -1402,29 +1402,29 @@ describe("buildScenePacing", () => {
 
   it("nudges when scene is long and thread-heavy", () => {
     const scene = mockScene();
-    // 8 player exchanges
+    // 20 player exchanges
     scene.transcript = [];
-    for (let i = 0; i < 8; i++) {
+    for (let i = 0; i < 20; i++) {
       scene.transcript.push(`**[Aldric]** Action ${i}.`);
       scene.transcript.push(`**DM:** Response ${i}.`);
     }
-    scene.openThreads = "[[a]], [[b]], [[c]]";
+    scene.openThreads = "[[a]], [[b]], [[c]], [[d]], [[e]]";
     const result = buildScenePacing(scene)!;
-    expect(result).toContain("Exchanges: 8");
-    expect(result).toContain("Open threads: 3");
+    expect(result).toContain("Exchanges: 20");
+    expect(result).toContain("Open threads: 5");
     expect(result).toContain("Scene is long and thread-heavy");
   });
 
   it("nudges when scene is long even with few threads", () => {
     const scene = mockScene();
     scene.transcript = [];
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 30; i++) {
       scene.transcript.push(`**[Aldric]** Action ${i}.`);
       scene.transcript.push(`**DM:** Response ${i}.`);
     }
     scene.openThreads = "[[a]]";
     const result = buildScenePacing(scene)!;
-    expect(result).toContain("Exchanges: 10");
+    expect(result).toContain("Exchanges: 30");
     expect(result).toContain("running long");
   });
 
@@ -1434,9 +1434,9 @@ describe("buildScenePacing", () => {
       "**[Aldric]** I look around.",
       "**DM:** You see many things.",
     ];
-    scene.openThreads = "[[a]], [[b]], [[c]], [[d]]";
+    scene.openThreads = "[[a]], [[b]], [[c]], [[d]], [[e]]";
     const result = buildScenePacing(scene)!;
-    expect(result).toContain("Open threads: 4");
+    expect(result).toContain("Open threads: 5");
     expect(result).toContain("Many open threads");
   });
 

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -1173,11 +1173,11 @@ export function buildScenePacing(scene: SceneState): string | undefined {
   parts.push(`Open threads: ${threadCount}`);
 
   // Advisory nudge when the scene is running long or overloaded
-  if (exchangeCount >= 8 && threadCount >= 3) {
+  if (exchangeCount >= 20 && threadCount >= 5) {
     parts.push("→ Scene is long and thread-heavy. Consider ending it — unresolved threads carry forward, and your alarms and clocks need a transition to fire.");
-  } else if (exchangeCount >= 10) {
+  } else if (exchangeCount >= 30) {
     parts.push("→ Scene is running long. Look for a cut point.");
-  } else if (threadCount >= 4) {
+  } else if (threadCount >= 5) {
     parts.push("→ Many open threads. Resolve or cut — don't open more.");
   }
 


### PR DESCRIPTION
## Summary

The transition-reminder nudges in `buildScenePacing` were firing too early — the combined "long and thread-heavy" branch hit at 8 exchanges + 3 threads, which comfortably fits inside a single well-paced scene. Observed live: DMs getting nudged to transition while the scene still had runway.

## Changes

| Branch | Before | After |
|---|---|---|
| Long AND thread-heavy | `exchanges ≥ 8 && threads ≥ 3` | `exchanges ≥ 20 && threads ≥ 5` |
| Running long (exchange-only) | `exchanges ≥ 10` | `exchanges ≥ 30` |
| Many threads (thread-only) | `threads ≥ 4` | `threads ≥ 5` |

Injection cadence (every 3rd exchange via `ctx.conversationSize % 3`) is unchanged — only the advisory message thresholds move.

Tests updated to match.

## Test plan

- [x] `npx vitest run --changed` — 166/166 pass
- [x] ESLint clean on modified files
- [ ] Observe the next few live sessions to confirm nudges land at roughly the right moments

🤖 Generated with [Claude Code](https://claude.com/claude-code)