### PR TITLE
Let Scribe rename entities; flag starting location as a placeholder

### DIFF
--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -640,6 +640,7 @@ Front matter lines appear immediately after the H1 heading and before the body. 
 | `hp` | HP | Characters | `28/35` |
 | `ac` | AC | Characters | `16` |
 | `xp` | XP | Characters | `1200` |
+| `placeholder` | Placeholder | Any | `true` — flags a stub entity that the Scribe should rename + flesh out (e.g. the bootstrap `Starting Location`). Removed once the entity has a real name and content. |
 
 The `_title` key is internal (extracted from the H1 heading) and never serialized.
 

--- a/packages/engine/src/agents/game-engine.test.ts
+++ b/packages/engine/src/agents/game-engine.test.ts
@@ -76,6 +76,7 @@ vi.mock("./subagents/scribe.js", () => ({
     created: ["/tmp/test-campaign/characters/grimjaw.md"],
     updated: [],
     entityDeltas: [{ slug: "grimjaw", name: "Grimjaw", aliases: [], type: "character", path: "characters/grimjaw.md" }],
+    removedSlugs: [],
     usage: { inputTokens: 30, outputTokens: 15, cacheReadTokens: 0, cacheCreationTokens: 0 },
   })),
 }));

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -985,6 +985,11 @@ export class GameEngine {
           this.sceneManager.upsertEntity(delta);
         }
       }
+      if (result.removedSlugs) {
+        for (const slug of result.removedSlugs) {
+          this.sceneManager.removeEntity(slug);
+        }
+      }
 
       logEvent("subagent:end", { name: "scribe", durationMs: Date.now() - subStart });
       accUsage(this.sessionUsage, result.usage);

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -608,6 +608,12 @@ export class SceneManager {
     };
   }
 
+  /** Remove an entry from the entity tree (e.g. after rename). */
+  removeEntity(slug: string): void {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete this.entityTree[slug];
+  }
+
   /** Get the current entity tree (for passing to subagents). */
   getEntityTree(): EntityTree {
     return this.entityTree;

--- a/packages/engine/src/agents/setup-agent.test.ts
+++ b/packages/engine/src/agents/setup-agent.test.ts
@@ -199,9 +199,13 @@ describe("buildCampaignWorld", () => {
     expect(logData.campaignName).toBe(result.campaignName);
     expect(logData.entries).toEqual([]);
 
-    // Location was created
+    // Location was created — and explicitly flagged as a placeholder
+    // so the Scribe knows to rename it once the DM names the opening locale.
     const locationFile = Object.keys(files).find((p) => p.includes("/locations/"));
     expect(locationFile).toBeTruthy();
+    expect(locationFile).toContain("starting-location/index.md");
+    expect(files[locationFile!]).toContain("**Placeholder:** true");
+    expect(files[locationFile!]).toContain("Placeholder");
 
     // Party file was written with PC as member
     const partyFile = Object.keys(files).find((p) => p.endsWith("/party.md"));

--- a/packages/engine/src/agents/subagents/scribe.test.ts
+++ b/packages/engine/src/agents/subagents/scribe.test.ts
@@ -533,6 +533,20 @@ describe("buildScribeToolHandler", () => {
       expect(result.content).toContain("nothing to rename");
     });
 
+    it("rejects player entities (machine-scope, not campaign-scope)", async () => {
+      const fio = mockFileIO();
+      const handler = buildScribeToolHandler(fio, "/camp", 1, [], [], [], []);
+
+      const result = await handler("rename_entity", {
+        entity_type: "player",
+        old_name: "Alex",
+        new_name: "Alexandra",
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(result.content).toContain("player");
+    });
+
     it("rejects when deleteFile is unavailable", async () => {
       const fio = mockFileIO({ "/camp/locations/starting-location/index.md": placeholder });
       fio.deleteFile = undefined;

--- a/packages/engine/src/agents/subagents/scribe.test.ts
+++ b/packages/engine/src/agents/subagents/scribe.test.ts
@@ -36,6 +36,17 @@ function mockFileIO(files: Record<string, string> = {}): ScribeFileIO {
       return [...entries];
     }),
     mkdir: vi.fn(async () => {}),
+    deleteFile: vi.fn(async (path: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete store[norm(path)];
+    }),
+    rmdir: vi.fn(async (path: string) => {
+      // Reject if any keys still live under this directory.
+      const prefix = norm(path) + "/";
+      for (const key of Object.keys(store)) {
+        if (key.startsWith(prefix)) throw new Error("ENOTEMPTY");
+      }
+    }),
   };
 }
 
@@ -390,6 +401,152 @@ describe("buildScribeToolHandler", () => {
     const handler = buildScribeToolHandler(fio, "/camp", 1, [], [], []);
     const result = await handler("unknown_tool", {});
     expect(result.is_error).toBe(true);
+  });
+
+  describe("rename_entity", () => {
+    const placeholder = [
+      "# Starting Location",
+      "",
+      "**Type:** Location",
+      "**Placeholder:** true",
+      "",
+      "_Placeholder._",
+      "",
+    ].join("\n");
+
+    it("moves the file, updates the H1, rewrites wikilinks, and tracks tree deltas", async () => {
+      const fio = mockFileIO({
+        "/camp/locations/starting-location/index.md": placeholder,
+        "/camp/characters/aldric.md": [
+          "# Aldric",
+          "",
+          "**Type:** character",
+          "**Location:** [Starting Location](../locations/starting-location/index.md)",
+          "",
+          "Met at the [Starting Location](../locations/starting-location/index.md).",
+          "",
+        ].join("\n"),
+      });
+      const updated: string[] = [];
+      const deltas: { slug: string; name: string; aliases: string[]; type: string; path: string }[] = [];
+      const removedSlugs: string[] = [];
+      const handler = buildScribeToolHandler(fio, "/camp", 7, [], updated, deltas, removedSlugs);
+
+      const result = await handler("rename_entity", {
+        entity_type: "location",
+        old_name: "Starting Location",
+        new_name: "The Crooked Coin Tavern",
+      });
+
+      expect(result.is_error).toBeFalsy();
+      expect(result.content).toContain("Renamed");
+      expect(result.content).toContain("Crooked Coin Tavern");
+
+      // Old file is gone, new file exists. Note: `slugify` strips leading
+      // articles, so "The Crooked Coin Tavern" lands at `crooked-coin-tavern`.
+      expect(await fio.exists("/camp/locations/starting-location/index.md")).toBe(false);
+      expect(await fio.exists("/camp/locations/crooked-coin-tavern/index.md")).toBe(true);
+
+      // New file has the new H1 + carries the placeholder flag forward
+      // (Scribe is supposed to remove `Placeholder:` in a follow-up update.)
+      const moved = await fio.readFile("/camp/locations/crooked-coin-tavern/index.md");
+      expect(moved).toContain("# The Crooked Coin Tavern");
+      expect(moved).toContain("**Placeholder:** true");
+      expect(moved).toContain("Renamed from Starting Location to The Crooked Coin Tavern");
+      expect(moved).toContain("Scene 007");
+
+      // Wikilinks in aldric.md are rewritten
+      const aldric = await fio.readFile("/camp/characters/aldric.md");
+      expect(aldric).not.toContain("starting-location");
+      expect(aldric).toContain("crooked-coin-tavern");
+
+      // Tree bookkeeping
+      expect(removedSlugs).toEqual(["starting-location"]);
+      expect(deltas).toHaveLength(1);
+      expect(deltas[0].slug).toBe("crooked-coin-tavern");
+      expect(deltas[0].name).toBe("The Crooked Coin Tavern");
+      expect(deltas[0].type).toBe("location");
+      expect(norm(deltas[0].path)).toBe("locations/crooked-coin-tavern/index.md");
+
+      // Old empty location dir was rmdir'd
+      expect(fio.rmdir).toHaveBeenCalled();
+    });
+
+    it("uses caller-supplied changelog entry when provided", async () => {
+      const fio = mockFileIO({ "/camp/locations/starting-location/index.md": placeholder });
+      const handler = buildScribeToolHandler(fio, "/camp", 2, [], [], [], []);
+
+      await handler("rename_entity", {
+        entity_type: "location",
+        old_name: "Starting Location",
+        new_name: "Bell Harbor",
+        changelog_entry: "Named on entry to the city",
+      });
+
+      const moved = await fio.readFile("/camp/locations/bell-harbor/index.md");
+      expect(moved).toContain("Named on entry to the city");
+      expect(moved).not.toContain("Renamed from Starting Location");
+    });
+
+    it("rejects when the target slug already exists", async () => {
+      const fio = mockFileIO({
+        "/camp/locations/starting-location/index.md": placeholder,
+        "/camp/locations/bell-harbor/index.md": "# Bell Harbor\n\n**Type:** Location\n",
+      });
+      const handler = buildScribeToolHandler(fio, "/camp", 1, [], [], [], []);
+
+      const result = await handler("rename_entity", {
+        entity_type: "location",
+        old_name: "Starting Location",
+        new_name: "Bell Harbor",
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(result.content).toContain("already exists");
+    });
+
+    it("rejects when the source entity does not exist", async () => {
+      const fio = mockFileIO();
+      const handler = buildScribeToolHandler(fio, "/camp", 1, [], [], [], []);
+
+      const result = await handler("rename_entity", {
+        entity_type: "location",
+        old_name: "Nowhere",
+        new_name: "Somewhere",
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(result.content).toContain("not found");
+    });
+
+    it("rejects when both names slugify identically", async () => {
+      const fio = mockFileIO({ "/camp/locations/starting-location/index.md": placeholder });
+      const handler = buildScribeToolHandler(fio, "/camp", 1, [], [], [], []);
+
+      const result = await handler("rename_entity", {
+        entity_type: "location",
+        old_name: "Starting Location",
+        new_name: "starting-location",
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(result.content).toContain("nothing to rename");
+    });
+
+    it("rejects when deleteFile is unavailable", async () => {
+      const fio = mockFileIO({ "/camp/locations/starting-location/index.md": placeholder });
+      fio.deleteFile = undefined;
+      const handler = buildScribeToolHandler(fio, "/camp", 1, [], [], [], []);
+
+      const result = await handler("rename_entity", {
+        entity_type: "location",
+        old_name: "Starting Location",
+        new_name: "Bell Harbor",
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(result.content).toContain("file deletion support");
+    });
   });
 });
 

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -11,6 +11,8 @@ import { formatChangelogEntry } from "../../tools/filesystem/index.js";
 import type { EntityFrontMatter, EntityTree } from "@machine-violet/shared/types/entities.js";
 import { renderEntityTree } from "../../tools/filesystem/index.js";
 import { norm } from "../../utils/paths.js";
+import { renameEntity as renameEntityOp } from "../../tools/campaign-ops/rename-entity.js";
+import type { FileIO } from "../scene-manager.js";
 
 // Re-export slugify from world-builder so the game engine doesn't need a separate import
 export { slugify } from "../world-builder.js";
@@ -51,6 +53,8 @@ export interface ScribeResult {
   updated: string[];
   /** Entity tree deltas — entries to upsert into the entity tree */
   entityDeltas: ScribeEntityDelta[];
+  /** Slugs to remove from the entity tree (e.g. after a rename). */
+  removedSlugs: string[];
   /** Usage stats */
   usage: UsageStats;
 }
@@ -62,6 +66,10 @@ export interface ScribeFileIO {
   exists(path: string): Promise<boolean>;
   listDir(path: string): Promise<string[]>;
   mkdir(path: string): Promise<void>;
+  /** Optional. Required for `rename_entity`. */
+  deleteFile?(path: string): Promise<void>;
+  /** Optional. Used by `rename_entity` to clean up an emptied location dir. */
+  rmdir?(path: string): Promise<void>;
 }
 
 // --- Scribe Tools (given to the subagent) ---
@@ -135,6 +143,34 @@ const SCRIBE_TOOLS: NormalizedTool[] = [
         },
       },
       required: ["mode", "entity_type", "name"],
+    },
+  },
+  {
+    name: "rename_entity",
+    description:
+      "Rename an existing entity. Moves the file to the new slug, updates its H1 to the new display name, and rewrites every wikilink across the campaign that pointed to the old entity. Use this when an entity is renamed in fiction (e.g. a tavern reveals its real name) — and especially to replace the placeholder `Starting Location` once the opening locale has a real name.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        entity_type: {
+          type: "string",
+          enum: ["character", "location", "faction", "lore", "item", "player"],
+          description: "Entity type",
+        },
+        old_name: {
+          type: "string",
+          description: "Current display name of the entity (e.g. \"Starting Location\"). Used to derive the existing slug.",
+        },
+        new_name: {
+          type: "string",
+          description: "New display name (e.g. \"The Crooked Coin Tavern\"). The new slug is derived from this name.",
+        },
+        changelog_entry: {
+          type: "string",
+          description: "Optional changelog entry. If omitted, a default \"Renamed from X to Y\" entry is added.",
+        },
+      },
+      required: ["entity_type", "old_name", "new_name"],
     },
   },
 ];
@@ -236,6 +272,7 @@ export function buildScribeToolHandler(
   created: string[],
   updated: string[],
   entityDeltas: ScribeEntityDelta[],
+  removedSlugs: string[] = [],
   homeDir?: string,
 ) {
   const paths = campaignPaths(campaignRoot);
@@ -390,6 +427,88 @@ export function buildScribeToolHandler(
         }
       }
 
+      case "rename_entity": {
+        const entityType = input.entity_type as string;
+        const oldName = input.old_name as string;
+        const newName = input.new_name as string;
+        if (!oldName || !newName) {
+          return { content: "rename_entity requires 'old_name' and 'new_name'", is_error: true };
+        }
+        const oldSlug = slugify(oldName);
+        const newSlug = slugify(newName);
+        if (oldSlug === newSlug) {
+          return { content: `Old and new names slugify to the same value (${oldSlug}); nothing to rename`, is_error: true };
+        }
+        if (!fileIO.deleteFile) {
+          return { content: "rename_entity requires file deletion support, which is unavailable in this environment", is_error: true };
+        }
+
+        const oldFilePath = norm(entityPath(entityType, oldSlug));
+        const newFilePath = norm(entityPath(entityType, newSlug));
+        if (!(await fileIO.exists(oldFilePath))) {
+          return { content: `Entity not found: ${entityType}/${oldSlug}`, is_error: true };
+        }
+        if (await fileIO.exists(newFilePath)) {
+          return { content: `Cannot rename: ${entityType}/${newSlug} already exists`, is_error: true };
+        }
+
+        const normRoot = norm(campaignRoot);
+        const oldRelative = oldFilePath.replace(normRoot + "/", "");
+        const newRelative = newFilePath.replace(normRoot + "/", "");
+
+        try {
+          // Move the file and rewrite incoming wikilinks campaign-wide.
+          // ScribeFileIO is a structural subset of the FileIO that
+          // renameEntity needs; deleteFile is the only optional method
+          // it touches and we already checked it above.
+          const renameResult = await renameEntityOp(
+            campaignRoot,
+            fileIO as FileIO,
+            oldRelative,
+            newRelative,
+            false,
+          );
+
+          // Update the H1 to the new display name and add a changelog entry.
+          const moved = await fileIO.readFile(newFilePath);
+          const { frontMatter, body, changelog } = parseFrontMatter(moved);
+          const entry = (input.changelog_entry as string | undefined)?.trim()
+            || `Renamed from ${oldName} to ${newName}`;
+          const updatedChangelog = [
+            ...changelog,
+            formatChangelogEntry(sceneNumber, unescapeNewlines(entry)),
+          ];
+          const finalContent = serializeEntity(newName, frontMatter, body, updatedChangelog);
+          await fileIO.writeFile(newFilePath, finalContent);
+
+          // Best-effort: remove the now-empty location subdirectory.
+          if (entityType === "location" && fileIO.rmdir) {
+            const oldDir = oldFilePath.replace(/\/index\.md$/, "");
+            try {
+              await fileIO.rmdir(oldDir);
+            } catch {
+              // Directory may still contain map JSONs — leave it.
+            }
+          }
+
+          // Track tree changes and updated-file list.
+          const aliasRaw = frontMatter.additional_names as string | undefined;
+          const aliases = aliasRaw ? aliasRaw.split(",").map(a => a.trim()).filter(Boolean) : [];
+          entityDeltas.push({ slug: newSlug, name: newName, aliases, type: entityType, path: newRelative });
+          removedSlugs.push(oldSlug);
+          updated.push(newFilePath);
+
+          const fileWord = renameResult.filesUpdated.length === 1 ? "file" : "files";
+          const linkWord = renameResult.linksUpdated === 1 ? "link" : "links";
+          return {
+            content: `Renamed ${entityType} "${oldName}" -> "${newName}". Rewrote ${renameResult.linksUpdated} ${linkWord} across ${renameResult.filesUpdated.length} ${fileWord}.`,
+          };
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return { content: `rename_entity failed: ${msg}`, is_error: true };
+        }
+      }
+
       default:
         return { content: `Unknown tool: ${name}`, is_error: true };
     }
@@ -412,6 +531,7 @@ export async function runScribe(
   const created: string[] = [];
   const updated: string[] = [];
   const entityDeltas: ScribeEntityDelta[] = [];
+  const removedSlugs: string[] = [];
 
   const toolHandler = buildScribeToolHandler(
     fileIO,
@@ -420,6 +540,7 @@ export async function runScribe(
     created,
     updated,
     entityDeltas,
+    removedSlugs,
     input.homeDir,
   );
 
@@ -451,6 +572,7 @@ export async function runScribe(
     created,
     updated,
     entityDeltas,
+    removedSlugs,
     usage: result.usage,
   };
 }

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -148,14 +148,14 @@ const SCRIBE_TOOLS: NormalizedTool[] = [
   {
     name: "rename_entity",
     description:
-      "Rename an existing entity. Moves the file to the new slug, updates its H1 to the new display name, and rewrites every wikilink across the campaign that pointed to the old entity. Use this when an entity is renamed in fiction (e.g. a tavern reveals its real name) — and especially to replace the placeholder `Starting Location` once the opening locale has a real name.",
+      "Rename an existing entity. Moves the file to the new slug, updates its H1 to the new display name, and rewrites every wikilink across the campaign that pointed to the old entity. Use this when an entity is renamed in fiction (e.g. a tavern reveals its real name) — and especially to replace the placeholder `Starting Location` once the opening locale has a real name. Player entities are machine-scope and not renamable through this tool.",
     inputSchema: {
       type: "object" as const,
       properties: {
         entity_type: {
           type: "string",
-          enum: ["character", "location", "faction", "lore", "item", "player"],
-          description: "Entity type",
+          enum: ["character", "location", "faction", "lore", "item"],
+          description: "Entity type. `player` is intentionally excluded — player files are machine-scope.",
         },
         old_name: {
           type: "string",
@@ -434,6 +434,12 @@ export function buildScribeToolHandler(
         if (!oldName || !newName) {
           return { content: "rename_entity requires 'old_name' and 'new_name'", is_error: true };
         }
+        // Player entities live under homeDir, not campaignRoot — renaming them
+        // would mean retargeting every campaign that knows the player.
+        // Out of scope for an in-campaign Scribe.
+        if (entityType === "player") {
+          return { content: "rename_entity does not support player entities (machine-scope, not campaign-scope)", is_error: true };
+        }
         const oldSlug = slugify(oldName);
         const newSlug = slugify(newName);
         if (oldSlug === newSlug) {
@@ -445,6 +451,12 @@ export function buildScribeToolHandler(
 
         const oldFilePath = norm(entityPath(entityType, oldSlug));
         const newFilePath = norm(entityPath(entityType, newSlug));
+        // Defense in depth: refuse anything that didn't resolve under campaignRoot.
+        // Catches future bugs where a new entity type lands outside the campaign tree.
+        const normRoot = norm(campaignRoot);
+        if (!oldFilePath.startsWith(normRoot + "/") || !newFilePath.startsWith(normRoot + "/")) {
+          return { content: `rename_entity refused: ${entityType} resolves outside the campaign root`, is_error: true };
+        }
         if (!(await fileIO.exists(oldFilePath))) {
           return { content: `Entity not found: ${entityType}/${oldSlug}`, is_error: true };
         }
@@ -452,9 +464,8 @@ export function buildScribeToolHandler(
           return { content: `Cannot rename: ${entityType}/${newSlug} already exists`, is_error: true };
         }
 
-        const normRoot = norm(campaignRoot);
-        const oldRelative = oldFilePath.replace(normRoot + "/", "");
-        const newRelative = newFilePath.replace(normRoot + "/", "");
+        const oldRelative = oldFilePath.slice(normRoot.length + 1);
+        const newRelative = newFilePath.slice(normRoot.length + 1);
 
         try {
           // Move the file and rewrite incoming wikilinks campaign-wide.

--- a/packages/engine/src/agents/world-builder.ts
+++ b/packages/engine/src/agents/world-builder.ts
@@ -99,15 +99,16 @@ export async function buildCampaignWorld(
   );
   await fileIO.writeFile(logPath, logContent);
 
-  // 7. Write starting location (minimal)
+  // 7. Write starting location (placeholder — DM renames via Scribe once it
+  // has named the opening locale; see scribe.md "Placeholder entities").
   const locationSlug = "starting-location";
   const locationPath = norm(paths.location(locationSlug));
   const locationDir = locationPath.replace(/\/index\.md$/, "");
   await fileIO.mkdir(locationDir);
   const locationContent = serializeEntity(
     "Starting Location",
-    { type: "Location" },
-    "The story begins here.",
+    { type: "Location", placeholder: true },
+    "_Placeholder — rename via `rename_entity` once the opening locale has a real name in the fiction._",
     [],
   );
   await fileIO.writeFile(locationPath, locationContent);

--- a/packages/engine/src/prompts/scribe.md
+++ b/packages/engine/src/prompts/scribe.md
@@ -25,6 +25,21 @@ When checking `list_entities`, watch for near-matches that differ only by articl
 
 If an entity was introduced under a provisional name ("a hooded figure") and the true name is now known, update the EXISTING entity. Add revealed names to `Additional Names` in front matter and note the reveal in the changelog.
 
+### Renaming entities
+Use `rename_entity` when an entity's *canonical display name* changes — not just an alias reveal, but a true rename. The tool moves the file to the new slug, updates the H1, and rewrites every wikilink across the campaign that pointed to the old entity. Examples:
+- The opening locale starts as a placeholder (see "Placeholder entities" below) and the DM has just named it.
+- A tavern called "the Crooked Tankard" turns out to actually be "The Last Chance Saloon" — and the old name was simply wrong, not a nickname.
+- A character changes legal name (marriage, exile, royal title).
+
+If the old name is still meaningful as an alias, add it to `Additional Names` *after* the rename via `write_entity` update.
+
+### Placeholder entities
+When a new campaign starts, world-builder creates a stub `Starting Location` with `**Placeholder:** true`. The first time the DM gives the opening locale a real name in narration, you should:
+1. Call `rename_entity` with `entity_type: "location"`, `old_name: "Starting Location"`, `new_name: "<the real name>"`.
+2. Then `write_entity` (mode: update) on the renamed location to set `placeholder: null` (which removes the front matter key) and add real description content.
+
+Never leave `**Placeholder:** true` on an entity that has been fleshed out. If you see any other entity with the placeholder flag, treat it the same way the moment a real name appears.
+
 ### File format
 Entity files are **markdown**. The body field in `write_entity` is markdown text — use real line breaks between paragraphs, not literal `\n` sequences.
 

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -936,7 +936,11 @@ export class SessionManager {
     if (entityListing) {
       priming += "\n\nPre-existing entities (created during setup — write to these paths,"
         + " do not create duplicates under alternate names):\n"
-        + entityListing;
+        + entityListing
+        + "\n\nThe `Starting Location` entry is a placeholder. The first time"
+        + " your opening narration names the locale, dispatch a Scribe update"
+        + " naming the location — the Scribe will call `rename_entity` to move"
+        + " the placeholder to the real name and rewrite any wikilinks.";
     }
 
     this.syncUIState();


### PR DESCRIPTION
## Summary

- New `rename_entity` Scribe tool — moves the file, updates the H1, adds a changelog entry, and rewrites every wikilink across the campaign via the existing `renameEntity` op. Best-effort cleans up the now-empty location subdir.
- World-builder marks the bootstrap `Starting Location` with `**Placeholder:** true` and a body that explicitly flags it as a stub.
- Scribe prompt + first-turn priming tell the DM to dispatch a Scribe rename the moment the opening narration names the locale.
- `ScribeFileIO` widens with optional `deleteFile` + `rmdir`; `ScribeResult` gains `removedSlugs`; scene-manager gets a `removeEntity(slug)` mirror; game-engine applies removals after upserts.
- `format-spec.md` documents the new `placeholder` front-matter key.

Why: the previous bootstrap created a `starting-location/` directory that lived forever even after the DM named the actual locale, because the DM had no way to rename it during normal play (`rename_entity` was dev-mode-only).

## Test plan

- [x] `npm run check` (142 files / 2493 tests, lint clean)
- [ ] Sanity-check on a fresh campaign that the Scribe actually fires `rename_entity` on the first scene where a real location name appears, and that wikilinks in the character sheet's `Location:` field follow the rename
- [ ] After rename, confirm the Scribe's follow-up `write_entity` clears `placeholder: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)