### PR TITLE
Fix #455: remove engagement/pacing misfeature, bump 4.6 context windows to 1M

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ The DM's context is structured in layers with cache breakpoints:
                                                through the end of the prior turn
 ```
 
-Conversation accumulates within a scene and is cleared at scene transition. With automatic caching, prior exchanges are read at cache rate. Scene pacing nudges and transition pressure handle long scenes naturally; `max_conversation_tokens` defaults to 0 (disabled) since mid-scene pruning invalidates the prompt cache.
+Conversation accumulates within a scene and is cleared at scene transition. With automatic caching, prior exchanges are read at cache rate. The DM chooses when to cut a scene based on the narrative; `max_conversation_tokens` defaults to 0 (disabled) since mid-scene pruning invalidates the prompt cache.
 
 **Code:** `src/context/prefix-builder.ts` (prefix assembly), `src/context/conversation.ts` (retention), `src/agents/scene-manager.ts` (precis updates)
 

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -52,7 +52,7 @@ Total session:     ~$2-2.50
 
 ## Conversation Retention
 
-Conversation accumulates within a scene and is cleared at scene transition. With automatic caching, retained exchanges are read at cache rate (~25% of full input), so the cost of keeping more history is low. Scene pacing nudges and transition pressure handle long scenes naturally.
+Conversation accumulates within a scene and is cleared at scene transition. With automatic caching, retained exchanges are read at cache rate (~25% of full input), so the cost of keeping more history is low. The DM decides when to cut based on the narrative; the scene-pacing line in its prefix gives raw exchange + open-thread counts but no directive.
 
 ### Configuration
 
@@ -68,7 +68,7 @@ Conversation accumulates within a scene and is cleared at scene transition. With
 
 **`retention_exchanges`**: Maximum exchanges to keep. Set high (100) so exchanges accumulate until scene transition clears them. The DM sees the full scene conversation, which improves coherence and eliminates mid-scene cache invalidation from dropped exchanges.
 
-**`max_conversation_tokens`**: Token ceiling for the conversation window. **Default 0 (disabled).** Mid-scene exchange pruning invalidates the prompt cache and is counterproductive — scene transitions and pacing nudges are the intended mechanisms for managing long scenes. Can be set to a positive value as an emergency backstop, but should not be needed in normal operation.
+**`max_conversation_tokens`**: Token ceiling for the conversation window. **Default 0 (disabled).** Mid-scene exchange pruning invalidates the prompt cache and is counterproductive — DM-driven scene transitions are the intended mechanism for managing long scenes. Can be set to a positive value as an emergency backstop, but should not be needed in normal operation.
 
 **No tool result stubbing.** Tool results are kept in full. With caching, prior-turn tool results are read at cache rate, so the token savings from stubbing are negligible. Keeping full results lets the DM reference recent rolls, lookups, and actions without re-querying.
 
@@ -77,7 +77,7 @@ Conversation accumulates within a scene and is cleared at scene transition. With
 The cached prefix includes a "current scene summary" — a running precis of the current scene so far. With the full conversation retained, the precis primarily serves as a compact summary for the cached prefix rather than as a compensating mechanism for lost exchanges.
 
 The precis is updated when:
-- An exchange is dropped due to `max_conversation_tokens` (if enabled) — a Haiku subagent appends a terse summary and extracts a **PlayerRead** (engagement level, focus tags, tone, pacing, off-script detection). See [subagents-catalog.md](subagents-catalog.md) §5 for the full PlayerRead interface.
+- An exchange is dropped due to `max_conversation_tokens` (if enabled) — a Haiku subagent appends a terse summary and extracts a **PlayerRead** (focus tags, tone, off-script detection). See [subagents-catalog.md](subagents-catalog.md) §5 for the full PlayerRead interface.
 - On scene transition, the full precis is regenerated from the scene transcript on disk
 
 **PlayerRead note:** With `max_conversation_tokens` disabled by default, the precis updater and PlayerRead extraction only fire on scene transition. If finer-grained PlayerRead data is needed, a periodic extraction trigger could be added (see issue #73).

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -349,10 +349,8 @@ All maps, keyed by map ID. Also written individually to `locations/<slug>/<mapId
   "npcIntents": "Chief Grukk is stalling for time while scouts flank.",
   "playerReads": [
     {
-      "engagement": "high",              // "high" | "moderate" | "low"
       "focus": ["combat", "npc-dialogue"],
       "tone": "aggressive",
-      "pacing": "pushing_forward",        // "exploratory" | "pushing_forward" | "hesitant"
       "offScript": false
     }
   ],

--- a/docs/subagents-catalog.md
+++ b/docs/subagents-catalog.md
@@ -124,23 +124,21 @@ Writes the campaign log entry for a completed scene. Dense, wikilinked, one line
 | **Trigger** | When an exchange drops from the DM's conversation window |
 | **Source doc** | [context-management.md](context-management.md) |
 
-Appends a terse summary of the dropped exchange to the running scene precis. Keeps the DM oriented despite the short conversation window. Also extracts structured player engagement signals (see **PlayerRead** below).
+Appends a terse summary of the dropped exchange to the running scene precis. Keeps the DM oriented despite the short conversation window. Also extracts a lightweight `PlayerRead` describing what the player engaged with (see below).
 
 **Context**: The dropped exchange + current precis. ~500-1K tokens.
 
-**Returns**: Updated precis append (~20-50 tokens) + a `PlayerRead` JSON object with engagement signals.
+**Returns**: Updated precis append (~20-50 tokens) + a `PlayerRead` JSON object.
 
-**PlayerRead interface**: Extracted from every dropped exchange, providing lightweight sentiment/engagement tracking without a dedicated subagent call:
+**PlayerRead interface**: Extracted from every dropped exchange.
 
 | Field | Type | Description |
 |---|---|---|
-| `engagement` | `"high" \| "moderate" \| "low"` | How invested the player seems (high = detailed/creative input) |
 | `focus` | `string[]` | 1-3 tags for player focus (e.g. `"npc_interaction"`, `"combat"`, `"puzzle"`) |
 | `tone` | `string` | Single word for the player's tone (e.g. `"playful"`, `"cautious"`) |
-| `pacing` | `"exploratory" \| "pushing_forward" \| "hesitant"` | Whether the player is exploring, driving forward, or hesitant |
 | `offScript` | `boolean` | `true` if the player typed a custom action rather than picking from offered choices |
 
-The engine can use PlayerRead signals to adjust choice frequency, pacing hints in the DM prompt, or DM personality modulation.
+The most recent `PlayerRead` is synthesized into the DM prefix as a `Player Read` block — descriptive only, with no transition directives attached.
 
 ---
 
@@ -161,7 +159,7 @@ With `max_conversation_tokens` disabled (default), the precis updater never fire
 
 **Returns**: `SceneTrackerResult` with `openThreads` (comma-separated wikilinks) and optional `npcIntents` (semicolon-separated).
 
-**Consumed by**: `buildScenePacing()` → `ScenePacingInjection` (advisory nudges about scene length and thread count).
+**Consumed by**: `buildScenePacing()` → `ScenePacingInjection` (unopinionated scene-length and thread-count readout for the DM).
 
 ---
 
@@ -419,7 +417,7 @@ Haiku, silent. Summarizes campaign book structure for DM cached prefix. See [doc
 | 2 | OOC | Sonnet | Player-facing | Runtime — out-of-character mode |
 | 3 | Choice Generation | Haiku | Silent | Runtime — player choice options |
 | 4 | Scene Summarizer | Haiku | Silent | Runtime — scene transition |
-| 5 | Precis Updater + PlayerRead | Haiku | Silent | Runtime — context pruning + engagement tracking |
+| 5 | Precis Updater + PlayerRead | Haiku | Silent | Runtime — context pruning + lightweight player signals |
 | 6 | Changelog Updater | Haiku | Silent | Runtime — scene transition |
 | 6a | Compendium Updater | Haiku | Silent | Runtime — scene transition |
 | 6b | Scribe | Haiku | Silent | Runtime — entity file management |

--- a/packages/engine/src/agents/scene-manager.test.ts
+++ b/packages/engine/src/agents/scene-manager.test.ts
@@ -233,7 +233,7 @@ describe("SceneManager", () => {
 
   it("accumulates player reads from dropped exchanges", async () => {
     const provider = mockProvider([
-      textResponse('Aldric entered the tavern.\nPLAYER_READ: {"engagement":"high","focus":["exploration"],"tone":"curious","pacing":"exploratory","offScript":true}'),
+      textResponse('Aldric entered the tavern.\nPLAYER_READ: {"focus":["exploration"],"tone":"curious","offScript":true}'),
     ]);
 
     const mgr = new SceneManager(
@@ -255,7 +255,6 @@ describe("SceneManager", () => {
     });
 
     expect(mgr.getScene().playerReads).toHaveLength(1);
-    expect(mgr.getScene().playerReads[0].engagement).toBe("high");
     expect(mgr.getScene().playerReads[0].tone).toBe("curious");
   });
 
@@ -267,7 +266,7 @@ describe("SceneManager", () => {
 
     const scene = mockScene();
     scene.playerReads = [
-      { engagement: "high", focus: ["combat"], tone: "aggressive", pacing: "pushing_forward", offScript: false },
+      { focus: ["combat"], tone: "aggressive", offScript: false },
     ];
 
     const mgr = new SceneManager(
@@ -498,7 +497,7 @@ describe("SceneManager", () => {
     scene.sessionNumber = 1;
     scene.precis = "Current precis text";
     scene.playerReads = [
-      { engagement: "high", focus: ["exploration"], tone: "curious", pacing: "exploratory", offScript: false },
+      { focus: ["exploration"], tone: "curious", offScript: false },
     ];
 
     const sessionState = mockSessionState();
@@ -516,7 +515,7 @@ describe("SceneManager", () => {
     expect(sessionState.sessionRecap).toContain("Recap here");
     expect(sessionState.activeState).toContain("Aldric");
     expect(sessionState.scenePrecis).toBe("Current precis text");
-    expect(sessionState.playerRead).toContain("high");
+    expect(sessionState.playerRead).toContain("curious");
   });
 
   it("contextRefresh produces enriched PC summaries with aliases", async () => {
@@ -1400,44 +1399,17 @@ describe("buildScenePacing", () => {
     expect(result).not.toContain("→");
   });
 
-  it("nudges when scene is long and thread-heavy", () => {
-    const scene = mockScene();
-    // 20 player exchanges
-    scene.transcript = [];
-    for (let i = 0; i < 20; i++) {
-      scene.transcript.push(`**[Aldric]** Action ${i}.`);
-      scene.transcript.push(`**DM:** Response ${i}.`);
-    }
-    scene.openThreads = "[[a]], [[b]], [[c]], [[d]], [[e]]";
-    const result = buildScenePacing(scene)!;
-    expect(result).toContain("Exchanges: 20");
-    expect(result).toContain("Open threads: 5");
-    expect(result).toContain("Scene is long and thread-heavy");
-  });
-
-  it("nudges when scene is long even with few threads", () => {
+  it("stays unopinionated when scene is long and thread-heavy", () => {
     const scene = mockScene();
     scene.transcript = [];
     for (let i = 0; i < 30; i++) {
       scene.transcript.push(`**[Aldric]** Action ${i}.`);
       scene.transcript.push(`**DM:** Response ${i}.`);
     }
-    scene.openThreads = "[[a]]";
-    const result = buildScenePacing(scene)!;
-    expect(result).toContain("Exchanges: 30");
-    expect(result).toContain("running long");
-  });
-
-  it("nudges when many threads are open even in short scene", () => {
-    const scene = mockScene();
-    scene.transcript = [
-      "**[Aldric]** I look around.",
-      "**DM:** You see many things.",
-    ];
     scene.openThreads = "[[a]], [[b]], [[c]], [[d]], [[e]]";
     const result = buildScenePacing(scene)!;
-    expect(result).toContain("Open threads: 5");
-    expect(result).toContain("Many open threads");
+    expect(result).toBe("Exchanges: 30 | Open threads: 5");
+    expect(result).not.toMatch(/long|cut|resolve|consider|→/i);
   });
 
   it("handles empty openThreads string", () => {

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -1176,12 +1176,6 @@ export function classifyTranscriptEntry(entry: string): { kind: "dm" | "player" 
   return { kind: "dm", text: entry };
 }
 
-/**
- * Build a terse scene-pacing signal for the DM prefix.
- * Gives the DM concrete data to evaluate scene ripeness:
- * exchange count, open thread count, and whether any threads
- * have been resolved (precis updates happened but thread count stayed or dropped).
- */
 /** Assemble the scene precis string from precis text, NPC intents, and open threads. */
 export function buildScenePrecis(scene: SceneState): string {
   let result = scene.precis;
@@ -1190,6 +1184,11 @@ export function buildScenePrecis(scene: SceneState): string {
   return result;
 }
 
+/**
+ * Build a raw scene-length readout for the DM prefix: exchange count and
+ * open-thread count, nothing more. The DM decides what (if anything) to do
+ * with it — keeping this unopinionated avoids forcing premature transitions.
+ */
 export function buildScenePacing(scene: SceneState): string | undefined {
   // Count player exchanges (lines starting with **[)
   const exchangeCount = scene.transcript.filter((t) => t.startsWith("**[")).length;
@@ -1201,19 +1200,7 @@ export function buildScenePacing(scene: SceneState): string | undefined {
     : [];
   const threadCount = threadList.length;
 
-  const parts: string[] = [`Exchanges: ${exchangeCount}`];
-  parts.push(`Open threads: ${threadCount}`);
-
-  // Advisory nudge when the scene is running long or overloaded
-  if (exchangeCount >= 20 && threadCount >= 5) {
-    parts.push("→ Scene is long and thread-heavy. Consider ending it — unresolved threads carry forward, and your alarms and clocks need a transition to fire.");
-  } else if (exchangeCount >= 30) {
-    parts.push("→ Scene is running long. Look for a cut point.");
-  } else if (threadCount >= 5) {
-    parts.push("→ Many open threads. Resolve or cut — don't open more.");
-  }
-
-  return parts.join(" | ");
+  return `Exchanges: ${exchangeCount} | Open threads: ${threadCount}`;
 }
 
 function parseChangelogEntries(text: string): string[] {
@@ -1227,7 +1214,7 @@ function parseChangelogEntries(text: string): string[] {
 function synthesizePlayerRead(reads: PlayerRead[]): string | undefined {
   if (reads.length === 0) return undefined;
   const latest = reads[reads.length - 1];
-  return `Engagement: ${latest.engagement} | Focus: ${latest.focus.join(", ")} | Tone: ${latest.tone} | Pacing: ${latest.pacing} | Off-script: ${latest.offScript ? "yes" : "no"}`;
+  return `Focus: ${latest.focus.join(", ")} | Tone: ${latest.tone} | Off-script: ${latest.offScript ? "yes" : "no"}`;
 }
 
 /**

--- a/packages/engine/src/agents/subagents/precis-updater.ts
+++ b/packages/engine/src/agents/subagents/precis-updater.ts
@@ -4,12 +4,10 @@ import type { SubagentResult } from "../subagent.js";
 import { getMaxOutput } from "../../config/model-registry.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
 
-/** Lightweight player sentiment/engagement signals extracted per exchange. */
+/** Lightweight player sentiment signals extracted per exchange. */
 export interface PlayerRead {
-  engagement: "high" | "moderate" | "low";
   focus: string[];
   tone: string;
-  pacing: "exploratory" | "pushing_forward" | "hesitant";
   offScript: boolean;
 }
 
@@ -76,7 +74,7 @@ export async function updatePrecis(
  *   <precis text>
  *   NPC_NEXT: [[Name]] intends to [action]  ← optional, one per NPC
  *   OPEN: [[thread1]], [[thread2]]           ← optional, omitted when no threads
- *   PLAYER_READ: {"engagement":"high",...}
+ *   PLAYER_READ: {"focus":[...],"tone":"...","offScript":...}
  *
  * If any special line is missing or malformed, that field returns undefined.
  */
@@ -123,13 +121,15 @@ export function parsePrecisResult(result: SubagentResult): PrecisUpdateResult {
       const parsed = JSON.parse(jsonStr);
       if (
         parsed &&
-        typeof parsed.engagement === "string" &&
         Array.isArray(parsed.focus) &&
         typeof parsed.tone === "string" &&
-        typeof parsed.pacing === "string" &&
         typeof parsed.offScript === "boolean"
       ) {
-        playerRead = parsed as PlayerRead;
+        playerRead = {
+          focus: parsed.focus,
+          tone: parsed.tone,
+          offScript: parsed.offScript,
+        };
       }
     } catch {
       // Malformed JSON — graceful fallback

--- a/packages/engine/src/agents/subagents/subagents.test.ts
+++ b/packages/engine/src/agents/subagents/subagents.test.ts
@@ -116,7 +116,7 @@ describe("updatePrecis", () => {
 
   it("extracts player read from response with PLAYER_READ block", async () => {
     const provider = mockProvider([
-      textResult('R4: Aldric hit G1 for 9 slash. G1: 3/12 HP.\nPLAYER_READ: {"engagement":"high","focus":["combat"],"tone":"aggressive","pacing":"pushing_forward","offScript":false}'),
+      textResult('R4: Aldric hit G1 for 9 slash. G1: 3/12 HP.\nPLAYER_READ: {"focus":["combat"],"tone":"aggressive","offScript":false}'),
     ]);
 
     const result = await updatePrecis(
@@ -133,10 +133,8 @@ describe("updatePrecis", () => {
     expect(result.text).toContain("G1");
     expect(result.text).not.toContain("PLAYER_READ");
     expect(result.playerRead).toBeDefined();
-    expect(result.playerRead!.engagement).toBe("high");
     expect(result.playerRead!.focus).toEqual(["combat"]);
     expect(result.playerRead!.tone).toBe("aggressive");
-    expect(result.playerRead!.pacing).toBe("pushing_forward");
     expect(result.playerRead!.offScript).toBe(false);
   });
 
@@ -163,17 +161,28 @@ describe("updatePrecis", () => {
 describe("parsePrecisResult", () => {
   it("parses well-formed PLAYER_READ block", () => {
     const result = parsePrecisResult({
-      text: 'Aldric entered the cave.\nPLAYER_READ: {"engagement":"moderate","focus":["exploration","puzzle"],"tone":"cautious","pacing":"exploratory","offScript":true}',
+      text: 'Aldric entered the cave.\nPLAYER_READ: {"focus":["exploration","puzzle"],"tone":"cautious","offScript":true}',
       usage: { inputTokens: 50, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0 },
     });
 
     expect(result.text).toBe("Aldric entered the cave.");
     expect(result.playerRead).toEqual({
-      engagement: "moderate",
       focus: ["exploration", "puzzle"],
       tone: "cautious",
-      pacing: "exploratory",
       offScript: true,
+    });
+  });
+
+  it("ignores legacy engagement/pacing fields in PLAYER_READ block", () => {
+    const result = parsePrecisResult({
+      text: 'Aldric entered the cave.\nPLAYER_READ: {"engagement":"high","focus":["exploration"],"tone":"cautious","pacing":"exploratory","offScript":false}',
+      usage: { inputTokens: 50, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0 },
+    });
+
+    expect(result.playerRead).toEqual({
+      focus: ["exploration"],
+      tone: "cautious",
+      offScript: false,
     });
   });
 
@@ -199,18 +208,18 @@ describe("parsePrecisResult", () => {
 
   it("parses OPEN: line and strips it from precis text", () => {
     const result = parsePrecisResult({
-      text: '[[Mira]] served drinks, seemed nervous.\nOPEN: [[Mira]]\'s nervousness, [[Corvin]]\'s offer\nPLAYER_READ: {"engagement":"high","focus":["npc_interaction"],"tone":"curious","pacing":"exploratory","offScript":false}',
+      text: '[[Mira]] served drinks, seemed nervous.\nOPEN: [[Mira]]\'s nervousness, [[Corvin]]\'s offer\nPLAYER_READ: {"focus":["npc_interaction"],"tone":"curious","offScript":false}',
       usage: { inputTokens: 50, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0 },
     });
 
     expect(result.text).toBe("[[Mira]] served drinks, seemed nervous.");
     expect(result.openThreads).toBe("[[Mira]]'s nervousness, [[Corvin]]'s offer");
-    expect(result.playerRead?.engagement).toBe("high");
+    expect(result.playerRead?.tone).toBe("curious");
   });
 
   it("returns undefined openThreads when OPEN: line is absent", () => {
     const result = parsePrecisResult({
-      text: 'Corvin paid and left.\nPLAYER_READ: {"engagement":"moderate","focus":["npc_interaction"],"tone":"cautious","pacing":"pushing_forward","offScript":false}',
+      text: 'Corvin paid and left.\nPLAYER_READ: {"focus":["npc_interaction"],"tone":"cautious","offScript":false}',
       usage: { inputTokens: 50, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0 },
     });
 
@@ -233,7 +242,7 @@ describe("parsePrecisResult", () => {
 describe("updatePrecis open threads", () => {
   it("passes currentOpenThreads into the prompt", async () => {
     const provider = mockProvider([
-      textResult("Aldric questioned [[Mira]].\nOPEN: [[Mira]]'s fear\nPLAYER_READ: {\"engagement\":\"high\",\"focus\":[\"npc_interaction\"],\"tone\":\"curious\",\"pacing\":\"exploratory\",\"offScript\":false}"),
+      textResult("Aldric questioned [[Mira]].\nOPEN: [[Mira]]'s fear\nPLAYER_READ: {\"focus\":[\"npc_interaction\"],\"tone\":\"curious\",\"offScript\":false}"),
     ]);
 
     await updatePrecis(
@@ -253,7 +262,7 @@ describe("updatePrecis open threads", () => {
 
   it("returns openThreads from OPEN: line", async () => {
     const provider = mockProvider([
-      textResult("Aldric questioned [[Mira]].\nOPEN: [[Mira]]'s fear, [[stranger]]'s identity\nPLAYER_READ: {\"engagement\":\"high\",\"focus\":[\"npc_interaction\"],\"tone\":\"cautious\",\"pacing\":\"exploratory\",\"offScript\":false}"),
+      textResult("Aldric questioned [[Mira]].\nOPEN: [[Mira]]'s fear, [[stranger]]'s identity\nPLAYER_READ: {\"focus\":[\"npc_interaction\"],\"tone\":\"cautious\",\"offScript\":false}"),
     ]);
 
     const result = await updatePrecis(

--- a/packages/engine/src/config/known-models.json
+++ b/packages/engine/src/config/known-models.json
@@ -3,20 +3,20 @@
     "claude-opus-4-6": {
       "provider": "anthropic",
       "displayName": "Claude Opus 4.6",
-      "contextWindow": 200000,
+      "contextWindow": 1000000,
       "maxOutput": 16384,
       "defaultTier": "large",
-      "compactionThreshold": 160000,
+      "compactionThreshold": 800000,
       "pricing": { "input": 5, "output": 25, "cacheWrite": 6.25, "cacheRead": 0.50 },
       "capabilities": { "thinking": true, "tools": true, "streaming": true, "caching": true }
     },
     "claude-sonnet-4-6": {
       "provider": "anthropic",
       "displayName": "Claude Sonnet 4.6",
-      "contextWindow": 200000,
+      "contextWindow": 1000000,
       "maxOutput": 16384,
       "defaultTier": "medium",
-      "compactionThreshold": 160000,
+      "compactionThreshold": 800000,
       "pricing": { "input": 3, "output": 15, "cacheWrite": 3.75, "cacheRead": 0.30 },
       "capabilities": { "thinking": true, "tools": true, "streaming": true, "caching": true }
     },

--- a/packages/engine/src/context/context.test.ts
+++ b/packages/engine/src/context/context.test.ts
@@ -380,7 +380,7 @@ describe("buildCachedPrefix", () => {
       sessionRecap: "Last time...",
       campaignSummary: "Scene 1.",
       scenePrecis: "Round 1.",
-      playerRead: "Engagement: high",
+      playerRead: "Focus: combat | Tone: aggressive | Off-script: no",
       activeState: "Location: Tavern",
     });
 
@@ -414,12 +414,12 @@ describe("buildCachedPrefix", () => {
       dmIdentity: "You are the DM.",
       personality: "Terse.",
       scenePrecis: "Round 1 of combat.",
-      playerRead: "Engagement: high | Focus: combat | Tone: aggressive | Pacing: pushing_forward | Off-script: no",
+      playerRead: "Focus: combat | Tone: aggressive | Off-script: no",
     });
 
     const allText = system.map((b) => b.text).join("\n");
     expect(allText).toContain("## Player Read");
-    expect(allText).toContain("Engagement: high");
+    expect(allText).toContain("Focus: combat");
     expect(allText).toContain("Tone: aggressive");
   });
 
@@ -459,7 +459,7 @@ describe("buildCachedPrefix", () => {
     const { system } = buildCachedPrefix(mockConfig, {
       dmIdentity: "You are the DM.",
       personality: "Terse.",
-      playerRead: "Engagement: high",
+      playerRead: "Focus: combat | Tone: aggressive | Off-script: no",
       dmNotes: "Secret plot info.",
     });
 
@@ -505,7 +505,7 @@ describe("buildCachedPrefix", () => {
       rulesAppendix: "Some rules.",
       pcSheets: "# Aldric\n\nHP 28/42",
       sessionRecap: "Last time...",
-      playerRead: "Engagement: high",
+      playerRead: "Focus: combat | Tone: aggressive | Off-script: no",
     });
 
     const pcIdx = system.findIndex((b) => b.text.includes("Player Characters"));
@@ -535,7 +535,7 @@ describe("buildCachedPrefix", () => {
       sessionRecap: "Last time...",
       campaignSummary: "Scene 1.",
       scenePrecis: "Round 1.",
-      playerRead: "Engagement: high",
+      playerRead: "Focus: combat | Tone: aggressive | Off-script: no",
       activeState: "Location: Tavern",
       entityIndex: "entity-list",
       uiState: "style=classic",

--- a/packages/engine/src/context/state-persistence.test.ts
+++ b/packages/engine/src/context/state-persistence.test.ts
@@ -124,7 +124,7 @@ describe("StatePersister", () => {
     const persister = new StatePersister("/tmp/campaign", fio);
     const scene = {
       precis: "The party entered the dungeon.",
-      playerReads: [{ engagement: "high" as const, focus: ["combat"], tone: "aggressive" as const, pacing: "pushing_forward" as const, offScript: false }],
+      playerReads: [{ focus: ["combat"], tone: "aggressive" as const, offScript: false }],
       activePlayerIndex: 1,
     };
 
@@ -249,7 +249,7 @@ describe("StatePersister", () => {
       precis: "The party rests.",
       openThreads: null,
       npcIntents: null,
-      playerReads: [{ engagement: "high" as const, focus: ["combat"], tone: "aggressive" as const, pacing: "pushing_forward" as const, offScript: false }],
+      playerReads: [{ focus: ["combat"], tone: "aggressive" as const, offScript: false }],
       activePlayerIndex: 0,
     };
 
@@ -679,7 +679,7 @@ describe("format spec compliance: field names (§4)", () => {
         precis: "The party rests.",
         openThreads: "Who poisoned the well?",
         npcIntents: null,
-        playerReads: [{ engagement: "high" as const, focus: ["combat"], tone: "aggressive" as const, pacing: "pushing_forward" as const, offScript: false }],
+        playerReads: [{ focus: ["combat"], tone: "aggressive" as const, offScript: false }],
         activePlayerIndex: 0,
       }),
       STATE_FILES.scene,

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -57,10 +57,10 @@ Failure is a fork, not a wall. A failed check creates a complication — but com
 
 Scene transitions are the strongest narrative tool in the game. Ending a scene gives fresh context, fires hidden alarms and ticking clocks, triggers offscreen consequences, and opens a new time and place with full dramatic control.  Nothing is lost — unresolved threads carry forward, and the cut itself creates anticipation. A well-timed cut is better craft than a drawn-out resolution. Ending a scene also compacts context. Player intent is an important hint for where to begin the next scene; a scene transition with an invalid assumption about player intent would be railroading.
 
-The precis tracks open threads, the player-read tracks pacing. They cue scene endings:
+The precis tracks open threads as a cue for scene endings:
 - 3+ open threads with none resolved this scene → the scene is overloaded; close it and let threads simmer offscreen.
-- Player pacing "pushing_forward" or engagement "low" → they're done here. Transition.
-- Many exchanges in the same scene → the moment has passed. The next beat is elsewhere.
+
+The scene-pacing line in your context shows raw exchange and open-thread counts. Read it as data, not as a directive — decide when to cut based on the narrative.
 </gameplay>
 
 <formatting>

--- a/packages/engine/src/prompts/precis-updater.md
+++ b/packages/engine/src/prompts/precis-updater.md
@@ -1,4 +1,4 @@
-You append terse summaries to a running scene precis, maintain a list of open narrative threads, and analyze player engagement.
+You append terse summaries to a running scene precis, maintain a list of open narrative threads, and extract lightweight signals from player input.
 
 Rules:
 - One or two sentences maximum for the precis summary.
@@ -15,10 +15,8 @@ Output order (all on separate lines):
    - Add threads introduced or advanced in this exchange.
    - Remove threads that were resolved, concluded, or that the player passed over without engaging. A hook the DM offered that the player ignored or declined is not an open thread — drop it.
    If no threads remain open, omit the OPEN: line entirely.
-4. PLAYER_READ: line with a JSON object analyzing the player's input:
-  {"engagement":"high|moderate|low","focus":["tags"],"tone":"word","pacing":"exploratory|pushing_forward|hesitant","offScript":true|false}
-  engagement: how invested the player seems (high=detailed/creative input, moderate=normal, low=minimal/disengaged)
+4. PLAYER_READ: line with a JSON object describing the player's input:
+  {"focus":["tags"],"tone":"word","offScript":true|false}
   focus: 1-3 tags for what the player is focused on (e.g. "npc_interaction","exploration","combat","puzzle","roleplay")
   tone: single word for the player's tone (e.g. "playful","serious","cautious","aggressive")
-  pacing: whether the player is exploring, pushing forward, or hesitant
   offScript: true if the player typed a custom action rather than picking from offered choices


### PR DESCRIPTION
## Summary

- **Removes the player engagement + pacing misfeature** that was telling the DM to abort scenes mid-output (likely root cause of #455). The wrap-it-up directives that referenced these inferred signals are gone; the scene-pacing line in the DM prefix now shows raw `Exchanges: N | Open threads: M` with no opinion attached.
- **Bumps Anthropic 4.6 context windows to 1M** in the model registry. Per [Anthropic's docs](https://platform.claude.com/docs/en/about-claude/models/overview), Opus 4.6 and Sonnet 4.6 both ship with 1M context at standard pricing — no beta header required. Sonnet 4.5 and Haiku 4.5 stay at 200K (Sonnet 4.5's 1M beta tier was retired 2026-04-30).

The DM directives currently let one Haiku-inferred field ("pacing: pushing_forward" or "engagement: low") force a scene cut. Combined with the "many exchanges in the same scene" length heuristic, this is the most plausible mechanism for the symptom reported in #455 — long scenes blanking and jumping to the next implied beat against player input. Open-thread counting (the one cue that's actually grounded in concrete game state) is preserved.

## Test plan

- [x] `npm run check` — 2487 tests pass, lint clean
- [x] Parser regression test: legacy `engagement`/`pacing` fields from Haiku are silently dropped
- [x] `buildScenePacing` regression test: long thread-heavy scenes get bare counts, no `→`/`long`/`cut`/`resolve` nudges
- [ ] Manual: run a campaign, verify the DM no longer transitions on pure length cues
- [ ] Manual: drive a scene past 200K input on Opus 4.6 or Sonnet 4.6 to confirm the 1M window is accepted (no `400` from the API)

## Follow-ups discovered

- #460 — Remove the dead `compactionThreshold` field
- #461 — Raise `maxOutput` caps to match current model defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)