### PR TITLE
Show version and release date in Settings (fixes #427)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Build distribution
         shell: bash
         run: |
-          node scripts/build-dist.js --version="${{ needs.prepare.outputs.nightly_version }}"
+          RELEASE_DATE="$(date -u +'%Y-%m-%d %H:%M')"
+          node scripts/build-dist.js --version="${{ needs.prepare.outputs.nightly_version }}" --release-date="$RELEASE_DATE"
 
       - name: Bundle Windows Terminal portable
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           TAG="${{ inputs.tag || github.ref_name }}"
           VERSION="${TAG#v}"
-          node scripts/build-dist.js --version="$VERSION"
+          RELEASE_DATE="$(date -u +'%Y-%m-%d %H:%M')"
+          node scripts/build-dist.js --version="$VERSION" --release-date="$RELEASE_DATE"
 
       - name: Bundle Windows Terminal portable
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -41,7 +41,8 @@ jobs:
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          node scripts/build-dist.js --version="${VERSION}-test"
+          RELEASE_DATE="$(date -u +'%Y-%m-%d %H:%M')"
+          node scripts/build-dist.js --version="${VERSION}-test" --release-date="$RELEASE_DATE"
 
       - name: Bundle Windows Terminal portable
         shell: bash
@@ -112,7 +113,8 @@ jobs:
       - name: Build distribution
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          node scripts/build-dist.js --version="${VERSION}-test"
+          RELEASE_DATE="$(date -u +'%Y-%m-%d %H:%M')"
+          node scripts/build-dist.js --version="${VERSION}-test" --release-date="$RELEASE_DATE"
 
       - name: Package
         run: tar -czf machine-violet-test-darwin-arm64.tar.gz -C dist .
@@ -142,7 +144,8 @@ jobs:
       - name: Build distribution
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          node scripts/build-dist.js --version="${VERSION}-test"
+          RELEASE_DATE="$(date -u +'%Y-%m-%d %H:%M')"
+          node scripts/build-dist.js --version="${VERSION}-test" --release-date="$RELEASE_DATE"
 
       - name: Package
         run: tar -czf machine-violet-test-linux-x64.tar.gz -C dist .

--- a/packages/client-ink/src/phases/SettingsPhase.test.tsx
+++ b/packages/client-ink/src/phases/SettingsPhase.test.tsx
@@ -4,6 +4,7 @@ import { render } from "ink-testing-library";
 import { SettingsPhase } from "./SettingsPhase.js";
 import type { SettingsPhaseProps } from "./SettingsPhase.js";
 import { resetThemeCache, resolveTheme, BUILTIN_DEFINITIONS } from "../tui/themes/index.js";
+import { APP_VERSION } from "../version.js";
 
 beforeEach(() => {
   resetThemeCache();
@@ -61,8 +62,9 @@ describe("SettingsPhase", () => {
   });
 
   it("renders a version label pinned to the bottom-left", () => {
-    // In tests, MV_VERSION is unset so APP_VERSION falls back to "dev".
+    // Read APP_VERSION at runtime so the test is robust to whatever
+    // MV_VERSION/MV_RELEASE_DATE the environment happens to have set.
     const { lastFrame } = render(<SettingsPhase {...defaultProps()} />);
-    expect(lastFrame()).toContain("vdev");
+    expect(lastFrame()).toContain(`v${APP_VERSION}`);
   });
 });

--- a/packages/client-ink/src/phases/SettingsPhase.test.tsx
+++ b/packages/client-ink/src/phases/SettingsPhase.test.tsx
@@ -59,4 +59,10 @@ describe("SettingsPhase", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(onApiKeys).toHaveBeenCalled();
   });
+
+  it("renders a version label pinned to the bottom-left", () => {
+    // In tests, MV_VERSION is unset so APP_VERSION falls back to "dev".
+    const { lastFrame } = render(<SettingsPhase {...defaultProps()} />);
+    expect(lastFrame()).toContain("vdev");
+  });
 });

--- a/packages/client-ink/src/phases/SettingsPhase.tsx
+++ b/packages/client-ink/src/phases/SettingsPhase.tsx
@@ -4,6 +4,7 @@ import type { ResolvedTheme } from "../tui/themes/types.js";
 import { TerminalTooSmall, FullScreenFrame } from "../tui/components/index.js";
 import { MIN_COLUMNS, MIN_ROWS } from "../tui/responsive.js";
 import { themeColor } from "../tui/themes/color-resolve.js";
+import { APP_VERSION, RELEASE_DATE } from "../version.js";
 
 const noop = () => { /* no-op */ };
 
@@ -105,8 +106,19 @@ export function SettingsPhase({
     );
   }
 
+  const versionLabel = RELEASE_DATE
+    ? `v${APP_VERSION} · released ${RELEASE_DATE} UTC`
+    : `v${APP_VERSION}`;
+
   return (
-    <FullScreenFrame theme={theme} columns={cols} rows={termRows} title="Settings" contentRows={menuLines.length}>
+    <FullScreenFrame
+      theme={theme}
+      columns={cols}
+      rows={termRows}
+      title="Settings"
+      contentRows={menuLines.length}
+      bottomLeft={<Text color={dimColor}>{versionLabel}</Text>}
+    >
       {menuLines}
     </FullScreenFrame>
   );

--- a/packages/client-ink/src/tui/components/FullScreenFrame.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.tsx
@@ -15,6 +15,12 @@ export interface FullScreenFrameProps {
   contentRows: number;
   /** Enable an animated starfield in the padding areas around content. */
   starfield?: boolean | StarfieldConfig;
+  /**
+   * Optional one-row content pinned to the bottom-left of the frame (just above
+   * the bottom border). Consumes one row from the bottom padding; does not
+   * affect the vertical centering of the main children.
+   */
+  bottomLeft?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -30,6 +36,7 @@ export function FullScreenFrame({
   title,
   contentRows,
   starfield,
+  bottomLeft,
   children,
 }: FullScreenFrameProps) {
   const sideWidth = theme.asset.components.edge_left.width;
@@ -39,7 +46,11 @@ export function FullScreenFrame({
   const contentHeight = rows - borderHeight * 2;
 
   const topPad = Math.max(0, Math.floor((contentHeight - contentRows) / 2));
-  const bottomPad = Math.max(0, contentHeight - contentRows - topPad);
+  const rawBottomPad = Math.max(0, contentHeight - contentRows - topPad);
+  // Pinned bottom-left row eats one row from the bottom padding so it doesn't
+  // disturb the vertical centering of the main children.
+  const hasBottomLeft = bottomLeft != null && rawBottomPad >= 1;
+  const bottomPad = hasBottomLeft ? rawBottomPad - 1 : rawBottomPad;
 
   const sfEnabled = !!starfield;
   const sfConfig: StarfieldConfig = {
@@ -76,6 +87,12 @@ export function FullScreenFrame({
             sfEnabled
               ? <StarfieldRows grid={grid} startRow={topPad + contentRows} rowCount={bottomPad} />
               : <Box height={bottomPad} />
+          )}
+
+          {hasBottomLeft && (
+            <Box width={contentWidth} justifyContent="flex-start">
+              {bottomLeft}
+            </Box>
           )}
         </Box>
         <ThemedSideFrame theme={theme} side="right" height={contentHeight} />

--- a/packages/client-ink/src/tui/components/FullScreenFrame.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.tsx
@@ -18,7 +18,12 @@ export interface FullScreenFrameProps {
   /**
    * Optional one-row content pinned to the bottom-left of the frame (just above
    * the bottom border). Consumes one row from the bottom padding; does not
-   * affect the vertical centering of the main children.
+   * affect the vertical centering of the main children. Content is clipped to
+   * a single row to keep the layout stable.
+   *
+   * Note: not currently composited with starfield — when both are enabled, the
+   * slot row appears as a non-animated stripe within the otherwise-animated
+   * padding. Add starfield-aware rendering here when a caller needs both.
    */
   bottomLeft?: React.ReactNode;
   children: React.ReactNode;
@@ -90,7 +95,12 @@ export function FullScreenFrame({
           )}
 
           {hasBottomLeft && (
-            <Box width={contentWidth} justifyContent="flex-start">
+            <Box
+              width={contentWidth}
+              height={1}
+              overflow="hidden"
+              justifyContent="flex-start"
+            >
               {bottomLeft}
             </Box>
           )}

--- a/packages/client-ink/src/version.ts
+++ b/packages/client-ink/src/version.ts
@@ -1,0 +1,15 @@
+/**
+ * Build-time version constants.
+ *
+ * Injected by scripts/build-dist.js via esbuild `define`. In dev (no bundling),
+ * these env vars are unset and we fall back to "dev" / null.
+ */
+
+export const APP_VERSION: string =
+  (typeof process.env.MV_VERSION === "string" && process.env.MV_VERSION) || "dev";
+
+/** UTC release timestamp baked at build time, e.g. "2026-04-13 18:32". Null in dev. */
+export const RELEASE_DATE: string | null =
+  typeof process.env.MV_RELEASE_DATE === "string" && process.env.MV_RELEASE_DATE
+    ? process.env.MV_RELEASE_DATE
+    : null;

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -10,8 +10,9 @@
  * (--build-sea breaks Velopack/Authenticode signing).
  *
  * Usage:
- *   node scripts/build-dist.js                          # build for current platform
- *   node scripts/build-dist.js --version=1.0.0-nightly  # override version
+ *   node scripts/build-dist.js                                       # build for current platform
+ *   node scripts/build-dist.js --version=1.0.0-nightly               # override version
+ *   node scripts/build-dist.js --release-date="2026-04-13 18:32"     # bake release date (UTC, minute precision)
  */
 
 import { build } from "esbuild";
@@ -38,6 +39,11 @@ const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
 const versionArg = process.argv.find((a) => a.startsWith("--version="));
 const version = versionArg ? versionArg.split("=")[1] : pkg.version;
 
+// Release date is baked in at build time so the Settings screen can show
+// "released YYYY-MM-DD HH:MM UTC" — empty string in local dev builds.
+const releaseDateArg = process.argv.find((a) => a.startsWith("--release-date="));
+const releaseDate = releaseDateArg ? releaseDateArg.split("=").slice(1).join("=") : "";
+
 const isWindows = process.platform === "win32";
 const exeName = isWindows ? "MachineViolet.exe" : "MachineViolet";
 const exePath = join(DIST, exeName);
@@ -61,6 +67,7 @@ await build({
   external: ["node:*"],
   define: {
     "process.env.MV_VERSION": JSON.stringify(version),
+    "process.env.MV_RELEASE_DATE": JSON.stringify(releaseDate),
   },
   banner: {
     js: [
@@ -208,7 +215,10 @@ if (existsSync(licensePath)) {
 }
 
 // Version file
-writeFileSync(join(DIST, "version.json"), JSON.stringify({ version }, null, 2));
+writeFileSync(
+  join(DIST, "version.json"),
+  JSON.stringify({ version, releaseDate: releaseDate || null }, null, 2),
+);
 
 console.log(`\nDone! Distribution in ${DIST}/`);
 console.log(`  Binary: ${exeName} (${(statSync(exePath).size / 1024 / 1024).toFixed(1)} MB)`);


### PR DESCRIPTION
## Summary
- Adds a small dim version line to the bottom-left of the Settings screen: `v1.0.1 · released 2026-04-13 18:32 UTC`. Dev builds show just `vdev`.
- Release date is baked at build time (UTC, minute precision) via a new `--release-date` flag on `scripts/build-dist.js`, exposed through esbuild `define` as `process.env.MV_RELEASE_DATE`.
- `FullScreenFrame` gains an optional `bottomLeft` slot that takes one row from the bottom padding without disturbing the centered content. Additive only — no other callers affected.

## CI changes
All five `build-dist.js` invocations now pass `--release-date="$(date -u +'%Y-%m-%d %H:%M')"`:
- `.github/workflows/release.yml`
- `.github/workflows/nightly.yml`
- `.github/workflows/test-build.yml` (Windows, macOS, Linux jobs)

The build runs minutes before `gh release create` publishes, so build-time and publish-time agree at minute precision — exactly what players need to confirm an update landed.

Closes #427.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 2488 passing (added one assertion for the version label)
- [ ] Trigger `test-build` workflow on this PR (touches build script + CI)
- [ ] Manually verify in a built binary that Settings shows the expected `vX · released YYYY-MM-DD HH:MM UTC` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)