### PR TITLE
Fix narrative duplication on streaming retries (#431)

### DIFF
--- a/docs/websocket-api.md
+++ b/docs/websocket-api.md
@@ -47,6 +47,8 @@ The `type` field is a string discriminant. The `data` field varies by event type
 
 Streaming DM narration text, buffered by word boundaries (whitespace/newline, or >200 chars, with a 50ms flush timeout). Multiple chunks arrive during a single DM response.
 
+If a streaming API call fails mid-response and the engine is about to retry, the server first publishes a `state:snapshot` containing the committed `narrativeLines` (everything before the failed turn). Clients should treat that snapshot as authoritative and replace their accumulated log — otherwise the retry's chunks will visibly duplicate the partial text from the failed attempt. See `state:snapshot` below.
+
 | Field     | Type     | Description |
 |-----------|----------|-------------|
 | `text`    | string   | A buffered fragment of DM output. |
@@ -198,6 +200,7 @@ Full game state. Sent on initial connect, after every DM turn completes, after s
 | `sceneNumber`      | number?  | Current scene number. |
 | `scenePrecis`      | string?  | One-line scene summary. |
 | `sessionRecap`     | object?  | `{ id, lines }` — present only in the first snapshot after a clean session-end. Client renders the "Previously on..." modal; server clears the pending flag as it emits. Omitted on mid-session reconnects and fresh campaigns. |
+| `narrativeLines`   | array?   | Authoritative committed transcript (`{ kind: "dm" \| "player", text }`). When present, the client REPLACES its accumulated narrative log; when omitted, the existing log is preserved. Sent on connect (so reconnecting clients see history) and on retry rollback (so a partial DM stream that's about to be re-issued doesn't accumulate twice on the client). Per-turn snapshots intentionally omit it to avoid clobbering in-flight stream deltas. |
 
 **Player** (nested in `players` array):
 

--- a/packages/client-ink/src/event-handler.test.ts
+++ b/packages/client-ink/src/event-handler.test.ts
@@ -267,6 +267,74 @@ describe("event-handler", () => {
       expect(h.state.stateSnapshot).not.toBeNull();
       expect(h.state.stateSnapshot!.campaignId).toBe("c1");
     });
+
+    // Issue #431: snapshots that include narrativeLines act as authoritative
+    // resets — the server uses this on retry rollback to discard a partial
+    // DM stream that's about to be re-issued, and on connect to give
+    // reconnecting clients the prior history.
+    it("REPLACES narrativeLines when snapshot includes them", () => {
+      const h = makeHarness();
+      // Accumulate some chunks (simulating the partial bug-causing stream)
+      h.dispatch({ type: "narrative:chunk", data: { text: "The bell ", kind: "dm" } });
+      h.dispatch({ type: "narrative:chunk", data: { text: "chimes. Mol", kind: "dm" } });
+      expect(h.state.narrativeLines.length).toBeGreaterThan(0);
+
+      // Server publishes a corrective snapshot — committed transcript only.
+      h.dispatch({
+        type: "state:snapshot",
+        data: {
+          campaignId: "c1", campaignName: "Test", players: [],
+          activePlayerIndex: 0, displayResources: {}, resourceValues: {},
+          modelines: {}, mode: "play",
+          narrativeLines: [
+            { kind: "player", text: "[Aldric] open the door" },
+          ],
+        },
+      });
+
+      expect(h.state.narrativeLines).toEqual([
+        { kind: "player", text: "[Aldric] open the door" },
+      ]);
+    });
+
+    // Per-turn snapshots omit narrativeLines specifically so they don't
+    // clobber in-flight stream deltas. Client must coalesce to existing
+    // state in that case.
+    it("PRESERVES narrativeLines when snapshot omits them", () => {
+      const h = makeHarness();
+      h.dispatch({ type: "narrative:chunk", data: { text: "Hello world", kind: "dm" } });
+      const before = h.state.narrativeLines;
+
+      h.dispatch({
+        type: "state:snapshot",
+        data: {
+          campaignId: "c1", campaignName: "Test", players: [],
+          activePlayerIndex: 0, displayResources: {}, resourceValues: {},
+          modelines: {}, mode: "play",
+          // No narrativeLines field
+        },
+      });
+
+      expect(h.state.narrativeLines).toEqual(before);
+    });
+
+    it("treats empty narrativeLines as 'replace with empty' (not omitted)", () => {
+      const h = makeHarness();
+      h.dispatch({ type: "narrative:chunk", data: { text: "stale", kind: "dm" } });
+      expect(h.state.narrativeLines.length).toBeGreaterThan(0);
+
+      h.dispatch({
+        type: "state:snapshot",
+        data: {
+          campaignId: "c1", campaignName: "Test", players: [],
+          activePlayerIndex: 0, displayResources: {}, resourceValues: {},
+          modelines: {}, mode: "play",
+          narrativeLines: [],
+        },
+      });
+
+      expect(h.state.narrativeLines).toEqual([]);
+    });
   });
 
   describe("set_display_resources", () => {

--- a/packages/client-ink/src/event-handler.test.ts
+++ b/packages/client-ink/src/event-handler.test.ts
@@ -318,6 +318,40 @@ describe("event-handler", () => {
       expect(h.state.narrativeLines).toEqual(before);
     });
 
+    // Server only sends dm/player kinds. Turn separators must be re-derived
+    // client-side so the post-replace rendering matches what live streaming
+    // would produce — otherwise a rolled-back retry would visibly drop the
+    // turn-boundary divider that was rendered before the failure.
+    it("re-derives turn separators between player and dm transitions", () => {
+      const h = makeHarness();
+      h.dispatch({
+        type: "state:snapshot",
+        data: {
+          campaignId: "c1", campaignName: "Test", players: [],
+          activePlayerIndex: 0, displayResources: {}, resourceValues: {},
+          modelines: {}, mode: "play",
+          narrativeLines: [
+            { kind: "dm", text: "Opening narration." },
+            { kind: "player", text: "[Aldric] open the door" },
+            { kind: "dm", text: "The door swings open." },
+            { kind: "dm", text: "" },
+            { kind: "dm", text: "A bell chimes." },
+          ],
+        },
+      });
+
+      // Separator inserted only at the player→dm boundary, not before the
+      // very first dm line and not between consecutive dm lines.
+      expect(h.state.narrativeLines).toEqual([
+        { kind: "dm", text: "Opening narration." },
+        { kind: "player", text: "[Aldric] open the door" },
+        { kind: "separator", text: "---" },
+        { kind: "dm", text: "The door swings open." },
+        { kind: "dm", text: "" },
+        { kind: "dm", text: "A bell chimes." },
+      ]);
+    });
+
     it("treats empty narrativeLines as 'replace with empty' (not omitted)", () => {
       const h = makeHarness();
       h.dispatch({ type: "narrative:chunk", data: { text: "stale", kind: "dm" } });

--- a/packages/client-ink/src/event-handler.ts
+++ b/packages/client-ink/src/event-handler.ts
@@ -172,6 +172,32 @@ function shouldInjectDmSeparator(lines: NarrativeLine[]): boolean {
   return false;
 }
 
+/**
+ * Reconstruct the rendered narrative shape (with turn separators) from a
+ * flat dm/player line sequence — used when handleStateSnapshot replaces
+ * the local log with the server's authoritative committed transcript.
+ *
+ * Mirrors the per-chunk separator injection that happens during live
+ * streaming so the rendered output looks identical whether the lines
+ * arrived live or via snapshot replace. Spacers between turns aren't
+ * recreated (they're added by handleNarrativeComplete during live play
+ * and by appendDelta on intra-paragraph newlines, neither of which
+ * applies to a one-shot replace) — empty dm lines in the source serve
+ * the same paragraph-boundary role.
+ */
+function withTurnSeparators(
+  source: readonly { kind: "dm" | "player"; text: string }[],
+): NarrativeLine[] {
+  const out: NarrativeLine[] = [];
+  for (const line of source) {
+    if (line.kind === "dm" && shouldInjectDmSeparator(out)) {
+      out.push({ kind: "separator", text: "---" });
+    }
+    out.push(line);
+  }
+  return out;
+}
+
 function handleNarrativeChunk(event: NarrativeChunkEvent, update: StateUpdater): void {
   const { text, kind } = event.data;
   const lineKind = (kind ?? "dm") as NarrativeLine["kind"];
@@ -352,8 +378,12 @@ function handleStateSnapshot(event: StateSnapshotEvent, update: StateUpdater): v
       // rollback (to discard a partial DM stream that's about to be
       // re-issued). Snapshots that omit narrativeLines preserve whatever
       // we've already accumulated, so per-turn snapshots don't clobber
-      // in-flight stream deltas.
-      narrativeLines: snapshot.narrativeLines ?? prev.narrativeLines,
+      // in-flight stream deltas. The server only carries dm/player lines;
+      // we re-derive turn separators here so the post-replace rendering
+      // matches what the live-streaming path produces.
+      narrativeLines: snapshot.narrativeLines
+        ? withTurnSeparators(snapshot.narrativeLines)
+        : prev.narrativeLines,
     };
   });
 }

--- a/packages/client-ink/src/event-handler.ts
+++ b/packages/client-ink/src/event-handler.ts
@@ -347,6 +347,13 @@ function handleStateSnapshot(event: StateSnapshotEvent, update: StateUpdater): v
       displayResources: snapshot.displayResources ?? prev.displayResources,
       resourceValues: snapshot.resourceValues ?? prev.resourceValues,
       modelines: snapshot.modelines ?? prev.modelines,
+      // Authoritative transcript replace, when the server includes one.
+      // Sent on connect (so reconnecting clients see history) and on retry
+      // rollback (to discard a partial DM stream that's about to be
+      // re-issued). Snapshots that omit narrativeLines preserve whatever
+      // we've already accumulated, so per-turn snapshots don't clobber
+      // in-flight stream deltas.
+      narrativeLines: snapshot.narrativeLines ?? prev.narrativeLines,
     };
   });
 }

--- a/packages/engine/src/agents/agent-loop.ts
+++ b/packages/engine/src/agents/agent-loop.ts
@@ -57,6 +57,8 @@ export interface AgentLoopConfig {
   onError?: (error: Error) => void;
   /** Called when a retryable API error triggers a backoff wait */
   onRetry?: (status: number, delayMs: number) => void;
+  /** Called when a streaming attempt fails after emitting partial deltas — consumers should discard that leaked output before the retry begins. */
+  onRollback?: () => void;
 }
 
 import type { UsageStats, TuiCommand } from "@machine-violet/shared/types/engine.js";
@@ -147,6 +149,7 @@ async function runAgentLoopInternal(
     onComplete: config.onComplete,
     onError: config.onError,
     onRetry: config.onRetry,
+    onRollback: config.onRollback,
   });
 
   return {

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -1349,6 +1349,7 @@ export class GameEngine {
         this.callbacks.onTuiCommand(cmd);
       },
       onRetry: (status, delayMs) => this.callbacks.onRetry(status, delayMs),
+      onRollback: () => this.callbacks.onRollback?.(),
     };
   }
 

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -274,4 +274,123 @@ describe("runProviderLoop retry", () => {
     expect(result.text).toBe("Streamed OK");
     expect(onRetry).toHaveBeenCalledWith(502, expect.any(Number));
   });
+
+  // The rollback signal exists for issue #431: a streaming call that emits
+  // partial deltas before failing leaves those deltas accumulated on the
+  // client. Without onRollback, the retry would re-stream from scratch and
+  // visibly duplicate the text. The signal lets the consumer publish a
+  // corrective snapshot before the retry begins.
+  it("fires onRollback when a partial stream fails before retrying", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          // Emit some deltas, then fail — simulates the actual bug shape.
+          onDelta("The bell ");
+          onDelta("chimes. Mollie ");
+          throw apiError(502, "Bad gateway");
+        }
+        const result = textResult("The bell chimes. Mollie glances up.");
+        onDelta(result.text);
+        return result;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    const onRollback = vi.fn();
+    const onTextDelta = vi.fn();
+    const promise = runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta,
+      onRetry,
+      onRollback,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result.text).toBe("The bell chimes. Mollie glances up.");
+    // Critical ordering: rollback must fire before retry, so the corrective
+    // snapshot lands before the next attempt's deltas start arriving.
+    expect(onRollback).toHaveBeenCalledOnce();
+    const rollbackOrder = onRollback.mock.invocationCallOrder[0];
+    const retryOrder = onRetry.mock.invocationCallOrder[0];
+    expect(rollbackOrder).toBeLessThan(retryOrder);
+  });
+
+  it("does NOT fire onRollback when stream fails before emitting any delta", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) throw apiError(529, "Overloaded");
+        const result = textResult("OK");
+        onDelta(result.text);
+        return result;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onRollback = vi.fn();
+    const promise = runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta: vi.fn(),
+      onRollback,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    // Nothing leaked to the client, so no rollback needed — avoids a
+    // pointless snapshot round-trip on every transient pre-stream failure.
+    expect(onRollback).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire onRollback for non-streaming retries", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) throw apiError(503, "Service unavailable");
+        return textResult("OK");
+      }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRollback = vi.fn();
+    const promise = runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      onRollback,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    // Non-streaming responses are emitted as a single onTextDelta on success
+    // only. A failed non-streaming attempt has no partial output to roll back.
+    expect(onRollback).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -73,6 +73,14 @@ export interface ProviderLoopConfig {
   onError?: (error: Error) => void;
   /** Called when a retryable API error triggers a backoff wait. */
   onRetry?: (status: number, delayMs: number) => void;
+  /**
+   * Called when a streaming attempt fails mid-stream and is about to be
+   * retried. Fires only if `onTextDelta` was actually invoked during the
+   * failed attempt (i.e., partial output may have leaked to consumers).
+   * Fires before the backoff sleep, so consumers can publish a corrective
+   * snapshot before the retry begins streaming again.
+   */
+  onRollback?: () => void;
   /** Max retries after the initial attempt (default 5 → up to 6 total attempts, ~27s backoff). */
   maxRetries?: number;
 }
@@ -157,9 +165,17 @@ export async function runProviderLoop(
     let result: ChatResult;
     const apiStart = Date.now();
     for (let attempt = 0; ; attempt++) {
+      // Per-attempt flag: did this attempt actually stream any text before
+      // erroring? If so, a retry needs to roll back the partial output that
+      // leaked to consumers via onTextDelta.
+      let attemptEmittedDeltas = false;
+      const wrappedDelta = (delta: string): void => {
+        if (delta) attemptEmittedDeltas = true;
+        config.onTextDelta?.(delta);
+      };
       try {
         if (shouldStream) {
-          result = await provider.stream(chatParams, (delta) => config.onTextDelta?.(delta));
+          result = await provider.stream(chatParams, wrappedDelta);
         } else {
           result = await provider.chat(chatParams);
           // In non-streaming mode, emit the full text
@@ -180,10 +196,20 @@ export async function runProviderLoop(
           status,
           attempt,
           willRetry: retryable,
+          partialStream: attemptEmittedDeltas,
         });
 
         if (!retryable) {
           throw apiErr;
+        }
+
+        // If the failed attempt streamed any text, the next attempt will
+        // re-emit it from scratch — instruct consumers to discard the
+        // partial leak before we retry. Skipped when nothing leaked, so
+        // pre-stream failures (e.g. immediate 429s) don't cause a needless
+        // snapshot round-trip to clients.
+        if (attemptEmittedDeltas) {
+          config.onRollback?.();
         }
 
         const delay = retryDelay(attempt);

--- a/packages/engine/src/server/bridge.test.ts
+++ b/packages/engine/src/server/bridge.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ServerEvent } from "@machine-violet/shared";
+import { createBridge } from "./bridge.js";
+
+describe("createBridge onRollback", () => {
+  // Issue #431: a streaming retry leaves partial deltas accumulated on the
+  // client. The bridge needs to drop its own un-flushed buffer (so a stale
+  // tail-fragment doesn't sneak out after the corrective snapshot) and
+  // delegate to the consumer (typically SessionManager) which knows the
+  // snapshot shape.
+  it("drops un-flushed delta buffer on rollback", () => {
+    const events: ServerEvent[] = [];
+    const cb = createBridge({
+      broadcast: (e) => events.push(e),
+    });
+
+    // Push deltas that don't end at a word boundary — they sit in the
+    // bridge's internal buffer waiting to be flushed at the next boundary.
+    cb.onNarrativeDelta("Mid-word fragment");
+
+    // No flush yet — still buffered.
+    expect(events.filter((e) => e.type === "narrative:chunk")).toHaveLength(0);
+
+    cb.onRollback?.();
+
+    // Buffer should be discarded — no chunk event leaks out.
+    expect(events.filter((e) => e.type === "narrative:chunk")).toHaveLength(0);
+
+    // After rollback, a fresh delta starts a clean buffer (no carry-over).
+    cb.onNarrativeDelta("Fresh attempt ");
+    const chunks = events.filter((e) => e.type === "narrative:chunk");
+    expect(chunks).toHaveLength(1);
+    expect((chunks[0].data as { text: string }).text).toBe("Fresh attempt ");
+  });
+
+  it("calls consumer onRollback after clearing its own buffer", () => {
+    const onRollback = vi.fn();
+    const events: ServerEvent[] = [];
+    const cb = createBridge({
+      broadcast: (e) => events.push(e),
+      onRollback,
+    });
+
+    cb.onNarrativeDelta("partial ");
+    cb.onRollback?.();
+
+    expect(onRollback).toHaveBeenCalledOnce();
+  });
+
+  it("works without consumer onRollback (silent rollback)", () => {
+    // A bridge created without an onRollback option still cleans up its
+    // own state without throwing — the consumer just doesn't get notified.
+    const events: ServerEvent[] = [];
+    const cb = createBridge({
+      broadcast: (e) => events.push(e),
+    });
+
+    cb.onNarrativeDelta("partial ");
+    expect(() => cb.onRollback?.()).not.toThrow();
+  });
+});

--- a/packages/engine/src/server/bridge.ts
+++ b/packages/engine/src/server/bridge.ts
@@ -25,6 +25,13 @@ export interface BridgeOptions {
   costTracker?: CostTracker;
   /** Fired after each completed DM narrative — used to drive Discord rich-presence updates. */
   onDmNarrative?: (text: string) => void;
+  /**
+   * Fired when a streaming retry has just discarded its in-flight delta
+   * buffer. Consumers (typically SessionManager) should publish a
+   * corrective state:snapshot so the client replaces its accumulated
+   * narrative before the retry's deltas arrive.
+   */
+  onRollback?: () => void;
 }
 
 export function createBridge(
@@ -33,7 +40,7 @@ export function createBridge(
   const opts: BridgeOptions = typeof broadcastOrOpts === "function"
     ? { broadcast: broadcastOrOpts }
     : broadcastOrOpts;
-  const { broadcast, costTracker, onDmNarrative } = opts;
+  const { broadcast, costTracker, onDmNarrative, onRollback } = opts;
   // --- Narrative buffering ---
   let buffer = "";
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -129,6 +136,24 @@ export function createBridge(
         type: "error",
         data: { message: `API retry (status ${status})`, recoverable: true, status, delayMs },
       });
+    },
+
+    onRollback(): void {
+      // A streaming attempt failed after emitting partial deltas. Drop our
+      // pending un-flushed buffer so a stale tail-fragment from the failed
+      // attempt can't sneak out after the corrective snapshot. (Already-sent
+      // chunks live on the client and are cleared by the snapshot's
+      // narrativeLines replace.)
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      buffer = "";
+      logEvent("api:rollback", {});
+      // Hand off to the consumer so it can publish the corrective snapshot
+      // — bridge doesn't know the snapshot shape, only that the client
+      // needs an authoritative reset before the retry's deltas arrive.
+      onRollback?.();
     },
 
     onRefusal(): void {

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -38,7 +38,7 @@ import { createObjectivesState } from "../tools/objectives/index.js";
 import { markdownToNarrativeLines } from "../context/display-log.js";
 import { CostTracker } from "../context/cost-tracker.js";
 import { TurnManager } from "./turn-manager.js";
-import type { StyleVariant, NarrativeLine } from "@machine-violet/shared/types/tui.js";
+import type { StyleVariant } from "@machine-violet/shared/types/tui.js";
 import { createBridge } from "./bridge.js";
 import { createBaseFileIO } from "./fileio.js";
 import { SetupSession } from "./setup-session.js";
@@ -81,17 +81,24 @@ export class SessionManager {
   /**
    * Authoritative committed transcript for the active session.
    *
-   * Tracks only `dm` and `player` lines (the same kinds the persisted
-   * display log records) so it can be replayed verbatim into a state:snapshot
-   * when the client needs an authoritative reset — on connect (so reconnects
-   * see history) or on retry rollback (so a partial DM stream that's about
-   * to be re-issued doesn't accumulate twice in the client log).
+   * Tracks only `dm` and `player` lines — the kinds the state:snapshot
+   * narrativeLines schema accepts. (The persisted display log additionally
+   * keeps `system` and `separator` lines, but those are presentation-only
+   * and not mirrored into the live committed log.) Stored as one entry per
+   * text line — multi-paragraph DM/player text is split on `\n` at append
+   * time so the shape matches what `appendDelta` produces during live
+   * streaming and what `markdownToNarrativeLines` produces from the on-disk
+   * log on resume; the client can therefore replace its narrative log with
+   * this verbatim and have it render identically.
    *
-   * Seeded from the display log on resume; appended to as DM responses
-   * complete and as `client`-source contributions arrive. Reset on each
-   * new session start.
+   * Replayed into a state:snapshot when the client needs an authoritative
+   * reset — on connect (so reconnects see history) or on retry rollback
+   * (so a partial DM stream that's about to be re-issued doesn't
+   * accumulate twice in the client log). Seeded from the display log on
+   * resume; appended to as DM responses complete and as `client`-source
+   * contributions arrive. Reset on each new session start.
    */
-  private committedNarrative: NarrativeLine[] = [];
+  private committedNarrative: { kind: "dm" | "player"; text: string }[] = [];
   private setupSession: SetupSession | null = null;
 
   /** Campaign ID of the currently active session (null if none). */
@@ -525,10 +532,7 @@ export class SessionManager {
         const data = event.data as { contribution?: { source?: string; playerId?: string; text?: string } };
         const c = data.contribution;
         if (c?.source === "client" && c.playerId && typeof c.text === "string") {
-          this.committedNarrative.push({
-            kind: "player",
-            text: `[${c.playerId}] ${c.text}`,
-          });
+          this.appendCommittedLines("player", `[${c.playerId}] ${c.text}`);
         }
       }
       this.broadcast(event);
@@ -596,7 +600,7 @@ export class SessionManager {
     const originalOnNarrativeComplete = callbacks.onNarrativeComplete;
     callbacks.onNarrativeComplete = (text, playerAction) => {
       if (this.sessionGeneration === gen && text) {
-        this.committedNarrative.push({ kind: "dm", text });
+        this.appendCommittedLines("dm", text);
       }
       originalOnNarrativeComplete(text, playerAction);
     };
@@ -1086,6 +1090,20 @@ export class SessionManager {
   }
 
   /**
+   * Push a multi-line text blob into the committed transcript as one entry
+   * per `\n`-separated line — matching the per-line shape that
+   * `appendDelta` produces during live streaming and that
+   * `markdownToNarrativeLines` produces from the on-disk log on resume.
+   * Empty splits ARE preserved: they render as blank lines, which act as
+   * paragraph boundaries in the formatting pipeline.
+   */
+  private appendCommittedLines(kind: "dm" | "player", text: string): void {
+    for (const line of text.split("\n")) {
+      this.committedNarrative.push({ kind, text: line });
+    }
+  }
+
+  /**
    * Build a state snapshot for broadcast.
    *
    * @param opts.includeNarrative — when true, include the committed transcript
@@ -1125,7 +1143,7 @@ export class SessionManager {
       mode: this.currentMode,
       sessionRecap: recap ?? undefined,
       narrativeLines: opts?.includeNarrative
-        ? this.committedNarrative.map((l) => ({ kind: l.kind, text: l.text }))
+        ? this.committedNarrative.slice()
         : undefined,
     };
   }

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -38,7 +38,7 @@ import { createObjectivesState } from "../tools/objectives/index.js";
 import { markdownToNarrativeLines } from "../context/display-log.js";
 import { CostTracker } from "../context/cost-tracker.js";
 import { TurnManager } from "./turn-manager.js";
-import type { StyleVariant } from "@machine-violet/shared/types/tui.js";
+import type { StyleVariant, NarrativeLine } from "@machine-violet/shared/types/tui.js";
 import { createBridge } from "./bridge.js";
 import { createBaseFileIO } from "./fileio.js";
 import { SetupSession } from "./setup-session.js";
@@ -78,6 +78,20 @@ export class SessionManager {
    *  buildStateSnapshot() call and cleared. Ensures only the first snapshot
    *  after a clean session-end carries the recap. */
   private pendingSessionRecap: { id: string; lines: string[] } | null = null;
+  /**
+   * Authoritative committed transcript for the active session.
+   *
+   * Tracks only `dm` and `player` lines (the same kinds the persisted
+   * display log records) so it can be replayed verbatim into a state:snapshot
+   * when the client needs an authoritative reset — on connect (so reconnects
+   * see history) or on retry rollback (so a partial DM stream that's about
+   * to be re-issued doesn't accumulate twice in the client log).
+   *
+   * Seeded from the display log on resume; appended to as DM responses
+   * complete and as `client`-source contributions arrive. Reset on each
+   * new session start.
+   */
+  private committedNarrative: NarrativeLine[] = [];
   private setupSession: SetupSession | null = null;
 
   /** Campaign ID of the currently active session (null if none). */
@@ -114,9 +128,12 @@ export class SessionManager {
       this.checkIdleTimeout();
     });
 
-    // Send current state snapshot on connect
+    // Send current state snapshot on connect. Include the committed
+    // narrative so reconnecting clients see history without needing the
+    // server to re-stream it; first-time connections during an active
+    // session pick up everything that was committed before they joined.
     if (this.status === "active") {
-      const snapshot = this.buildStateSnapshot();
+      const snapshot = this.buildStateSnapshot({ includeNarrative: true });
       this.sendTo(ws, {
         type: "state:snapshot",
         data: snapshot,
@@ -494,8 +511,26 @@ export class SessionManager {
     // silently discard their events instead of leaking into the new session.
     this.sessionGeneration++;
     const gen = this.sessionGeneration;
+    // Reset the committed transcript for the new session. Resume seeds it
+    // from the display log later in resumeSession().
+    this.committedNarrative = [];
     const scopedBroadcast = (event: ServerEvent) => {
       if (this.sessionGeneration !== gen) return;
+      // Mirror client-side narrative accumulation into the committed log
+      // so a snapshot can replay it verbatim. We watch turn:updated for
+      // player contributions; DM lines are appended via onNarrativeComplete
+      // below. Only client-source contributions are mirrored — engine-source
+      // (AI player) contributions follow a separate path.
+      if (event.type === "turn:updated") {
+        const data = event.data as { contribution?: { source?: string; playerId?: string; text?: string } };
+        const c = data.contribution;
+        if (c?.source === "client" && c.playerId && typeof c.text === "string") {
+          this.committedNarrative.push({
+            kind: "player",
+            text: `[${c.playerId}] ${c.text}`,
+          });
+        }
+      }
       this.broadcast(event);
     };
     // Discord rich-presence: counter resets per backend session load. Every
@@ -529,6 +564,18 @@ export class SessionManager {
       broadcast: scopedBroadcast,
       costTracker: this.costTracker,
       onDmNarrative,
+      // Fires after the bridge has dropped its pending delta buffer, when
+      // a streaming retry is about to re-issue the request. We publish a
+      // corrective snapshot so the client replaces its accumulated
+      // narrative (which includes the leaked partial output) with the
+      // last committed transcript before the retry's deltas arrive.
+      onRollback: () => {
+        if (this.sessionGeneration !== gen) return;
+        scopedBroadcast({
+          type: "state:snapshot",
+          data: this.buildStateSnapshot({ includeNarrative: true }),
+        });
+      },
     });
 
     // Intercept TUI commands so persistedUI stays in sync — ensures
@@ -540,6 +587,18 @@ export class SessionManager {
       if (this.sessionGeneration !== gen) return;
       this.trackTuiState(cmd);
       originalOnTui(cmd);
+    };
+
+    // Mirror DM narrative completions into the committed transcript.
+    // Wrapped (not folded into onDmNarrative) because onDmNarrative is
+    // sampled — only fires every Nth narrative for Discord status updates,
+    // whereas the committed log needs every one.
+    const originalOnNarrativeComplete = callbacks.onNarrativeComplete;
+    callbacks.onNarrativeComplete = (text, playerAction) => {
+      if (this.sessionGeneration === gen && text) {
+        this.committedNarrative.push({ kind: "dm", text });
+      }
+      originalOnNarrativeComplete(text, playerAction);
     };
 
     // --- Instantiate GameEngine ---
@@ -737,6 +796,16 @@ export class SessionManager {
     const historyLines = await persister.loadDisplayLogFull();
     if (historyLines.length > 0) {
       const narrativeLines = markdownToNarrativeLines(historyLines);
+      // Seed the committed transcript with dm/player lines from history so a
+      // mid-session rollback after resume produces a snapshot that contains
+      // the prior session's text — not just lines accumulated since this load.
+      // Skip separators/spacers/system/dev: those are presentation-only and
+      // re-derived (or simply absent post-replace, which is acceptable).
+      for (const line of narrativeLines) {
+        if (line.kind === "dm" || line.kind === "player") {
+          this.committedNarrative.push({ kind: line.kind, text: line.text });
+        }
+      }
       // Group consecutive same-kind lines and send each group as one chunk.
       // Separators (---) are sent as DM lines — the formatting pipeline
       // converts them to styled horizontal rules during rendering.
@@ -1016,7 +1085,18 @@ export class SessionManager {
     }
   }
 
-  buildStateSnapshot(): StateSnapshot {
+  /**
+   * Build a state snapshot for broadcast.
+   *
+   * @param opts.includeNarrative — when true, include the committed transcript
+   *   (DM + player lines). The client treats this as authoritative and
+   *   REPLACES its accumulated narrative log. Pass true on connect (so
+   *   reconnecting clients see history) and on retry rollback (to discard
+   *   a partial DM stream that's about to be re-issued). Default false:
+   *   per-turn snapshots omit narrative so they don't clobber in-flight
+   *   stream deltas with a stale committed view.
+   */
+  buildStateSnapshot(opts?: { includeNarrative?: boolean }): StateSnapshot {
     const gs = this.gameState;
     const config = gs?.config;
 
@@ -1044,6 +1124,9 @@ export class SessionManager {
       keyColor: this.persistedUI.keyColor ?? undefined,
       mode: this.currentMode,
       sessionRecap: recap ?? undefined,
+      narrativeLines: opts?.includeNarrative
+        ? this.committedNarrative.map((l) => ({ kind: l.kind, text: l.text }))
+        : undefined,
     };
   }
 

--- a/packages/shared/src/protocol/state.ts
+++ b/packages/shared/src/protocol/state.ts
@@ -72,9 +72,16 @@ export const StateSnapshot = Type.Object({
    * about to be re-issued). It is intentionally omitted from per-turn
    * snapshots so live-streamed deltas aren't clobbered.
    *
-   * Only `dm` and `player` kinds are tracked server-side; transient kinds
-   * (separator, spacer, dev, system) are presentation-only and re-derived
-   * by the client from the line sequence.
+   * Only `dm` and `player` kinds cross the wire; turn separators are
+   * re-derived by the client from kind transitions so post-replace
+   * rendering matches live streaming, while system/dev lines and any
+   * spacers from a prior live stream are dropped on replace (they're
+   * presentation-only and not worth round-tripping).
+   *
+   * Each entry is one rendered line — multi-paragraph DM/player text is
+   * split on `\n` server-side so the shape matches what `appendDelta`
+   * produces during live streaming. Empty entries represent paragraph
+   * boundaries.
    */
   narrativeLines: Type.Optional(Type.Array(Type.Union([
     Type.Object({

--- a/packages/shared/src/protocol/state.ts
+++ b/packages/shared/src/protocol/state.ts
@@ -60,6 +60,32 @@ export const StateSnapshot = Type.Object({
     id: Type.String(),
     lines: Type.Array(Type.String()),
   })),
+
+  /**
+   * Authoritative committed transcript (DM + player lines only).
+   *
+   * When present, the client REPLACES its accumulated narrative log with
+   * these lines. When absent, the client's existing narrative is preserved.
+   *
+   * The server populates this on connect (so reconnecting clients see
+   * history) and on retry rollback (to discard a partial DM stream that's
+   * about to be re-issued). It is intentionally omitted from per-turn
+   * snapshots so live-streamed deltas aren't clobbered.
+   *
+   * Only `dm` and `player` kinds are tracked server-side; transient kinds
+   * (separator, spacer, dev, system) are presentation-only and re-derived
+   * by the client from the line sequence.
+   */
+  narrativeLines: Type.Optional(Type.Array(Type.Union([
+    Type.Object({
+      kind: Type.Literal("dm"),
+      text: Type.String(),
+    }),
+    Type.Object({
+      kind: Type.Literal("player"),
+      text: Type.String(),
+    }),
+  ]))),
 });
 
 export type StateSnapshot = Static<typeof StateSnapshot>;

--- a/packages/shared/src/types/engine.ts
+++ b/packages/shared/src/types/engine.ts
@@ -100,6 +100,12 @@ export interface EngineCallbacks {
   onError: (error: Error) => void;
   /** API call is being retried after a retryable error */
   onRetry: (status: number, delayMs: number) => void;
+  /**
+   * A streaming API call failed mid-stream and is about to be retried.
+   * Implementations should drop any partial deltas already emitted to
+   * clients so the retry can stream cleanly from the start.
+   */
+  onRollback?: () => void;
   /** A player turn is starting (before any API work) */
   onTurnStart: (turn: TurnInfo) => void;
   /** A participant turn has ended */


### PR DESCRIPTION
## Summary

- Streaming DM responses sometimes duplicated in the game log: a retryable mid-stream API error (529, network blip) had already emitted partial deltas to the client, and the retry then re-emitted the full response on top.
- Extends `StateSnapshot` with an optional `narrativeLines` field. When present, the client REPLACES its accumulated narrative log; when absent, the existing log is preserved. Reuses the existing snapshot machinery as a cheap rollback channel — no new event type.
- Server tracks a committed transcript (DM + player lines) on `SessionManager` and, on a streaming retry that leaked partial output, publishes a corrective snapshot before the retry begins. Bridge also drops its own un-flushed delta buffer so a stale tail-fragment can't sneak out after the snapshot.
- Bonus: connect-time snapshots now include narrative too, so reconnecting clients see prior history instead of a blank log until the next chunk arrives.

## Design notes

- Pre-stream failures (no deltas leaked) skip the rollback round-trip — only fires when there's actually something to roll back.
- Per-turn snapshots intentionally omit `narrativeLines` so they don't clobber in-flight stream deltas with a stale committed view.
- Committed log is seeded from the persisted display log on resume, so post-resume rollbacks include prior-session text.
- Only `dm` and `player` kinds are tracked server-side; transient kinds (separator, spacer, system, dev) are presentation-only and re-derived by the client.
- No spin-loop risk: rollback fires at most once per failed attempt, then the existing exponential backoff (1s → 12s cap) and `maxRetries` ceiling apply.

## Test plan

- [x] `npm run check` — lint clean, 2390/2390 tests pass
- [x] 7 new unit tests covering: rollback fires before retry on partial-stream failure; doesn't fire when nothing leaked; doesn't fire for non-streaming retries; bridge drops un-flushed buffer; bridge calls consumer onRollback; bridge works without consumer; client snapshot replaces / preserves / handles empty `narrativeLines`
- [x] Smoke-tested locally — normal gameplay unaffected (precipitating API errors are hard to replicate on demand)

Fixes #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)