### PR TITLE
Skip stdout/stderr mirror when stdout is a TTY

### DIFF
--- a/packages/engine/src/server/server.test.ts
+++ b/packages/engine/src/server/server.test.ts
@@ -65,15 +65,24 @@ describe("createServer stdio mirror", () => {
   let tempRoot: string;
   let savedStdoutWrite: typeof process.stdout.write;
   let savedStderrWrite: typeof process.stderr.write;
-  let savedStdoutTTY: boolean | undefined;
+  let savedTTYDescriptor: PropertyDescriptor | undefined;
   let savedNodeEnv: string | undefined;
   let server: FastifyInstance | undefined;
+
+  function setIsTTY(value: boolean): void {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      writable: true,
+      enumerable: true,
+      value,
+    });
+  }
 
   beforeEach(() => {
     tempRoot = mkdtempSync(join(tmpdir(), "mv-server-mirror-"));
     savedStdoutWrite = process.stdout.write;
     savedStderrWrite = process.stderr.write;
-    savedStdoutTTY = process.stdout.isTTY;
+    savedTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
     savedNodeEnv = process.env.NODE_ENV;
     // The mirror is short-circuited when NODE_ENV === "test", so flip it
     // to exercise the real branch.
@@ -87,18 +96,24 @@ describe("createServer stdio mirror", () => {
     }
     process.stdout.write = savedStdoutWrite;
     process.stderr.write = savedStderrWrite;
-    if (savedStdoutTTY === undefined) {
-      delete (process.stdout as { isTTY?: boolean }).isTTY;
+    if (savedTTYDescriptor) {
+      Object.defineProperty(process.stdout, "isTTY", savedTTYDescriptor);
     } else {
-      process.stdout.isTTY = savedStdoutTTY;
+      delete (process.stdout as { isTTY?: boolean }).isTTY;
     }
     if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
     else process.env.NODE_ENV = savedNodeEnv;
-    rmSync(tempRoot, { recursive: true, force: true });
+    // The mirror's WriteStream stays open (production never closes it; the
+    // process exits). On Windows, that holds a lock on .debug/server.log and
+    // rmSync will fail — tolerate it; mkdtemp lives under os.tmpdir() and the
+    // OS will reap it eventually.
+    try {
+      rmSync(tempRoot, { recursive: true, force: true });
+    } catch { /* see comment above */ }
   });
 
   it("wraps stdout.write when stdout is not a TTY (headless run)", async () => {
-    process.stdout.isTTY = false;
+    setIsTTY(false);
     const before = process.stdout.write;
     server = await createServer({
       campaignsDir: join(tempRoot, "campaigns"),
@@ -108,7 +123,7 @@ describe("createServer stdio mirror", () => {
   });
 
   it("does not wrap stdout.write when stdout is a TTY (launcher / interactive)", async () => {
-    process.stdout.isTTY = true;
+    setIsTTY(true);
     const before = process.stdout.write;
     server = await createServer({
       campaignsDir: join(tempRoot, "campaigns"),

--- a/packages/engine/src/server/server.test.ts
+++ b/packages/engine/src/server/server.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
 import { createServer } from "./server.js";
 
@@ -55,5 +58,62 @@ describe("engine server", () => {
       });
       expect(response.statusCode).toBe(400);
     });
+  });
+});
+
+describe("createServer stdio mirror", () => {
+  let tempRoot: string;
+  let savedStdoutWrite: typeof process.stdout.write;
+  let savedStderrWrite: typeof process.stderr.write;
+  let savedStdoutTTY: boolean | undefined;
+  let savedNodeEnv: string | undefined;
+  let server: FastifyInstance | undefined;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "mv-server-mirror-"));
+    savedStdoutWrite = process.stdout.write;
+    savedStderrWrite = process.stderr.write;
+    savedStdoutTTY = process.stdout.isTTY;
+    savedNodeEnv = process.env.NODE_ENV;
+    // The mirror is short-circuited when NODE_ENV === "test", so flip it
+    // to exercise the real branch.
+    process.env.NODE_ENV = "development";
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = undefined;
+    }
+    process.stdout.write = savedStdoutWrite;
+    process.stderr.write = savedStderrWrite;
+    if (savedStdoutTTY === undefined) {
+      delete (process.stdout as { isTTY?: boolean }).isTTY;
+    } else {
+      process.stdout.isTTY = savedStdoutTTY;
+    }
+    if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = savedNodeEnv;
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("wraps stdout.write when stdout is not a TTY (headless run)", async () => {
+    process.stdout.isTTY = false;
+    const before = process.stdout.write;
+    server = await createServer({
+      campaignsDir: join(tempRoot, "campaigns"),
+      configDir: tempRoot,
+    });
+    expect(process.stdout.write).not.toBe(before);
+  });
+
+  it("does not wrap stdout.write when stdout is a TTY (launcher / interactive)", async () => {
+    process.stdout.isTTY = true;
+    const before = process.stdout.write;
+    server = await createServer({
+      campaignsDir: join(tempRoot, "campaigns"),
+      configDir: tempRoot,
+    });
+    expect(process.stdout.write).toBe(before);
   });
 });

--- a/packages/engine/src/server/server.ts
+++ b/packages/engine/src/server/server.ts
@@ -43,8 +43,10 @@ export async function createServer(
 ): Promise<FastifyInstance> {
   const cfg = { ...DEFAULTS, ...config };
 
-  // Mirror stdout/stderr to .debug/server.log (not in test mode)
-  if (process.env.NODE_ENV !== "test" && cfg.campaignsDir) {
+  // Mirror stdout/stderr to .debug/server.log (not in test mode).
+  // Skip when stdout is a TTY: a human (or Ink TUI in launcher mode) is
+  // attached, and duplicating ANSI redraws into the log balloons it to GBs.
+  if (process.env.NODE_ENV !== "test" && cfg.campaignsDir && !process.stdout.isTTY) {
     try {
       const logDir = join(dirname(cfg.campaignsDir), ".debug");
       mkdirSync(logDir, { recursive: true });


### PR DESCRIPTION
## Summary

`createServer` mirrors `process.stdout` and `process.stderr` to `.debug/server.log` so headless runs leave a record. In single-process launcher mode (the default), the same process later starts Ink — every TUI frame redraw, BSU/ESU sync marker, cursor move, and color code gets duplicated to disk. A normal play session was producing multi-GB ANSI-laden log files (reproduced from `~/Documents/.machine-violet/campaigns/Open Table-2026-05-09T01-56-55/.debug/server.log`).

Adding `&& !process.stdout.isTTY` skips the mirror when a human (or Ink) owns the terminal. Daemon-style headless runs (systemd, Windows Service, nohup-redirected) still get the log because their stdout isn't a TTY.

- Tweak: one extra condition on the `if` guard at [server.ts:47](packages/engine/src/server/server.ts:47).
- Tests: two new cases in [server.test.ts](packages/engine/src/server/server.test.ts) toggling `process.stdout.isTTY` and asserting `process.stdout.write` is wrapped only when not a TTY.

Note: the mirror itself is a hack — Fastify uses pino under the hood, which supports multiple destinations natively via `pino.multistream`. A proper pino transport would be cleaner, but is out of scope for this fix.

## Test plan

- [x] `npm run check` — lint clean, 2426 tests pass
- [x] New unit tests cover both TTY and non-TTY paths
- [ ] Manual: launch `npm run dev`, play a few turns, exit, verify `.debug/server.log` no longer contains `\x1b[` ANSI sequences from TUI redraws (existing on-disk logs won't shrink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)