### PR TITLE
Exclude server.log from /diagnostics bundles

### DIFF
--- a/docs/error-recovery.md
+++ b/docs/error-recovery.md
@@ -82,11 +82,12 @@ The `/retry` command retries the last DM turn at any time — useful for recover
 
 ### `/diagnostics` slash command
 
-The `/diagnostics` command bundles the current campaign folder together with the top-level `.debug/` (engine.jsonl, server.log, context dumps) into a single zip and reveals it in the OS file explorer:
+The `/diagnostics` command bundles the current campaign folder together with the top-level `.debug/` (engine.jsonl, context dumps) into a single zip and reveals it in the OS file explorer:
 
 - Output path: `<homeDir>/diagnostics/<campaign-name>-<timestamp>.mvdiag` (a zip with a Machine Violet-specific extension — any zip tool can still read it).
 - The bundle includes a `manifest.json` at the root with the collection timestamp, campaign name, platform, and Node version.
 - Per-campaign `.debug/` is captured as part of the campaign walk; the top-level `.debug/` is added under a `.debug/` prefix in the archive.
+- The top-level `.debug/server.log` (mirrored stdout/stderr) is excluded — it's noisy and rarely useful for triage compared with `engine.jsonl`.
 - Reveal-in-folder uses platform-specific commands (`explorer /select,` on Windows, `open -R` on macOS, `xdg-open <parent>` on Linux). The system message in the chat always prints the absolute path as a fallback when reveal is unavailable or silently fails.
 
 Use this when sending a triage bundle for a bug report.

--- a/packages/engine/src/server/diagnostics.test.ts
+++ b/packages/engine/src/server/diagnostics.test.ts
@@ -115,8 +115,9 @@ describe("collectDiagnostics", () => {
 
     // Top-level .debug content prefixed with .debug/
     expect(keys).toContain(".debug/engine.jsonl");
-    expect(keys).toContain(".debug/server.log");
     expect(keys).toContain(".debug/context/dump-1.txt");
+    // server.log is intentionally excluded (noisy stdout/stderr mirror).
+    expect(keys).not.toContain(".debug/server.log");
 
     // Manifest is present, with safe-to-share metadata only
     expect(keys).toContain("manifest.json");

--- a/packages/engine/src/server/diagnostics.ts
+++ b/packages/engine/src/server/diagnostics.ts
@@ -2,9 +2,12 @@
  * Diagnostic bundle collection.
  *
  * Zips the active campaign folder together with the top-level `.debug/`
- * folder (engine.jsonl, server.log, context dumps) into a single archive
- * for triage. The campaign's own per-campaign `.debug/` is captured as
- * part of the campaign walk.
+ * folder (engine.jsonl, context dumps) into a single archive for triage.
+ * The campaign's own per-campaign `.debug/` is captured as part of the
+ * campaign walk.
+ *
+ * `server.log` (mirrored stdout/stderr) is intentionally excluded — it's
+ * noisy and rarely useful for triage compared with `engine.jsonl`.
  *
  * Output: `<homeDir>/diagnostics/<campaignSlug>-<timestamp>.mvdiag`
  * (a zip file with a Machine Violet-specific extension for easy
@@ -33,6 +36,8 @@ const DEBUG_DIR = ".debug";
 const BUNDLE_EXT = "mvdiag";
 /** Directory names skipped during the recursive walk (heavy / not useful for triage). */
 const SKIP_DIRS = new Set([".git"]);
+/** File names (relative to the top-level `.debug/`) excluded from the bundle. */
+const SKIP_TOP_LEVEL_DEBUG_FILES = new Set(["server.log"]);
 
 /** Sanitize a name for use as a filename component. */
 function sanitizeFilename(name: string): string {
@@ -107,7 +112,7 @@ function buildManifest(args: {
  *  - The current campaign folder (under `campaign/`) — captures per-campaign
  *    `.debug/`, state, config, characters. The campaign's `.git/` is skipped.
  *  - The top-level `.debug/` folder (under `.debug/`) — engine.jsonl,
- *    server.log, top-level context dumps.
+ *    top-level context dumps. `server.log` is excluded.
  *  - A `manifest.json` at the root of the archive.
  *
  * The bundle is written to `<homeDir>/diagnostics/<campaignSlug>-<ts>.mvdiag`.
@@ -133,6 +138,7 @@ export async function collectDiagnostics(
     if (await io.exists(debugRoot)) {
       const debugFiles = await walkForDiagnostics(io, debugRoot, "");
       for (const f of debugFiles) {
+        if (SKIP_TOP_LEVEL_DEBUG_FILES.has(f.relativePath)) continue;
         fileMap[`${DEBUG_DIR}/${f.relativePath}`] = f.content;
       }
     }


### PR DESCRIPTION
## Summary
- Skip `.debug/server.log` (mirrored stdout/stderr) when collecting a `/diagnostics` bundle — it's noisy and rarely useful next to `engine.jsonl`.
- Implemented as a `SKIP_TOP_LEVEL_DEBUG_FILES` set in the top-level `.debug/` walk so we can extend it later if needed.
- Updated header comment, diagnostics test, and `docs/error-recovery.md` to match.

## Test plan
- [x] `npx vitest run packages/engine/src/server/diagnostics.test.ts` — 6/6 pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)