### PR TITLE
Make API retries indefinite, add Esc to dismiss the retry modal

### DIFF
--- a/docs/error-recovery.md
+++ b/docs/error-recovery.md
@@ -60,6 +60,8 @@ Retry with exponential backoff (1s, 2s, 4s, 8s, capped at 12s) **indefinitely** 
 
 Retryable statuses: 429, 500, 502, 503, 529, plus synthetic status 0 for connection-level errors. No state has changed — the API call didn't complete — so there's nothing to roll back.
 
+The retry modal can be dismissed with **Esc** so the player can open the pause menu and Save & Exit instead of waiting for the connection. Dismissal is scoped to the current retry attempt — the next failed attempt brings the modal back automatically (each `onRetry` event bumps `attemptId`, which is what the dismissal latch keys on). Retries continue in the background regardless of whether the modal is on screen.
+
 ### Non-retryable API errors (manual retry)
 
 When an API call fails with an error that exhausts automatic retries or isn't in the retryable set, the engine stores the failed input and prompts the player:

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -12,7 +12,7 @@
  *
  * The component just renders what the server says and sends what the player types.
  */
-import React, { useState, useRef, useCallback, useMemo } from "react";
+import React, { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { useInput, Box, useWindowSize } from "ink";
 import type { NarrativeAreaHandle } from "../tui/components/index.js";
 import type { KeyHint } from "../tui/components/index.js";
@@ -66,6 +66,12 @@ export function PlayingPhase() {
   const [characterPaneOpen, setCharacterPaneOpen] = useState(false);
   const [characterSheetCache, setCharacterSheetCache] = useState<string | null>(null);
   const characterSheetCacheCharRef = useRef<string>("");
+  // attemptId the user last dismissed the API-error modal at. The modal hides
+  // while this matches the current overlay's attemptId; each fresh onRetry
+  // bumps attemptId, so the next failure brings the modal back. Reset to null
+  // whenever the overlay clears so a future outage that starts at the same
+  // numeric attemptId still re-shows the modal.
+  const [dismissedAttemptId, setDismissedAttemptId] = useState<number | null>(null);
 
   const clearInput = useCallback(() => { setPendingInput(""); setResetKey((k) => k + 1); }, []);
   /** Reset the input but pre-fill it with text (e.g. after a rejected contribution). */
@@ -75,13 +81,29 @@ export function PlayingPhase() {
   const modalScrollRef = useRef<CenteredModalHandle>(null);
   const escTimestamps = useRef<number[]>([]);
 
+  // Clear the dismissal latch whenever the retry overlay goes away so the
+  // next outage shows the modal again — even if the new attemptId numerically
+  // matches what was dismissed previously (attemptId resets to 1 after the
+  // engine clears lastError on success). Keyed on the boolean rather than the
+  // overlay object itself because app.tsx rebuilds the overlay on every render.
+  const hasRetryOverlay = !!retryOverlay;
+  useEffect(() => {
+    if (!hasRetryOverlay) setDismissedAttemptId(null);
+  }, [hasRetryOverlay]);
+
+  // The modal is "active" only when there's an unresolved retry AND the user
+  // hasn't dismissed this specific attempt. Each fresh retry bumps attemptId,
+  // so dismissal is scoped to a single failure — the next failure shows again.
+  const apiErrorModalActive =
+    !!retryOverlay && retryOverlay.attemptId !== dismissedAttemptId;
+
   // Whether TextInput should be disabled.
   // Never block on engine state — the server rejects input if inappropriate.
   // This prevents the client from getting permanently wedged.
   const textInputDisabled =
     !!activeChoices ||
     !!activeModal ||
-    !!retryOverlay ||
+    apiErrorModalActive ||
     menuOpen;
 
   // Resolve player info from state snapshot
@@ -287,7 +309,15 @@ export function PlayingPhase() {
       }
     }
 
-    if (retryOverlay || activeChoices || activeModal || menuOpen) return;
+    // Esc on the API-error modal dismisses it (latched on attemptId so the
+    // next retry brings it back). Handled before the catch-all blocker below
+    // so the user isn't trapped while the engine retries in the background.
+    if (key.escape && apiErrorModalActive && retryOverlay) {
+      setDismissedAttemptId(retryOverlay.attemptId);
+      return;
+    }
+
+    if (apiErrorModalActive || activeChoices || activeModal || menuOpen) return;
 
     // Tab: toggle character pane
     if (key.tab) {
@@ -400,7 +430,7 @@ export function PlayingPhase() {
           onContentLoaded={handleCharacterSheetLoaded}
         />
       )}
-      {retryOverlay && (
+      {apiErrorModalActive && retryOverlay && (
         <ApiErrorModal theme={theme} width={cols} height={rows} overlay={retryOverlay} />
       )}
       {am?.kind === "character_sheet" && (

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -100,10 +100,15 @@ export function PlayingPhase() {
   // Whether TextInput should be disabled.
   // Never block on engine state — the server rejects input if inappropriate.
   // This prevents the client from getting permanently wedged.
+  // Note: gated on `retryOverlay`, not `apiErrorModalActive`. Dismissing the
+  // modal unblocks the keyboard-event path (so Esc can open the pause menu),
+  // but the engine is still retrying and the server has no open turn to
+  // contribute to — letting the input accept text would produce a flash of
+  // optimistic narrative that gets yanked out when the contribute rejects.
   const textInputDisabled =
     !!activeChoices ||
     !!activeModal ||
-    apiErrorModalActive ||
+    !!retryOverlay ||
     menuOpen;
 
   // Resolve player info from state snapshot

--- a/packages/client-ink/src/tui/modals/ApiErrorModal.tsx
+++ b/packages/client-ink/src/tui/modals/ApiErrorModal.tsx
@@ -55,6 +55,7 @@ export function ApiErrorModal({ theme, width, height, overlay }: ApiErrorModalPr
       minWidth={36}
       maxWidth={44}
       lines={lines}
+      footer="Esc to dismiss"
     />
   );
 }

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -179,6 +179,50 @@ describe("runProviderLoop retry", () => {
     expect(onRetry).toHaveBeenCalledTimes(2);
   });
 
+  it("retries indefinitely by default (no maxRetries cap)", async () => {
+    // Regression: an earlier default of maxRetries=5 caused the engine to give
+    // up after ~27s of backoff during a network outage, silently dropping the
+    // retry modal and stranding the player. The spec promises indefinite
+    // retry; this test pins the default by exercising more failures than the
+    // old cap would have permitted.
+    const FAILURES_BEFORE_RECOVERY = 10;
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(async () => {
+        callCount++;
+        if (callCount <= FAILURES_BEFORE_RECOVERY) throw networkError();
+        return textResult("Reconnected");
+      }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    const onRetry = vi.fn();
+    const promise = runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      onRetry,
+      // Note: no maxRetries — use the default.
+    });
+
+    // Backoff sequence is 1, 2, 4, 8, 12, 12, 12, 12, 12, 12 (capped at 12s).
+    // Advance through all of them so each retry actually fires.
+    const delays = [1, 2, 4, 8, 12, 12, 12, 12, 12, 12];
+    for (const d of delays) {
+      await vi.advanceTimersByTimeAsync(d * 1000);
+    }
+    const result = await promise;
+
+    expect(result.text).toBe("Reconnected");
+    expect(callCount).toBe(FAILURES_BEFORE_RECOVERY + 1);
+    expect(onRetry).toHaveBeenCalledTimes(FAILURES_BEFORE_RECOVERY);
+  });
+
   it("does not retry non-retryable errors (400)", async () => {
     const provider: LLMProvider = {
       providerId: "test",

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -210,11 +210,14 @@ describe("runProviderLoop retry", () => {
       // Note: no maxRetries — use the default.
     });
 
-    // Backoff sequence is 1, 2, 4, 8, 12, 12, 12, 12, 12, 12 (capped at 12s).
-    // Advance through all of them so each retry actually fires.
-    const delays = [1, 2, 4, 8, 12, 12, 12, 12, 12, 12];
-    for (const d of delays) {
-      await vi.advanceTimersByTimeAsync(d * 1000);
+    // Step through one pending timer at a time rather than baking in the
+    // current backoff schedule (1,2,4,8,12,…) — that decouples the test from
+    // the exact `retryDelay()` curve so future tuning of the backoff doesn't
+    // break this test even though the "no default cap" behavior is unchanged.
+    // Bounded loop in case the implementation regresses and stops scheduling.
+    for (let i = 0; i < FAILURES_BEFORE_RECOVERY * 2; i++) {
+      if (callCount > FAILURES_BEFORE_RECOVERY) break;
+      await vi.advanceTimersToNextTimerAsync();
     }
     const result = await promise;
 

--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -81,7 +81,11 @@ export interface ProviderLoopConfig {
    * snapshot before the retry begins streaming again.
    */
   onRollback?: () => void;
-  /** Max retries after the initial attempt (default 5 → up to 6 total attempts, ~27s backoff). */
+  /** Max retries after the initial attempt. Defaults to Infinity — the spec
+   *  promises indefinite retry on transient errors (status 0, 429, 500, 502,
+   *  503, 529) and the user-facing modal says "auto-resume on reconnect", so
+   *  giving up after a fixed cap silently strands the player. Tests override
+   *  this with a small number to exercise the exhaustion path. */
   maxRetries?: number;
 }
 
@@ -104,7 +108,7 @@ export async function runProviderLoop(
   config: ProviderLoopConfig,
 ): Promise<ProviderLoopResult> {
   const maxToolRounds = config.maxToolRounds ?? 3;
-  const maxRetries = config.maxRetries ?? 5;
+  const maxRetries = config.maxRetries ?? Number.POSITIVE_INFINITY;
   const shouldStream = config.stream !== false && !!config.onTextDelta;
 
   // Only enable thinking for models that support it (per model registry).


### PR DESCRIPTION
## Summary

- Default `maxRetries` to `Number.POSITIVE_INFINITY` in `agent-loop-bridge.ts`. The old default of 5 caused the engine to give up after ~27s of cumulative backoff during a network outage; the modal vanished silently (`retryOverlay` only renders for `recoverable` errors), no other UI surfaced the non-recoverable error, and the player was stranded. Backoff is capped at 12s so indefinite retry doesn't escalate. Matches `docs/error-recovery.md`'s "indefinitely — we never give up" promise.
- Add **Esc to dismiss** for the `ApiErrorModal` so the player can open the pause menu and Save & Exit while retries continue in the background. Dismissal is latched on the overlay's current `attemptId`; each fresh `onRetry` bumps `attemptId`, so the next failed attempt brings the modal back automatically. The latch resets when the overlay clears, so a later outage that happens to start at the same numeric attemptId still re-shows the modal.
- Regression test exercises 10 consecutive network failures through the full backoff sequence — would have failed under the old cap on call seven.

Reported bug: during a brief outage the modal appeared, counted down, then disappeared and did not reappear even though the connection was still down. Gameplay resumed when the connection came back. Root cause was the silent fallthrough to non-recoverable error state after retries exhausted.

## Test plan

- [x] `npx vitest run packages/engine` — 1600 passed
- [x] `npx vitest run --changed` — 597 passed
- [x] `npx tsc -b` clean
- [x] `npx eslint --cache` on touched files clean
- [ ] Manual: drop wifi mid-DM-turn → modal appears, counts down, resets on each retry indefinitely; Esc dismisses, modal reappears on next retry; pause menu (Esc again) reachable while retries continue; Save & Exit works
- [ ] Manual: restore connection while modal is up → modal clears, narrative streams as expected
- [ ] Manual: restore connection while modal is dismissed → narrative streams as expected, no orphaned state

🤖 Generated with [Claude Code](https://claude.com/claude-code)