### PR TITLE
Add diagnostic logging for missed-Enter bug

### DIFF
--- a/packages/client-ink/src/start-client.ts
+++ b/packages/client-ink/src/start-client.ts
@@ -19,6 +19,7 @@ import {
   kittyKeyToLegacy,
 } from "./tui/hooks/kittyProtocol.js";
 import { installStdinFilterChain } from "./tui/hooks/stdinFilterChain.js";
+import { logInputEvent, bytesToHex, getInputDebugLogPath } from "./tui/hooks/inputDebugLog.js";
 import { getAgentClientState } from "./agent-state-ref.js";
 
 export interface StartClientOptions {
@@ -95,11 +96,22 @@ export async function startClient(opts: StartClientOptions = {}): Promise<Client
   const hasKitty = !mockStdin && activeStdin.isTTY
     ? await detectKittySupport({ stdin: activeStdin, stdout: process.stdout })
     : false;
+  logInputEvent("start-client", {
+    hasKitty,
+    isTTY: !!activeStdin.isTTY,
+    mockStdin: !!mockStdin,
+    logPath: getInputDebugLogPath(),
+  });
   if (hasKitty) {
     enableKittyProtocol(process.stdout);
     filterChain.add(createKittyFilter((key) => {
       // Re-emit as legacy bytes so Ink's useInput picks them up.
       const legacy = kittyKeyToLegacy(key);
+      logInputEvent("kitty-legacy-push", {
+        key: key.key,
+        legacy: legacy === null ? null : bytesToHex(legacy),
+        legacyLen: legacy?.length ?? 0,
+      });
       if (legacy !== null) activeStdin.push(legacy);
     }));
   }

--- a/packages/client-ink/src/tui/components/InlineTextInput.tsx
+++ b/packages/client-ink/src/tui/components/InlineTextInput.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useInput, usePaste, useStdin } from "ink";
 import chalk from "chalk";
+import { logInputEvent, bytesToHex } from "../hooks/inputDebugLog.js";
+
+// Diagnostic logging — see inputDebugLog.ts. Remove with the rest of the
+// instrumentation once the missed-Enter bug is resolved.
+let nextInstanceId = 1;
 
 interface State {
   value: string;
@@ -146,6 +151,18 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
 
   const viewStartRef = useRef(0);
 
+  // Diagnostic logging — see inputDebugLog.ts.
+  const instanceIdRef = useRef<number>(0);
+  if (instanceIdRef.current === 0) instanceIdRef.current = nextInstanceId++;
+  const instanceId = instanceIdRef.current;
+  useEffect(() => {
+    logInputEvent("inline-mount", { instanceId });
+    return () => { logInputEvent("inline-unmount", { instanceId }); };
+  }, [instanceId]);
+  useEffect(() => {
+    logInputEvent("inline-disabled", { instanceId, isDisabled });
+  }, [instanceId, isDisabled]);
+
   /** Apply an action and immediately sync to render state. */
   const processAction = useCallback((action: Action) => {
     const prev = stateRef.current;
@@ -168,6 +185,12 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
     if (!emitter) return;
 
     const handleRaw = (data: string) => {
+      logInputEvent("inline-raw-input", {
+        instanceId,
+        isDisabled,
+        len: typeof data === "string" ? data.length : -1,
+        hex: typeof data === "string" ? bytesToHex(data) : "<non-string>",
+      });
       if (HOME_SEQUENCES.has(data)) {
         processAction({ type: "move-cursor-start" });
       } else if (END_SEQUENCES.has(data)) {
@@ -180,8 +203,10 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
   }, [isDisabled, stdinCtx, processAction]);
 
   const submit = useCallback(() => {
-    onSubmit?.(stateRef.current.value);
-  }, [onSubmit]);
+    const value = stateRef.current.value;
+    logInputEvent("inline-submit", { instanceId, valueLen: value.length, value });
+    onSubmit?.(value);
+  }, [onSubmit, instanceId]);
 
   // Fire onChange when the rendered value diverges from the last reported value.
   useEffect(() => {
@@ -197,10 +222,37 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
   // trailing-newline paste ("foo\n") doesn't land an extra space in the value.
   usePaste((text) => {
     const sanitized = text.replace(/[\r\n]+/g, " ").trim();
+    logInputEvent("inline-paste", {
+      instanceId,
+      isDisabled,
+      rawLen: text.length,
+      sanitizedLen: sanitized.length,
+      hex: bytesToHex(text),
+    });
     if (sanitized.length > 0) processAction({ type: "insert", text: sanitized });
   }, { isActive: !isDisabled });
 
   useInput((input, key) => {
+    logInputEvent("inline-key", {
+      instanceId,
+      isDisabled,
+      inputLen: input.length,
+      inputHex: bytesToHex(input),
+      keyReturn: key.return,
+      keyEscape: key.escape,
+      keyTab: key.tab,
+      keyBackspace: key.backspace,
+      keyDelete: key.delete,
+      keyLeft: key.leftArrow,
+      keyRight: key.rightArrow,
+      keyUp: key.upArrow,
+      keyDown: key.downArrow,
+      keyHome: (key as { home?: boolean }).home,
+      keyEnd: (key as { end?: boolean }).end,
+      keyCtrl: key.ctrl,
+      keyMeta: key.meta,
+      keyShift: key.shift,
+    });
     // Pass through keys we don't handle
     if (key.upArrow || key.downArrow || (key.ctrl && input === "c") || key.tab || (key.shift && key.tab)) {
       return;

--- a/packages/client-ink/src/tui/hooks/inputDebugLog.ts
+++ b/packages/client-ink/src/tui/hooks/inputDebugLog.ts
@@ -15,7 +15,14 @@
  *
  * Logged unconditionally because the bug is intermittent and we want
  * data on every run. Remove once the underlying issue is fixed.
+ *
+ * Privacy: the log captures user keystrokes and submitted values — that's
+ * the whole point — so the file is created with mode 0o600 and lives in
+ * the user's per-account config dir. Each launch writes a fresh file
+ * named with start timestamp + pid so logs never grow unboundedly and
+ * are easy to attach to a single repro session.
  */
+import { Buffer } from "node:buffer";
 import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { join } from "node:path";
 import { defaultConfigDir } from "../../utils/platform.js";
@@ -25,15 +32,37 @@ const LOG_DIR_ENV = "MV_INPUT_DEBUG_LOG_DIR";
 let stream: WriteStream | null = null;
 let resolvedPath: string | null = null;
 let setupAttempted = false;
+let exitHandlersRegistered = false;
+
+function registerExitHandlers(): void {
+  if (exitHandlersRegistered) return;
+  exitHandlersRegistered = true;
+  // Best-effort flush. 'exit' is sync-only; calling end() at least drains
+  // any data already in the JS-side queue. SIGINT/SIGTERM allow async work.
+  const flush = () => {
+    try { stream?.end(); } catch { /* ignore */ }
+  };
+  process.on("exit", flush);
+  process.on("SIGINT", flush);
+  process.on("SIGTERM", flush);
+}
 
 function ensureStream(): WriteStream | null {
   if (stream || setupAttempted) return stream;
   setupAttempted = true;
+  // Skip in unit tests — vitest workers would otherwise litter the user's
+  // config dir with stray log files.
+  if (process.env["NODE_ENV"] === "test" || process.env["VITEST"]) return null;
   try {
     const dir = process.env[LOG_DIR_ENV] ?? defaultConfigDir();
     mkdirSync(dir, { recursive: true });
-    const path = join(dir, "input-debug.log");
-    const s = createWriteStream(path, { flags: "a" });
+    // Per-launch filename so logs never accumulate into one giant file.
+    // Colons in ISO timestamp are illegal on Windows paths, so swap them.
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const path = join(dir, `input-debug-${stamp}-${process.pid}.log`);
+    // mode 0o600: log captures user input (typed text, submitted values), so
+    // restrict to the owner. No-op on Windows but harmless.
+    const s = createWriteStream(path, { flags: "a", mode: 0o600 });
     s.on("error", () => { /* swallow — diagnostic logging must never crash the app */ });
     stream = s;
     resolvedPath = path;
@@ -44,13 +73,14 @@ function ensureStream(): WriteStream | null {
       platform: process.platform,
       nodeVersion: process.version,
     }) + "\n");
+    registerExitHandlers();
   } catch {
     stream = null;
   }
   return stream;
 }
 
-/** Resolved log file path, or null if logger setup failed. */
+/** Resolved log file path, or null if logger setup failed or is disabled. */
 export function getInputDebugLogPath(): string | null {
   ensureStream();
   return resolvedPath;
@@ -71,13 +101,18 @@ export function logInputEvent(kind: string, data: Record<string, unknown> = {}):
   }
 }
 
-/** Convert a string of bytes to a hex-dump string like "1b 5b 31 33 75". */
-export function bytesToHex(s: string): string {
-  if (!s) return "";
+/**
+ * Hex-dump a string or Buffer as space-separated byte values.
+ * Strings are encoded to UTF-8 first, so multibyte sequences appear as
+ * their actual on-the-wire bytes rather than UTF-16 code units.
+ */
+export function bytesToHex(input: string | Buffer | Uint8Array): string {
+  if (!input || (typeof input === "string" && input.length === 0)) return "";
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : Buffer.from(input);
   let result = "";
-  for (let i = 0; i < s.length; i++) {
+  for (let i = 0; i < buf.length; i++) {
     if (i > 0) result += " ";
-    result += s.charCodeAt(i).toString(16).padStart(2, "0");
+    result += buf[i].toString(16).padStart(2, "0");
   }
   return result;
 }

--- a/packages/client-ink/src/tui/hooks/inputDebugLog.ts
+++ b/packages/client-ink/src/tui/hooks/inputDebugLog.ts
@@ -1,0 +1,83 @@
+/**
+ * TEMPORARY diagnostic logger for the missed-Enter bug.
+ *
+ * Captures the full input pipeline as JSONL so a single reproduction
+ * tells us exactly which stage swallowed the Enter byte:
+ *   - stdin-raw           : bytes pulled from stdin before any filter
+ *   - stdin-after-filter  : bytes the filter chain returns to Ink
+ *   - kitty-extract       : CSI-u keys parsed by the kitty filter
+ *   - kitty-legacy-push   : legacy bytes pushed back into stdin for Ink
+ *   - inline-key          : every (input, key) Ink dispatches to InlineTextInput
+ *   - inline-paste        : usePaste deliveries (bracketed-paste content)
+ *   - inline-submit       : every submit() call inside InlineTextInput
+ *   - inline-mount/unmount: InlineTextInput mount lifecycle
+ *   - inline-disabled     : isDisabled toggled on a mounted InlineTextInput
+ *
+ * Logged unconditionally because the bug is intermittent and we want
+ * data on every run. Remove once the underlying issue is fixed.
+ */
+import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
+import { join } from "node:path";
+import { defaultConfigDir } from "../../utils/platform.js";
+
+const LOG_DIR_ENV = "MV_INPUT_DEBUG_LOG_DIR";
+
+let stream: WriteStream | null = null;
+let resolvedPath: string | null = null;
+let setupAttempted = false;
+
+function ensureStream(): WriteStream | null {
+  if (stream || setupAttempted) return stream;
+  setupAttempted = true;
+  try {
+    const dir = process.env[LOG_DIR_ENV] ?? defaultConfigDir();
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "input-debug.log");
+    const s = createWriteStream(path, { flags: "a" });
+    s.on("error", () => { /* swallow — diagnostic logging must never crash the app */ });
+    stream = s;
+    resolvedPath = path;
+    s.write(JSON.stringify({
+      ts: new Date().toISOString(),
+      kind: "session-start",
+      pid: process.pid,
+      platform: process.platform,
+      nodeVersion: process.version,
+    }) + "\n");
+  } catch {
+    stream = null;
+  }
+  return stream;
+}
+
+/** Resolved log file path, or null if logger setup failed. */
+export function getInputDebugLogPath(): string | null {
+  ensureStream();
+  return resolvedPath;
+}
+
+/** Append a JSONL entry to the input debug log. Never throws. */
+export function logInputEvent(kind: string, data: Record<string, unknown> = {}): void {
+  const s = ensureStream();
+  if (!s) return;
+  try {
+    s.write(JSON.stringify({
+      ts: new Date().toISOString(),
+      kind,
+      ...data,
+    }) + "\n");
+  } catch {
+    // ignore — diagnostic logging must never crash the app
+  }
+}
+
+/** Convert a string of bytes to a hex-dump string like "1b 5b 31 33 75". */
+export function bytesToHex(s: string): string {
+  if (!s) return "";
+  let result = "";
+  for (let i = 0; i < s.length; i++) {
+    if (i > 0) result += " ";
+    result += s.charCodeAt(i).toString(16).padStart(2, "0");
+  }
+  return result;
+}

--- a/packages/client-ink/src/tui/hooks/kittyProtocol.ts
+++ b/packages/client-ink/src/tui/hooks/kittyProtocol.ts
@@ -15,6 +15,7 @@
  */
 
 import type { StdinFilter } from "./stdinFilterChain.js";
+import { logInputEvent } from "./inputDebugLog.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -299,8 +300,26 @@ export function createKittyFilter(onKey: (key: KittyKey) => void): StdinFilter {
     process(data: string): string | null {
       const { keys, remainder } = extractKittyKeys(data);
       if (keys.length > 0) {
+        logInputEvent("kitty-extract", {
+          keyCount: keys.length,
+          keys: keys.map((k) => ({
+            key: k.key,
+            code: k.code,
+            shift: k.shift,
+            ctrl: k.ctrl,
+            alt: k.alt,
+          })),
+          remainderLen: remainder?.length ?? 0,
+        });
         process.nextTick(() => {
           for (const key of keys) {
+            logInputEvent("kitty-dispatch", {
+              key: key.key,
+              code: key.code,
+              shift: key.shift,
+              ctrl: key.ctrl,
+              alt: key.alt,
+            });
             onKey(key);
           }
         });

--- a/packages/client-ink/src/tui/hooks/stdinFilterChain.ts
+++ b/packages/client-ink/src/tui/hooks/stdinFilterChain.ts
@@ -12,6 +12,7 @@
  * remainder. Filters run in registration order; each receives the output
  * of the previous filter.
  */
+import { logInputEvent, bytesToHex } from "./inputDebugLog.js";
 
 export interface ReadableStdin {
   read(size?: number): Buffer | string | null;
@@ -54,12 +55,17 @@ export function installStdinFilterChain(input: ReadableStdin): StdinFilterChain 
     if (chunk === null) return null;
 
     const str = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    logInputEvent("stdin-raw", { len: str.length, bytes: bytesToHex(str) });
+
     let current: string | null = str;
 
     for (const filter of filters) {
       if (current === null || current.length === 0) break;
       current = filter.process(current);
     }
+
+    const out = current ?? "";
+    logInputEvent("stdin-after-filter", { len: out.length, bytes: bytesToHex(out) });
 
     // Return empty (not null) when fully consumed — null would signal
     // "no data available" and desync the stream's internal buffer.


### PR DESCRIPTION
## Summary

Adds JSONL diagnostic logging across the full input pipeline so the next reproduction of the intermittent missed-Enter bug in the player input field tells us exactly where the byte is lost.

Logs to \`<configDir>/input-debug.log\` (override with \`MV_INPUT_DEBUG_LOG_DIR\`). Always on — the bug repros maybe once per session and we want data on every run.

Removal tracked in #436.

## Stages instrumented

- \`stdin-raw\` / \`stdin-after-filter\` — bytes before/after the filter chain
- \`kitty-extract\` / \`kitty-dispatch\` / \`kitty-legacy-push\` — kitty CSI-u path
- \`inline-key\` / \`inline-paste\` / \`inline-submit\` — \`InlineTextInput\` dispatches
- \`inline-mount\` / \`inline-unmount\` / \`inline-disabled\` — lifecycle changes
- \`inline-raw-input\` — bytes seen by Ink's \`internal_eventEmitter\` (Home/End path)

Each entry timestamped + tagged with \`instanceId\` so the player input is distinguishable from custom-input fields in choice modals.

## Test plan

- [x] \`npm run check\` (lint + 2381 tests passing)
- [ ] Launch dev mode, confirm \`input-debug.log\` appears in config dir
- [ ] Verify a normal turn produces the expected log sequence (stdin-raw → kitty-extract → kitty-dispatch → kitty-legacy-push → inline-key → inline-submit)
- [ ] Reproduce missed Enter; capture log; share with maintainer