### PR TITLE
Stop duplicate DM narration deep in long campaigns

### DIFF
--- a/packages/engine/src/agents/agent-loop.test.ts
+++ b/packages/engine/src/agents/agent-loop.test.ts
@@ -227,7 +227,14 @@ describe("agentLoop", () => {
       mockConfig({ provider }),
     );
 
-    expect(result.text).toBe("Let me roll for you... A natural 20!");
+    // Last-non-empty-round-wins: only the final assistant message's text is
+    // returned, mirroring `finalAssistantText` in the game engine and the
+    // conversation history. This was changed from accumulation in PR/commit
+    // for the duplicate-DM bug — Claude re-narrates after deferred TUI
+    // tool_results often enough that accumulation produced verbatim
+    // doubling in long campaigns. See agent-loop-bridge.test.ts for the
+    // round-boundary cases.
+    expect(result.text).toBe("A natural 20!");
   });
 
   it("accumulates usage across rounds", async () => {

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -888,13 +888,13 @@ const TOOL_DEFS: RegisteredTool[] = [
       },
     },
     handler: (_state, input) => {
-      const character = input.character as string;
-      const context = input.context as string;
-      if (!character?.trim()) return err("Character name is required.");
-      if (!context?.trim()) return err("Context is required — describe what changed.");
+      const character = (input.character as string)?.trim();
+      const context = (input.context as string)?.trim();
+      if (!character) return err("Character name is required.");
+      if (!context) return err("Context is required — describe what changed.");
       return {
         content: `Promotion queued for ${character}.`,
-        _tui: { type: "promote_character", character: character.trim(), context: context.trim() },
+        _tui: { type: "promote_character", character, context },
       };
     },
   },

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -893,7 +893,7 @@ const TOOL_DEFS: RegisteredTool[] = [
       if (!character?.trim()) return err("Character name is required.");
       if (!context?.trim()) return err("Context is required — describe what changed.");
       return {
-        content: `Promoting ${character}...`,
+        content: `Promotion queued for ${character}.`,
         _tui: { type: "promote_character", character: character.trim(), context: context.trim() },
       };
     },

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { LLMProvider, ChatResult, NormalizedUsage } from "./types.js";
+import type { LLMProvider, ChatResult, NormalizedUsage, ContentPart } from "./types.js";
 import { runProviderLoop } from "./agent-loop-bridge.js";
 
 function mockUsage(): NormalizedUsage {
@@ -534,6 +534,166 @@ describe("runProviderLoop round-boundary rollback", () => {
     // Nothing leaked from round 1, so a corrective snapshot would be a
     // pointless round-trip — same reasoning as the pre-stream-failure case.
     expect(onRollback).not.toHaveBeenCalled();
+  });
+
+  // Deferred TUI tools (scribe / scene_transition / dm_notes /
+  // promote_character / session_end) execute server-side after the agent
+  // loop returns, so their tool_result is just a queue confirmation. The
+  // bridge appends a uniform "narrative was delivered" signal so the model
+  // doesn't ambiguously interpret the ack and re-narrate.
+  it("appends the narrative-delivered suffix to deferred TUI tool results", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          const r = textPlusToolResult("Some narrative.", "scribe");
+          onDelta(r.text);
+          return r;
+        }
+        // Capture is on round 2's messages — tool_result is in there.
+        const r = textResult("Done.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      tuiToolNames: new Set(["scribe"]),
+      onTextDelta: vi.fn(),
+      toolHandler: () => ({
+        content: "Scribe queued: 2 update(s)",
+        _tui: { type: "scribe", updates: [] },
+      }),
+    });
+
+    const streamCalls = (provider.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const round2Messages = streamCalls[1][0].messages;
+    const toolResultMsg = round2Messages.find(
+      (m: { role: string; content: unknown }) =>
+        m.role === "user" && Array.isArray(m.content),
+    ) as { content: ContentPart[] } | undefined;
+    const toolResultBlock = toolResultMsg?.content.find(
+      (b) => b.type === "tool_result",
+    );
+
+    expect(toolResultBlock).toBeDefined();
+    expect(toolResultBlock?.content).toContain("Scribe queued: 2 update(s)");
+    expect(toolResultBlock?.content).toContain("delivered to the player");
+    expect(toolResultBlock?.content).toContain("End your turn");
+  });
+
+  it("does NOT append the suffix to non-deferred TUI tools", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          // update_modeline is a TUI tool but not in DEFERRED_TUI_TYPES —
+          // it's broadcast immediately and the model often continues
+          // narrating mid-turn, so the "end your turn" signal would
+          // actively mislead.
+          const r = textPlusToolResult("Mid-narrative.", "update_modeline");
+          onDelta(r.text);
+          return r;
+        }
+        const r = textResult("Continued.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      tuiToolNames: new Set(["update_modeline"]),
+      onTextDelta: vi.fn(),
+      toolHandler: () => ({
+        content: "Modeline updated.",
+        _tui: { type: "update_modeline", character: "Adrian", text: "..." },
+      }),
+    });
+
+    const streamCalls = (provider.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const round2Messages = streamCalls[1][0].messages;
+    const toolResultMsg = round2Messages.find(
+      (m: { role: string; content: unknown }) =>
+        m.role === "user" && Array.isArray(m.content),
+    ) as { content: ContentPart[] } | undefined;
+    const toolResultBlock = toolResultMsg?.content.find(
+      (b) => b.type === "tool_result",
+    );
+
+    expect(toolResultBlock).toBeDefined();
+    expect(toolResultBlock?.content).toBe("Modeline updated.");
+    expect(toolResultBlock?.content).not.toContain("delivered to the player");
+  });
+
+  it("does NOT append the suffix when the deferred tool errored", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          const r = textPlusToolResult("", "scribe");
+          return r;
+        }
+        const r = textResult("Recovered.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      tuiToolNames: new Set(["scribe"]),
+      onTextDelta: vi.fn(),
+      toolHandler: () => ({
+        content: "Scribe failed: invalid update",
+        is_error: true,
+        _tui: { type: "scribe", updates: [] },
+      }),
+    });
+
+    const streamCalls = (provider.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const round2Messages = streamCalls[1][0].messages;
+    const toolResultMsg = round2Messages.find(
+      (m: { role: string; content: unknown }) =>
+        m.role === "user" && Array.isArray(m.content),
+    ) as { content: ContentPart[] } | undefined;
+    const toolResultBlock = toolResultMsg?.content.find(
+      (b) => b.type === "tool_result",
+    );
+
+    // Errors stay clean so the model sees the actual failure, not a
+    // diluted version mixed with end-your-turn boilerplate.
+    expect(toolResultBlock).toBeDefined();
+    expect(toolResultBlock?.is_error).toBe(true);
+    expect(toolResultBlock?.content).toBe("Scribe failed: invalid update");
   });
 
   it("fires both per-attempt and inter-round rollbacks when both apply", async () => {

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -16,6 +16,20 @@ function textResult(text: string): ChatResult {
   };
 }
 
+/** A round that emits text alongside a tool_use, prompting another loop iteration. */
+function textPlusToolResult(text: string, toolName: string, toolId = "toolu_1"): ChatResult {
+  const assistantContent: ChatResult["assistantContent"] = [];
+  if (text) assistantContent.push({ type: "text", text });
+  assistantContent.push({ type: "tool_use", id: toolId, name: toolName, input: {} });
+  return {
+    text,
+    toolCalls: [{ id: toolId, name: toolName, input: {} }],
+    usage: mockUsage(),
+    stopReason: "tool_use",
+    assistantContent,
+  };
+}
+
 function apiError(status: number, message = "error"): Error {
   const err = new Error(message);
   (err as unknown as Record<string, unknown>).status = status;
@@ -392,5 +406,183 @@ describe("runProviderLoop retry", () => {
     // Non-streaming responses are emitted as a single onTextDelta on success
     // only. A failed non-streaming attempt has no partial output to roll back.
     expect(onRollback).not.toHaveBeenCalled();
+  });
+});
+
+// Round-boundary handling: when the model emits narrative text alongside a
+// tool call (especially a deferred TUI tool that doesn't broadcast on its
+// own), Claude can re-narrate the same content after the tool_result. The
+// loop must (a) keep result.text aligned with the final assistant message,
+// not the running concatenation, and (b) tell consumers to roll back the
+// streamed deltas from the prior round before the next round's stream
+// begins, so the live UI doesn't show the response twice.
+describe("runProviderLoop round-boundary rollback", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns only the final round's text, not the accumulation", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          // Model speaks, then calls a deferred TUI tool.
+          const r = textPlusToolResult("Round one narrative.", "scribe");
+          onDelta(r.text);
+          return r;
+        }
+        // Model re-narrates after seeing the tool_result.
+        const r = textResult("Round one narrative.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onTextDelta = vi.fn();
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta,
+      toolHandler: () => ({ content: "ok" }),
+    });
+
+    // Without last-round-wins, fullText would be "Round one narrative.Round
+    // one narrative." — the bug from the playtester report.
+    expect(result.text).toBe("Round one narrative.");
+    expect(callCount).toBe(2);
+  });
+
+  it("fires onRollback between rounds when the prior round emitted text", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          const r = textPlusToolResult("Round one text.", "scribe");
+          onDelta(r.text);
+          return r;
+        }
+        const r = textResult("Round two text.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onRollback = vi.fn();
+    const onTextDelta = vi.fn();
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta,
+      onRollback,
+      toolHandler: () => ({ content: "ok" }),
+    });
+
+    expect(result.text).toBe("Round two text.");
+    // Exactly one rollback at the round boundary — clears round-1's "Round
+    // one text." from the client before round 2's deltas arrive.
+    expect(onRollback).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT fire onRollback when the prior round emitted no text", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          // Tool-only round — no narrative text. (The common case: model
+          // calls a tool, gets the result, then narrates.)
+          return textPlusToolResult("", "roll_dice");
+        }
+        const r = textResult("You rolled a 17.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onRollback = vi.fn();
+    const onTextDelta = vi.fn();
+    await runProviderLoop(provider, "system", [
+      { role: "user", content: "Roll" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta,
+      onRollback,
+      toolHandler: () => ({ content: "17" }),
+    });
+
+    // Nothing leaked from round 1, so a corrective snapshot would be a
+    // pointless round-trip — same reasoning as the pre-stream-failure case.
+    expect(onRollback).not.toHaveBeenCalled();
+  });
+
+  it("fires both per-attempt and inter-round rollbacks when both apply", async () => {
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          // Round 1, attempt 1: partial stream then 502 → per-attempt rollback.
+          onDelta("Round one ");
+          throw apiError(502, "Bad gateway");
+        }
+        if (callCount === 2) {
+          // Round 1, attempt 2: success, with text + tool call.
+          const r = textPlusToolResult("Round one narrative.", "scribe");
+          onDelta(r.text);
+          return r;
+        }
+        // Round 2: final narration → triggers inter-round rollback before it streams.
+        const r = textResult("Round two final.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onRollback = vi.fn();
+    const onTextDelta = vi.fn();
+    const promise = runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta,
+      onRollback,
+      toolHandler: () => ({ content: "ok" }),
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result.text).toBe("Round two final.");
+    // One for the failed attempt's partial leak, one for the round-1 → round-2
+    // boundary. Both are necessary: the first protects against retry duplication,
+    // the second against re-narration duplication.
+    expect(onRollback).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -135,6 +135,10 @@ export async function runProviderLoop(
   const tuiCommands: TuiCommand[] = [];
   let fullText = "";
   let truncated = false;
+  // Tracks whether the round we just completed emitted any text deltas.
+  // Used to roll the client back at the boundary into the next round —
+  // see the inter-round rollback comment inside the loop.
+  let priorRoundEmittedText = false;
 
   const workingMessages = [...messages];
   const loopStartIndex = workingMessages.length;
@@ -143,6 +147,19 @@ export async function runProviderLoop(
   const priorAssistantCount = messages.filter((m) => m.role === "assistant").length;
 
   for (let round = 0; round < maxToolRounds; round++) {
+    // Inter-round rollback: when a round emitted narrative text alongside a
+    // tool call (typically a deferred TUI tool like scribe / scene_transition
+    // / dm_notes), Claude often re-narrates the same content in the next
+    // round after seeing the synthetic tool_result. The streamed deltas from
+    // round N are still in the client's narrative log; without a rollback,
+    // round N+1's stream is appended after them and the user sees the same
+    // text twice. Reuse the retry-rollback path so the bridge clears its
+    // delta buffer and the session-manager publishes a corrective snapshot
+    // before round N+1's deltas begin arriving.
+    if (priorRoundEmittedText) {
+      config.onRollback?.();
+    }
+
     const chatParams: ChatParams = {
       model: config.model,
       systemPrompt: effectiveSystem,
@@ -163,6 +180,7 @@ export async function runProviderLoop(
     });
 
     let result: ChatResult;
+    let roundEmittedDeltas: boolean;
     const apiStart = Date.now();
     for (let attempt = 0; ; attempt++) {
       // Per-attempt flag: did this attempt actually stream any text before
@@ -181,6 +199,12 @@ export async function runProviderLoop(
           // In non-streaming mode, emit the full text
           if (result.text) config.onTextDelta?.(result.text);
         }
+        // Successful attempt: capture whether deltas leaked so the
+        // inter-round rollback at the top of the next iteration knows
+        // whether a corrective snapshot is needed. Per-attempt rollbacks
+        // for retries already cleared the failed-attempt streams; this
+        // flag reflects only the surviving (successful) attempt.
+        roundEmittedDeltas = shouldStream ? attemptEmittedDeltas : !!result.text;
         break; // success — exit retry loop
       } catch (apiErr) {
         const status = extractStatus(apiErr);
@@ -255,7 +279,22 @@ export async function runProviderLoop(
       dumpThinking(config.name, priorAssistantCount + round, result.thinkingText);
     }
 
-    fullText += result.text;
+    // Last-non-empty-round-wins: each round with text overwrites prior text.
+    // When the model emits text alongside a tool call and then re-narrates
+    // after the tool_result (Claude does this routinely with deferred TUI
+    // tools, see the inter-round rollback comment above), accumulating across
+    // rounds doubles the response in every downstream sink — display log,
+    // scene transcript, committed narrative, etc. Overwriting keeps
+    // `result.text` consistent with the final assistant message in
+    // `roundMessages`, which is what the conversation history already
+    // collapses to via `finalAssistantText` in game-engine.ts. The non-empty
+    // guard preserves the prior round's text for the unusual case where the
+    // model said its piece alongside a tool call and then end_turn'd in the
+    // next round without further narration.
+    if (result.text) {
+      fullText = result.text;
+    }
+    priorRoundEmittedText = roundEmittedDeltas;
 
     // Process tool calls concurrently. Sync handlers still run sequentially
     // on the JS event loop; async handlers (subagent spawns, search) genuinely

--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -345,11 +345,31 @@ export async function runProviderLoop(
           } catch { /* not a TUI command */ }
         }
 
+        // Deferred TUI tools (scribe, scene_transition, dm_notes,
+        // promote_character, session_end) execute server-side after the
+        // agent loop returns, so their tool_result is just a queue
+        // confirmation. Without an explicit signal that the prior narrative
+        // was already delivered, the model treats the generic ack
+        // ambiguously and frequently re-narrates in the next round —
+        // verbatim or lightly regenerated, but always wasting an inference
+        // call. Append a uniform signal here so tool handlers don't each
+        // have to remember to include it (and so updating the wording is
+        // a one-line change). Skipped on errors so failure messages aren't
+        // diluted, and on non-deferred TUI tools (update_modeline,
+        // set_resource_values, etc.) where the model often continues
+        // narrating mid-turn legitimately.
+        const isDeferred = tui !== undefined
+          && DEFERRED_TUI_TYPES.has(tui.type)
+          && !toolResult.is_error;
+        const content = isDeferred
+          ? `${toolResult.content}\n\n(Your prior narrative has been delivered to the player. End your turn unless you have new narrative to add.)`
+          : toolResult.content;
+
         return {
           result: {
             type: "tool_result",
             tool_use_id: tc.id,
-            content: toolResult.content,
+            content,
             is_error: toolResult.is_error,
           },
           tui,


### PR DESCRIPTION
## Summary

Found via a playtester's diagnostic dump from a deep `Open Table` campaign — DM responses were appearing twice in the rendered transcript. 21 mass-doubled blocks (and many shorter dupes) in [display-log.md](packages/engine/src/context/display-log.ts), all clustered after the conversation cap kicked in around block 95.

Two commits, layered:

- **[23f511b](https://github.com/octopollux/machine-violet/commit/23f511b)** — defensive: stop accumulating `result.text` across tool-using rounds in [agent-loop-bridge.ts](packages/engine/src/providers/agent-loop-bridge.ts). Last-non-empty-round-wins, plus an inter-round `onRollback` that reuses the existing retry-rollback path so the live UI also stops showing duplicates.
- **[8f80e2c](https://github.com/octopollux/machine-violet/commit/8f80e2c)** — root cause: the deferred TUI tools (`scribe` / `scene_transition` / `dm_notes` / `promote_character` / `session_end`) return generic acks like `"Scribe queued: 2 update(s)"`, which the model reads ambiguously deep in context and resolves by re-narrating. Centralized a "narrative was delivered, end your turn" suffix in agent-loop-bridge gated on `DEFERRED_TUI_TYPES && !is_error`, so adding new deferred tools picks it up automatically. Also dropped the trailing `...` on `Promoting <name>...` — reads as "continue from here" and was almost certainly contributing.

The two fixes are complementary: the signal cuts how often duplication happens (saving inference cost — a re-narration is real output tokens); the dedup catches whatever still slips through under context pressure.

## Why this happens

Real inference, not an API artifact. Round 2 is a billed call, the model reads its own round-1 message in context, and chooses to redo. Sometimes verbatim; sometimes a polished pass — the YouTube-channel block in the dump dropped a `[city]` placeholder and a bracket-staring beat in its second emission, which is the giveaway that it's regeneration rather than echoing.

## Test plan

- [x] `npm run check` (lint + 2433 tests, 7 new) clean
- [x] Targeted `vitest run` on agent-loop-bridge + agent-loop confirms last-round-wins, inter-round rollback fires when prior round emitted text, no rollback on tool-only rounds, both rollback paths fire when both apply
- [x] Suffix tests: lands on deferred TUI tools, stays off non-deferred ones, stays off errors
- [ ] Manual: replay a deep campaign and confirm transcript contains no duplicates (best done by playtester since it requires a live API key + long enough run to trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)