### PR TITLE
Render glued horizontal rules; dedup adjacent separators

### DIFF
--- a/packages/client-ink/src/tui/formatting.test.ts
+++ b/packages/client-ink/src/tui/formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseFormatting, toPlainText, stripFormatting, stripLeadingBullet, highlightQuotesWithState, markdownToTags, nodeVisibleLength, wrapNodes, processNarrativeLines, isHorizontalRule } from "./formatting.js";
+import { parseFormatting, toPlainText, stripFormatting, stripLeadingBullet, highlightQuotesWithState, markdownToTags, nodeVisibleLength, wrapNodes, processNarrativeLines, isHorizontalRule, splitTrailingHorizontalRule } from "./formatting.js";
 import type { FormattingTag, FormattingNode, NarrativeLine } from "@machine-violet/shared/types/tui.js";
 
 describe("parseFormatting", () => {
@@ -941,6 +941,180 @@ describe("processNarrativeLines — horizontal rule conversion", () => {
     ], 80);
     // The separator should break the DM line sequence but italic
     // should still heal across because separators don't reset the stack
+    const dmLines = result.filter((l) => l.kind === "dm");
+    const lastDM = dmLines[dmLines.length - 1];
+    const hasItalic = lastDM.nodes.some(
+      (n) => typeof n !== "string" && n.type === "italic",
+    );
+    expect(hasItalic).toBe(true);
+  });
+});
+
+describe("splitTrailingHorizontalRule", () => {
+  it("splits a rule glued to the end of a sentence", () => {
+    expect(splitTrailingHorizontalRule("You drive home.---")).toBe("You drive home.");
+  });
+
+  it("splits with whitespace between text and rule", () => {
+    expect(splitTrailingHorizontalRule("text ---")).toBe("text");
+    expect(splitTrailingHorizontalRule("text   ---")).toBe("text");
+  });
+
+  it("splits trailing asterisks and underscores", () => {
+    expect(splitTrailingHorizontalRule("text***")).toBe("text");
+    expect(splitTrailingHorizontalRule("text___")).toBe("text");
+  });
+
+  it("splits 4+ trailing rule chars", () => {
+    expect(splitTrailingHorizontalRule("text----")).toBe("text");
+    expect(splitTrailingHorizontalRule("text---------")).toBe("text");
+  });
+
+  it("tolerates trailing whitespace after the rule", () => {
+    expect(splitTrailingHorizontalRule("text---   ")).toBe("text");
+  });
+
+  it("returns null when there is no trailing rule", () => {
+    expect(splitTrailingHorizontalRule("plain text")).toBeNull();
+    expect(splitTrailingHorizontalRule("text--")).toBeNull();
+    expect(splitTrailingHorizontalRule("text-")).toBeNull();
+  });
+
+  it("returns null when rule is followed by more text", () => {
+    expect(splitTrailingHorizontalRule("text---more")).toBeNull();
+  });
+
+  it("returns null for a pure horizontal rule line", () => {
+    // The whole-line case is handled by isHorizontalRule, not this helper.
+    expect(splitTrailingHorizontalRule("---")).toBeNull();
+    expect(splitTrailingHorizontalRule("   ---")).toBeNull();
+  });
+});
+
+describe("processNarrativeLines — adjacent separator dedup", () => {
+  const dm = (text: string): NarrativeLine => ({ kind: "dm", text });
+  const sep = (): NarrativeLine => ({ kind: "separator", text: "---" });
+
+  it("collapses two source separators in a row", () => {
+    const result = processNarrativeLines([sep(), sep()], 80);
+    const seps = result.filter((l) => l.kind === "separator");
+    expect(seps).toHaveLength(1);
+  });
+
+  it("collapses a source separator followed by a dm:--- horizontal rule", () => {
+    const result = processNarrativeLines([sep(), dm("---")], 80);
+    const seps = result.filter((l) => l.kind === "separator");
+    expect(seps).toHaveLength(1);
+  });
+
+  it("collapses two dm:--- horizontal rules in a row", () => {
+    const result = processNarrativeLines([dm("---"), dm("---")], 80);
+    const seps = result.filter((l) => l.kind === "separator");
+    expect(seps).toHaveLength(1);
+  });
+
+  it("collapses separators that are only padded apart by an empty dm line", () => {
+    const result = processNarrativeLines([sep(), dm(""), sep()], 80);
+    const seps = result.filter((l) => l.kind === "separator");
+    expect(seps).toHaveLength(1);
+  });
+
+  it("collapses separators that are only padded apart by a spacer", () => {
+    const result = processNarrativeLines([
+      sep(),
+      { kind: "spacer", text: "" },
+      sep(),
+    ], 80);
+    const seps = result.filter((l) => l.kind === "separator");
+    expect(seps).toHaveLength(1);
+  });
+
+  it("does NOT collapse separators with substantive content between them", () => {
+    const result = processNarrativeLines([sep(), dm("middle text"), sep()], 80);
+    const seps = result.filter((l) => l.kind === "separator");
+    expect(seps).toHaveLength(2);
+  });
+
+  it("post-resume duplicate: injected separator + chunk-leading dm:--- collapses to one", () => {
+    // Mirrors the shape produced when the client receives a DM chunk that
+    // starts with the disk separator marker (resume replay): the chunk-arrival
+    // path injects a separator before the player's reply, then appendDelta
+    // splits "---\ntext\n\n---" into a leading dm:"---" — both become
+    // separators in Phase 0, so without dedup the rendering shows two
+    // adjacent horizontal rules between every player turn and DM response.
+    const result = processNarrativeLines([
+      dm("---"),
+      { kind: "player", text: "[Adrian] action" },
+      sep(),                  // injected by handleNarrativeChunk
+      dm("---"),              // first split-part of the chunk text
+      { kind: "spacer", text: "" },
+      dm("Some narration."),
+      dm(""),
+      dm("---"),              // leading rule of the next turn from same chunk
+    ], 80);
+    const kinds = result.map((l) => l.kind);
+    // Expected per turn: separator (lead), player, separator (between),
+    // dm content, dm:"" paragraph break, separator (lead of next turn).
+    // No two separators in a row.
+    for (let i = 1; i < kinds.length; i++) {
+      const prev = kinds[i - 1];
+      const cur = kinds[i];
+      // Adjacent separators are forbidden.
+      expect(prev === "separator" && cur === "separator").toBe(false);
+    }
+    // And there should be exactly three separators in total.
+    expect(kinds.filter((k) => k === "separator")).toHaveLength(3);
+  });
+});
+
+describe("processNarrativeLines — trailing horizontal rule split", () => {
+  const dm = (text: string): NarrativeLine => ({ kind: "dm", text });
+
+  it("splits 'text.---' into a DM line plus a separator", () => {
+    const result = processNarrativeLines(
+      [dm("You drive home with the laptop bag on the passenger seat.---")],
+      80,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].kind).toBe("dm");
+    expect(toPlainText(result[0].nodes)).toBe(
+      "You drive home with the laptop bag on the passenger seat.",
+    );
+    expect(result[1].kind).toBe("separator");
+  });
+
+  it("splits 'text ---' (with space) into DM line plus separator", () => {
+    const result = processNarrativeLines([dm("Some narration ---")], 80);
+    expect(result).toHaveLength(2);
+    expect(toPlainText(result[0].nodes)).toBe("Some narration");
+    expect(result[1].kind).toBe("separator");
+  });
+
+  it("preserves DM lines around an inline trailing rule", () => {
+    const result = processNarrativeLines([
+      dm("Before."),
+      dm("End of scene.---"),
+      dm("After."),
+    ], 80);
+    expect(result).toHaveLength(4);
+    expect(toPlainText(result[0].nodes)).toBe("Before.");
+    expect(toPlainText(result[1].nodes)).toBe("End of scene.");
+    expect(result[2].kind).toBe("separator");
+    expect(toPlainText(result[3].nodes)).toBe("After.");
+  });
+
+  it("does not split lines that merely contain dashes", () => {
+    const result = processNarrativeLines([dm("a-b-c")], 80);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("dm");
+    expect(toPlainText(result[0].nodes)).toBe("a-b-c");
+  });
+
+  it("preserves cross-line healing across an inline trailing rule", () => {
+    const result = processNarrativeLines([
+      dm("<i>still italic.---"),
+      dm("more italic</i>"),
+    ], 80);
     const dmLines = result.filter((l) => l.kind === "dm");
     const lastDM = dmLines[dmLines.length - 1];
     const hasItalic = lastDM.nodes.some(

--- a/packages/client-ink/src/tui/formatting.test.ts
+++ b/packages/client-ink/src/tui/formatting.test.ts
@@ -988,6 +988,14 @@ describe("splitTrailingHorizontalRule", () => {
     // The whole-line case is handled by isHorizontalRule, not this helper.
     expect(splitTrailingHorizontalRule("---")).toBeNull();
     expect(splitTrailingHorizontalRule("   ---")).toBeNull();
+    // Without the isHorizontalRule guard, the lazy prefix would eat the
+    // first `-` and return "-" for these — bogus.
+    expect(splitTrailingHorizontalRule("----")).toBeNull();
+    expect(splitTrailingHorizontalRule("----------")).toBeNull();
+    expect(splitTrailingHorizontalRule("***")).toBeNull();
+    expect(splitTrailingHorizontalRule("****")).toBeNull();
+    expect(splitTrailingHorizontalRule("- - -")).toBeNull();
+    expect(splitTrailingHorizontalRule("   ----")).toBeNull();
   });
 });
 

--- a/packages/client-ink/src/tui/formatting.ts
+++ b/packages/client-ink/src/tui/formatting.ts
@@ -229,8 +229,14 @@ export function isHorizontalRule(text: string): boolean {
  * (e.g. "You drive home.---"), return the prefix text. Returns null when
  * no trailing rule is present. The rule must be 3+ adjacent identical
  * chars (-, *, _); whitespace between the prefix and rule is permitted.
+ *
+ * Returns null for whole-line rules — those are the caller's job to
+ * detect via isHorizontalRule(). Without this guard, an input like
+ * "----" would match with the lazy prefix consuming the first `-`,
+ * producing "-" as the bogus prefix.
  */
 export function splitTrailingHorizontalRule(text: string): string | null {
+  if (isHorizontalRule(text)) return null;
   const m = text.match(/^(.*?\S)\s*([-*_])\2{2,}\s*$/);
   return m ? m[1] : null;
 }

--- a/packages/client-ink/src/tui/formatting.ts
+++ b/packages/client-ink/src/tui/formatting.ts
@@ -225,6 +225,17 @@ export function isHorizontalRule(text: string): boolean {
 }
 
 /**
+ * If a DM line ends with a horizontal rule glued to narrative text
+ * (e.g. "You drive home.---"), return the prefix text. Returns null when
+ * no trailing rule is present. The rule must be 3+ adjacent identical
+ * chars (-, *, _); whitespace between the prefix and rule is permitted.
+ */
+export function splitTrailingHorizontalRule(text: string): string | null {
+  const m = text.match(/^(.*?\S)\s*([-*_])\2{2,}\s*$/);
+  return m ? m[1] : null;
+}
+
+/**
  * Unified processing pipeline for NarrativeLines.
  * Heal → parse → wrap → pad alignment → quote highlight.
  * Returns ProcessedLine[] ready for direct rendering.
@@ -236,18 +247,31 @@ export function processNarrativeLines(
 ): ProcessedLine[] {
   // Phase 0: Split inline <center> and <right> blocks onto their own lines.
   // The rendering pipeline expects these to be the sole content of a line.
-  // Also converts DM horizontal rules (---, ***, ___) into separator lines.
+  // Also converts DM horizontal rules (---, ***, ___) into separator lines,
+  // including rules glued to the end of a narrative line ("text.---").
+  // Adjacent separators (with only spacer/empty-dm padding between) collapse
+  // to one — multiple sources can emit a separator for the same turn boundary
+  // (e.g. on session resume, the disk's "---" markers are streamed as DM
+  // chunks AND the client injects a separator before the first DM chunk
+  // after a player line).
   const expandedLines: NarrativeLine[] = [];
   for (const srcLine of lines) {
     if (srcLine.kind === "dm" && srcLine.text.trim() !== "") {
       if (isHorizontalRule(srcLine.text)) {
-        expandedLines.push({ kind: "separator", text: "" });
+        pushSeparator(expandedLines);
       } else {
-        const split = splitAlignmentBlocks(srcLine.text);
+        const trailingPrefix = splitTrailingHorizontalRule(srcLine.text);
+        const text = trailingPrefix ?? srcLine.text;
+        const split = splitAlignmentBlocks(text);
         for (const part of split) {
           expandedLines.push({ kind: "dm", text: part });
         }
+        if (trailingPrefix !== null) {
+          pushSeparator(expandedLines);
+        }
       }
+    } else if (srcLine.kind === "separator") {
+      pushSeparator(expandedLines, srcLine);
     } else {
       expandedLines.push(srcLine);
     }
@@ -401,6 +425,24 @@ function splitAlignmentBlocks(text: string): string[] {
     if (trimmed) result.push(trimmed);
   }
   return result.length > 0 ? result : [text];
+}
+
+/**
+ * Append a separator line, collapsing against an immediately-prior separator
+ * (skipping `spacer` and empty-dm padding between them). Pass the original
+ * source line when the separator came from a NarrativeLine of `kind: "separator"`
+ * so its text/tag are preserved; omit it when the separator was synthesized
+ * from a horizontal rule conversion.
+ */
+function pushSeparator(lines: NarrativeLine[], source?: NarrativeLine): void {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (line.kind === "spacer") continue;
+    if (line.kind === "dm" && line.text === "") continue;
+    if (line.kind === "separator") return;
+    break;
+  }
+  lines.push(source && source.kind === "separator" ? source : { kind: "separator", text: "" });
 }
 
 function isAlignmentNode(nodes: FormattingNode[]): boolean {


### PR DESCRIPTION
## Summary

Two narrative-rendering fixes in the same `processNarrativeLines` Phase 0 expansion:

- **Glued horizontal rules** — A DM line ending with `Some text.---` (no newline before the rule) now splits into a normal narrative line plus a separator, so the rule renders as the intended horizontal divider instead of literal trailing dashes.

- **Duplicate separators after player turns** — On session resume, the engine groups consecutive same-kind disk lines into chunks; a DM group ends up carrying both the `---` between player and DM AND the leading `---` of the next turn (chunk text like `"---\ntext\n\n---"`). The client then injects its own separator before the first DM chunk after a player line, while `appendDelta` splits the chunk text and Phase 0 converts the leading `dm:"---"` into another separator right next to it. Result: every resumed turn rendered with two horizontal rules between player input and DM response. All separator pushes now route through a `pushSeparator` helper that walks back through `spacer`/empty-`dm` padding and bails if the previous meaningful line is already a separator. Defensive — collapses any path that produces adjacent separators, not just the resume case.

## Test plan

- [x] `npm run check` (lint + 2446 tests passing)
- [ ] Resume the `open-table` campaign and confirm only one horizontal rule between each player turn and DM response in scrollback
- [ ] Submit a DM-style message ending in `text.---` and confirm it renders as text + horizontal rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)