### PR TITLE
Keep activity line alive across the setup→DM handoff

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -97,9 +97,27 @@ The activity line shows what the engine is doing, mapped automatically from in-f
 | Rule lookup subagent | `Checking rules...` | `📖` |
 | `scene_transition` cascade | `Scene transition...` | `⟳` |
 | Waiting for DM API response | `The DM is thinking...` | `◆` |
+| Tool call in flight (`tool_running`) | `The DM is working...` | `◆` |
+| Setup→game handoff in flight | `Preparing your campaign...` | `◆` |
 | Player's turn (idle) | *(hidden)* | *(hidden)* |
 
+The `tool_running` row matters because subagent-backed tools (e.g. `style_scene` → theme-styler) routinely take 20-60s. ActivityLine also renders any accumulated tool glyphs even when the engine state itself has no mapped label, so a transient or unmapped state can never silently wipe the row.
+
 The modeline glyph column is used when the activity line has been dropped due to viewport size (see [Responsive Design](#responsive-design)). The glyph appears at the start of the modeline.
+
+### Elapsed-time hints and tier escalation
+
+For known-slow states (the first DM turn, the setup→game handoff), the activity line escalates the label after configurable elapsed-time thresholds and appends a `(Ns)` seconds counter once the wait passes ~5s. This turns a 60–90s silent wait (the cost of one giant first-turn LLM call) into visible progress instead of an ambiguous-looking "control returned to player."
+
+Tiers live in `ACTIVITY_MAP` ([packages/client-ink/src/tui/activity.ts](../packages/client-ink/src/tui/activity.ts)). Example progression for `starting_session`:
+
+| Elapsed | Label |
+|---|---|
+| 0–14s | `Preparing your campaign...` |
+| 15–44s | `Setting the scene...` |
+| 45s+ | `Almost there...` |
+
+The timestamp is set client-side: `engineStateSince` is stamped whenever `engineState` transitions to a new value (`event-handler.ts`), and the `session:transition` handler also sets it so the elapsed counter spans the WS reconnect.
 
 
 ## DM Text Formatting

--- a/docs/websocket-api.md
+++ b/docs/websocket-api.md
@@ -230,6 +230,8 @@ The server is transitioning from the setup session to a newly created campaign. 
 | `campaignId`   | string  | The campaign ID of the newly created campaign. |
 | `campaignName` | string? | Human-readable campaign name for immediate display. |
 
+The reference client keeps its activity line live across the transition by setting `engineState` to `"starting_session"` on receipt (and timestamping the change), so the indicator survives the WS reconnect and the long first DM call. See [Activity Indicators / Elapsed-time hints](tui-design.md#elapsed-time-hints-and-tier-escalation).
+
 #### `session:ended`
 
 The campaign session has ended.

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -207,12 +207,18 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
     setSessionKey((k) => k + 1); // remount PlayingPhase
     // Preserve live UI state through the handoff so the transition is seamless:
     // - narrativeLines: setup conversation stays visible as the DM's opening streams in
-    // - engineState: "DM is thinking..." indicator survives (first turn is already in progress)
+    // - engineState: the session:transition handler sets this to "starting_session"
+    //   so the activity line keeps spinning across the WS reconnect and the long
+    //   first DM call (60-90s of LLM silence). Without this the UI reads as
+    //   "control returned to player" until the first tool call lands.
+    // - engineStateSince: timestamp paired with engineState; preserves the
+    //   elapsed-time hint shown by ActivityLine.
     // - toolGlyphs: early tool activity stays visible until replaced
     setClientState((prev) => ({
       ...initialClientState(),
       narrativeLines: prev.narrativeLines,
       engineState: prev.engineState,
+      engineStateSince: prev.engineStateSince,
       toolGlyphs: prev.toolGlyphs,
     }));
   }, [clientState.transitionCampaignId]);
@@ -585,6 +591,7 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
       activePlayerIndex: stateSnapshot?.activePlayerIndex ?? 0,
       setActivePlayerIndex: () => { /* server manages this */ },
       engineState: clientState.engineState,
+      engineStateSince: clientState.engineStateSince,
       toolGlyphs: clientState.toolGlyphs,
       resources: Object.keys(clientState.displayResources).length > 0
         ? formatResources(clientState.displayResources, clientState.resourceValues)

--- a/packages/client-ink/src/event-handler.test.ts
+++ b/packages/client-ink/src/event-handler.test.ts
@@ -372,6 +372,25 @@ describe("event-handler", () => {
       expect(h.state.displayResources).toEqual({ Aldric: ["HP", "Spell Slots"] });
     });
 
+    it("does not override engineState (tui:* values are data carriers)", () => {
+      // Regression: tui:* states used to overwrite engineState, briefly
+      // dropping the activity indicator into an unmapped state during every
+      // TUI command. They're routing metadata, not real state transitions.
+      const h = makeHarness();
+      h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
+      const stampBefore = h.state.engineStateSince;
+
+      h.dispatch({
+        type: "activity:update",
+        data: { engineState: "tui:set_display_resources", character: "Aldric", resources: ["HP"] },
+      });
+
+      expect(h.state.engineState).toBe("dm_thinking");
+      expect(h.state.engineStateSince).toBe(stampBefore);
+      // Data payload still applied
+      expect(h.state.displayResources).toEqual({ Aldric: ["HP"] });
+    });
+
     it("merges resources for multiple characters", () => {
       const h = makeHarness();
       h.dispatch({

--- a/packages/client-ink/src/event-handler.test.ts
+++ b/packages/client-ink/src/event-handler.test.ts
@@ -231,6 +231,29 @@ describe("event-handler", () => {
       expect(h.state.toolGlyphs).toEqual([]);
     });
 
+    it("clears tool glyphs when turn ends (engineState → waiting_input)", () => {
+      const h = makeHarness();
+      // Mid-turn: glyphs accumulate
+      h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
+      h.dispatch({ type: "activity:update", data: { toolStarted: "roll_dice" } });
+      h.dispatch({ type: "activity:update", data: { toolStarted: "scribe" } });
+      expect(h.state.toolGlyphs.length).toBe(2);
+
+      // Turn ends — glyphs belong to the previous turn, not the player's input window
+      h.dispatch({ type: "activity:update", data: { engineState: "waiting_input" } });
+      expect(h.state.toolGlyphs).toEqual([]);
+    });
+
+    it("clears tool glyphs when engine returns to idle", () => {
+      const h = makeHarness();
+      h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
+      h.dispatch({ type: "activity:update", data: { toolStarted: "roll_dice" } });
+      expect(h.state.toolGlyphs.length).toBe(1);
+
+      h.dispatch({ type: "activity:update", data: { engineState: "idle" } });
+      expect(h.state.toolGlyphs).toEqual([]);
+    });
+
     it("preserves tool glyphs on tool_running → dm_thinking within a turn", () => {
       const h = makeHarness();
       // DM starts thinking
@@ -249,6 +272,76 @@ describe("event-handler", () => {
       const h = makeHarness();
       h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
       expect(h.state.engineState).toBe("dm_thinking");
+    });
+
+    it("stamps engineStateSince when state changes", () => {
+      const h = makeHarness();
+      const before = Date.now();
+      h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
+      const after = Date.now();
+      expect(h.state.engineStateSince).not.toBeNull();
+      expect(h.state.engineStateSince!).toBeGreaterThanOrEqual(before);
+      expect(h.state.engineStateSince!).toBeLessThanOrEqual(after);
+    });
+
+    it("does not bump engineStateSince when state value is unchanged", () => {
+      const h = makeHarness();
+      h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
+      const firstStamp = h.state.engineStateSince;
+      // tool start without state change should preserve the timestamp
+      h.dispatch({ type: "activity:update", data: { toolStarted: "roll_dice" } });
+      expect(h.state.engineStateSince).toBe(firstStamp);
+    });
+
+    it("bumps engineStateSince on transition between distinct states", async () => {
+      const h = makeHarness();
+      h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
+      const first = h.state.engineStateSince!;
+      // Wait a tick so Date.now() advances reliably even on coarse clocks
+      await new Promise((r) => setTimeout(r, 5));
+      h.dispatch({ type: "activity:update", data: { engineState: "tool_running" } });
+      expect(h.state.engineStateSince!).toBeGreaterThan(first);
+    });
+  });
+
+  describe("session:transition", () => {
+    it("sets engineState to starting_session and stamps engineStateSince", () => {
+      const h = makeHarness();
+      const before = Date.now();
+      h.dispatch({
+        type: "session:transition",
+        data: { campaignId: "new-campaign", campaignName: "New Campaign" },
+      });
+      const after = Date.now();
+
+      expect(h.state.engineState).toBe("starting_session");
+      expect(h.state.engineStateSince).not.toBeNull();
+      expect(h.state.engineStateSince!).toBeGreaterThanOrEqual(before);
+      expect(h.state.engineStateSince!).toBeLessThanOrEqual(after);
+      expect(h.state.transitionCampaignId).toBe("new-campaign");
+      expect(h.state.transitionCampaignName).toBe("New Campaign");
+      // Tool glyphs and stale per-session state get cleared
+      expect(h.state.toolGlyphs).toEqual([]);
+      expect(h.state.currentTurn).toBeNull();
+      expect(h.state.activeChoices).toBeNull();
+      expect(h.state.stateSnapshot).toBeNull();
+    });
+
+    it("clears tool glyphs when first dm_thinking arrives after starting_session", () => {
+      const h = makeHarness();
+      // Stale glyph from the dying setup session
+      h.dispatch({ type: "activity:update", data: { toolStarted: "roll_dice" } });
+      // Transition arrives — glyphs cleared, state becomes starting_session
+      h.dispatch({
+        type: "session:transition",
+        data: { campaignId: "c2" },
+      });
+      expect(h.state.toolGlyphs).toEqual([]);
+      // First dm_thinking from the new session is treated as a new turn,
+      // so any glyphs accumulated in between are cleared.
+      h.dispatch({ type: "activity:update", data: { toolStarted: "scribe" } });
+      h.dispatch({ type: "activity:update", data: { engineState: "dm_thinking" } });
+      expect(h.state.toolGlyphs).toEqual([]);
     });
   });
 

--- a/packages/client-ink/src/event-handler.ts
+++ b/packages/client-ink/src/event-handler.ts
@@ -331,6 +331,14 @@ function handleActivityUpdate(event: ActivityUpdateEvent, update: StateUpdater):
   const data = event.data as Record<string, unknown>;
   const { engineState, toolStarted } = data;
 
+  // tui:* engineState values are data carriers (TUI command payloads riding
+  // on the activity:update channel), not real engine state transitions. They
+  // must not override engineState — otherwise the activity indicator briefly
+  // drops to an unmapped state during every TUI command, blanking the
+  // full-height activity line label and the standard-tier modeline glyph.
+  const isTuiPayload = typeof engineState === "string" && engineState.startsWith("tui:");
+  const incomingState = isTuiPayload ? undefined : (engineState as string | undefined);
+
   update((prev) => {
     // Accumulate tool glyphs for the turn (don't remove on end — they persist visually)
     let glyphs = prev.toolGlyphs;
@@ -352,13 +360,13 @@ function handleActivityUpdate(event: ActivityUpdateEvent, update: StateUpdater):
     // "starting_session" counts as idle — the first dm_thinking after a
     // setup→game handoff is the start of a fresh turn.
     // tool_running → dm_thinking transitions within a turn must NOT clear.
-    const newState = (engineState as string) ?? prev.engineState;
+    const newState = incomingState ?? prev.engineState;
     const wasIdle = !prev.engineState
       || prev.engineState === "waiting_input"
       || prev.engineState === "starting_session";
-    if (engineState === "waiting_input" || engineState === "idle") {
+    if (incomingState === "waiting_input" || incomingState === "idle") {
       glyphs = [];
-    } else if (engineState === "dm_thinking" && wasIdle) {
+    } else if (incomingState === "dm_thinking" && wasIdle) {
       glyphs = [];
     }
 
@@ -374,10 +382,10 @@ function handleActivityUpdate(event: ActivityUpdateEvent, update: StateUpdater):
       toolGlyphs: glyphs,
     };
 
-    // Handle embedded TUI command payloads
-    const tuiType = typeof engineState === "string" && engineState.startsWith("tui:")
-      ? engineState.slice(4)
-      : null;
+    // Handle embedded TUI command payloads (engineState carries the tui:*
+    // discriminator only as routing metadata — the actual engine state was
+    // preserved above).
+    const tuiType = isTuiPayload ? (engineState as string).slice(4) : null;
 
     if (tuiType === "update_modeline") {
       const character = data.character as string | undefined;

--- a/packages/client-ink/src/event-handler.ts
+++ b/packages/client-ink/src/event-handler.ts
@@ -35,6 +35,10 @@ export interface ClientState {
   currentTurn: Turn | null;
   activeChoices: ChoicesData | null;
   engineState: string | null;
+  /** Wall-clock timestamp (ms) when `engineState` last changed value.
+   *  Used by ActivityLine to render elapsed-time hints during long waits.
+   *  null when engineState is null. */
+  engineStateSince: number | null;
   /** Accumulated tool glyphs for the current DM turn. Cleared on new turn. */
   toolGlyphs: ToolGlyph[];
   variant: StyleVariant;
@@ -75,6 +79,7 @@ export function initialClientState(): ClientState {
     currentTurn: null,
     activeChoices: null,
     engineState: null,
+    engineStateSince: null,
     toolGlyphs: [],
     variant: "exploration",
     mode: "play",
@@ -176,6 +181,11 @@ export function createEventHandler(update: StateUpdater): (event: ServerEvent) =
       case "session:transition": {
         // Clear state that could trigger stale detection before the
         // app's useEffect runs and reconnects the WebSocket.
+        //
+        // engineState becomes "starting_session" (not null) so the activity
+        // line keeps spinning across the WS reconnect and the long first
+        // DM call. Without this the UI reads as "control returned to player"
+        // for 60-90s while the DM agent thinks silently.
         const transition = event.data as { campaignId: string; campaignName?: string };
         update((prev) => ({
           ...prev,
@@ -184,7 +194,8 @@ export function createEventHandler(update: StateUpdater): (event: ServerEvent) =
           stateSnapshot: null,
           currentTurn: null,
           activeChoices: null,
-          engineState: null,
+          engineState: "starting_session",
+          engineStateSince: Date.now(),
           toolGlyphs: [],
         }));
         break;
@@ -328,17 +339,38 @@ function handleActivityUpdate(event: ActivityUpdateEvent, update: StateUpdater):
       if (tg) glyphs = [...glyphs, tg];
     }
 
-    // Clear glyphs only when entering dm_thinking from idle (new turn),
-    // not on tool_running → dm_thinking transitions within a turn.
+    // Clear glyphs at two natural turn boundaries:
+    //   1. End of turn — engine transitions to "waiting_input" or "idle".
+    //      Glyphs belong to the turn that just ended; they should not bleed
+    //      into the player's input window. (This mattered less before
+    //      ActivityLine learned to render glyphs without a label, because
+    //      the row was hidden during idle states. Now it stays visible, so
+    //      we have to clear explicitly.)
+    //   2. Start of next turn — entering "dm_thinking" from an idle state.
+    //      Belt-and-suspenders: covers cases where the engine skips straight
+    //      to thinking without an explicit waiting_input event.
+    // "starting_session" counts as idle — the first dm_thinking after a
+    // setup→game handoff is the start of a fresh turn.
+    // tool_running → dm_thinking transitions within a turn must NOT clear.
     const newState = (engineState as string) ?? prev.engineState;
-    const wasIdle = !prev.engineState || prev.engineState === "waiting_input";
-    if (engineState === "dm_thinking" && wasIdle) {
+    const wasIdle = !prev.engineState
+      || prev.engineState === "waiting_input"
+      || prev.engineState === "starting_session";
+    if (engineState === "waiting_input" || engineState === "idle") {
+      glyphs = [];
+    } else if (engineState === "dm_thinking" && wasIdle) {
       glyphs = [];
     }
 
+    // Stamp engineStateSince whenever engineState transitions to a new value
+    // so ActivityLine can render elapsed-time hints during long waits.
+    const stateChanged = newState !== prev.engineState;
     let next = {
       ...prev,
       engineState: newState,
+      engineStateSince: stateChanged
+        ? (newState ? Date.now() : null)
+        : prev.engineStateSince,
       toolGlyphs: glyphs,
     };
 

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -38,7 +38,7 @@ export function PlayingPhase() {
     narrativeLines, setNarrativeLines,
     theme,
     campaignName, activePlayerIndex,
-    engineState, toolGlyphs, resources, modelines,
+    engineState, engineStateSince, toolGlyphs, resources, modelines,
     currentTurn,
     activeChoices, setActiveChoices,
     activeModal, setActiveModal,
@@ -374,6 +374,7 @@ export function PlayingPhase() {
         resources={resources}
         turnHolder={engineState === "waiting_input" ? activeChar : "DM"}
         engineState={engineState}
+        engineStateSince={engineStateSince}
         toolGlyphs={toolGlyphs}
         quoteColor="#ffffff"
         playerColor={stateSnapshot?.players?.[activePlayerIndex]?.color}

--- a/packages/client-ink/src/tui/activity.test.ts
+++ b/packages/client-ink/src/tui/activity.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { getActivity, getToolGlyph, ACTIVITY_MAP, parseRetryState, retryLabel } from "./activity.js";
+import {
+  getActivity,
+  getActivityLabel,
+  getToolGlyph,
+  ACTIVITY_MAP,
+  parseRetryState,
+  retryLabel,
+} from "./activity.js";
 
 describe("activity indicators", () => {
   it("returns indicator for known states", () => {
@@ -28,6 +35,50 @@ describe("activity indicators", () => {
     expect(ACTIVITY_MAP.rule_lookup).toBeDefined();
     expect(ACTIVITY_MAP.scene_transition).toBeDefined();
     expect(ACTIVITY_MAP.dm_thinking).toBeDefined();
+    expect(ACTIVITY_MAP.starting_session).toBeDefined();
+  });
+
+  it("returns starting_session indicator for setup→game handoff", () => {
+    const indicator = getActivity("starting_session");
+    expect(indicator).toBeDefined();
+    expect(indicator!.label).toMatch(/preparing|setting/i);
+    expect(indicator!.glyph).toBe("◆");
+  });
+});
+
+describe("getActivityLabel", () => {
+  it("returns base label below first tier threshold", () => {
+    expect(getActivityLabel("starting_session", 0)).toBe("Preparing your campaign...");
+    expect(getActivityLabel("starting_session", 14)).toBe("Preparing your campaign...");
+  });
+
+  it("escalates to next tier once threshold is reached", () => {
+    expect(getActivityLabel("starting_session", 15)).toBe("Setting the scene...");
+    expect(getActivityLabel("starting_session", 44)).toBe("Setting the scene...");
+    expect(getActivityLabel("starting_session", 45)).toBe("Almost there...");
+    expect(getActivityLabel("starting_session", 200)).toBe("Almost there...");
+  });
+
+  it("returns base label for states without tiers", () => {
+    expect(getActivityLabel("roll_dice", 0)).toBe("Rolling...");
+    expect(getActivityLabel("roll_dice", 999)).toBe("Rolling...");
+  });
+
+  it("escalates dm_thinking after long waits", () => {
+    expect(getActivityLabel("dm_thinking", 0)).toBe("The DM is thinking...");
+    expect(getActivityLabel("dm_thinking", 30)).toBe("The DM is composing the scene...");
+    expect(getActivityLabel("dm_thinking", 75)).toBe("The DM is still working...");
+  });
+
+  it("escalates tool_running so subagent-backed tools don't blank the line", () => {
+    expect(getActivityLabel("tool_running", 0)).toBe("The DM is working...");
+    expect(getActivityLabel("tool_running", 15)).toBe("Working on the world...");
+    expect(getActivityLabel("tool_running", 45)).toBe("Still working...");
+  });
+
+  it("returns undefined for null or unknown state", () => {
+    expect(getActivityLabel(null, 0)).toBeUndefined();
+    expect(getActivityLabel("nope", 0)).toBeUndefined();
   });
 });
 

--- a/packages/client-ink/src/tui/activity.test.ts
+++ b/packages/client-ink/src/tui/activity.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getActivity,
   getActivityLabel,
+  hasElapsedAwareLabel,
   getToolGlyph,
   ACTIVITY_MAP,
   parseRetryState,
@@ -79,6 +80,25 @@ describe("getActivityLabel", () => {
   it("returns undefined for null or unknown state", () => {
     expect(getActivityLabel(null, 0)).toBeUndefined();
     expect(getActivityLabel("nope", 0)).toBeUndefined();
+  });
+});
+
+describe("hasElapsedAwareLabel", () => {
+  it("is true only for states that declare tier escalations", () => {
+    // Known-slow states with tiers
+    expect(hasElapsedAwareLabel("dm_thinking")).toBe(true);
+    expect(hasElapsedAwareLabel("tool_running")).toBe(true);
+    expect(hasElapsedAwareLabel("starting_session")).toBe(true);
+    // Mapped but tier-less — fast states should NOT trigger ticker/suffix
+    expect(hasElapsedAwareLabel("roll_dice")).toBe(false);
+    expect(hasElapsedAwareLabel("rule_lookup")).toBe(false);
+    expect(hasElapsedAwareLabel("scene_transition")).toBe(false);
+  });
+
+  it("is false for null or unmapped states", () => {
+    expect(hasElapsedAwareLabel(null)).toBe(false);
+    expect(hasElapsedAwareLabel("waiting_input")).toBe(false);
+    expect(hasElapsedAwareLabel("nope")).toBe(false);
   });
 });
 

--- a/packages/client-ink/src/tui/activity.ts
+++ b/packages/client-ink/src/tui/activity.ts
@@ -1,11 +1,54 @@
 import type { ActivityIndicator } from "@machine-violet/shared/types/tui.js";
 
-/** Map of engine states to their display indicators */
-export const ACTIVITY_MAP: Record<string, ActivityIndicator> = {
+/** A label tier that becomes active once `atSec` of elapsed time has passed. */
+export interface LabelTier {
+  atSec: number;
+  label: string;
+}
+
+/** Internal indicator with optional escalation tiers. */
+type IndicatorWithTiers = ActivityIndicator & { tiers?: LabelTier[] };
+
+/** Map of engine states to their display indicators.
+ *  `tiers` (optional) escalate the label after the listed elapsed seconds —
+ *  used for known-slow states (campaign start, first DM turn) so a long
+ *  silent wait reads as progress rather than a hung UI. */
+export const ACTIVITY_MAP: Record<string, IndicatorWithTiers> = {
   roll_dice: { label: "Rolling...", glyph: "⚄" },
   rule_lookup: { label: "Checking rules...", glyph: "📖" },
   scene_transition: { label: "Scene transition...", glyph: "⟳" },
-  dm_thinking: { label: "The DM is thinking...", glyph: "◆" },
+  dm_thinking: {
+    label: "The DM is thinking...",
+    glyph: "◆",
+    tiers: [
+      { atSec: 30, label: "The DM is composing the scene..." },
+      { atSec: 75, label: "The DM is still working..." },
+    ],
+  },
+  // Engine emits this for the duration of any in-flight tool call.
+  // Most tools finish in milliseconds, but subagent-backed tools (style_scene
+  // → theme-styler, scribe, etc.) routinely run 20-60s. Without an entry
+  // here the activity line goes blank — taking the accumulated tool glyphs
+  // with it — and the user sees what looks like a player-turn pause.
+  tool_running: {
+    label: "The DM is working...",
+    glyph: "◆",
+    tiers: [
+      { atSec: 15, label: "Working on the world..." },
+      { atSec: 45, label: "Still working..." },
+    ],
+  },
+  // Spans the gap between setup→game handoff and the first DM event.
+  // The first DM turn after setup is a long single LLM call (theme + modelines
+  // + resources + opening narration) and routinely takes 60-90s of silence.
+  starting_session: {
+    label: "Preparing your campaign...",
+    glyph: "◆",
+    tiers: [
+      { atSec: 15, label: "Setting the scene..." },
+      { atSec: 45, label: "Almost there..." },
+    ],
+  },
 };
 
 /** A glyph with an optional color (for non-emoji unicode characters). */
@@ -85,5 +128,26 @@ export function getActivity(
   state: string | null,
 ): ActivityIndicator | undefined {
   if (!state) return undefined;
-  return ACTIVITY_MAP[state];
+  const ind = ACTIVITY_MAP[state];
+  if (!ind) return undefined;
+  return { label: ind.label, glyph: ind.glyph };
+}
+
+/** Resolve the label for an engine state at a given elapsed time.
+ *  Walks the indicator's tier list (if any) and returns the latest tier
+ *  whose threshold has been reached, falling back to the base label. */
+export function getActivityLabel(
+  state: string | null,
+  elapsedSec: number,
+): string | undefined {
+  if (!state) return undefined;
+  const ind = ACTIVITY_MAP[state];
+  if (!ind) return undefined;
+  let label = ind.label;
+  if (ind.tiers) {
+    for (const t of ind.tiers) {
+      if (elapsedSec >= t.atSec) label = t.label;
+    }
+  }
+  return label;
 }

--- a/packages/client-ink/src/tui/activity.ts
+++ b/packages/client-ink/src/tui/activity.ts
@@ -151,3 +151,13 @@ export function getActivityLabel(
   }
   return label;
 }
+
+/** True when the state's indicator declares tier escalations — i.e. it's a
+ *  known-slow state that should display elapsed-time hints and tick its
+ *  label. Fast states (roll_dice, rule_lookup) return false here so they
+ *  don't accumulate "(Ns)" suffixes or burn an interval timer. */
+export function hasElapsedAwareLabel(state: string | null): boolean {
+  if (!state) return false;
+  const ind = ACTIVITY_MAP[state];
+  return !!(ind?.tiers && ind.tiers.length > 0);
+}

--- a/packages/client-ink/src/tui/components/ActivityLine.tsx
+++ b/packages/client-ink/src/tui/components/ActivityLine.tsx
@@ -1,12 +1,20 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Text, Box } from "ink";
-import { getActivity } from "../activity.js";
+import { getActivity, getActivityLabel } from "../activity.js";
 import type { ToolGlyph } from "../activity.js";
 
 interface ActivityLineProps {
   engineState: string | null;
   toolGlyphs?: ToolGlyph[];
+  /** Wall-clock timestamp (ms) when engineState last changed.
+   *  When provided and the state has tiered/elapsed messaging, the label
+   *  escalates and an "(Ns)" suffix appears once a few seconds have passed. */
+  engineStateSince?: number | null;
 }
+
+// Elapsed seconds before we start surfacing the "(Ns)" suffix. Below this,
+// the wait feels normal and the count is noise.
+const ELAPSED_VISIBLE_THRESHOLD_SEC = 5;
 
 /**
  * Shows what the engine is doing — mapped from in-flight tool calls.
@@ -15,17 +23,53 @@ interface ActivityLineProps {
  *
  * Tool glyphs accumulate as the DM calls tools during a turn,
  * building a visual impression of compounding effort.
+ *
+ * For long-running states (dm_thinking, starting_session), the label
+ * escalates through tiers and an elapsed-seconds suffix is appended so
+ * a 60-90s silent wait reads as progress instead of a hung UI.
  */
-export const ActivityLine = React.memo(function ActivityLine({ engineState, toolGlyphs }: ActivityLineProps) {
+export const ActivityLine = React.memo(function ActivityLine({
+  engineState,
+  toolGlyphs,
+  engineStateSince,
+}: ActivityLineProps) {
   const activity = getActivity(engineState);
-  if (!activity) return null;
+  const hasGlyphs = !!(toolGlyphs && toolGlyphs.length > 0);
+
+  // Tick every second while a tiered/elapsed-aware state is active so the
+  // suffix and tier label stay accurate. The interval is only registered
+  // when needed and cleans up on state change.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!engineState || !engineStateSince) return;
+    if (!getActivityLabel(engineState, 0)) return;
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [engineState, engineStateSince]);
+
+  // Render whenever we have *anything* to show — an indicator label or
+  // accumulated tool glyphs. This keeps the row alive across unmapped or
+  // transient engine states (the entire row disappearing — including the
+  // glyphs that were already there — reads as "control returned to player").
+  if (!activity && !hasGlyphs) return null;
+
+  const elapsedSec = engineStateSince
+    ? Math.max(0, Math.floor((Date.now() - engineStateSince) / 1000))
+    : 0;
+  const tieredLabel = getActivityLabel(engineState, elapsedSec) ?? activity?.label;
+  const showElapsed = tieredLabel != null
+    && engineStateSince != null
+    && elapsedSec >= ELAPSED_VISIBLE_THRESHOLD_SEC;
+  const display = tieredLabel
+    ? (showElapsed ? `${tieredLabel} (${elapsedSec}s)` : tieredLabel)
+    : null;
 
   return (
     <Box>
-      <Text dimColor>{activity.label}</Text>
+      {display && <Text dimColor>{display}</Text>}
       {toolGlyphs && toolGlyphs.length > 0 && (
         <Text>
-          {" "}
+          {display ? " " : ""}
           {toolGlyphs.map((tg, i) =>
             tg.color
               ? <Text key={i} color={tg.color}>{tg.glyph}</Text>

--- a/packages/client-ink/src/tui/components/ActivityLine.tsx
+++ b/packages/client-ink/src/tui/components/ActivityLine.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Text, Box } from "ink";
-import { getActivity, getActivityLabel } from "../activity.js";
+import { getActivity, getActivityLabel, hasElapsedAwareLabel } from "../activity.js";
 import type { ToolGlyph } from "../activity.js";
 
 interface ActivityLineProps {
@@ -37,15 +37,16 @@ export const ActivityLine = React.memo(function ActivityLine({
   const hasGlyphs = !!(toolGlyphs && toolGlyphs.length > 0);
 
   // Tick every second while a tiered/elapsed-aware state is active so the
-  // suffix and tier label stay accurate. The interval is only registered
-  // when needed and cleans up on state change.
+  // suffix and tier label stay accurate. The interval is gated on
+  // hasElapsedAwareLabel — fast states (roll_dice, rule_lookup) don't get
+  // a ticker or an "(Ns)" suffix.
+  const elapsedAware = hasElapsedAwareLabel(engineState);
   const [, setTick] = useState(0);
   useEffect(() => {
-    if (!engineState || !engineStateSince) return;
-    if (!getActivityLabel(engineState, 0)) return;
+    if (!elapsedAware || !engineStateSince) return;
     const id = setInterval(() => setTick((t) => t + 1), 1000);
     return () => clearInterval(id);
-  }, [engineState, engineStateSince]);
+  }, [elapsedAware, engineStateSince]);
 
   // Render whenever we have *anything* to show — an indicator label or
   // accumulated tool glyphs. This keeps the row alive across unmapped or
@@ -57,7 +58,9 @@ export const ActivityLine = React.memo(function ActivityLine({
     ? Math.max(0, Math.floor((Date.now() - engineStateSince) / 1000))
     : 0;
   const tieredLabel = getActivityLabel(engineState, elapsedSec) ?? activity?.label;
-  const showElapsed = tieredLabel != null
+  // Suffix is gated on elapsedAware so fast states (roll_dice, rule_lookup)
+  // don't grow a "(Ns)" tail just because the player paused before the tool fired.
+  const showElapsed = elapsedAware
     && engineStateSince != null
     && elapsedSec >= ELAPSED_VISIBLE_THRESHOLD_SEC;
   const display = tieredLabel

--- a/packages/client-ink/src/tui/components/components.test.tsx
+++ b/packages/client-ink/src/tui/components/components.test.tsx
@@ -216,6 +216,21 @@ describe("ActivityLine", () => {
     expect(diceCount).toBe(2);
     expect(frame).toContain("◈");
   });
+
+  it("renders glyphs when engine state has no label", () => {
+    // Unmapped states (or transient ones) shouldn't make the whole row
+    // disappear — that wipes accumulated tool glyphs and reads as a pause.
+    const glyphs = [{ glyph: "⚄", color: "yellow" }];
+    const { lastFrame } = render(
+      <ActivityLine engineState="some_unmapped_state" toolGlyphs={glyphs} />,
+    );
+    expect(lastFrame()!).toContain("⚄");
+  });
+
+  it("renders tool_running with the working label so subagent calls stay visible", () => {
+    const { lastFrame } = render(<ActivityLine engineState="tool_running" />);
+    expect(lastFrame()!).toContain("DM is working");
+  });
 });
 
 describe("NarrativeArea", () => {

--- a/packages/client-ink/src/tui/components/components.test.tsx
+++ b/packages/client-ink/src/tui/components/components.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render } from "ink-testing-library";
 import { Modeline, buildModelineDisplay, splitModeline, modelineVisibleLength } from "./Modeline.js";
 import { InputLine } from "./InputLine.js";
@@ -230,6 +230,52 @@ describe("ActivityLine", () => {
   it("renders tool_running with the working label so subagent calls stay visible", () => {
     const { lastFrame } = render(<ActivityLine engineState="tool_running" />);
     expect(lastFrame()!).toContain("DM is working");
+  });
+
+  describe("elapsed-time ticker", () => {
+    it("appends (Ns) suffix after the visibility threshold and escalates tier labels", async () => {
+      vi.useFakeTimers();
+      try {
+        const since = Date.now();
+        const { lastFrame } = render(
+          <ActivityLine engineState="starting_session" engineStateSince={since} />,
+        );
+        // Initial render: base label, no elapsed suffix yet (under 5s threshold).
+        expect(lastFrame()!).toContain("Preparing your campaign");
+        expect(lastFrame()!).not.toMatch(/\(\d+s\)/);
+
+        // Past the visibility threshold but before the first tier (15s).
+        // advanceTimersByTimeAsync flushes the React state updates triggered
+        // by the setInterval tick so lastFrame() observes the new render.
+        await vi.advanceTimersByTimeAsync(6000);
+        expect(lastFrame()!).toContain("Preparing your campaign");
+        expect(lastFrame()!).toMatch(/\(6s\)/);
+
+        // Past the first tier — label escalates and counter keeps climbing.
+        await vi.advanceTimersByTimeAsync(10000);
+        expect(lastFrame()!).toContain("Setting the scene");
+        expect(lastFrame()!).toMatch(/\(16s\)/);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not tick or append a suffix for fast (non-tiered) states", async () => {
+      vi.useFakeTimers();
+      try {
+        const since = Date.now();
+        const { lastFrame } = render(
+          <ActivityLine engineState="roll_dice" engineStateSince={since} />,
+        );
+        expect(lastFrame()!).toContain("Rolling");
+
+        // Even at 30s, roll_dice has no tiers and should not grow a suffix.
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(lastFrame()!).not.toMatch(/\(\d+s\)/);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });
 

--- a/packages/client-ink/src/tui/game-context.ts
+++ b/packages/client-ink/src/tui/game-context.ts
@@ -35,6 +35,8 @@ export interface GameContextValue {
   activePlayerIndex: number;
   setActivePlayerIndex: (i: number) => void;
   engineState: string | null;
+  /** Wall-clock timestamp (ms) when engineState last changed. */
+  engineStateSince: number | null;
   toolGlyphs: ToolGlyph[];
   resources: string[];
   modelines: Record<string, string>;

--- a/packages/client-ink/src/tui/layout.tsx
+++ b/packages/client-ink/src/tui/layout.tsx
@@ -61,6 +61,8 @@ export interface LayoutProps {
   // Turn/activity
   turnHolder?: string;
   engineState: string | null;
+  /** Wall-clock timestamp (ms) when engineState last changed. */
+  engineStateSince?: number | null;
   toolGlyphs?: ToolGlyph[];
 
   // Display options
@@ -113,6 +115,7 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
     resources,
     turnHolder,
     engineState,
+    engineStateSince,
     toolGlyphs,
     showVerbose,
     quoteColor,
@@ -234,7 +237,13 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
           />
 
           {/* Activity Line */}
-          {elements.activityLine && <ActivityLine engineState={engineState} toolGlyphs={toolGlyphs} />}
+          {elements.activityLine && (
+            <ActivityLine
+              engineState={engineState}
+              engineStateSince={engineStateSince}
+              toolGlyphs={toolGlyphs}
+            />
+          )}
         </Box>
 
         {rightSide}

--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -250,6 +250,29 @@ describe("createSetupConversation", () => {
     expect(result.text).toContain("May your blade stay sharp!");
   });
 
+  it("finalize_setup tool result forbids DM-style narration (regression guard)", async () => {
+    // Without an explicit prohibition, the model stretches "say a brief
+    // farewell" into a full improvised cold-open scene that the real DM then
+    // rewrites with different content — the player reads two contradictory
+    // openings. This test pins the wording so a future drift can't
+    // reintroduce the bug.
+    const provider = mockProvider([
+      finalizeResponse(FINALIZE_INPUT),
+      textResponse("Let's begin.\n\n---"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    await conv.start(noop);
+
+    // The second stream call carries the tool_result fed back into the model.
+    expect(provider.stream).toHaveBeenCalledTimes(2);
+    const secondCallParams = (provider.stream as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    const serialized = JSON.stringify(secondCallParams);
+    // Must instruct the agent NOT to narrate on the DM's behalf.
+    expect(serialized).toMatch(/don't narrate/i);
+    // Must request a separator so the handoff to the DM has a clean visual seam.
+    expect(serialized).toContain("---");
+  });
+
   it("co-emitted load_world + present_choices: both tool_results flushed on resolveChoice", async () => {
     // Model emits load_world AND present_choices in the same assistant turn.
     // Regression: previously the load_world tool_result was discarded on early-return,

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -503,7 +503,7 @@ export function createSetupConversation(
           toolResults.push({
             type: "tool_result",
             tool_use_id: tc.id,
-            content: "Setup finalized. Say a brief farewell to the player before the adventure begins.",
+            content: "Setup finalized. Say a brief farewell (don't narrate on behalf of the DM!) and finish with a separator: `---`",
           });
         }
       }


### PR DESCRIPTION
## Summary

The handoff between the setup agent and the DM's first turn read as ~60-90s of "control returned to player" — the activity line went blank during `session:transition`, again during the long first LLM call, and again whenever a `tool_running` state had no mapped label. Accumulated tool glyphs also disappeared during those windows because `ActivityLine` returned null whenever the engine state had no indicator entry.

This PR keeps the activity line alive across the entire handoff and the DM's opening turn, surfaces elapsed-time hints for known-slow states, and stops the setup agent from improvising opening narration that the real DM then overwrites.

- **Activity line survives the WS reconnect.** `session:transition` now sets `engineState` to a new `"starting_session"` state (with a tracked `engineStateSince` timestamp) instead of clearing to null. The indicator carries through the WS reconnect into the new campaign.
- **Elapsed-time + tier escalation.** ActivityLine ticks once a second when an elapsed-aware state is active and appends `(Ns)` after 5s. Known-slow states (`starting_session`, `dm_thinking`, `tool_running`) escalate their labels at configurable thresholds (e.g. `Preparing your campaign...` → `Setting the scene...` → `Almost there...`).
- **`tool_running` no longer blanks the line.** Subagent-backed tools (`style_scene` → theme-styler) routinely take 20-60s; the unmapped state used to make the whole row vanish, taking accumulated glyphs with it. Now mapped to `The DM is working...` with its own tier ladder.
- **Glyph row resilience.** ActivityLine renders accumulated glyphs even when the state has no mapped label, so any future transient or unmapped state can dim the label without wiping the glyph row.
- **Glyphs clear at end of turn.** `engineState → waiting_input` (or `idle`) clears `toolGlyphs` so per-turn glyphs don't bleed into the next turn's input window. The original design relied on the row being null during idle states, which the glyph fallback above no longer guarantees.
- **Setup agent stops playing DM.** The `finalize_setup` tool result was previously instructing the agent to *"Say a brief farewell to the player before the adventure begins"* — combined with a model steeped in dramatic flourishes for the whole setup conversation, it stretched into a full improvised cold-open with HEARTH dialogue, which the real DM then rewrote with different content. Tightened to *"Say a brief farewell (don't narrate on behalf of the DM!) and finish with a separator: \`---\`"*.

Docs updated: tui-design's activity-indicators table gains the `tool_running` and `starting_session` rows plus a section on tier escalation; websocket-api's `session:transition` entry points at it.

## Test plan

- [x] `npm run check` (lint + 2409 tests) passes
- [x] New unit tests cover: `starting_session` indicator, `getActivityLabel` tier escalation, `engineStateSince` stamping/preservation, `session:transition` setting starting_session, glyph clearing on `waiting_input`/`idle`, glyph fallback rendering when state has no label, `tool_running` label rendering
- [ ] Manual: start a fresh campaign through setup → confirm activity line stays alive through the entire handoff with no blank stretches
- [ ] Manual: confirm elapsed time + tier escalation visibly progress (`Preparing your campaign...` → `Setting the scene...` etc.)
- [ ] Manual: confirm setup agent's farewell is short and ends with `---`, with no improvised opening scene
- [ ] Manual: confirm tool glyphs clear when DM's opening turn ends (no leftover glyphs in player input window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)