### PR TITLE
Drop capability gating in OOC tool list (closes #458)

### DIFF
--- a/packages/engine/src/agents/subagents/ooc-mode.test.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.test.ts
@@ -306,7 +306,7 @@ describe("enterOOC", () => {
     expect(result.usage.outputTokens).toBe(20);
   });
 
-  it("works without tools when no game state, no repo, no fileIO", async () => {
+  it("always advertises the OOC-only extras even with no registry/fileIO/repo", async () => {
     const provider = mockProvider([textResponse("Done.")]);
     await enterOOC(provider, "test", {
       campaignName: "Test",
@@ -315,30 +315,17 @@ describe("enterOOC", () => {
     });
 
     const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      expect(createCall.tools).toBeUndefined();
-    }
-  });
-
-  it("exposes only OOC-only file extras when fileIO is set but no gameState", async () => {
-    const provider = mockProvider([textResponse("Done.")]);
-    const fio = mockFileIO();
-    await enterOOC(provider, "test", {
-      campaignName: "Test",
-      previousVariant: "playing",
-      fileIO: fio,
-      campaignRoot: "/camp",
-      model: "claude-sonnet-4-6",
-    });
-
-    const createCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    if (createCall) {
-      const names = createCall.tools.map((t: { name: string }) => t.name);
-      expect(names).toEqual(expect.arrayContaining(["read_file", "find_references", "validate_campaign"]));
-      // No DM tools without gameState
-      expect(names).not.toContain("roll_dice");
-      expect(names).not.toContain("scribe");
-    }
+    expect(createCall).toBeDefined();
+    const names = createCall.tools.map((t: { name: string }) => t.name);
+    // Extras are always present so the prompt's tool advertisement stays
+    // truthful regardless of caller plumbing. They return recoverable errors
+    // at dispatch time when their backing capability isn't wired up.
+    expect(names).toEqual(expect.arrayContaining([
+      "read_file", "find_references", "validate_campaign", "get_commit_log",
+    ]));
+    // No DM tools without a registry.
+    expect(names).not.toContain("roll_dice");
+    expect(names).not.toContain("scribe");
   });
 });
 
@@ -418,25 +405,14 @@ describe("enterOOC with gameState + DM registry", () => {
 // --- buildOOCTools ---
 
 describe("buildOOCTools", () => {
-  it("returns empty when given empty registry + no extras", () => {
-    const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0], false, false);
-    expect(tools).toEqual([]);
-  });
-
-  it("returns file extras when hasFileIO is true (no registry contributions)", () => {
-    const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0], true, false);
+  it("returns just the OOC-only extras when given an empty registry", () => {
+    const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0]);
     const names = tools.map((t) => t.name);
-    expect(names).toEqual(["read_file", "find_references", "validate_campaign"]);
-  });
-
-  it("adds get_commit_log when hasRepo is true", () => {
-    const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0], false, true);
-    const names = tools.map((t) => t.name);
-    expect(names).toEqual(["get_commit_log"]);
+    expect(names).toEqual(["read_file", "find_references", "validate_campaign", "get_commit_log"]);
   });
 
   it("returns all DM tools (minus enter_ooc) plus extras with the real registry", () => {
-    const tools = buildOOCTools(singletonRegistry, true, true);
+    const tools = buildOOCTools(singletonRegistry);
     const names = tools.map((t) => t.name);
 
     expect(names).not.toContain("enter_ooc");

--- a/packages/engine/src/agents/subagents/ooc-mode.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.ts
@@ -368,11 +368,12 @@ export async function enterOOC(
     wasMidNarration: options.wasMidNarration ?? false,
   };
 
-  // Build tools: full DM registry (minus enter_ooc) plus the OOC-only extras.
-  // The agent always sees the same toolset regardless of caller plumbing —
-  // if a capability isn't wired up (no registry, no fileIO, no repo), the
-  // affected tool returns a recoverable error at dispatch time. We trust the
-  // OOC system prompt to keep the agent in its lane.
+  // Build tools: the four OOC-only extras (always advertised) plus the DM
+  // registry minus enter_ooc when `options.registry` is provided. Production
+  // always provides a registry, so in practice the agent sees the full
+  // toolset; test-only callers that omit the registry get just the extras.
+  // Capabilities that aren't wired at dispatch time (no fileIO, no repo)
+  // surface as recoverable errors — the prompt doesn't have to gate.
   const toolRegistry: ToolRegistry = options.registry
     ?? ({ getDefinitions: () => [] } as unknown as ToolRegistry);
   const tools: NormalizedTool[] = buildOOCTools(toolRegistry);

--- a/packages/engine/src/agents/subagents/ooc-mode.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.ts
@@ -138,50 +138,50 @@ export function buildOOCPrompt(options: OOCPromptOptions): string | SystemBlock[
 
 /**
  * Build the OOC tool list: every DM tool (so OOC is self-documenting from
- * the same code path as the DM) minus `enter_ooc`, plus a small set of
- * OOC-only extras for file/git inspection.
+ * the same code path as the DM) minus `enter_ooc`, plus the OOC-only extras
+ * for file/git inspection.
+ *
+ * The OOC-only extras are always included. When the corresponding capability
+ * isn't available at dispatch time (no `fileIO`, no `repo`), the tool returns
+ * a recoverable error — the agent learns by trying, and the prompt doesn't
+ * have to gate its tool advertisement on caller plumbing.
  */
-export function buildOOCTools(registry: ToolRegistry, hasFileIO: boolean, hasRepo: boolean): NormalizedTool[] {
+export function buildOOCTools(registry: ToolRegistry): NormalizedTool[] {
   const tools: NormalizedTool[] = registry.getDefinitions(OOC_EXCLUDED_FROM_REGISTRY);
 
-  if (hasFileIO) {
-    tools.push(
-      {
-        name: "read_file",
-        description: "Read a campaign file by relative path (e.g. 'characters/kael.md').",
-        inputSchema: {
-          type: "object" as const,
-          properties: {
-            path: { type: "string", description: "Relative path within the campaign directory" },
-          },
-          required: ["path"],
+  tools.push(
+    {
+      name: "read_file",
+      description: "Read a campaign file by relative path (e.g. 'characters/kael.md').",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: { type: "string", description: "Relative path within the campaign directory" },
         },
+        required: ["path"],
       },
-      {
-        name: "find_references",
-        description: "Find all wikilinks pointing to an entity. Returns file, display text, and line number for each reference.",
-        inputSchema: {
-          type: "object" as const,
-          properties: {
-            path: { type: "string", description: "Entity path relative to campaign root (e.g. 'characters/kael.md')" },
-          },
-          required: ["path"],
+    },
+    {
+      name: "find_references",
+      description: "Find all wikilinks pointing to an entity. Returns file, display text, and line number for each reference.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: { type: "string", description: "Entity path relative to campaign root (e.g. 'characters/kael.md')" },
         },
+        required: ["path"],
       },
-      {
-        name: "validate_campaign",
-        description: "Run the full campaign validation suite: broken links, malformed entities, clock/map issues.",
-        inputSchema: {
-          type: "object" as const,
-          properties: {},
-          required: [],
-        },
+    },
+    {
+      name: "validate_campaign",
+      description: "Run the full campaign validation suite: broken links, malformed entities, clock/map issues.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+        required: [],
       },
-    );
-  }
-
-  if (hasRepo) {
-    tools.push({
+    },
+    {
       name: "get_commit_log",
       description: "List git snapshot commits for this campaign. Shows commit hash, type, message, and timestamp. Use to review game history for rollback or debugging.",
       inputSchema: {
@@ -193,8 +193,8 @@ export function buildOOCTools(registry: ToolRegistry, hasFileIO: boolean, hasRep
         },
         required: [],
       },
-    });
-  }
+    },
+  );
 
   return tools;
 }
@@ -368,20 +368,19 @@ export async function enterOOC(
     wasMidNarration: options.wasMidNarration ?? false,
   };
 
-  const hasFileIO = !!(options.fileIO && options.campaignRoot);
-  const hasRepo = !!options.repo;
-  const hasGameState = !!options.gameState && !!options.registry;
-  const hasTools = hasFileIO || hasRepo || hasGameState;
+  // Build tools: full DM registry (minus enter_ooc) plus the OOC-only extras.
+  // The agent always sees the same toolset regardless of caller plumbing —
+  // if a capability isn't wired up (no registry, no fileIO, no repo), the
+  // affected tool returns a recoverable error at dispatch time. We trust the
+  // OOC system prompt to keep the agent in its lane.
+  const toolRegistry: ToolRegistry = options.registry
+    ?? ({ getDefinitions: () => [] } as unknown as ToolRegistry);
+  const tools: NormalizedTool[] = buildOOCTools(toolRegistry);
 
-  // Build tools: full DM registry minus enter_ooc, plus OOC-only extras.
-  // If we don't have game state, only the OOC-only extras are available.
-  const toolRegistry: ToolRegistry = hasGameState && options.registry
-    ? options.registry
-    : ({ getDefinitions: () => [] } as unknown as ToolRegistry);
-  const tools: NormalizedTool[] = buildOOCTools(toolRegistry, hasFileIO, hasRepo);
-
-  // Build handler chain.
-  const toolHandler = hasTools && hasGameState && options.registry && options.gameState
+  // Handler chain. With a full registry + gameState we use buildOOCToolHandler
+  // (engine-async → registry dispatch). Without them, only the OOC-only
+  // extras have a chance — anything else returns an error.
+  const toolHandler = options.registry && options.gameState
     ? buildOOCToolHandler(
         options.registry,
         options.gameState,
@@ -390,17 +389,12 @@ export async function enterOOC(
         options.campaignRoot,
         options.fileIO,
       )
-    : hasTools
-      ? // No game state: OOC-only extras only. validate_campaign runs
-        // against empty stubs in this branch — the no-gameState path is
-        // for pre-session / test callers without live maps or clocks.
-        async (name: string, input: Record<string, unknown>) => {
-          if (OOC_ONLY_TOOL_SET.has(name)) {
-            return dispatchOOCExtra(name, input, options.repo, options.campaignRoot, options.fileIO, undefined, undefined);
-          }
-          return { content: `Unknown tool: ${name}`, is_error: true };
+    : async (name: string, input: Record<string, unknown>) => {
+        if (OOC_ONLY_TOOL_SET.has(name)) {
+          return dispatchOOCExtra(name, input, options.repo, options.campaignRoot, options.fileIO, undefined, undefined);
         }
-      : undefined;
+        return { content: `Tool unavailable: ${name} requires an active game session`, is_error: true };
+      };
 
   // Wrap the player message with volatile-context preamble, mirroring the
   // DM turn shape. Ephemeral so it doesn't poison the next-turn cache.
@@ -419,11 +413,11 @@ export async function enterOOC(
     name: "ooc",
     model: options.model,
     maxTokens: getMaxOutput(options.model),
-    maxToolRounds: hasTools ? 10 : 1,
+    maxToolRounds: 10,
     stream: !!onStream,
-    tools: tools.length > 0 ? tools : undefined,
+    tools,
     toolHandler,
-    cacheHints: tools.length > 0 ? [{ target: "tools", ttl: "1h" }] : undefined,
+    cacheHints: [{ target: "tools", ttl: "1h" }],
     tuiToolNames: TUI_TOOLS,
     onTuiCommand: options.onTuiCommand,
     onTextDelta: onStream,


### PR DESCRIPTION
## Summary

- `buildOOCTools(registry)` always emits the four OOC-only extras (`read_file`, `find_references`, `validate_campaign`, `get_commit_log`) instead of gating them on `hasFileIO` / `hasRepo`. Missing capabilities surface as recoverable dispatch-time errors instead of a prompt that lies.
- `enterOOC` drops the `hasFileIO` / `hasRepo` / `hasGameState` / `hasTools` branching — always builds tools, handler, cache hints, and `maxToolRounds: 10`. Test-only paths without a registry still get a fallback handler that only dispatches the OOC-only extras.
- Resolves the "prompt advertises tools that aren't loaded" half of #458. The production `/ooc` threading half was already fixed in 193a3da.

## Test plan

- [x] `npm run check` — 146 test files / 2511 tests pass, lint clean
- [x] `npx vitest run packages/engine/src/agents/subagents/ooc-mode.test.ts` — 59 OOC-specific tests pass
- [ ] Manual smoke: `/ooc` mid-session and confirm the agent's tool list now matches its prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)