### PR TITLE
Use last player message as git auto-commit body

### DIFF
--- a/docs/error-recovery.md
+++ b/docs/error-recovery.md
@@ -10,7 +10,7 @@ The campaign directory is all markdown and JSON — a perfect fit for version co
 
 | Event | Commit | Rationale |
 |---|---|---|
-| Every N exchanges (configurable, default 3) | `auto: exchanges 45-47` | Frequent recovery points during play |
+| Every N exchanges (configurable, default 3) | `auto: I draw my sword and charge the troll.` (the player's last message, single-line and truncated to 72 chars; falls back to `auto: exchanges` for synthetic system turns) | Frequent recovery points during play, browsable as a savestate log |
 | Scene transition | `scene: Escape from the Goblin Caves` | Natural checkpoint |
 | Session end | `session: end session 3` | Clean save point |
 | Before destructive operations | `checkpoint: before scene_transition` | Safety net for cascades |

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -760,7 +760,7 @@ The campaign directory contains a local git repository managed by isomorphic-git
 
 | Type | Message format | Trigger |
 |---|---|---|
-| `auto` | `auto: exchanges 45-47` | Every N exchanges (configurable) |
+| `auto` | `auto: I draw my sword and charge the troll.` (player's last message, single-line, truncated to 72 chars; `auto: exchanges` for synthetic system turns) | Every N exchanges (configurable) |
 | `scene` | `scene: Escape from the Goblin Caves` | Scene transition checkpoint |
 | `session` | `session: end session 3` | Session end |
 | `character` | `character: Marta Voss promoted` | Character promotion/update |

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -595,8 +595,9 @@ export class GameEngine {
       await this.sceneManager.flushTranscript();
 
       // Track exchange for git auto-commit. Use the raw player message as the
-      // commit body so the savestate log is browsable; synthetic system turns
-      // (skipTranscript: session open/resume) fall back to the generic label.
+      // commit subject so the savestate log is browsable; synthetic system
+      // turns (skipTranscript: session open/resume) fall back to the generic
+      // label.
       await this.repo?.trackExchange(opts?.skipTranscript ? undefined : text);
 
       // Run scene tracker periodically to maintain open threads / NPC intents

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -594,8 +594,10 @@ export class GameEngine {
       // during scene transitions, leaving it stale during normal play.
       await this.sceneManager.flushTranscript();
 
-      // Track exchange for git auto-commit
-      await this.repo?.trackExchange();
+      // Track exchange for git auto-commit. Use the raw player message as the
+      // commit body so the savestate log is browsable; synthetic system turns
+      // (skipTranscript: session open/resume) fall back to the generic label.
+      await this.repo?.trackExchange(opts?.skipTranscript ? undefined : text);
 
       // Run scene tracker periodically to maintain open threads / NPC intents
       if (!opts?.skipTranscript) {

--- a/packages/engine/src/tools/git/campaign-repo.ts
+++ b/packages/engine/src/tools/git/campaign-repo.ts
@@ -135,14 +135,19 @@ export class CampaignRepo {
   /**
    * Track an exchange. Triggers auto-commit when interval is reached.
    * Returns the commit oid if a commit was made, null otherwise.
+   *
+   * `playerMessage` (when provided) becomes the commit body so the log reads
+   * like a savestate browser. The `auto:` prefix stays so commit-type parsing
+   * and `exchanges_ago:N` rollback continue to work.
    */
-  async trackExchange(): Promise<string | null> {
+  async trackExchange(playerMessage?: string): Promise<string | null> {
     if (!this.enabled) return null;
     await this.ensureInit();
     this.exchangeCount++;
     if (this.exchangeCount >= this.autoCommitInterval) {
       this.exchangeCount = 0;
-      return this.autoCommit(`auto: exchanges`);
+      const body = playerMessageToCommitBody(playerMessage);
+      return this.autoCommit(`auto: ${body}`);
     }
     return null;
   }
@@ -288,6 +293,20 @@ export class CampaignRepo {
 }
 
 // --- Helpers ---
+
+/**
+ * Pure local string op (no LLM): collapse the player message to a single line
+ * and truncate so it fits a commit subject. Empty/missing input falls back to
+ * "exchanges" so synthetic system turns (session open/resume) don't leak into
+ * the log.
+ */
+function playerMessageToCommitBody(text: string | undefined): string {
+  if (!text) return "exchanges";
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  if (cleaned.length === 0) return "exchanges";
+  const MAX = 72;
+  return cleaned.length <= MAX ? cleaned : cleaned.slice(0, MAX - 1) + "…";
+}
 
 function parseCommitType(message: string): CommitType {
   if (message.startsWith("scene:")) return "scene";

--- a/packages/engine/src/tools/git/campaign-repo.ts
+++ b/packages/engine/src/tools/git/campaign-repo.ts
@@ -136,9 +136,9 @@ export class CampaignRepo {
    * Track an exchange. Triggers auto-commit when interval is reached.
    * Returns the commit oid if a commit was made, null otherwise.
    *
-   * `playerMessage` (when provided) becomes the commit body so the log reads
-   * like a savestate browser. The `auto:` prefix stays so commit-type parsing
-   * and `exchanges_ago:N` rollback continue to work.
+   * `playerMessage` (when provided) becomes the commit subject so the log
+   * reads like a savestate browser. The `auto:` prefix stays so commit-type
+   * parsing and `exchanges_ago:N` rollback continue to work.
    */
   async trackExchange(playerMessage?: string): Promise<string | null> {
     if (!this.enabled) return null;
@@ -146,8 +146,8 @@ export class CampaignRepo {
     this.exchangeCount++;
     if (this.exchangeCount >= this.autoCommitInterval) {
       this.exchangeCount = 0;
-      const body = playerMessageToCommitBody(playerMessage);
-      return this.autoCommit(`auto: ${body}`);
+      const subject = playerMessageToCommitSubject(playerMessage);
+      return this.autoCommit(`auto: ${subject}`);
     }
     return null;
   }
@@ -295,14 +295,17 @@ export class CampaignRepo {
 // --- Helpers ---
 
 /**
- * Pure local string op (no LLM): collapse the player message to a single line
- * and truncate so it fits a commit subject. Empty/missing input falls back to
- * "exchanges" so synthetic system turns (session open/resume) don't leak into
- * the log.
+ * Pure local string op (no LLM): sanitize a player message into a single-line
+ * commit subject. Strips C0/C1 control chars + DEL (so ANSI escapes pasted
+ * from a terminal can't mangle `git log` output), collapses remaining
+ * whitespace, and truncates. Empty/missing input falls back to "exchanges"
+ * so synthetic system turns (session open/resume) don't leak into the log.
  */
-function playerMessageToCommitBody(text: string | undefined): string {
+function playerMessageToCommitSubject(text: string | undefined): string {
   if (!text) return "exchanges";
-  const cleaned = text.replace(/\s+/g, " ").trim();
+  // eslint-disable-next-line no-control-regex -- stripping these is the point
+  const stripped = text.replace(/[\x00-\x1F\x7F-\x9F]/g, " ");
+  const cleaned = stripped.replace(/\s+/g, " ").trim();
   if (cleaned.length === 0) return "exchanges";
   const MAX = 72;
   return cleaned.length <= MAX ? cleaned : cleaned.slice(0, MAX - 1) + "…";

--- a/packages/engine/src/tools/git/git.test.ts
+++ b/packages/engine/src/tools/git/git.test.ts
@@ -186,6 +186,19 @@ describe("CampaignRepo", () => {
     expect(msg.includes("\n")).toBe(false);
   });
 
+  it("strips C0/C1 control chars and DEL from player messages", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git, autoCommitInterval: 1 });
+
+    // ESC[31m red, BEL, NULL, DEL, U+0085 NEL — none should reach the log.
+    await repo.trackExchange("hello \x1b[31mworld\x1b[0m\x07\x00 next\x7f line\u0085done");
+
+    const msg = git.commits[0].message;
+    expect(msg).toBe("auto: hello [31mworld [0m next line done");
+    // eslint-disable-next-line no-control-regex -- assertion intentionally checks for control chars
+    expect(/[\x00-\x1F\x7F-\x9F]/.test(msg)).toBe(false);
+  });
+
   it("falls back to 'auto: exchanges' for an empty/whitespace player message", async () => {
     const git = mockGitIO();
     const repo = new CampaignRepo({ dir: "/tmp/campaign", git, autoCommitInterval: 1 });

--- a/packages/engine/src/tools/git/git.test.ts
+++ b/packages/engine/src/tools/git/git.test.ts
@@ -152,9 +152,46 @@ describe("CampaignRepo", () => {
     expect(await repo.trackExchange()).toBeNull();
     expect(await repo.trackExchange()).toBeNull();
 
-    // Third exchange triggers auto-commit
+    // Third exchange triggers auto-commit; with no player message it falls
+    // back to the generic label.
     const oid = await repo.trackExchange();
     expect(oid).toBeTruthy();
+    expect(git.commits[0].message).toBe("auto: exchanges");
+  });
+
+  it("uses the player message as the auto-commit body when provided", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git, autoCommitInterval: 1 });
+
+    await repo.trackExchange("I draw my sword and charge the troll.");
+
+    // Repo.init() lays down "auto: initial state" as commit[1]; the exchange
+    // commit lands at the head.
+    expect(git.commits[0].message).toBe("auto: I draw my sword and charge the troll.");
+  });
+
+  it("collapses whitespace and truncates long player messages", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git, autoCommitInterval: 1 });
+
+    const long = "  I peer\ninto  the  abyss " + "and ".repeat(40) + "wait.";
+    await repo.trackExchange(long);
+
+    const msg = git.commits[0].message;
+    expect(msg.startsWith("auto: I peer into the abyss and ")).toBe(true);
+    // Body (after "auto: " prefix) capped at 72 chars and ellipsized
+    expect(msg.length).toBeLessThanOrEqual("auto: ".length + 72);
+    expect(msg.endsWith("…")).toBe(true);
+    // No raw newlines leaked through
+    expect(msg.includes("\n")).toBe(false);
+  });
+
+  it("falls back to 'auto: exchanges' for an empty/whitespace player message", async () => {
+    const git = mockGitIO();
+    const repo = new CampaignRepo({ dir: "/tmp/campaign", git, autoCommitInterval: 1 });
+
+    await repo.trackExchange("   \n\t  ");
+
     expect(git.commits[0].message).toBe("auto: exchanges");
   });
 


### PR DESCRIPTION
## Summary
- `trackExchange()` now accepts the raw player text and uses it (single-line, whitespace-collapsed, truncated to 72 chars with ellipsis) as the auto-commit body, so the campaign git log reads like a savestate browser.
- The `auto:` prefix is preserved so commit-type parsing and `exchanges_ago:N` rollback keep working unchanged.
- Synthetic system turns (`skipTranscript`: session open/resume) fall back to the existing `auto: exchanges` label so internal instructions don't leak into the log.
- Pure local string op — no LLM call per commit.

Before / after example:
```
- auto: exchanges
- auto: exchanges
+ auto: I draw my sword and charge the troll.
+ auto: Ask the innkeeper about the missing caravan.
  scene: Escape from the Goblin Caves
```

## Test plan
- [x] `npx vitest run packages/engine/src/tools/git/git.test.ts` — 36 tests pass (3 new: provided message, whitespace+truncation, empty fallback)
- [x] `npm run typecheck` and `npm run lint` clean
- [ ] Manual: play a few turns in `npm run dev`, inspect `git log` inside the campaign dir, confirm subjects are the player's actual messages and `exchanges_ago:N` rollback still resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)