### PR TITLE
Rework OOC mode to share the DM's prompt + toolset

### DIFF
--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -274,6 +274,66 @@ export class GameEngine {
     return this.tierProviders[tier];
   }
 
+  /** Get the engine's FileIO (campaign-root anchored). OOC/Dev reuse it. */
+  getFileIO(): FileIO {
+    return this.fileIO;
+  }
+
+  /** Get live game state. OOC dispatches tools against this same object. */
+  getGameState(): GameState {
+    return this.gameState;
+  }
+
+  /** Get the tool registry the DM uses. OOC dispatches through the same singleton. */
+  getRegistry(): ToolRegistry {
+    return this.registry;
+  }
+
+  /**
+   * Async tool handler exposed for mode sessions (OOC/Dev) that want to
+   * reuse the DM's async tool surface (resolve_turn, search_campaign,
+   * search_content, style_scene). Returns null for tools the handler
+   * doesn't cover — callers should fall back to `registry.dispatch`.
+   */
+  handleAsyncTool(name: string, input: Record<string, unknown>): Promise<import("./tool-registry.js").ToolResult | null> {
+    return this.handleAsyncToolInternal(name, input);
+  }
+
+  /**
+   * Forward an immediate (non-deferred) TUI command through the same
+   * pipeline DM tool calls use — broadcasts to the client and updates
+   * persisted UI state. Exposed so OOC/Dev's immediate TUI tool calls
+   * (style_scene, update_modeline, set_resource_values, etc.) reach the
+   * client just like the DM's.
+   */
+  dispatchImmediateTuiCommand(cmd: TuiCommand): void {
+    this.callbacks.onTuiCommand(cmd);
+  }
+
+  /**
+   * Process a batch of deferred TUI commands (scribe, promote_character,
+   * dm_notes, scene_transition, session_end, rollback) the same way the DM
+   * does after its agent loop completes. Exposed so OOC can share the
+   * exact same teardown semantics. May throw RollbackCompleteError.
+   */
+  async applyDeferredTuiCommands(commands: TuiCommand[]): Promise<void> {
+    for (const cmd of commands) {
+      if (cmd.type === "scene_transition") {
+        await this.transitionScene(cmd.title as string, cmd.time_advance as number | undefined);
+      } else if (cmd.type === "session_end") {
+        await this.endSession(cmd.title as string, cmd.time_advance as number | undefined);
+      } else if (cmd.type === "rollback") {
+        await this.rollbackAndExit(cmd.target as string);
+      } else if (cmd.type === "scribe") {
+        await this.handleScribe(cmd);
+      } else if (cmd.type === "promote_character") {
+        await this.handlePromoteCharacter(cmd);
+      } else if (cmd.type === "dm_notes") {
+        await this.handleDmNotes(cmd);
+      }
+    }
+  }
+
   /** Active mode session (OOC/Dev). Null when in normal play mode. */
   private modeSession: import("@machine-violet/shared/types/engine.js").ModeSession | null = null;
   /** Variant active before entering a mode session, for restoration on exit. */
@@ -624,27 +684,7 @@ export class GameEngine {
       // work (scene transitions, subagent spawns, file I/O) remain here.
       // Visual-only commands (modeline, resources, choices, theme) were
       // already broadcast to the client immediately when the tool fired.
-      for (const cmd of result.tuiCommands) {
-        if (cmd.type === "scene_transition") {
-          await this.transitionScene(
-            cmd.title as string,
-            cmd.time_advance as number | undefined,
-          );
-        } else if (cmd.type === "session_end") {
-          await this.endSession(
-            cmd.title as string,
-            cmd.time_advance as number | undefined,
-          );
-        } else if (cmd.type === "rollback") {
-          await this.rollbackAndExit(cmd.target as string);
-        } else if (cmd.type === "scribe") {
-          await this.handleScribe(cmd);
-        } else if (cmd.type === "promote_character") {
-          await this.handlePromoteCharacter(cmd);
-        } else if (cmd.type === "dm_notes") {
-          await this.handleDmNotes(cmd);
-        }
-      }
+      await this.applyDeferredTuiCommands(result.tuiCommands);
 
       // Accumulate usage
       accUsage(this.sessionUsage, result.usage);
@@ -1364,7 +1404,7 @@ export class GameEngine {
       provider: this.provider,
       maxTokens: getMaxOutput(this.model),
       maxToolRounds: 10,
-      asyncToolHandler: (name, input) => this.handleAsyncTool(name, input),
+      asyncToolHandler: (name, input) => this.handleAsyncToolInternal(name, input),
       onTextDelta: (delta) => this.callbacks.onNarrativeDelta(delta),
       onToolStart: (name) => {
         this.setState("tool_running");
@@ -1389,7 +1429,7 @@ export class GameEngine {
   }
 
   /** Handle tools that require async work (subagent spawning, I/O). */
-  private async handleAsyncTool(
+  private async handleAsyncToolInternal(
     name: string,
     input: Record<string, unknown>,
   ): Promise<import("./tool-registry.js").ToolResult | null> {

--- a/packages/engine/src/agents/phase8.test.ts
+++ b/packages/engine/src/agents/phase8.test.ts
@@ -315,18 +315,24 @@ describe("aiPlayerTurn", () => {
 
 describe("buildOOCPrompt", () => {
   it("builds base OOC prompt", () => {
-    const prompt = buildOOCPrompt("Shattered Crown");
+    const prompt = buildOOCPrompt({ campaignName: "Shattered Crown" });
     expect(prompt).toContain("Out-of-Character");
     expect(prompt).toContain("Shattered Crown");
   });
 
   it("includes system rules when provided", () => {
-    const prompt = buildOOCPrompt("Campaign", "Grappling: contested STR check...");
+    const prompt = buildOOCPrompt({
+      campaignName: "Campaign",
+      systemRules: "Grappling: contested STR check...",
+    });
     expect(prompt).toContain("Grappling: contested STR check");
   });
 
   it("includes character sheet when provided", () => {
-    const prompt = buildOOCPrompt("Campaign", undefined, "Aldric - Paladin, HP 42/42");
+    const prompt = buildOOCPrompt({
+      campaignName: "Campaign",
+      characterSheet: "Aldric - Paladin, HP 42/42",
+    });
     expect(prompt).toContain("Aldric - Paladin");
   });
 });

--- a/packages/engine/src/agents/subagents/ooc-mode.test.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { LLMProvider, ChatResult, SystemBlock } from "../../providers/types.js";
-import { buildOOCPrompt, buildOOCTools, buildOOCToolHandler, enterOOC, parseEndOOCSignal, extractSummary } from "./ooc-mode.js";
+import {
+  buildOOCPrompt,
+  buildOOCTools,
+  buildOOCToolHandler,
+  enterOOC,
+  parseEndOOCSignal,
+  parseSummaryTag,
+  extractSummary,
+} from "./ooc-mode.js";
 import type { DMSessionState } from "../dm-prompt.js";
 import type { FileIO } from "../scene-manager.js";
 import type { GameState } from "../game-state.js";
-import type { TuiCommand } from "../agent-loop.js";
+import { registry as singletonRegistry } from "../tool-registry.js";
 import { CampaignRepo } from "../../tools/git/index.js";
 import type { GitIO } from "../../tools/git/index.js";
 import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
@@ -73,28 +81,35 @@ function mockSessionState(overrides?: Partial<DMSessionState>): DMSessionState {
   };
 }
 
+// --- buildOOCPrompt ---
+
 describe("buildOOCPrompt (legacy)", () => {
   it("includes campaign name", () => {
-    const prompt = buildOOCPrompt("Shadow of the Dragon");
-    expect(prompt).toContain("Campaign: Shadow of the Dragon");
+    const prompt = buildOOCPrompt({ campaignName: "Shadow of the Dragon" });
+    expect(typeof prompt).toBe("string");
+    expect(prompt as string).toContain("Campaign: Shadow of the Dragon");
   });
 
   it("includes rules and character sheet when provided", () => {
-    const prompt = buildOOCPrompt("TestCampaign", "FATE rules here", "Aldric the Bold");
+    const prompt = buildOOCPrompt({
+      campaignName: "TestCampaign",
+      systemRules: "FATE rules here",
+      characterSheet: "Aldric the Bold",
+    }) as string;
     expect(prompt).toContain("Game system rules:\nFATE rules here");
     expect(prompt).toContain("Active character:\nAldric the Bold");
   });
 
   it("omits optional blocks when absent", () => {
-    const prompt = buildOOCPrompt("TestCampaign");
+    const prompt = buildOOCPrompt({ campaignName: "TestCampaign" }) as string;
     expect(prompt).not.toContain("Game system rules:");
     expect(prompt).not.toContain("Active character:");
     expect(prompt).not.toContain("undefined");
   });
 });
 
-describe("buildOOCPrompt (structured)", () => {
-  it("returns TextBlockParam[] when config and sessionState provided", () => {
+describe("buildOOCPrompt (structured — reuses DM prefix)", () => {
+  it("returns SystemBlock[] when config and sessionState provided", () => {
     const result = buildOOCPrompt({
       campaignName: "TestCampaign",
       config: mockConfig(),
@@ -102,7 +117,7 @@ describe("buildOOCPrompt (structured)", () => {
     });
     expect(Array.isArray(result)).toBe(true);
     const blocks = result as SystemBlock[];
-    expect(blocks.length).toBeGreaterThan(1);
+    expect(blocks.length).toBeGreaterThan(2);
     expect(blocks.every((b) => typeof b.text === "string")).toBe(true);
   });
 
@@ -120,7 +135,18 @@ describe("buildOOCPrompt (structured)", () => {
     expect(typeof result).toBe("string");
   });
 
-  it("has cache_control on stable blocks (identity, rules, campaign log)", () => {
+  it("ends with the OOC-mode suffix block (uncached)", () => {
+    const result = buildOOCPrompt({
+      campaignName: "TestCampaign",
+      config: mockConfig(),
+      sessionState: mockSessionState(),
+    }) as SystemBlock[];
+    const last = result[result.length - 1];
+    expect(last.text).toContain("Out-of-Character Mode");
+    expect(last.cacheControl).toBeUndefined();
+  });
+
+  it("preserves DM-prefix cache breakpoints (BP1 and BP2)", () => {
     const result = buildOOCPrompt({
       campaignName: "TestCampaign",
       config: mockConfig(),
@@ -128,21 +154,12 @@ describe("buildOOCPrompt (structured)", () => {
     }) as SystemBlock[];
 
     const cached = result.filter((b) => "cacheControl" in b && b.cacheControl);
-    expect(cached.length).toBe(3); // identity, rules, campaign log
-
-    // Identity is first cached block
-    expect(cached[0].text).toContain("Out-of-Character");
-
-    // Rules block
-    expect(cached[1].text).toContain("Rules Reference");
-    expect(cached[1].text).toContain("FATE Core");
-
-    // Campaign log block
-    expect(cached[2].text).toContain("Campaign Log");
-    expect(cached[2].text).toContain("party met at the tavern");
+    // buildDMPrefix stamps BP1 on the last Tier 1 block and BP2 on the last
+    // Tier 2 block. The OOC suffix added after is intentionally uncached.
+    expect(cached.length).toBe(2);
   });
 
-  it("includes campaign setting from config", () => {
+  it("includes DM-style campaign setting and rules in cached prefix", () => {
     const result = buildOOCPrompt({
       campaignName: "TestCampaign",
       config: mockConfig(),
@@ -151,12 +168,12 @@ describe("buildOOCPrompt (structured)", () => {
 
     const allText = result.map((b) => b.text).join("\n");
     expect(allText).toContain("Campaign Setting");
-    expect(allText).toContain("Game System: FATE");
     expect(allText).toContain("Genre: fantasy");
-    expect(allText).toContain("A world in shadow");
+    expect(allText).toContain("Rules Reference");
+    expect(allText).toContain("FATE Core");
   });
 
-  it("includes session recap and active state (uncached)", () => {
+  it("includes session recap and scene precis from DM prefix", () => {
     const result = buildOOCPrompt({
       campaignName: "TestCampaign",
       config: mockConfig(),
@@ -166,59 +183,40 @@ describe("buildOOCPrompt (structured)", () => {
     const allText = result.map((b) => b.text).join("\n");
     expect(allText).toContain("Last Session");
     expect(allText).toContain("defeated the goblins");
-    expect(allText).toContain("Current State");
-    expect(allText).toContain("Tavern");
     expect(allText).toContain("Scene So Far");
     expect(allText).toContain("Merchant Giles");
   });
 
-  it("includes character sheet when provided", () => {
+  it("appends DM-initiated entry context when wasMidNarration is true", () => {
     const result = buildOOCPrompt({
       campaignName: "TestCampaign",
       config: mockConfig(),
       sessionState: mockSessionState(),
-      characterSheet: "# Kael\n**HP:** 10",
+      wasMidNarration: true,
+      enterReason: "rules question about grappling",
     }) as SystemBlock[];
 
-    const allText = result.map((b) => b.text).join("\n");
-    expect(allText).toContain("Active Character");
-    expect(allText).toContain("Kael");
+    const lastText = result[result.length - 1].text;
+    expect(lastText).toContain("enter_ooc");
+    expect(lastText).toContain("rules question about grappling");
   });
 
-  it("omits empty session state sections", () => {
+  it("omits entry context block when not provided", () => {
     const result = buildOOCPrompt({
       campaignName: "TestCampaign",
       config: mockConfig(),
-      sessionState: { rulesAppendix: "Some rules" },
+      sessionState: mockSessionState(),
     }) as SystemBlock[];
 
-    const allText = result.map((b) => b.text).join("\n");
-    // Check for section headings (not inline mentions in the identity prompt)
-    expect(allText).not.toContain("## Campaign Log");
-    expect(allText).not.toContain("## Last Session");
-    expect(allText).not.toContain("## Current State");
-    expect(allText).not.toContain("## Scene So Far");
-  });
-
-  it("does not include DM-internal sections (playerRead, uiState)", () => {
-    const result = buildOOCPrompt({
-      campaignName: "TestCampaign",
-      config: mockConfig(),
-      sessionState: {
-        ...mockSessionState(),
-        playerRead: "Player seems engaged",
-        uiState: "style=classic, variant=exploration",
-      },
-    }) as SystemBlock[];
-
-    const allText = result.map((b) => b.text).join("\n");
-    expect(allText).not.toContain("Player Read");
-    expect(allText).not.toContain("UI State");
+    const lastText = result[result.length - 1].text;
+    expect(lastText).not.toContain("OOC Entry Context");
   });
 });
 
+// --- enterOOC: summary / snapshot / streaming ---
+
 describe("enterOOC", () => {
-  it("returns summary from first sentence", async () => {
+  it("returns summary from first sentence (no SUMMARY tag)", async () => {
     const provider = mockProvider([textResponse("Grappling lets you restrain foes. You need a STR check.")]);
     const result = await enterOOC(provider, "How does grappling work?", {
       campaignName: "Test",
@@ -228,7 +226,21 @@ describe("enterOOC", () => {
     expect(result.summary).toBe("Grappling lets you restrain foes.");
   });
 
-  it("truncates summary over 100 chars", async () => {
+  it("prefers SUMMARY tag when present", async () => {
+    const provider = mockProvider([textResponse(
+      "Conversational reply here.\n<SUMMARY>Clarified grappling rules.</SUMMARY>\n<END_OOC />"
+    )]);
+    const result = await enterOOC(provider, "How does grappling work?", {
+      campaignName: "Test",
+      previousVariant: "playing",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.summary).toBe("Clarified grappling rules.");
+    expect(result.text).toBe("Conversational reply here.");
+    expect(result.endSession).toBe(true);
+  });
+
+  it("truncates fallback summary over 100 chars", async () => {
     const longText = "A".repeat(110) + ". More text here.";
     const provider = mockProvider([textResponse(longText)]);
     const result = await enterOOC(provider, "Tell me everything", {
@@ -240,7 +252,7 @@ describe("enterOOC", () => {
     expect(result.summary).toMatch(/\.\.\.$/);
   });
 
-  it("defaults summary for text without sentence boundary", async () => {
+  it("defaults summary for empty text", async () => {
     const provider = mockProvider([textResponse("")]);
     const result = await enterOOC(provider, "test", {
       campaignName: "Test",
@@ -294,25 +306,7 @@ describe("enterOOC", () => {
     expect(result.usage.outputTokens).toBe(20);
   });
 
-  it("passes tools when repo is provided", async () => {
-    const git = mockGitIO();
-    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
-    const provider = mockProvider([textResponse("Done.")]);
-    await enterOOC(provider, "test", {
-      campaignName: "Test",
-      previousVariant: "playing",
-      repo,
-      model: "claude-sonnet-4-6",
-    });
-
-    const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      expect(createCall.tools).toHaveLength(1);
-      expect(createCall.tools[0].name).toBe("get_commit_log");
-    }
-  });
-
-  it("works without tools when repo not provided", async () => {
+  it("works without tools when no game state, no repo, no fileIO", async () => {
     const provider = mockProvider([textResponse("Done.")]);
     await enterOOC(provider, "test", {
       campaignName: "Test",
@@ -326,7 +320,7 @@ describe("enterOOC", () => {
     }
   });
 
-  it("passes 4 tools when fileIO and campaignRoot are provided", async () => {
+  it("exposes only OOC-only file extras when fileIO is set but no gameState", async () => {
     const provider = mockProvider([textResponse("Done.")]);
     const fio = mockFileIO();
     await enterOOC(provider, "test", {
@@ -339,200 +333,139 @@ describe("enterOOC", () => {
 
     const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     if (createCall) {
-      expect(createCall.tools).toHaveLength(4);
       const names = createCall.tools.map((t: { name: string }) => t.name);
-      expect(names).toContain("read_file");
-      expect(names).toContain("find_references");
-      expect(names).toContain("validate_campaign");
-      expect(names).toContain("get_commit_log");
+      expect(names).toEqual(expect.arrayContaining(["read_file", "find_references", "validate_campaign"]));
+      // No DM tools without gameState
+      expect(names).not.toContain("roll_dice");
+      expect(names).not.toContain("scribe");
     }
   });
+});
 
-  it("sends structured system prompt when sessionState and config provided", async () => {
-    const provider = mockProvider([textResponse("The merchant offered you a quest.")]);
-    await enterOOC(provider, "What did the merchant say?", {
-      campaignName: "TestCampaign",
+// --- enterOOC volatile context injection ---
+
+describe("enterOOC volatile context", () => {
+  it("wraps player text with a <context> block when volatileContext is provided", async () => {
+    const provider = mockProvider([textResponse("Done.")]);
+    await enterOOC(provider, "What's my HP?", {
+      campaignName: "Test",
       previousVariant: "playing",
-      config: mockConfig(),
-      sessionState: mockSessionState(),
+      volatileContext: "## Current State\nTurn: Kael",
       model: "claude-sonnet-4-6",
     });
 
     const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      // System prompt should be an array of TextBlockParam
-      expect(Array.isArray(createCall.systemPrompt)).toBe(true);
-      const blocks = createCall.systemPrompt as SystemBlock[];
-      expect(blocks.length).toBeGreaterThan(1);
-      const allText = blocks.map((b: SystemBlock) => b.text).join("\n");
-      expect(allText).toContain("Scene So Far");
-      expect(allText).toContain("Merchant Giles");
-    }
+    expect(createCall).toBeDefined();
+    const userMsg = createCall.messages[0].content as string;
+    expect(userMsg).toContain("<context>");
+    expect(userMsg).toContain("Turn: Kael");
+    expect(userMsg).toContain("What's my HP?");
   });
 
-  it("sends flat string system prompt without sessionState", async () => {
+  it("passes the raw player text when volatileContext is omitted", async () => {
     const provider = mockProvider([textResponse("Done.")]);
-    await enterOOC(provider, "test", {
+    await enterOOC(provider, "What's my HP?", {
       campaignName: "Test",
       previousVariant: "playing",
       model: "claude-sonnet-4-6",
     });
 
     const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      // System prompt should be a plain string (with terse suffix)
-      expect(typeof createCall.systemPrompt).toBe("string");
-    }
+    const userMsg = createCall.messages[0].content as string;
+    expect(userMsg).toBe("What's my HP?");
   });
 });
 
-// --- Git mock ---
+// --- enterOOC DM-toolset wiring ---
 
-const MOCK_BASE_TS = Math.floor(new Date("2025-03-15T12:00:00Z").getTime() / 1000);
+describe("enterOOC with gameState + DM registry", () => {
+  it("passes the full DM toolset (minus enter_ooc) when gameState + registry are provided", async () => {
+    const gs = mockGameState();
+    const fio = mockFileIO();
+    const provider = mockProvider([textResponse("Done.")]);
+    await enterOOC(provider, "test", {
+      campaignName: "Test",
+      previousVariant: "playing",
+      fileIO: fio,
+      campaignRoot: "/camp",
+      gameState: gs,
+      registry: singletonRegistry,
+      model: "claude-sonnet-4-6",
+    });
 
-function mockGitIO(): GitIO {
-  const commits: { message: string; oid: string; timestamp: number }[] = [];
-  const staged = new Set<string>();
-  let oidCounter = 0;
+    const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(createCall).toBeDefined();
+    const names = createCall.tools.map((t: { name: string }) => t.name);
 
-  return {
-    init: vi.fn(async () => {}),
-    add: vi.fn(async (_dir, filepath) => { staged.add(filepath); }),
-    commit: vi.fn(async (_dir, message) => {
-      const oid = `commit_${++oidCounter}`;
-      commits.unshift({ message, oid, timestamp: MOCK_BASE_TS + oidCounter * 86400 });
-      staged.clear();
-      return oid;
-    }),
-    log: vi.fn(async (_dir, depth = 50) =>
-      commits.slice(0, depth).map((c) => ({
-        oid: c.oid,
-        commit: { message: c.message, author: { timestamp: c.timestamp } },
-      })),
-    ),
-    checkout: vi.fn(async () => {}),
-    resetTo: vi.fn(async () => {}),
-    pruneUnreachable: vi.fn(async () => 0),
-    statusMatrix: vi.fn(async () =>
-      staged.size > 0
-        ? [...staged].map((f) => [f, 1, 2, 2] as [string, number, number, number])
-        : [["config.json", 1, 2, 1] as [string, number, number, number]],
-    ),
-    listFiles: vi.fn(async () => ["config.json"]),
-    remove: vi.fn(async () => {}),
-  };
-}
+    // Hard contract: enter_ooc is excluded; rollback/show_character_sheet
+    // (DM-excluded but OOC-included) are present; OOC-only file extras are present.
+    expect(names).not.toContain("enter_ooc");
+    expect(names).toContain("rollback");
+    expect(names).toContain("show_character_sheet");
+    expect(names).toContain("read_file");
+    expect(names).toContain("find_references");
+    expect(names).toContain("validate_campaign");
 
-// --- OOC tools ---
-
-function mockFileIO(
-  files: Record<string, string> = {},
-  dirs: Record<string, string[]> = {},
-): FileIO {
-  // Normalize paths for cross-platform matching
-  const n = (p: string) => p.replace(/\\/g, "/");
-  const normFiles: Record<string, string> = {};
-  for (const [k, v] of Object.entries(files)) normFiles[n(k)] = v;
-  const normDirs: Record<string, string[]> = {};
-  for (const [k, v] of Object.entries(dirs)) normDirs[n(k)] = v;
-
-  return {
-    readFile: vi.fn(async (p: string) => {
-      const np = n(p);
-      if (np in normFiles) return normFiles[np];
-      throw new Error(`ENOENT: ${p}`);
-    }),
-    writeFile: vi.fn(async () => {}),
-    appendFile: vi.fn(async () => {}),
-    mkdir: vi.fn(async () => {}),
-    exists: vi.fn(async (p: string) => n(p) in normFiles || n(p) in normDirs),
-    listDir: vi.fn(async (p: string) => {
-      const np = n(p);
-      if (np in normDirs) return normDirs[np];
-      throw new Error(`ENOENT: ${p}`);
-    }),
-    deleteFile: vi.fn(async () => {}),
-  };
-}
-
-describe("buildOOCTools", () => {
-  it("returns only get_commit_log when no fileIO and no gameState", () => {
-    const tools = buildOOCTools(false, false);
-    expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe("get_commit_log");
-  });
-
-  it("returns 4 tools when fileIO is available but no gameState", () => {
-    const tools = buildOOCTools(true, false);
-    expect(tools).toHaveLength(4);
-    const names = tools.map((t) => t.name);
-    expect(names).toEqual(["get_commit_log", "read_file", "find_references", "validate_campaign"]);
-  });
-
-  it("returns 16 tools when both fileIO and gameState are available", () => {
-    const tools = buildOOCTools(true, true);
-    expect(tools).toHaveLength(16);
-    const names = tools.map((t) => t.name);
+    // Smoke: representative DM tools are present.
     expect(names).toContain("roll_dice");
-    expect(names).toContain("alarm");
     expect(names).toContain("scribe");
     expect(names).toContain("style_scene");
-    expect(names).toContain("show_character_sheet");
-    expect(names).toContain("rollback");
-  });
-
-  it("returns 13 tools when gameState but no fileIO", () => {
-    const tools = buildOOCTools(false, true);
-    expect(tools).toHaveLength(13);
-    const names = tools.map((t) => t.name);
-    expect(names).toContain("roll_dice");
-    expect(names).not.toContain("read_file");
+    expect(names).toContain("promote_character");
+    expect(names).toContain("resolve_turn");
   });
 });
 
-describe("buildOOCToolHandler", () => {
-  it("returns commit log with distinct dates", async () => {
+// --- buildOOCTools ---
+
+describe("buildOOCTools", () => {
+  it("returns empty when given empty registry + no extras", () => {
+    const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0], false, false);
+    expect(tools).toEqual([]);
+  });
+
+  it("returns file extras when hasFileIO is true (no registry contributions)", () => {
+    const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0], true, false);
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual(["read_file", "find_references", "validate_campaign"]);
+  });
+
+  it("adds get_commit_log when hasRepo is true", () => {
+    const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0], false, true);
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual(["get_commit_log"]);
+  });
+
+  it("returns all DM tools (minus enter_ooc) plus extras with the real registry", () => {
+    const tools = buildOOCTools(singletonRegistry, true, true);
+    const names = tools.map((t) => t.name);
+
+    expect(names).not.toContain("enter_ooc");
+    expect(names).toContain("roll_dice");
+    expect(names).toContain("scribe");
+    expect(names).toContain("rollback");
+    expect(names).toContain("read_file");
+    expect(names).toContain("get_commit_log");
+  });
+});
+
+// --- buildOOCToolHandler ---
+
+describe("buildOOCToolHandler — OOC-only extras", () => {
+  it("get_commit_log returns commit log with distinct dates", async () => {
     const git = mockGitIO();
     const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
     await repo.sceneCommit("The Dragon's Lair");
     await repo.autoCommit("auto: exchanges");
 
-    const handler = buildOOCToolHandler(undefined, undefined, repo);
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined, repo);
     const result = await handler("get_commit_log", {});
     expect(result.is_error).toBeUndefined();
-    expect(result.content).toContain("[scene]");
     expect(result.content).toContain("Dragon's Lair");
-    expect(result.content).toContain("2025-03-");
-    const dateMatches = result.content.match(/\((\d{4}-\d{2}-\d{2})/g) ?? [];
-    const uniqueDates = new Set(dateMatches);
-    expect(uniqueDates.size).toBeGreaterThan(1);
-  });
-
-  it("filters by type", async () => {
-    const git = mockGitIO();
-    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
-    await repo.sceneCommit("The Dragon's Lair");
-    await repo.autoCommit("auto: exchanges");
-
-    const handler = buildOOCToolHandler(undefined, undefined, repo);
-    const result = await handler("get_commit_log", { type: "scene" });
-    expect(result.content).toContain("[scene]");
-    expect(result.content).not.toContain("[auto]");
-  });
-
-  it("returns error for unknown tool", async () => {
-    const git = mockGitIO();
-    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
-    const handler = buildOOCToolHandler(undefined, undefined, repo);
-    const result = await handler("nonexistent", {});
-    expect(result.is_error).toBe(true);
   });
 
   it("read_file reads a campaign file", async () => {
-    const fio = mockFileIO({
-      "/camp/characters/kael.md": "# Kael\n**Type:** PC",
-    });
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", fio);
+    const fio = mockFileIO({ "/camp/characters/kael.md": "# Kael\n**Type:** PC" });
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined, undefined, "/camp", fio);
 
     const result = await handler("read_file", { path: "characters/kael.md" });
     expect(result.is_error).toBeUndefined();
@@ -541,253 +474,85 @@ describe("buildOOCToolHandler", () => {
 
   it("read_file rejects path traversal", async () => {
     const fio = mockFileIO();
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", fio);
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined, undefined, "/camp", fio);
 
     const result = await handler("read_file", { path: "../etc/passwd" });
     expect(result.is_error).toBe(true);
     expect(result.content).toContain("Path traversal not allowed");
   });
 
-  it("read_file errors without fileIO", async () => {
-    const handler = buildOOCToolHandler(undefined, undefined);
+  it("read_file errors when fileIO is missing", async () => {
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined);
     const result = await handler("read_file", { path: "characters/kael.md" });
     expect(result.is_error).toBe(true);
     expect(result.content).toContain("File I/O not available");
   });
 
-  it("find_references returns references for a target entity", async () => {
+  it("find_references finds wikilinks", async () => {
     const fio = mockFileIO(
       {
         "/camp/characters/kael.md": "# Kael\n**Type:** PC",
         "/camp/campaign/log.md": "Met [Kael](../characters/kael.md) at the tavern.",
       },
-      {
-        "/camp/characters": ["kael.md"],
-      },
+      { "/camp/characters": ["kael.md"] },
     );
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", fio);
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined, undefined, "/camp", fio);
 
     const result = await handler("find_references", { path: "characters/kael.md" });
     expect(result.is_error).toBeUndefined();
     const parsed = JSON.parse(result.content);
     expect(parsed.references).toHaveLength(1);
-    expect(parsed.references[0].file).toBe("campaign/log.md");
-  });
-
-  it("validate_campaign returns validation report", async () => {
-    const fio = mockFileIO(
-      { "/camp/config.json": '{"name":"Test"}' },
-      {
-        "/camp/characters": [],
-        "/camp/locations": [],
-        "/camp/factions": [],
-        "/camp/items": [],
-        "/camp/lore": [],
-      },
-    );
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", fio);
-
-    const result = await handler("validate_campaign", {});
-    expect(result.is_error).toBeUndefined();
-    const parsed = JSON.parse(result.content);
-    expect(parsed).toHaveProperty("issues");
-    expect(parsed).toHaveProperty("errorCount");
   });
 });
 
-// --- GameState mock ---
-
-function mockGameState(overrides?: Partial<GameState>): GameState {
-  return {
-    maps: {},
-    clocks: createClocksState(),
-    combat: createCombatState(),
-    combatConfig: createDefaultConfig(),
-    decks: createDecksState(),
-    objectives: createObjectivesState(),
-    config: {
-      name: "TestCampaign",
-      dm_personality: { name: "Narrator", prompt_fragment: "terse" },
-      players: [{ name: "Player1", character: "Kael", type: "human" }],
-      combat: createDefaultConfig(),
-      context: { retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 },
-      recovery: { auto_commit_interval: 300, max_commits: 100, enable_git: false },
-      choices: { campaign_default: "never", player_overrides: {} },
-    },
-    campaignRoot: "/camp",
-    homeDir: "/tmp/home",
-    activePlayerIndex: 0,
-    displayResources: {},
-    resourceValues: {},
-    ...overrides,
-  };
-}
-
-describe("buildOOCToolHandler (DM tools)", () => {
-  it("roll_dice dispatches and returns result directly", async () => {
+describe("buildOOCToolHandler — DM tool dispatch via singleton registry", () => {
+  it("roll_dice dispatches via the singleton registry", async () => {
     const gs = mockGameState();
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", undefined, undefined, undefined, gs);
+    const handler = buildOOCToolHandler(singletonRegistry, gs, undefined);
     const result = await handler("roll_dice", { expression: "1d6" });
     expect(result.is_error).toBeUndefined();
     expect(result.content).toContain("1d6");
     expect(result.content).toContain("→");
   });
 
-  it("alarm check dispatches and returns result directly", async () => {
+  it("alarm dispatches via the singleton registry", async () => {
     const gs = mockGameState();
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", undefined, undefined, undefined, gs);
+    const handler = buildOOCToolHandler(singletonRegistry, gs, undefined);
     const result = await handler("alarm", { operation: "check" });
     expect(result.is_error).toBeUndefined();
     expect(result.content).toContain("calendar");
   });
 
-  it("style_scene dispatches and calls onTuiCommand", async () => {
-    const gs = mockGameState();
-    const onTuiCommand = vi.fn();
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", undefined, undefined, undefined, gs, onTuiCommand);
-    const result = await handler("style_scene", { key_color: "#8844aa" });
-    expect(result.is_error).toBeUndefined();
-    expect(result.content).toBe("Applied: style_scene");
-    expect(onTuiCommand).toHaveBeenCalledOnce();
-    const cmd = onTuiCommand.mock.calls[0][0] as TuiCommand;
-    expect(cmd.type).toBe("style_scene");
-    expect(cmd.key_color).toBe("#8844aa");
-  });
-
-  it("show_character_sheet dispatches and calls onTuiCommand", async () => {
-    const gs = mockGameState();
-    const onTuiCommand = vi.fn();
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", undefined, undefined, undefined, gs, onTuiCommand);
-    const result = await handler("show_character_sheet", { character: "Kael" });
-    expect(result.is_error).toBeUndefined();
-    expect(result.content).toBe("Applied: show_character_sheet");
-    expect(onTuiCommand).toHaveBeenCalledOnce();
-    const cmd = onTuiCommand.mock.calls[0][0] as TuiCommand;
-    expect(cmd.type).toBe("show_character_sheet");
-    expect(cmd.character).toBe("Kael");
-  });
-
-  it("scribe without small-tier provider returns error", async () => {
-    const gs = mockGameState();
-    const fio = mockFileIO();
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", fio, undefined, undefined, gs);
-    const result = await handler("scribe", {
-      updates: [{ visibility: "private", content: "Test" }],
-    });
+  it("unknown tool returns an error", async () => {
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined);
+    const result = await handler("nonexistent_tool_xyz", {});
     expect(result.is_error).toBe(true);
-    expect(result.content).toContain("Small-tier");
-  });
-
-  it("rollback calls performRollback and throws RollbackCompleteError", async () => {
-    const { RollbackCompleteError } = await import("@machine-violet/shared/types/errors.js");
-    const git = mockGitIO();
-    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
-    await repo.sceneCommit("The Dragon's Lair");
-    await repo.autoCommit("auto: exchanges");
-
-    const fio = mockFileIO({ "/camp/config.json": "{}" });
-    const gs = mockGameState();
-    const handler = buildOOCToolHandler(undefined, undefined, repo, "/camp", fio, undefined, undefined, gs);
-    await expect(handler("rollback", { target: "last" })).rejects.toThrow(RollbackCompleteError);
-    expect(git.resetTo).toHaveBeenCalled();
-  });
-
-  it("rollback without repo returns error", async () => {
-    const gs = mockGameState();
-    const fio = mockFileIO();
-    const handler = buildOOCToolHandler(undefined, undefined, undefined, "/camp", fio, undefined, undefined, gs);
-    const result = await handler("rollback", { target: "last" });
-    expect(result.is_error).toBe(true);
-    expect(result.content).toContain("not available");
-  });
-
-  it("rollback without fileIO returns error", async () => {
-    const git = mockGitIO();
-    const repo = new CampaignRepo({ dir: "/tmp/campaign", git });
-    await repo.sceneCommit("The Dragon's Lair");
-
-    const gs = mockGameState();
-    const handler = buildOOCToolHandler(undefined, undefined, repo, "/camp", undefined, undefined, undefined, gs);
-    const result = await handler("rollback", { target: "last" });
-    expect(result.is_error).toBe(true);
-    expect(result.content).toContain("File I/O not available");
-  });
-
-  it("scribe without fileIO returns error", async () => {
-    const gs = mockGameState();
-    const fakeSmallTier = { provider: { providerId: "test", chat: vi.fn(), stream: vi.fn(), healthCheck: vi.fn() }, model: "haiku" };
-    const handler = buildOOCToolHandler(undefined, fakeSmallTier, undefined, undefined, undefined, undefined, undefined, gs);
-    const result = await handler("scribe", {
-      updates: [{ visibility: "private", content: "Test" }],
-    });
-    expect(result.is_error).toBe(true);
-    expect(result.content).toContain("Small-tier");
   });
 });
 
-describe("enterOOC with gameState", () => {
-  it("passes 17 tools when gameState and fileIO are provided", async () => {
-    const gs = mockGameState();
-    const fio = mockFileIO();
-    const provider = mockProvider([textResponse("Done.")]);
-    await enterOOC(provider, "test", {
-      campaignName: "Test",
-      previousVariant: "playing",
-      fileIO: fio,
-      campaignRoot: "/camp",
-      gameState: gs,
-      model: "claude-sonnet-4-6",
+describe("buildOOCToolHandler — engine async chain", () => {
+  it("delegates to engineAsync when it returns a non-null ToolResult", async () => {
+    const engineAsync = vi.fn(async (name: string) => {
+      if (name === "search_campaign") return { content: "engine-handled" };
+      return null;
     });
-
-    const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      expect(createCall.tools).toHaveLength(16);
-      const names = createCall.tools.map((t: { name: string }) => t.name);
-      expect(names).toContain("roll_dice");
-      expect(names).toContain("scribe");
-      expect(names).toContain("style_scene");
-      expect(names).toContain("rollback");
-    }
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), engineAsync);
+    const result = await handler("search_campaign", { query: "hello" });
+    expect(engineAsync).toHaveBeenCalledWith("search_campaign", { query: "hello" });
+    expect(result.content).toBe("engine-handled");
   });
 
-  it("still passes only 4 tools without gameState", async () => {
-    const fio = mockFileIO();
-    const provider = mockProvider([textResponse("Done.")]);
-    await enterOOC(provider, "test", {
-      campaignName: "Test",
-      previousVariant: "playing",
-      fileIO: fio,
-      campaignRoot: "/camp",
-      model: "claude-sonnet-4-6",
-    });
-
-    const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      expect(createCall.tools).toHaveLength(4);
-    }
-  });
-
-  it("uses maxToolRounds=8 when tools are available", async () => {
-    const gs = mockGameState();
-    const fio = mockFileIO();
-    const provider = mockProvider([textResponse("Done.")]);
-    await enterOOC(provider, "test", {
-      campaignName: "Test",
-      previousVariant: "playing",
-      fileIO: fio,
-      campaignRoot: "/camp",
-      gameState: gs,
-      model: "claude-sonnet-4-6",
-    });
-
-    const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      // maxToolRounds is passed internally to spawnSubagent, not directly to API
-      // We verify tools exist to confirm hasTools path was taken
-      expect(createCall.tools).toBeDefined();
-    }
+  it("falls through to registry dispatch when engineAsync returns null", async () => {
+    const engineAsync = vi.fn(async () => null);
+    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), engineAsync);
+    const result = await handler("roll_dice", { expression: "1d6" });
+    expect(engineAsync).toHaveBeenCalled();
+    expect(result.is_error).toBeUndefined();
+    expect(result.content).toContain("1d6");
   });
 });
+
+// --- parseEndOOCSignal ---
 
 describe("parseEndOOCSignal", () => {
   it("detects self-closing tag", () => {
@@ -842,6 +607,38 @@ describe("parseEndOOCSignal", () => {
   });
 });
 
+// --- parseSummaryTag ---
+
+describe("parseSummaryTag", () => {
+  it("extracts summary content and strips the tag", () => {
+    const result = parseSummaryTag("Reply text.\n<SUMMARY>One-line digest.</SUMMARY>");
+    expect(result.summary).toBe("One-line digest.");
+    expect(result.cleanedText).toBe("Reply text.");
+  });
+
+  it("returns no summary when tag is absent", () => {
+    const result = parseSummaryTag("Just a plain reply.");
+    expect(result.summary).toBeUndefined();
+    expect(result.cleanedText).toBe("Just a plain reply.");
+  });
+
+  it("trims surrounding whitespace in the summary payload", () => {
+    const result = parseSummaryTag("Reply.\n<SUMMARY>  trimmed  </SUMMARY>\n");
+    expect(result.summary).toBe("trimmed");
+  });
+
+  it("strips the SUMMARY tag even when it sits before END_OOC", () => {
+    const text = "Reply body.\n<SUMMARY>Digest.</SUMMARY>\n<END_OOC />";
+    const result = parseSummaryTag(text);
+    expect(result.summary).toBe("Digest.");
+    // SUMMARY tag is removed; END_OOC remains in cleanedText for the next parser.
+    expect(result.cleanedText).toContain("<END_OOC />");
+    expect(result.cleanedText).not.toContain("<SUMMARY>");
+  });
+});
+
+// --- enterOOC END_OOC integration ---
+
 describe("enterOOC END_OOC integration", () => {
   it("sets endSession when agent emits END_OOC", async () => {
     const provider = mockProvider([textResponse("Grappling uses Athletics.\n<END_OOC />")]);
@@ -877,7 +674,23 @@ describe("enterOOC END_OOC integration", () => {
     expect(result.endSession).toBeUndefined();
     expect(result.playerAction).toBeUndefined();
   });
+
+  it("combines SUMMARY + END_OOC: summary forwarded, both tags stripped from visible text", async () => {
+    const text = "Conversational reply.\n<SUMMARY>Clarified rules.</SUMMARY>\n<END_OOC>I attack</END_OOC>";
+    const provider = mockProvider([textResponse(text)]);
+    const result = await enterOOC(provider, "x", {
+      campaignName: "Test",
+      previousVariant: "exploration",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.endSession).toBe(true);
+    expect(result.summary).toBe("Clarified rules.");
+    expect(result.playerAction).toBe("I attack");
+    expect(result.text).toBe("Conversational reply.");
+  });
 });
+
+// --- extractSummary fallback ---
 
 describe("extractSummary", () => {
   it("extracts first substantive sentence", () => {
@@ -908,7 +721,6 @@ describe("extractSummary", () => {
   });
 
   it("uses first sentence when all sentences are short filler", () => {
-    // All sentences under 15 chars — falls back to first
     expect(extractSummary("Got it. OK. Done.")).toBe("Got it.");
   });
 
@@ -917,3 +729,95 @@ describe("extractSummary", () => {
       .toBe("Explained the combat rules to the player.");
   });
 });
+
+// --- Mocks ---
+
+const MOCK_BASE_TS = Math.floor(new Date("2025-03-15T12:00:00Z").getTime() / 1000);
+
+function mockGitIO(): GitIO {
+  const commits: { message: string; oid: string; timestamp: number }[] = [];
+  const staged = new Set<string>();
+  let oidCounter = 0;
+
+  return {
+    init: vi.fn(async () => {}),
+    add: vi.fn(async (_dir, filepath) => { staged.add(filepath); }),
+    commit: vi.fn(async (_dir, message) => {
+      const oid = `commit_${++oidCounter}`;
+      commits.unshift({ message, oid, timestamp: MOCK_BASE_TS + oidCounter * 86400 });
+      staged.clear();
+      return oid;
+    }),
+    log: vi.fn(async (_dir, depth = 50) =>
+      commits.slice(0, depth).map((c) => ({
+        oid: c.oid,
+        commit: { message: c.message, author: { timestamp: c.timestamp } },
+      })),
+    ),
+    checkout: vi.fn(async () => {}),
+    resetTo: vi.fn(async () => {}),
+    pruneUnreachable: vi.fn(async () => 0),
+    statusMatrix: vi.fn(async () =>
+      staged.size > 0
+        ? [...staged].map((f) => [f, 1, 2, 2] as [string, number, number, number])
+        : [["config.json", 1, 2, 1] as [string, number, number, number]],
+    ),
+    listFiles: vi.fn(async () => ["config.json"]),
+    remove: vi.fn(async () => {}),
+  };
+}
+
+function mockFileIO(
+  files: Record<string, string> = {},
+  dirs: Record<string, string[]> = {},
+): FileIO {
+  const n = (p: string) => p.replace(/\\/g, "/");
+  const normFiles: Record<string, string> = {};
+  for (const [k, v] of Object.entries(files)) normFiles[n(k)] = v;
+  const normDirs: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(dirs)) normDirs[n(k)] = v;
+
+  return {
+    readFile: vi.fn(async (p: string) => {
+      const np = n(p);
+      if (np in normFiles) return normFiles[np];
+      throw new Error(`ENOENT: ${p}`);
+    }),
+    writeFile: vi.fn(async () => {}),
+    appendFile: vi.fn(async () => {}),
+    mkdir: vi.fn(async () => {}),
+    exists: vi.fn(async (p: string) => n(p) in normFiles || n(p) in normDirs),
+    listDir: vi.fn(async (p: string) => {
+      const np = n(p);
+      if (np in normDirs) return normDirs[np];
+      throw new Error(`ENOENT: ${p}`);
+    }),
+    deleteFile: vi.fn(async () => {}),
+  };
+}
+
+function mockGameState(overrides?: Partial<GameState>): GameState {
+  return {
+    maps: {},
+    clocks: createClocksState(),
+    combat: createCombatState(),
+    combatConfig: createDefaultConfig(),
+    decks: createDecksState(),
+    objectives: createObjectivesState(),
+    config: {
+      name: "TestCampaign",
+      dm_personality: { name: "Narrator", prompt_fragment: "terse" },
+      players: [{ name: "Player1", character: "Kael", type: "human" }],
+      combat: createDefaultConfig(),
+      context: { retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 },
+      recovery: { auto_commit_interval: 300, max_commits: 100, enable_git: false },
+      choices: { campaign_default: "never", player_overrides: {} },
+    },
+    campaignRoot: "/camp",
+    homeDir: "/tmp/home",
+    activePlayerIndex: 0,
+    displayResources: {},
+    resourceValues: {},
+    ...overrides,
+  } as GameState;
+}

--- a/packages/engine/src/agents/subagents/ooc-mode.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.ts
@@ -217,14 +217,14 @@ export function buildOOCToolHandler(
   repo?: CampaignRepo,
   campaignRoot?: string,
   fileIO?: FileIO,
-  maps?: Record<string, MapData>,
-  clocks?: ClocksState,
 ): (name: string, input: Record<string, unknown>) => Promise<ToolResult> {
   return async (name: string, input: Record<string, unknown>) => {
     try {
-      // 1. OOC-only extras
+      // 1. OOC-only extras — validate_campaign reads live maps/clocks
+      // straight from gameState so reports reflect current session state,
+      // not stubs.
       if (OOC_ONLY_TOOL_SET.has(name)) {
-        return await dispatchOOCExtra(name, input, repo, campaignRoot, fileIO, maps, clocks);
+        return await dispatchOOCExtra(name, input, repo, campaignRoot, fileIO, gameState.maps, gameState.clocks);
       }
 
       // 2. Engine async handler (DM-side async tools)
@@ -326,8 +326,6 @@ export async function enterOOC(
     repo?: CampaignRepo;
     fileIO?: FileIO;
     campaignRoot?: string;
-    maps?: Record<string, MapData>;
-    clocks?: ClocksState;
     gameState?: GameState;
     registry?: ToolRegistry;
     /**
@@ -391,14 +389,14 @@ export async function enterOOC(
         options.repo,
         options.campaignRoot,
         options.fileIO,
-        options.maps,
-        options.clocks,
       )
     : hasTools
-      ? // No game state: OOC-only extras only.
+      ? // No game state: OOC-only extras only. validate_campaign runs
+        // against empty stubs in this branch — the no-gameState path is
+        // for pre-session / test callers without live maps or clocks.
         async (name: string, input: Record<string, unknown>) => {
           if (OOC_ONLY_TOOL_SET.has(name)) {
-            return dispatchOOCExtra(name, input, options.repo, options.campaignRoot, options.fileIO, options.maps, options.clocks);
+            return dispatchOOCExtra(name, input, options.repo, options.campaignRoot, options.fileIO, undefined, undefined);
           }
           return { content: `Unknown tool: ${name}`, is_error: true };
         }
@@ -560,8 +558,6 @@ export function createOOCSession(
     repo?: CampaignRepo;
     fileIO?: FileIO;
     campaignRoot?: string;
-    maps?: Record<string, MapData>;
-    clocks?: ClocksState;
     gameState?: GameState;
     registry?: ToolRegistry;
     volatileContext?: string;

--- a/packages/engine/src/agents/subagents/ooc-mode.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.ts
@@ -1,46 +1,48 @@
-import type { LLMProvider, NormalizedTool, SystemBlock, TierProvider } from "../../providers/types.js";
+import type { LLMProvider, NormalizedTool, SystemBlock, TierProvider, NormalizedMessage } from "../../providers/types.js";
 import type { SubagentStreamCallback } from "../subagent.js";
-import { spawnSubagent } from "../subagent.js";
 import type { SubagentResult } from "../subagent.js";
 import type { DMSessionState } from "../dm-prompt.js";
+import { buildDMPrefix } from "../dm-prompt.js";
 import type { FileIO } from "../scene-manager.js";
 import type { GameState } from "../game-state.js";
 import type { TuiCommand } from "../agent-loop.js";
-import { registry } from "../tool-registry.js";
+import { TUI_TOOLS } from "../agent-loop.js";
+import type { ToolRegistry, ToolResult } from "../tool-registry.js";
 import { getMaxOutput } from "../../config/model-registry.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
 import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
 import type { CampaignRepo } from "../../tools/git/index.js";
-import { queryCommitLog, performRollback } from "../../tools/git/index.js";
+import { queryCommitLog } from "../../tools/git/index.js";
 import { RollbackCompleteError } from "@machine-violet/shared/types/errors.js";
 import type { MapData } from "@machine-violet/shared/types/maps.js";
 import type { ClocksState } from "@machine-violet/shared/types/clocks.js";
 import { findReferences } from "../../tools/campaign-ops/index.js";
 import { validateCampaign } from "../../tools/validation/index.js";
 import { resolveCampaignPath } from "../../utils/paths.js";
-import { runScribe } from "./scribe.js";
+import { runProviderLoop } from "../../providers/agent-loop-bridge.js";
 import type { ModeSession } from "@machine-violet/shared/types/engine.js";
 
-// --- DM tool categories available in OOC mode ---
+// --- Types ---
 
-const OOC_READONLY_TOOLS = [
-  "roll_dice", "map", "map_entity", "map_query", "alarm",
-];
+/**
+ * Async tool handler exposed by GameEngine. Returns a ToolResult for tools
+ * it handles (resolve_turn, style_scene, search_campaign, search_content),
+ * or null for tools the engine doesn't intercept — falls through to
+ * registry.dispatch in that case.
+ */
+export type EngineAsyncToolHandler = (
+  name: string,
+  input: Record<string, unknown>,
+) => Promise<ToolResult | null>;
 
-const OOC_ENTITY_TOOLS = ["scribe", "promote_character"];
+/** Tools that exist only in OOC — file/git inspection. Layered on top of the
+ *  full DM toolset; not present in the singleton registry. */
+const OOC_ONLY_TOOL_NAMES = ["read_file", "find_references", "validate_campaign", "get_commit_log"] as const;
+const OOC_ONLY_TOOL_SET = new Set<string>(OOC_ONLY_TOOL_NAMES);
 
-const OOC_TUI_TOOLS = ["style_scene", "set_display_resources", "set_resource_values", "show_character_sheet"];
-
-const OOC_RECOVERY_TOOLS = ["rollback"];
-
-const OOC_DM_TOOL_NAMES = [
-  ...OOC_READONLY_TOOLS,
-  ...OOC_ENTITY_TOOLS,
-  ...OOC_TUI_TOOLS,
-  ...OOC_RECOVERY_TOOLS,
-];
-
-const OOC_DM_TOOL_SET = new Set(OOC_DM_TOOL_NAMES);
+/** Tools deliberately excluded from OOC's view of the registry.
+ *  `enter_ooc` — we're already in OOC, no need to advertise re-entry. */
+const OOC_EXCLUDED_FROM_REGISTRY = new Set(["enter_ooc"]);
 
 /**
  * Context snapshot for OOC mode — captured when entering, restored when exiting.
@@ -73,164 +75,74 @@ export interface OOCPromptOptions {
   campaignName: string;
   config?: CampaignConfig;
   sessionState?: DMSessionState;
-  characterSheet?: string;
-  systemRules?: string;
-  /** Model ID for prompt-level conditional inclusion. Omit to skip conditionals. */
+  /**
+   * Reason given by the DM if the OOC session was entered via the
+   * `enter_ooc` tool call (DM-initiated). Surfaces in the suffix so the
+   * OOC agent knows what the DM intended to discuss.
+   */
+  enterReason?: string;
+  /** True when the DM was mid-narration — same heuristic for suffix wording. */
+  wasMidNarration?: boolean;
+  /** Model ID — passed through to loadPrompt for any model-specific tweaks. */
   model?: string;
+  /** Legacy: a system rules appendix when no `sessionState` is available. */
+  systemRules?: string;
+  /** Legacy: a character sheet block when no `sessionState` is available. */
+  characterSheet?: string;
 }
 
 /**
- * Build the OOC system prompt with campaign-specific context.
+ * Build the full OOC system prompt.
  *
- * When `config` + `sessionState` are provided, returns `TextBlockParam[]`
- * with cache_control on stable sections (identity, rules, campaign log).
+ * When `config` + `sessionState` are provided (the in-game path), reuses
+ * `buildDMPrefix` to produce a cache-coherent DM prefix and appends an
+ * OOC suffix block at the tail. Cache breakpoints on the DM prefix are
+ * preserved, so OOC enters/exits ride the same BP1/BP2 cache as normal play.
  *
- * When only `campaignName` is provided (pre-game-start / backward compat),
- * returns a flat string.
+ * Pre-session-state path (legacy / tests without a full SessionState)
+ * falls back to the standalone OOC suffix as a flat string.
  */
-export function buildOOCPrompt(options: OOCPromptOptions): string | SystemBlock[];
+export function buildOOCPrompt(options: OOCPromptOptions): string | SystemBlock[] {
+  const opts = options;
 
-/** @deprecated Legacy overload — use options object form. */
-export function buildOOCPrompt(
-  campaignName: string,
-  systemRules?: string,
-  characterSheet?: string,
-): string;
-
-export function buildOOCPrompt(
-  optionsOrName: OOCPromptOptions | string,
-  systemRules?: string,
-  characterSheet?: string,
-): string | SystemBlock[] {
-  // Legacy call: buildOOCPrompt("name", rules?, sheet?)
-  if (typeof optionsOrName === "string") {
-    return buildOOCPromptLegacy(optionsOrName, systemRules, characterSheet);
-  }
-
-  const opts = optionsOrName;
-
-  // If no session state, fall back to flat string
+  // No game state — fall back to a flat string of just the OOC suffix.
+  // The DM prefix is what makes OOC feel continuous with narration; without
+  // it (e.g. pre-game-start callers) we keep the suffix as-is.
   if (!opts.sessionState || !opts.config) {
-    return buildOOCPromptLegacy(opts.campaignName, opts.systemRules, opts.characterSheet, opts.model);
+    let prompt = loadPrompt("ooc-mode", opts.model);
+    if (opts.campaignName) prompt += `\n\nCampaign: ${opts.campaignName}`;
+    if (opts.systemRules) prompt += `\n\nGame system rules:\n${opts.systemRules}`;
+    if (opts.characterSheet) prompt += `\n\nActive character:\n${opts.characterSheet}`;
+    return prompt;
   }
 
-  // Build structured TextBlockParam[] with caching
-  return buildOOCPromptCached({ ...opts, config: opts.config, sessionState: opts.sessionState });
+  const prefix = buildDMPrefix(opts.config, opts.sessionState);
+
+  // OOC suffix — appended after all DM Tier 1+2 blocks. Uncached on purpose
+  // (it varies per entry and is small), and sits past the last cache_control
+  // marker so BP1/BP2 keep their hits.
+  const suffixParts: string[] = [`\n\n`, loadPrompt("ooc-mode", opts.model)];
+
+  if (opts.enterReason || opts.wasMidNarration) {
+    suffixParts.push(`\n\n### OOC Entry Context\n`);
+    if (opts.wasMidNarration) {
+      suffixParts.push(`The DM (you) called \`enter_ooc\` mid-narration. `);
+    }
+    if (opts.enterReason) {
+      suffixParts.push(`Reason given: ${opts.enterReason}`);
+    }
+  }
+
+  return [...prefix.system, { text: suffixParts.join("") }];
 }
 
-/** Legacy flat-string builder (backward compat / pre-game-start). */
-function buildOOCPromptLegacy(
-  campaignName: string,
-  systemRules?: string,
-  characterSheet?: string,
-  model?: string,
-): string {
-  let prompt = loadPrompt("ooc-mode", model);
-
-  if (campaignName) {
-    prompt += `\n\nCampaign: ${campaignName}`;
-  }
-
-  if (systemRules) {
-    prompt += `\n\nGame system rules:\n${systemRules}`;
-  }
-
-  if (characterSheet) {
-    prompt += `\n\nActive character:\n${characterSheet}`;
-  }
-
-  return prompt;
-}
-
-/** Structured cached-prefix builder — mirrors DM prefix layout minus DM-internal sections. */
-function buildOOCPromptCached(opts: Required<Pick<OOCPromptOptions, "config" | "sessionState">> & OOCPromptOptions): SystemBlock[] {
-  const blocks: SystemBlock[] = [];
-  const config = opts.config;
-  const ss = opts.sessionState;
-
-  // OOC identity prompt (stable — cached)
-  blocks.push({
-    text: loadPrompt("ooc-mode", opts.model),
-    cacheControl: { ttl: "1h" },
-  });
-
-  // Campaign setting
-  {
-    const settingLines: string[] = [`Campaign: ${opts.campaignName}`];
-    if (config.system) settingLines.push(`Game System: ${config.system}`);
-    if (config.genre) settingLines.push(`Genre: ${config.genre}`);
-    if (config.mood) settingLines.push(`Mood: ${config.mood}`);
-    if (config.difficulty) settingLines.push(`Difficulty: ${config.difficulty}`);
-    if (config.premise) settingLines.push(`Premise: ${config.premise}`);
-    blocks.push({
-      text: `\n\n## Campaign Setting\n${settingLines.join("\n")}`,
-    });
-  }
-
-  // Rules appendix (stable — cached)
-  if (ss.rulesAppendix || opts.systemRules) {
-    blocks.push({
-      text: `\n\n## Rules Reference\n${ss.rulesAppendix ?? opts.systemRules}`,
-      cacheControl: { ttl: "1h" },
-    });
-  }
-
-  // Campaign log (stable within a scene — cached)
-  if (ss.campaignSummary) {
-    blocks.push({
-      text: `\n\n## Campaign Log\n${ss.campaignSummary}`,
-      cacheControl: { ttl: "1h" },
-    });
-  }
-
-  // Session recap (changes once at session start)
-  if (ss.sessionRecap) {
-    blocks.push({
-      text: `\n\n## Last Session\n${ss.sessionRecap}`,
-    });
-  }
-
-  // Active state (location, PCs, alarms — changes during play)
-  if (ss.activeState) {
-    blocks.push({
-      text: `\n\n## Current State\n${ss.activeState}`,
-    });
-  }
-
-  // Scene precis (changes as exchanges are pruned)
-  if (ss.scenePrecis) {
-    blocks.push({
-      text: `\n\n## Scene So Far\n${ss.scenePrecis}`,
-    });
-  }
-
-  // Active character sheet (player-specific, uncached)
-  if (opts.characterSheet) {
-    blocks.push({
-      text: `\n\n## Active Character\n${opts.characterSheet}`,
-    });
-  }
-
-  return blocks;
-}
-
-/** Build OOC tool definitions (available when repo or fileIO is provided). */
-export function buildOOCTools(hasFileIO: boolean, hasGameState: boolean): NormalizedTool[] {
-  const tools: NormalizedTool[] = [
-    {
-      name: "get_commit_log",
-      description: "List git snapshot commits for this campaign. Shows commit hash, type, message, and timestamp. Use to review game history for rollback or debugging.",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          depth: { type: "number", description: "Number of commits to retrieve (default 20, max 100)" },
-          type: { type: "string", enum: ["auto", "scene", "session", "checkpoint", "character"], description: "Filter by commit type" },
-          search: { type: "string", description: "Filter by message content (case-insensitive)" },
-        },
-        required: [],
-      },
-    },
-  ];
+/**
+ * Build the OOC tool list: every DM tool (so OOC is self-documenting from
+ * the same code path as the DM) minus `enter_ooc`, plus a small set of
+ * OOC-only extras for file/git inspection.
+ */
+export function buildOOCTools(registry: ToolRegistry, hasFileIO: boolean, hasRepo: boolean): NormalizedTool[] {
+  const tools: NormalizedTool[] = registry.getDefinitions(OOC_EXCLUDED_FROM_REGISTRY);
 
   if (hasFileIO) {
     tools.push(
@@ -268,9 +180,20 @@ export function buildOOCTools(hasFileIO: boolean, hasGameState: boolean): Normal
     );
   }
 
-  // Append DM tool definitions when game state is available
-  if (hasGameState) {
-    tools.push(...registry.getDefinitionsFor(OOC_DM_TOOL_NAMES));
+  if (hasRepo) {
+    tools.push({
+      name: "get_commit_log",
+      description: "List git snapshot commits for this campaign. Shows commit hash, type, message, and timestamp. Use to review game history for rollback or debugging.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          depth: { type: "number", description: "Number of commits to retrieve (default 20, max 100)" },
+          type: { type: "string", enum: ["auto", "scene", "session", "checkpoint", "character"], description: "Filter by commit type" },
+          search: { type: "string", description: "Filter by message content (case-insensitive)" },
+        },
+        required: [],
+      },
+    });
   }
 
   return tools;
@@ -279,78 +202,39 @@ export function buildOOCTools(hasFileIO: boolean, hasGameState: boolean): Normal
 /**
  * Build the OOC tool handler.
  *
- * `smallTier` is the provider+model for spawning small-tier subagents from
- * within OOC tools (scribe, promote_character). Distinct from `provider` —
- * which is the medium-tier OOC session itself — because under heterogeneous
- * routing those two tiers may live on different vendors. Required when the
- * scribe/promote tools are wired up; otherwise unused.
+ * Dispatch order on every tool call:
+ *   1. OOC-only extras (file/git inspection) — handled here directly.
+ *   2. Engine async handler — resolve_turn, search_campaign, search_content,
+ *      style_scene live on GameEngine. Falls through with `null` if not its tool.
+ *   3. Registry dispatch — every other DM tool routes through the same
+ *      singleton the DM uses, so state mutations + persistence + the
+ *      onToolSuccess callbacks fire identically.
  */
 export function buildOOCToolHandler(
-  provider: LLMProvider | undefined,
-  smallTier: TierProvider | undefined,
+  registry: ToolRegistry,
+  gameState: GameState,
+  engineAsync: EngineAsyncToolHandler | undefined,
   repo?: CampaignRepo,
   campaignRoot?: string,
   fileIO?: FileIO,
   maps?: Record<string, MapData>,
   clocks?: ClocksState,
-  gameState?: GameState,
-  onTuiCommand?: (cmd: TuiCommand) => void,
-): (name: string, input: Record<string, unknown>) => Promise<{ content: string; is_error?: boolean }> {
+): (name: string, input: Record<string, unknown>) => Promise<ToolResult> {
   return async (name: string, input: Record<string, unknown>) => {
     try {
-      switch (name) {
-        case "get_commit_log": {
-          if (!repo) {
-            return { content: "Git is not available", is_error: true };
-          }
-          const result = await queryCommitLog(repo, {
-            depth: input.depth as number | undefined,
-            type: input.type as string | undefined,
-            search: input.search as string | undefined,
-          });
-          return { content: result };
-        }
-
-        case "read_file": {
-          if (!fileIO || !campaignRoot) {
-            return { content: "File I/O not available", is_error: true };
-          }
-          let abs: string;
-          try {
-            abs = resolveCampaignPath(campaignRoot, input.path as string);
-          } catch {
-            return { content: "Path traversal not allowed", is_error: true };
-          }
-          const content = await fileIO.readFile(abs);
-          return { content };
-        }
-
-        case "find_references": {
-          if (!fileIO || !campaignRoot) {
-            return { content: "File I/O not available", is_error: true };
-          }
-          const refResult = await findReferences(campaignRoot, fileIO, input.path as string);
-          return { content: JSON.stringify(refResult, null, 2) };
-        }
-
-        case "validate_campaign": {
-          if (!fileIO || !campaignRoot) {
-            return { content: "File I/O not available", is_error: true };
-          }
-          const validationResult = await validateCampaign(
-            campaignRoot, maps ?? {}, clocks ?? { calendar: { current: 0, epoch: "", display_format: "", alarms: [] }, combat: { current: 0, active: false, alarms: [] } },
-            fileIO,
-          );
-          return { content: JSON.stringify(validationResult, null, 2) };
-        }
-
-        default:
-          // DM tool dispatch
-          if (OOC_DM_TOOL_SET.has(name) && gameState) {
-            return await dispatchDMTool(name, input, gameState, provider, smallTier, repo, fileIO, campaignRoot, onTuiCommand);
-          }
-          return { content: `Unknown tool: ${name}`, is_error: true };
+      // 1. OOC-only extras
+      if (OOC_ONLY_TOOL_SET.has(name)) {
+        return await dispatchOOCExtra(name, input, repo, campaignRoot, fileIO, maps, clocks);
       }
+
+      // 2. Engine async handler (DM-side async tools)
+      if (engineAsync) {
+        const r = await engineAsync(name, input);
+        if (r !== null) return r;
+      }
+
+      // 3. Registry dispatch — full DM toolset, same semantics as DM use.
+      return registry.dispatch(gameState, name, input);
     } catch (err) {
       if (err instanceof RollbackCompleteError) throw err;
       const msg = err instanceof Error ? err.message : String(err);
@@ -359,126 +243,73 @@ export function buildOOCToolHandler(
   };
 }
 
-/**
- * Dispatch a DM tool from OOC context, post-processing based on category.
- *
- * `smallTier` is needed for tools that spawn small-tier subagents
- * (scribe, promote_character) — separate from the medium-tier `provider`
- * because the two tiers may map to different vendors.
- */
-async function dispatchDMTool(
+/** Handle the OOC-only tool set (file/git inspection). */
+async function dispatchOOCExtra(
   name: string,
   input: Record<string, unknown>,
-  gameState: GameState,
-  provider: LLMProvider | undefined,
-  smallTier: TierProvider | undefined,
-  repo?: CampaignRepo,
-  fileIO?: FileIO,
-  campaignRoot?: string,
-  onTuiCommand?: (cmd: TuiCommand) => void,
-): Promise<{ content: string; is_error?: boolean }> {
-  // Read-only tools — dispatch directly and return result
-  if (OOC_READONLY_TOOLS.includes(name)) {
-    const result = registry.dispatch(gameState, name, input);
-    return result;
-  }
-
-  // TUI tools — dispatch to get the command JSON, then forward via callback
-  if (OOC_TUI_TOOLS.includes(name)) {
-    const result = registry.dispatch(gameState, name, input);
-    if (result.is_error) return result;
-    if (onTuiCommand) {
-      const cmd = JSON.parse(result.content) as TuiCommand;
-      onTuiCommand(cmd);
-    }
-    return { content: `Applied: ${name}` };
-  }
-
-  // Scribe — spawn subagent to handle entity operations
-  if (name === "scribe") {
-    if (!smallTier || !fileIO || !campaignRoot) {
-      return { content: "Small-tier provider and file I/O required for scribe", is_error: true };
-    }
-    const result = registry.dispatch(gameState, name, input);
-    if (result.is_error) return result;
-    const cmd = result._tui ?? JSON.parse(result.content);
-    const scribeResult = await runScribe(smallTier.provider, {
-      updates: (cmd as Record<string, unknown>).updates as import("./scribe.js").ScribeUpdate[],
-      campaignRoot,
-      sceneNumber: 0, // OOC has no scene number
-      homeDir: gameState.homeDir,
-    }, fileIO, smallTier.model);
-    return { content: scribeResult.summary };
-  }
-
-  // Promote character — read sheet, spawn subagent, write back
-  if (name === "promote_character") {
-    if (!smallTier || !fileIO || !campaignRoot) {
-      return { content: "Small-tier provider and file I/O required for promote_character", is_error: true };
-    }
-    const result = registry.dispatch(gameState, name, input);
-    if (result.is_error) return result;
-    const cmd = result._tui ?? JSON.parse(result.content);
-    const characterName = (cmd as Record<string, unknown>).character as string;
-    const context = (cmd as Record<string, unknown>).context as string;
-
-    const { campaignPaths } = await import("../../tools/filesystem/index.js");
-    const { norm } = await import("../../utils/paths.js");
-    const paths = campaignPaths(campaignRoot);
-    const filePath = norm(paths.character(characterName));
-
-    let currentSheet: string;
-    try {
-      currentSheet = await fileIO.readFile(filePath);
-    } catch {
-      currentSheet = `# ${characterName}\n\n**Type:** character\n`;
+  repo: CampaignRepo | undefined,
+  campaignRoot: string | undefined,
+  fileIO: FileIO | undefined,
+  maps: Record<string, MapData> | undefined,
+  clocks: ClocksState | undefined,
+): Promise<ToolResult> {
+  switch (name) {
+    case "read_file": {
+      if (!fileIO || !campaignRoot) {
+        return { content: "File I/O not available", is_error: true };
+      }
+      let abs: string;
+      try {
+        abs = resolveCampaignPath(campaignRoot, input.path as string);
+      } catch {
+        return { content: "Path traversal not allowed", is_error: true };
+      }
+      const content = await fileIO.readFile(abs);
+      return { content };
     }
 
-    const { promoteCharacter } = await import("./character-promotion.js");
-    const promoResult = await promoteCharacter(smallTier.provider, {
-      characterName,
-      characterSheet: currentSheet,
-      context,
-    }, undefined, smallTier.model);
-
-    if (promoResult.updatedSheet) {
-      await fileIO.writeFile(filePath, promoResult.updatedSheet);
+    case "find_references": {
+      if (!fileIO || !campaignRoot) {
+        return { content: "File I/O not available", is_error: true };
+      }
+      const refResult = await findReferences(campaignRoot, fileIO, input.path as string);
+      return { content: JSON.stringify(refResult, null, 2) };
     }
 
-    return { content: `Updated ${characterName}: ${promoResult.changelogEntry}` };
-  }
+    case "validate_campaign": {
+      if (!fileIO || !campaignRoot) {
+        return { content: "File I/O not available", is_error: true };
+      }
+      const validationResult = await validateCampaign(
+        campaignRoot,
+        maps ?? {},
+        clocks ?? { calendar: { current: 0, epoch: "", display_format: "", alarms: [] }, combat: { current: 0, active: false, alarms: [] } },
+        fileIO,
+      );
+      return { content: JSON.stringify(validationResult, null, 2) };
+    }
 
-  // Rollback — execute via repo (prunes ghost dirs + exits)
-  if (OOC_RECOVERY_TOOLS.includes(name)) {
-    return await executeRollback(input, repo, campaignRoot, fileIO);
-  }
+    case "get_commit_log": {
+      if (!repo) return { content: "Git is not available", is_error: true };
+      const result = await queryCommitLog(repo, {
+        depth: input.depth as number | undefined,
+        type: input.type as string | undefined,
+        search: input.search as string | undefined,
+      });
+      return { content: result };
+    }
 
-  return { content: `Unknown OOC tool: ${name}`, is_error: true };
-}
-
-/** Execute rollback via performRollback — prunes ghost dirs then exits. */
-async function executeRollback(
-  input: Record<string, unknown>,
-  repo?: CampaignRepo,
-  campaignRoot?: string,
-  fileIO?: FileIO,
-): Promise<{ content: string; is_error?: boolean }> {
-  if (!repo) {
-    return { content: "Git is not available for rollback", is_error: true };
+    default:
+      return { content: `Unknown OOC tool: ${name}`, is_error: true };
   }
-  if (!campaignRoot || !fileIO) {
-    return { content: "File I/O not available for rollback cleanup", is_error: true };
-  }
-  const target = input.target as string;
-  const result = await performRollback(repo, target, campaignRoot, fileIO);
-  throw new RollbackCompleteError(result.summary);
 }
 
 /**
- * Enter OOC mode — spawn a Sonnet subagent that handles OOC conversation.
- * The subagent is player-facing (streams to TUI).
+ * Enter OOC mode — run one OOC exchange through the provider.
  *
- * Returns a terse summary for the DM when OOC ends.
+ * Reuses the DM's runProviderLoop directly so TUI command extraction, the
+ * deferred-command list, and async tool handling behave identically to a
+ * DM turn. Streams to the player via `onStream`.
  */
 export async function enterOOC(
   provider: LLMProvider,
@@ -491,20 +322,34 @@ export async function enterOOC(
     characterSheet?: string;
     previousVariant: string;
     wasMidNarration?: boolean;
+    enterReason?: string;
     repo?: CampaignRepo;
     fileIO?: FileIO;
     campaignRoot?: string;
     maps?: Record<string, MapData>;
     clocks?: ClocksState;
     gameState?: GameState;
-    onTuiCommand?: (cmd: TuiCommand) => void;
-    model: string;
+    registry?: ToolRegistry;
     /**
-     * Small-tier provider+model for spawning small-tier subagents (scribe,
-     * promote_character) from inside OOC tool handlers. Heterogeneous-routing
-     * safe: under Medium=Anthropic/Small=OpenAI the scribe call still routes
-     * through the OpenAI client + small model, not the medium-tier provider.
+     * Volatile context (Tier 3) injected as a user-message preamble.
+     * Mirrors the DM turn shape so OOC sees "current state", entity index,
+     * UI state without those blocks invalidating the BP3 tools cache.
      */
+    volatileContext?: string;
+    /**
+     * Async tool handler from GameEngine — surfaces resolve_turn,
+     * search_campaign, search_content, style_scene to OOC the same way
+     * the DM uses them.
+     */
+    engineAsyncTool?: EngineAsyncToolHandler;
+    /** Immediate TUI command callback (modeline, resources, theme, etc.). */
+    onTuiCommand?: (cmd: TuiCommand) => void;
+    /** Deferred TUI command consumer — typically `engine.applyDeferredTuiCommands`. */
+    onDeferredTuiCommands?: (cmds: TuiCommand[]) => Promise<void>;
+    model: string;
+    /** Heterogeneous-routing-safe small tier (unused now that scribe/promote
+     *  go through engine.applyDeferredTuiCommands, but kept on the surface for
+     *  callers that build via createOOCSession; remove once migrations land). */
     smallTier?: TierProvider;
   },
   onStream?: SubagentStreamCallback,
@@ -515,6 +360,8 @@ export async function enterOOC(
     sessionState: options.sessionState,
     characterSheet: options.characterSheet,
     systemRules: options.systemRules,
+    wasMidNarration: options.wasMidNarration,
+    enterReason: options.enterReason,
     model: options.model,
   });
 
@@ -524,36 +371,86 @@ export async function enterOOC(
   };
 
   const hasFileIO = !!(options.fileIO && options.campaignRoot);
-  const hasGameState = !!options.gameState;
-  const hasTools = !!options.repo || hasFileIO || hasGameState;
-  const tools = hasTools ? buildOOCTools(hasFileIO, hasGameState) : undefined;
-  const toolHandler = hasTools
-    ? buildOOCToolHandler(provider, options.smallTier, options.repo, options.campaignRoot, options.fileIO, options.maps, options.clocks, options.gameState, options.onTuiCommand)
-    : undefined;
+  const hasRepo = !!options.repo;
+  const hasGameState = !!options.gameState && !!options.registry;
+  const hasTools = hasFileIO || hasRepo || hasGameState;
 
-  const result = await spawnSubagent(
-    provider,
-    {
-      name: "ooc",
-      model: options.model,
-      visibility: "player_facing",
-      systemPrompt,
-      maxTokens: getMaxOutput(options.model),
-      ...(tools ? { tools, cacheTools: true } : {}),
-      ...(toolHandler ? { toolHandler } : {}),
-      maxToolRounds: hasTools ? 8 : undefined,
-    },
-    playerMessage,
-    onStream,
-  );
+  // Build tools: full DM registry minus enter_ooc, plus OOC-only extras.
+  // If we don't have game state, only the OOC-only extras are available.
+  const toolRegistry: ToolRegistry = hasGameState && options.registry
+    ? options.registry
+    : ({ getDefinitions: () => [] } as unknown as ToolRegistry);
+  const tools: NormalizedTool[] = buildOOCTools(toolRegistry, hasFileIO, hasRepo);
 
-  // Parse END_OOC signal if present
-  const signal = parseEndOOCSignal(result.text);
-  const summary = extractSummary(signal.cleanedText);
+  // Build handler chain.
+  const toolHandler = hasTools && hasGameState && options.registry && options.gameState
+    ? buildOOCToolHandler(
+        options.registry,
+        options.gameState,
+        options.engineAsyncTool,
+        options.repo,
+        options.campaignRoot,
+        options.fileIO,
+        options.maps,
+        options.clocks,
+      )
+    : hasTools
+      ? // No game state: OOC-only extras only.
+        async (name: string, input: Record<string, unknown>) => {
+          if (OOC_ONLY_TOOL_SET.has(name)) {
+            return dispatchOOCExtra(name, input, options.repo, options.campaignRoot, options.fileIO, options.maps, options.clocks);
+          }
+          return { content: `Unknown tool: ${name}`, is_error: true };
+        }
+      : undefined;
+
+  // Wrap the player message with volatile-context preamble, mirroring the
+  // DM turn shape. Ephemeral so it doesn't poison the next-turn cache.
+  const userContent = options.volatileContext
+    ? `<context>\n${options.volatileContext}\n</context>\n\n${playerMessage}`
+    : playerMessage;
+  const messages: NormalizedMessage[] = [{
+    role: "user",
+    content: userContent,
+    ephemeral: !!options.volatileContext,
+  }];
+
+  // Run through the same provider loop the DM uses — gets TUI command
+  // extraction, deferred-list collection, and streaming for free.
+  const result = await runProviderLoop(provider, systemPrompt, messages, {
+    name: "ooc",
+    model: options.model,
+    maxTokens: getMaxOutput(options.model),
+    maxToolRounds: hasTools ? 10 : 1,
+    stream: !!onStream,
+    tools: tools.length > 0 ? tools : undefined,
+    toolHandler,
+    cacheHints: tools.length > 0 ? [{ target: "tools", ttl: "1h" }] : undefined,
+    tuiToolNames: TUI_TOOLS,
+    onTuiCommand: options.onTuiCommand,
+    onTextDelta: onStream,
+  });
+
+  // Process deferred TUI commands (scribe, promote_character, dm_notes,
+  // scene_transition, session_end, rollback) the same way the DM does
+  // after its turn.
+  if (options.onDeferredTuiCommands && result.tuiCommands.length > 0) {
+    await options.onDeferredTuiCommands(result.tuiCommands);
+  }
+
+  // Parse the OOC end signal + optional SUMMARY tag.
+  const summaryParse = parseSummaryTag(result.text);
+  const signal = parseEndOOCSignal(summaryParse.cleanedText);
+  const summary = summaryParse.summary ?? extractSummary(signal.cleanedText);
 
   return {
-    ...result,
     text: signal.cleanedText,
+    usage: {
+      inputTokens: result.usage.inputTokens,
+      outputTokens: result.usage.outputTokens,
+      cacheReadTokens: result.usage.cacheReadTokens,
+      cacheCreationTokens: result.usage.cacheCreationTokens,
+    },
     summary,
     snapshot,
     endSession: signal.found || undefined,
@@ -601,7 +498,29 @@ export function parseEndOOCSignal(text: string): EndOOCSignal {
 }
 
 /**
- * Extract a terse summary from OOC text.
+ * Parse an optional `<SUMMARY>one-line digest</SUMMARY>` tag near the end
+ * of the response. Strips the tag from the visible text so the player
+ * never sees it; the digest is forwarded to the DM separately.
+ *
+ * Scans the last 600 chars only — the SUMMARY tag belongs at the end of
+ * the reply, and a tight scan keeps us from grabbing a literal example
+ * tag the agent might have written earlier in the message.
+ */
+export function parseSummaryTag(text: string): { summary?: string; cleanedText: string } {
+  const SUMMARY_RE = /<SUMMARY>([\s\S]*?)<\/SUMMARY>\s*/;
+  const tail = text.slice(Math.max(0, text.length - 600));
+  const tailMatch = tail.match(SUMMARY_RE);
+  if (!tailMatch) return { cleanedText: text };
+
+  // Match position in the full string.
+  const offset = text.length - tail.length + tail.indexOf(tailMatch[0]);
+  const cleaned = text.slice(0, offset) + text.slice(offset + tailMatch[0].length);
+  return { summary: tailMatch[1].trim(), cleanedText: cleaned.trimEnd() };
+}
+
+/**
+ * Extract a terse summary from OOC text — fallback when the agent omits the
+ * `<SUMMARY>` tag.
  * Takes the first substantive sentence (skips filler phrases < 15 chars).
  * Falls back to first 100 chars if no sentence boundary found.
  */
@@ -633,6 +552,8 @@ export function createOOCSession(
   options: {
     campaignName: string;
     previousVariant: string;
+    wasMidNarration?: boolean;
+    enterReason?: string;
     config?: CampaignConfig;
     sessionState?: DMSessionState;
     characterSheet?: string;
@@ -642,10 +563,15 @@ export function createOOCSession(
     maps?: Record<string, MapData>;
     clocks?: ClocksState;
     gameState?: GameState;
+    registry?: ToolRegistry;
+    volatileContext?: string;
+    engineAsyncTool?: EngineAsyncToolHandler;
     onTuiCommand?: (cmd: TuiCommand) => void;
+    onDeferredTuiCommands?: (cmds: TuiCommand[]) => Promise<void>;
     /** Model ID for the medium tier; threaded into enterOOC's options. */
     model: string;
-    /** Small-tier {provider, model} for OOC tools that spawn small-tier subagents. */
+    /** Small-tier provider+model — kept on the surface for caller back-compat
+     *  even though the engine async handler now owns small-tier dispatch. */
     smallTier?: TierProvider;
   },
 ): ModeSession {

--- a/packages/engine/src/prompts/ooc-mode.md
+++ b/packages/engine/src/prompts/ooc-mode.md
@@ -1,102 +1,44 @@
-You are the Out-of-Character (OOC) mode for a tabletop RPG session.
+## Out-of-Character Mode
 
-## Identity
+You are temporarily out-of-character. The player is talking with you as the storyteller, not as their character — answer rules questions, fix data, correct mistakes, recap events, customize the UI, chat. Do **not** narrate game fiction or advance the scene on this turn. Narrative play resumes on the next in-character exchange.
 
-You are an ablative context layer — you speak with the player as the DM out-of-character, handling everything outside the game narrative so the main DM's context stays focused on the fiction. When you're done, you return a terse summary so the DM knows what happened without having seen the full conversation.
+Your full DM toolkit is available — all the tools you have as the DM, with the same semantics. A few extras only exist in OOC, for inspecting and repairing the campaign:
 
-You ARE the DM speaking out-of-character. Do NOT narrate game events or advance the fiction.
+- `read_file`, `find_references`, `validate_campaign` — inspect entity files and link integrity.
+- `get_commit_log` — review the git snapshot history.
+- `rollback` — restore the campaign to a previous checkpoint. Confirm with the player before invoking; this is destructive and irreversible.
 
-## How to Handle a Request
+Reach for `scribe` for entity corrections and `promote_character` for character advancement just as you would in narration. Don't ask permission for routine fixes — verify the claim against the scene record, then act.
 
-**Answer from your context first.** Your system prompt contains the Campaign Log, Scene So Far, Rules Reference, and Active Character Sheet. Most questions about recent events, character stats, and game rules are answerable from these sections without any tool calls. Check them before reaching for tools.
+If the request needs Dev Mode (bulk file operations, direct game-state JSON patching, validation workflows beyond `validate_campaign`), say so and name the alternative. Don't attempt filesystem surgery or state-JSON manipulation from here.
 
-**If the answer requires a specific entity file, read it.** Player asks about an NPC's background, a location's layout, a faction's goals — call `read_file` with the inferred path. Do not ask the player what file to look up. Infer from the entity name:
-- "Captain Voss" → `characters/captain-voss.md`
-- "the Gilded Quarter" → `locations/gilded-quarter/index.md`
-- "the Thornwatch" → `factions/thornwatch.md`
+### Ending OOC
 
-If file tools aren't available in the current session, say so and answer from your system prompt context only. Suggest Dev Mode if the player needs file access.
+When the conversation reaches a natural close, end your turn with one of these signals as the very last thing in your reply:
 
-**If you're unsure which entity, search first.** Use `find_references` to locate wikilinks pointing at an entity, or try likely path variations with `read_file`. Two tool calls is better than asking the player to navigate their own campaign. If you can't find it, suggest Dev Mode for `search_files` or `list_dir`.
+- `<END_OOC />` — return to play, nothing to forward.
+- `<END_OOC>the player's in-character action</END_OOC>` — forward in-character speech back to the DM.
 
-**If the request involves changing data, act on it.** Stat corrections, missing NPCs, data errors — use `scribe` to update entities or `promote_character` for character advancement. Don't ask permission for minor fixes. Only confirm before `rollback` (destructive and irreversible).
+If the player has already shifted into in-character speech, emit just the `<END_OOC>` tag silently — do not acknowledge the transition, no "Back to the game!" framing. Reproduce the player's words faithfully; do not paraphrase.
 
-**If the request is beyond your scope, say so.** Name the alternative: "That needs Dev Mode — it can patch game state directly / do bulk file operations / run diagnostics." Don't attempt filesystem surgery or game state JSON manipulation.
+Only signal end-of-OOC when the exchange is genuinely complete. If the player still seems to have questions, keep the session open.
 
-## Examples
+### Summary line
 
-**Stat lookup — answer from context, no tools:**
-Player asks "What are my spell slots?" Your system prompt contains the Active Character section. Find the spell slot line, answer directly.
+On the turn you end OOC — and **only** that turn — include a one-line `<SUMMARY>` immediately before `<END_OOC>`. The player does not see this line; it is forwarded to the DM as a digest so they can pick up with context. Omit it on intermediate turns.
 
-**Entity lookup — one tool call:**
-Player asks "What do we know about Captain Voss?" The name appears in Scene So Far but details are sparse. Call `read_file("characters/captain-voss.md")`, then summarize the relevant public information. Don't dump the entire file.
+For entity corrections, include before/after values. For AI-related mistakes, lead with the reported mistake and the correction.
 
-**Error correction — verify, then fix:**
-Player says "My HP should be 45, not 38 — the DM forgot the healing potion." Check Scene So Far for the potion event. If confirmed, call `scribe` to update the character. If the scene record doesn't mention a potion, say so — do not blindly accept the claim. Lead your summary with the correction: "Corrected Kael's HP from 38 to 45 (healing potion in exchange 12 was not recorded)."
+Examples:
 
-**Rules question — context + file:**
-Player asks "How does grappling work?" Check the Rules Reference in your context first. If the system's rule card covers it, answer from there. If more detail is needed, `read_file` the relevant rules section.
-
-## Scope
-
-**In scope:**
-- Rules lookups and clarifications
-- Character sheet review and corrections (via `scribe`)
-- Character advancement (via `promote_character`)
-- Campaign history and session recap ("what happened when...")
-- Entity file reads and minor corrections
-- UI customization (`style_scene`, `set_display_resources`, `set_resource_values`, `show_character_sheet`)
-- Dice rolls for rules testing or the player's own rolls
-- Map queries (`map`, `map_entity`, `map_query`) and clock/alarm checks (`alarm`)
-- Git history browsing (`get_commit_log`)
-- Rollback to a previous checkpoint (with confirmation)
-- Addressing DM errors — verify claims against game state before agreeing
-
-**Out of scope — direct to Dev Mode:**
-- Bulk file operations, renames, merges, deletions
-- Direct game state JSON inspection or patching
-- Engine internals (agent loop, scene manager, prompt pipeline)
-- Campaign validation and repair workflows
-- File search by regex
-
-## Formatting
-
-Your replies render through the same pipeline as DM narration. Do not use Markdown. These HTML-subset tags are available:
-- `<b>bold</b>`, `<i>italic</i>`, `<u>underline</u>`
-- `<sub>subscript</sub>` — chemical formulas (H<sub>2</sub>O), footnote markers
-- `<sup>superscript</sup>` — exponents (x<sup>2</sup>), ordinals (1<sup>st</sup>), footnote callouts
-- `<color=#HEX>text</color>` — thematic color
-- `<center>…</center>`, `<right>…</right>` — alignment (must be on their own line)
-- `---` on its own line — horizontal separator
-
-Use formatting sparingly — OOC is for clear information, not drama.
-
-## Ending the OOC Session
-
-When the conversation reaches a natural conclusion — the player's question is answered, their concern is resolved, or they start speaking in-character — signal that OOC mode should end by placing one of these tags at the very end of your response:
-
-**No player action** (question resolved, returning to game):
-
+```
+<SUMMARY>Clarified grappling: contested Athletics; target uses Athletics or Acrobatics.</SUMMARY>
 <END_OOC />
+```
 
-**Player spoke in-character** (forward their words to the DM):
+```
+<SUMMARY>Corrected Kael's HP 38 → 45 (healing potion in exchange 12 was not recorded).</SUMMARY>
+<END_OOC>I shout to the others: "Keep moving!"</END_OOC>
+```
 
-<END_OOC>I grab the guard by the collar and shove him against the wall.</END_OOC>
-
-Rules:
-- The tag MUST be the very last thing in your response.
-- When forwarding in-character input, reproduce the player's words faithfully — do not paraphrase.
-- Only signal when the exchange is genuinely complete. If the player seems to have more questions, keep the session open.
-- If the player speaks in-character, just emit the tag silently — do not acknowledge the transition or say anything like "Back to the game!" The seamless handoff is better for immersion.
-
-## Summary
-
-Your response text is automatically summarized (first substantive sentence) for the DM's context. The DM won't see the full OOC conversation — only this summary.
-
-Your FIRST SENTENCE must describe what was discussed or resolved — not a filler phrase like "No worries" or "Sure thing."
-- Good: "Clarified grappling rules: contested Athletics check, target can use Athletics or Acrobatics."
-- Good: "Corrected Kael's HP from 38 to 45 (healing potion was not recorded)."
-- Bad: "Sure, let me look that up for you."
-
-For entity corrections, include the before and after values.
-For AI-related mistakes, lead with the reported mistake and the correct approach.
+If you forget the `<SUMMARY>` tag, the DM falls back to the first substantive sentence of your reply. Better to be deliberate.

--- a/packages/engine/src/server/command-handler.test.ts
+++ b/packages/engine/src/server/command-handler.test.ts
@@ -49,6 +49,7 @@ function makeMockEngine(performRollback = true) {
       mkdir: async () => {},
     }),
     getSessionState: () => ({}),
+    getSystemPrompt: () => ({ system: [], volatile: "## Current State\nstub", hardStats: "" }),
   };
   return {
     getRepo: () => repo,
@@ -60,6 +61,10 @@ function makeMockEngine(performRollback = true) {
     getPreviousVariant: vi.fn(() => "exploration"),
     getModeSession: vi.fn(() => null),
     setModeSession: vi.fn(),
+    getRegistry: vi.fn(() => ({ getDefinitions: () => [] })),
+    handleAsyncTool: vi.fn(async () => null),
+    applyDeferredTuiCommands: vi.fn(async () => {}),
+    dispatchImmediateTuiCommand: vi.fn(),
   } as unknown as GameEngine;
 }
 

--- a/packages/engine/src/server/command-handler.ts
+++ b/packages/engine/src/server/command-handler.ts
@@ -153,6 +153,7 @@ function handleModeToggle(
   const small = engine.getTier("small");
   if (target === "ooc") {
     const sm = engine.getSceneManager();
+    const prefix = sm.getSystemPrompt({});
     const session = createOOCSession(medium.provider, {
       campaignName: gameState.config.name,
       previousVariant,
@@ -161,12 +162,23 @@ function handleModeToggle(
       repo: engine.getRepo() ?? undefined,
       fileIO: sm.getFileIO(),
       campaignRoot: gameState.campaignRoot,
-      // Pass gameState so the DM-tier tool definitions (scribe,
-      // promote_character, roll_dice, etc.) register. The OOC system
-      // prompt explicitly directs the agent to use scribe for entity
-      // corrections; without gameState the registration is skipped and
-      // the agent correctly tells the player it doesn't have the tool.
       gameState,
+      // OOC dispatches the full DM toolset through the same singleton
+      // registry the DM uses — same state mutations, same persistence,
+      // same TUI side effects.
+      registry: engine.getRegistry(),
+      // Volatile DM context (Tier 3: current state, entity index, UI state)
+      // gets injected as a user-message preamble so OOC sees live game
+      // state without invalidating the cached system prefix.
+      volatileContext: prefix.volatile,
+      // Surface the DM's async tool handler (resolve_turn, search_campaign,
+      // search_content, style_scene) to OOC so the agent can use them the
+      // same way the DM does.
+      engineAsyncTool: (name, input) => engine.handleAsyncTool(name, input),
+      // Route immediate (visual) TUI commands through the engine so they
+      // reach the client + update persistedUI just like DM-side calls.
+      onTuiCommand: (cmd) => engine.dispatchImmediateTuiCommand(cmd),
+      onDeferredTuiCommands: (cmds) => engine.applyDeferredTuiCommands(cmds),
       model: medium.model,
       smallTier: small,
     });

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -703,8 +703,9 @@ export class SessionManager {
       // If a mode session (OOC/Dev) is active, route to it
       const modeSession = this.engine.getModeSession();
       if (modeSession) {
+        let modeResult: Awaited<ReturnType<typeof modeSession.send>> | undefined;
         try {
-          await modeSession.send(text, (delta) => {
+          modeResult = await modeSession.send(text, (delta) => {
             scopedBroadcast({ type: "narrative:chunk", data: { text: delta, kind: "dm" } });
           });
         } catch (err) {
@@ -725,6 +726,45 @@ export class SessionManager {
         }
         scopedBroadcast({ type: "narrative:complete", data: { text: "" } });
         this.persistTurnState();
+
+        // If OOC signaled end-of-session, exit OOC and stash the summary
+        // so the next DM turn picks up <ooc_summary> context. If OOC also
+        // produced a player action, forward it to the DM as the next turn —
+        // skipping openNextTurn() since processInput will close the gate.
+        if (modeResult?.endSession) {
+          this.engine.setModeSession(null);
+          const previousVariant = this.engine.getPreviousVariant() ?? "exploration";
+          scopedBroadcast({
+            type: "session:mode",
+            data: { mode: "play", variant: previousVariant },
+          });
+          if (modeResult.summary) {
+            this.engine.setPendingOOCSummary(modeResult.summary);
+          }
+          scopedBroadcast({ type: "state:snapshot", data: this.buildStateSnapshot() });
+          if (modeResult.playerAction && this.gameState) {
+            const active = getActivePlayer(this.gameState);
+            try {
+              await this.engine.processInput(active.characterName, modeResult.playerAction);
+            } catch (err) {
+              if (err instanceof RollbackCompleteError) {
+                scopedBroadcast({ type: "narrative:complete", data: { text: "" } });
+                scopedBroadcast({
+                  type: "narrative:chunk",
+                  data: { text: `[${err.message}]`, kind: "system" },
+                });
+                await this.endSession("rollback");
+                return;
+              }
+              throw err;
+            }
+            this.persistTurnState();
+            scopedBroadcast({ type: "state:snapshot", data: this.buildStateSnapshot() });
+          }
+          this.openNextTurn();
+          return;
+        }
+
         scopedBroadcast({ type: "state:snapshot", data: this.buildStateSnapshot() });
         this.openNextTurn();
         return;

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -729,8 +729,9 @@ export class SessionManager {
 
         // If OOC signaled end-of-session, exit OOC and stash the summary
         // so the next DM turn picks up <ooc_summary> context. If OOC also
-        // produced a player action, forward it to the DM as the next turn —
-        // skipping openNextTurn() since processInput will close the gate.
+        // produced a player action, run it through the DM right now so the
+        // same turn that exits OOC carries both the summary and the
+        // in-character action forward.
         if (modeResult?.endSession) {
           this.engine.setModeSession(null);
           const previousVariant = this.engine.getPreviousVariant() ?? "exploration";


### PR DESCRIPTION
## Summary

- OOC now derives its prompt and toolset from the same code paths the DM uses: `buildDMPrefix` for system blocks (cache-coherent with the DM, so BP1/BP2 hits survive the mode transition) + a short uncached suffix, and `registry.getDefinitions({"enter_ooc"})` plus OOC-only extras for inspection.
- Wires the OOC summary back into the DM's next turn via the existing (but dangling) `engine.setPendingOOCSummary` hook, so OOC events stop vanishing from the DM's context.
- Switches the summary mechanism from "first sentence is the summary" (which newer models were taking literally, fixes #456) to an explicit `<SUMMARY>` tag, with the first-sentence heuristic kept as a fallback.

Fixes #456, #458.

## Why

Both bugs traced back to the same underlying issue: OOC was diverging from the DM. The OOC system prompt hand-curated a list of tools that didn't always match what was actually loaded (#458). The summary instruction was conditioning the agent to emit summary-only replies (#456). And the summary, when produced correctly, was never forwarded — `session-manager.ts` was throwing away `modeSession.send()`'s return value.

Reusing the DM's prompt + tool surface fixes the first by construction (tool descriptions come straight from the registry), and lets the OOC prompt shrink to just what's actually OOC-specific.

## What changed

**Prompt** — `buildOOCPrompt` calls `buildDMPrefix(config, sessionState)` and appends an OOC suffix block at the tail. The suffix only describes what's OOC-specific: end signals, summary tag, the inspection-only extras. The DM directives already cover everything else.

**Tools** — Full DM toolset minus `enter_ooc` (we're already in OOC), plus four OOC-only extras: `read_file`, `find_references`, `validate_campaign`, `get_commit_log`.

**Dispatch** — `buildOOCToolHandler` chains: OOC-only extras → engine async handler (`resolve_turn`, `search_campaign`, `search_content`, `style_scene`) → `registry.dispatch`. Same state mutations, persistence callbacks, and `onToolSuccess` hooks as a DM turn. Deferred TUI commands (`scribe`, `promote_character`, `dm_notes`, etc.) route through `engine.applyDeferredTuiCommands`, factored out of `processInput` so OOC and DM share the teardown.

**Volatile context** — Tier 3 state (`Current State`, `Entity Registry`, `UI State`) injected as an ephemeral `<context>` preamble on the OOC user message, mirroring the DM turn shape. OOC sees live game state without invalidating the BP3 tools cache.

**Summary handler** — `session-manager.ts` now consumes `modeSession.send()`'s return value:
- `endSession=true` → clear mode session, restore variant, call `engine.setPendingOOCSummary(summary)`. The existing `<ooc_summary>` injection path in `processInput` picks it up on the next DM turn.
- `playerAction` set (player shifted in-character) → forward it via `processInput` immediately, so the same turn that exits OOC carries both the summary and the in-character action.

**`<SUMMARY>` tag** — Agent emits `<SUMMARY>one-line digest</SUMMARY>` right before `<END_OOC>` on the ending turn. `parseSummaryTag` strips it from visible text. `extractSummary`'s first-sentence heuristic is the fallback for turns where the agent forgets.

**New public engine accessors** so mode sessions can wire through the same machinery: `getFileIO`, `getGameState`, `getRegistry`, `handleAsyncTool`, `applyDeferredTuiCommands`, `dispatchImmediateTuiCommand`.

## Test plan

- [x] `npm run check` — 2483 tests pass, lint clean
- [ ] Manual: `/ooc` mid-narration → ask a rules question → exit → verify DM picks up `<ooc_summary>` on next turn
- [ ] Manual: `/ooc` → ask the agent to `scribe` an NPC correction → exit → verify entity file was updated and DM sees the change
- [ ] Manual: `/ooc` → player drifts into in-character speech → agent emits `<END_OOC>...</END_OOC>` with the action → verify same turn forwards to DM with `<ooc_summary>` prefix
- [ ] Manual: verify the player no longer sees summary-style replies during OOC chat (the #456 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)