### PR TITLE
Surface ChatGPT session-usage remaining in TUI

### DIFF
--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -624,6 +624,7 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
         : null,
       mode: clientState.mode,
       stateSnapshot,
+      usageStatus: clientState.usageStatus,
       hasKittyProtocol,
       stdinFilterChain,
       devModeEnabled,

--- a/packages/client-ink/src/event-handler.test.ts
+++ b/packages/client-ink/src/event-handler.test.ts
@@ -551,6 +551,80 @@ describe("event-handler", () => {
     });
   });
 
+  describe("usage:update", () => {
+    it("starts with null usageStatus", () => {
+      const h = makeHarness();
+      expect(h.state.usageStatus).toBeNull();
+    });
+
+    it("records the latest UsageStatus", () => {
+      const h = makeHarness();
+      const status = {
+        segments: [{
+          id: "primary",
+          label: "5-hour window",
+          kind: "percentage" as const,
+          usedPercent: 42,
+          status: "ok" as const,
+        }],
+        snapshotAt: 1234,
+        fresh: true,
+      };
+      h.dispatch({ type: "usage:update", data: status });
+      expect(h.state.usageStatus).toEqual(status);
+    });
+
+    it("clears usageStatus on session:transition", () => {
+      const h = makeHarness();
+      h.dispatch({
+        type: "usage:update",
+        data: {
+          segments: [{
+            id: "primary",
+            label: "5-hour window",
+            kind: "percentage",
+            usedPercent: 10,
+            status: "ok",
+          }],
+          snapshotAt: 1,
+          fresh: true,
+        },
+      });
+      expect(h.state.usageStatus).not.toBeNull();
+
+      h.dispatch({
+        type: "session:transition",
+        data: { campaignId: "new-campaign" },
+      });
+      expect(h.state.usageStatus).toBeNull();
+    });
+
+    it("clears recoverable lastError when usage update arrives", () => {
+      const h = makeHarness();
+      h.dispatch({
+        type: "error",
+        data: { message: "retrying", recoverable: true, status: 529 },
+      });
+      expect(h.state.lastError).not.toBeNull();
+
+      h.dispatch({
+        type: "usage:update",
+        data: {
+          segments: [{
+            id: "primary",
+            label: "5h",
+            kind: "percentage",
+            usedPercent: 10,
+            status: "ok",
+          }],
+          snapshotAt: 1,
+          fresh: true,
+        },
+      });
+      expect(h.state.lastError).toBeNull();
+    });
+  });
+
   describe("errors", () => {
     it("stores error with status and delayMs", () => {
       const h = makeHarness();

--- a/packages/client-ink/src/event-handler.ts
+++ b/packages/client-ink/src/event-handler.ts
@@ -21,9 +21,11 @@ import type {
   StateSnapshotEvent,
   SessionModeEvent,
   SessionEndedEvent,
+  UsageUpdateEvent,
   ErrorEvent,
   Turn,
   StateSnapshot,
+  UsageStatus,
 } from "@machine-violet/shared";
 import type { NarrativeLine, StyleVariant } from "@machine-violet/shared/types/tui.js";
 import { appendDelta } from "./tui/narrative-helpers.js";
@@ -71,6 +73,9 @@ export interface ClientState {
   displayResources: Record<string, string[]>;
   /** Per-character resource values: character → key → value. */
   resourceValues: Record<string, Record<string, string>>;
+  /** Latest provider usage snapshot. Null until a provider with a usage
+   *  concept (currently only openai-chatgpt) has reported one. */
+  usageStatus: UsageStatus | null;
 }
 
 export function initialClientState(): ClientState {
@@ -92,6 +97,7 @@ export function initialClientState(): ClientState {
     modelines: {},
     displayResources: {},
     resourceValues: {},
+    usageStatus: null,
   };
 }
 
@@ -127,6 +133,7 @@ const PROGRESS_EVENT_TYPES: ReadonlySet<ServerEvent["type"]> = new Set([
   "session:mode",
   "session:ended",
   "session:transition",
+  "usage:update",
 ]);
 
 /**
@@ -197,9 +204,13 @@ export function createEventHandler(update: StateUpdater): (event: ServerEvent) =
           engineState: "starting_session",
           engineStateSince: Date.now(),
           toolGlyphs: [],
+          usageStatus: null,
         }));
         break;
       }
+      case "usage:update":
+        handleUsageUpdate(event, update);
+        break;
       case "error":
         handleError(event, update);
         break;
@@ -489,6 +500,13 @@ function handleSessionEnded(_event: SessionEndedEvent, update: StateUpdater): vo
     activeChoices: null,
     engineState: null,
     toolGlyphs: [],
+  }));
+}
+
+function handleUsageUpdate(event: UsageUpdateEvent, update: StateUpdater): void {
+  update((prev) => ({
+    ...prev,
+    usageStatus: event.data,
   }));
 }
 

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -43,6 +43,7 @@ export function PlayingPhase() {
     activeChoices, setActiveChoices,
     activeModal, setActiveModal,
     mode, stateSnapshot,
+    usageStatus,
     hasKittyProtocol,
     devModeEnabled,
     showVerbose,
@@ -535,6 +536,7 @@ export function PlayingPhase() {
           devModeEnabled={devModeEnabled}
           devActive={mode === "dev"}
           tokenSummary={tokenSummary}
+          usageStatus={usageStatus}
           onSelect={handleMenuSelect}
           onDismiss={() => setMenuOpen(false)}
         />

--- a/packages/client-ink/src/tui/components/NarrativeArea.tsx
+++ b/packages/client-ink/src/tui/components/NarrativeArea.tsx
@@ -11,6 +11,7 @@ import { useMouseScroll } from "../hooks/useMouseScroll.js";
 import { useOptionalGameContext } from "../game-context.js";
 import { composeTurnSeparator } from "../themes/composer.js";
 import type { ThemeAsset } from "../themes/types.js";
+import { UsageGauge } from "./UsageGauge.js";
 
 
 // ---------------------------------------------------------------------------
@@ -244,6 +245,12 @@ export const NarrativeArea = forwardRef<NarrativeAreaHandle, NarrativeAreaProps>
   // Incremental pipeline: frozen prefix cached, only tail reprocessed
   const processedLines = useProcessedLines(visibleLines, width ?? 0, quoteColor);
 
+  // Bottom-right overlay: the scroll indicator (when there's content
+  // below) takes priority over the usage gauge. They share the same row,
+  // and rendering both would risk visual bleed through the absolute
+  // positioning — so we pick one and only mount the gauge when the
+  // scroll indicator is hidden.
+  const usageStatus = gameCtx?.usageStatus ?? null;
   return (
     <Box height={maxRows} flexDirection="column">
       <ScrollView ref={scrollRef} onScroll={handleScroll}>
@@ -258,9 +265,13 @@ export const NarrativeArea = forwardRef<NarrativeAreaHandle, NarrativeAreaProps>
           />
         ))}
       </ScrollView>
-      {linesBelow > 0 && (
+      {linesBelow > 0 ? (
         <Box position="absolute" width="100%" marginTop={maxRows - 1} justifyContent="flex-end">
           <Text color="greenBright">{` scroll (${linesBelow}) more `}</Text>
+        </Box>
+      ) : (
+        <Box position="absolute" width="100%" marginTop={maxRows - 1} justifyContent="flex-end">
+          <UsageGauge usage={usageStatus} />
         </Box>
       )}
     </Box>

--- a/packages/client-ink/src/tui/components/UsageGauge.test.tsx
+++ b/packages/client-ink/src/tui/components/UsageGauge.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import type { UsageStatus } from "@machine-violet/shared";
+import { UsageGauge, gaugeCells } from "./UsageGauge.js";
+
+function makeUsage(primaryUsedPercent: number, opts?: { includeSecondary?: boolean }): UsageStatus {
+  const segments: UsageStatus["segments"] = [
+    {
+      id: "primary",
+      label: "5-hour window",
+      kind: "percentage",
+      usedPercent: primaryUsedPercent,
+      status: primaryUsedPercent >= 80 ? "warning" : "ok",
+    },
+  ];
+  if (opts?.includeSecondary) {
+    segments.push({
+      id: "secondary",
+      label: "7-day window",
+      kind: "percentage",
+      usedPercent: 50,
+      status: "ok",
+    });
+  }
+  return { segments, snapshotAt: 1, fresh: true };
+}
+
+describe("gaugeCells", () => {
+  it("renders five full diamonds at 100% remaining", () => {
+    const cells = gaugeCells(100);
+    expect(cells.map((c) => c.glyph)).toEqual(["◆", "◆", "◆", "◆", "◆"]);
+  });
+
+  it("renders five spaces at 0% remaining", () => {
+    const cells = gaugeCells(0);
+    expect(cells.map((c) => c.glyph)).toEqual([" ", " ", " ", " ", " "]);
+  });
+
+  it("degrades the leftmost cell first", () => {
+    // 96% remaining: 24 ticks → leftmost cell holds 4 (⬢), rest 5 (◆)
+    const cells = gaugeCells(96);
+    expect(cells.map((c) => c.glyph)).toEqual(["⬢", "◆", "◆", "◆", "◆"]);
+  });
+
+  it("walks the leftmost cell through all states before touching the next", () => {
+    expect(gaugeCells(100).map((c) => c.glyph)).toEqual(["◆", "◆", "◆", "◆", "◆"]);
+    expect(gaugeCells(96).map((c) => c.glyph)).toEqual(["⬢", "◆", "◆", "◆", "◆"]);
+    expect(gaugeCells(92).map((c) => c.glyph)).toEqual(["■", "◆", "◆", "◆", "◆"]);
+    expect(gaugeCells(88).map((c) => c.glyph)).toEqual(["*", "◆", "◆", "◆", "◆"]);
+    // 84% (21 ticks): cell 0 has 1 bucket left → still `*`
+    expect(gaugeCells(84).map((c) => c.glyph)).toEqual(["*", "◆", "◆", "◆", "◆"]);
+    // 80% (20 ticks): cell 0 fully empty, cell 1 still full
+    expect(gaugeCells(80).map((c) => c.glyph)).toEqual([" ", "◆", "◆", "◆", "◆"]);
+    // 76% (19 ticks): cell 1 drops to ⬢
+    expect(gaugeCells(76).map((c) => c.glyph)).toEqual([" ", "⬢", "◆", "◆", "◆"]);
+  });
+
+  it("renders only the rightmost cell at very low remaining", () => {
+    // 4% remaining (1 tick): only rightmost cell, at state *
+    expect(gaugeCells(4).map((c) => c.glyph)).toEqual([" ", " ", " ", " ", "*"]);
+  });
+
+  it("clamps out-of-range inputs", () => {
+    expect(gaugeCells(-50).map((c) => c.glyph)).toEqual([" ", " ", " ", " ", " "]);
+    expect(gaugeCells(200).map((c) => c.glyph)).toEqual(["◆", "◆", "◆", "◆", "◆"]);
+  });
+});
+
+describe("<UsageGauge />", () => {
+  it("renders nothing when usage is null", () => {
+    const { lastFrame } = render(<UsageGauge usage={null} />);
+    expect(lastFrame()).toBe("");
+  });
+
+  it("renders nothing when there is no primary segment", () => {
+    const usage: UsageStatus = {
+      segments: [{
+        id: "credits",
+        label: "Credit balance",
+        kind: "balance",
+        used: 0,
+        total: 100,
+        status: "ok",
+      }],
+      snapshotAt: 1,
+      fresh: true,
+    };
+    const { lastFrame } = render(<UsageGauge usage={usage} />);
+    expect(lastFrame()).toBe("");
+  });
+
+  it("renders five glyphs for the primary segment", () => {
+    const { lastFrame } = render(<UsageGauge usage={makeUsage(0)} />);
+    expect(lastFrame()).toBe("◆◆◆◆◆");
+  });
+
+  it("ignores the secondary 7-day window", () => {
+    // Primary at 100% used → 0% remaining → all space. Secondary at 50%
+    // would otherwise pull the gauge to half if we accidentally summed.
+    // ink-testing-library trims trailing whitespace, so the rendered
+    // frame is empty — but no gem glyphs is the point.
+    const { lastFrame } = render(<UsageGauge usage={makeUsage(100, { includeSecondary: true })} />);
+    const frame = lastFrame()!;
+    expect(frame).not.toContain("◆");
+    expect(frame).not.toContain("⬢");
+    expect(frame).not.toContain("■");
+    expect(frame).not.toContain("*");
+
+    // And primary at 50% used → 50% remaining gives a clearly mixed gauge.
+    const { lastFrame: mixed } = render(<UsageGauge usage={makeUsage(50, { includeSecondary: true })} />);
+    const mixedFrame = mixed()!;
+    // 50% remaining = 13 ticks (rounded), cells from rightmost: [3,5,5] only the rightmost 3 cells get any ticks.
+    expect(mixedFrame).toContain("◆");
+  });
+});

--- a/packages/client-ink/src/tui/components/UsageGauge.tsx
+++ b/packages/client-ink/src/tui/components/UsageGauge.tsx
@@ -1,0 +1,96 @@
+/**
+ * UsageGauge — 5-cell gem-themed remaining-usage indicator for the
+ * bottom-right of the conversation pane.
+ *
+ * Reads the primary segment of the provider's UsageStatus (currently only
+ * openai-chatgpt's 5-hour window) and renders five horizontally-packed
+ * glyphs. The gauge is a unary countdown with 25 ticks (4% per tick): each
+ * cell holds five ticks, the leftmost cell depletes first, and each cell
+ * passes through five visual states as it drains:
+ *
+ *   ◆  light blue  (full)
+ *   ⬢  red         (ruby)
+ *   ■  brown       (garnet)
+ *   *  grey        (tarnished)
+ *   (space)        (empty)
+ *
+ * Because the user only specified four glyphs plus an empty cell, ticks 1
+ * and 2 within a cell share the `*` rendering — visually compressing the
+ * last 8% of a cell's drain into one state. The gauge still updates on
+ * every 4% step; just the bottom two states look identical.
+ *
+ * The component renders nothing when the snapshot has no `primary` segment
+ * or no usable `usedPercent` — providers without a usage concept never
+ * mount it.
+ */
+import React from "react";
+import { Text } from "ink";
+import type { UsageStatus } from "@machine-violet/shared";
+
+interface UsageGaugeProps {
+  usage: UsageStatus | null;
+}
+
+interface Cell {
+  glyph: string;
+  color?: string;
+}
+
+const FULL: Cell = { glyph: "◆", color: "#7AC7E8" };       // light-blue diamond
+const RUBY: Cell = { glyph: "⬢", color: "#D03A3A" };       // red hexagon
+const GARNET: Cell = { glyph: "■", color: "#8B4513" };     // brown square
+const TARNISHED: Cell = { glyph: "*", color: "gray" };     // grey asterisk
+const EMPTY: Cell = { glyph: " " };
+
+/**
+ * Map a cell's bucket count (0-5) to its rendered cell. Buckets 1 and 2
+ * collapse to the same `*` — see header comment.
+ */
+function cellFor(buckets: number): Cell {
+  if (buckets >= 5) return FULL;
+  if (buckets === 4) return RUBY;
+  if (buckets === 3) return GARNET;
+  if (buckets >= 1) return TARNISHED;
+  return EMPTY;
+}
+
+/** Compute the 5 cells for a remaining-percentage value (0-100). */
+export function gaugeCells(remainingPercent: number): Cell[] {
+  // 25 total ticks → 4% per tick. Round to the nearest tick so we don't
+  // bias high or low; clamp to [0, 25] in case the provider ever reports
+  // negative or >100% remaining.
+  const ticks = Math.max(0, Math.min(25, Math.round(remainingPercent / 4)));
+  // Cells fill right-to-left: rightmost cell holds ticks 1-5, then 6-10,
+  // etc. — so the leftmost cell is the first to empty.
+  const cells: Cell[] = [];
+  for (let i = 0; i < 5; i++) {
+    const buckets = Math.max(0, Math.min(5, ticks - (4 - i) * 5));
+    cells.push(cellFor(buckets));
+  }
+  return cells;
+}
+
+/** Return the primary segment's usedPercent, or null if unavailable. */
+function primaryUsedPercent(usage: UsageStatus | null): number | null {
+  if (!usage) return null;
+  const primary = usage.segments.find((s) => s.id === "primary");
+  if (!primary || primary.kind !== "percentage" || primary.usedPercent === undefined) {
+    return null;
+  }
+  return primary.usedPercent;
+}
+
+export function UsageGauge({ usage }: UsageGaugeProps) {
+  const usedPercent = primaryUsedPercent(usage);
+  if (usedPercent === null) return null;
+
+  const remaining = 100 - usedPercent;
+  const cells = gaugeCells(remaining);
+  return (
+    <Text>
+      {cells.map((c, i) => (
+        <Text key={i} color={c.color}>{c.glyph}</Text>
+      ))}
+    </Text>
+  );
+}

--- a/packages/client-ink/src/tui/game-context.ts
+++ b/packages/client-ink/src/tui/game-context.ts
@@ -7,7 +7,7 @@
  */
 import { createContext, useContext } from "react";
 import type { NarrativeLine, ActiveModal, RetryOverlay } from "@machine-violet/shared/types/tui.js";
-import type { ChoicesData, Turn, StateSnapshot } from "@machine-violet/shared";
+import type { ChoicesData, Turn, StateSnapshot, UsageStatus } from "@machine-violet/shared";
 import type { ToolGlyph } from "./activity.js";
 import type { ResolvedTheme, StyleVariant } from "./themes/types.js";
 import type { ApiClient } from "../api-client.js";
@@ -60,6 +60,9 @@ export interface GameContextValue {
 
   // State snapshot (latest from server)
   stateSnapshot: StateSnapshot | null;
+
+  // Provider remaining-usage snapshot (null when not on a usage-tracking provider).
+  usageStatus: UsageStatus | null;
 
   // Terminal capabilities
   /** Whether the Kitty keyboard protocol is active (affects raw mode guardian). */

--- a/packages/client-ink/src/tui/modals/GameMenu.tsx
+++ b/packages/client-ink/src/tui/modals/GameMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from "react";
 import { useInput } from "ink";
+import type { UsageStatus } from "@machine-violet/shared";
 import type { ResolvedTheme } from "../themes/types.js";
 import { CenteredModal } from "./CenteredModal.js";
 
@@ -11,8 +12,27 @@ interface GameMenuProps {
   devModeEnabled?: boolean;
   devActive?: boolean;
   tokenSummary?: string;
+  usageStatus?: UsageStatus | null;
   onSelect: (item: string) => void;
   onDismiss: () => void;
+}
+
+/**
+ * Build the footer string: token tier stats, then (only when the active
+ * provider exposes a primary `percentage` usage segment) a separator and
+ * the `<remaining>%` figure. We invert the provider's `usedPercent` so
+ * the displayed value matches the gem-gauge semantics (how much
+ * headroom is left, not how much has been spent). Width grows with the
+ * number — no padding — and `minWidth` on CenteredModal is bumped to fit.
+ */
+function buildFooter(tokenSummary: string | undefined, usage: UsageStatus | null | undefined): string | undefined {
+  if (!tokenSummary) return tokenSummary;
+  const primary = usage?.segments.find((s) => s.id === "primary");
+  if (!primary || primary.kind !== "percentage" || primary.usedPercent === undefined) {
+    return tokenSummary;
+  }
+  const remaining = Math.max(0, Math.min(100, Math.round(100 - primary.usedPercent)));
+  return `${tokenSummary} | ${remaining}%`;
 }
 
 const BASE_MENU_ITEMS = [
@@ -49,6 +69,7 @@ export function GameMenu({
   devModeEnabled,
   devActive,
   tokenSummary,
+  usageStatus,
   onSelect,
   onDismiss,
 }: GameMenuProps) {
@@ -70,5 +91,10 @@ export function GameMenu({
     return `  ${marker} ${label}`;
   });
 
-  return <CenteredModal theme={theme} width={width} height={height} title="Menu" footer={tokenSummary} lines={lines} />;
+  // Bump minWidth from the default 40 to 48 so the appended `<n>%` (up
+  // to four chars after a ` | ` separator) doesn't get clipped at the
+  // border. Harmless when usageStatus is absent — the modal just has a
+  // little extra horizontal breathing room.
+  const footer = buildFooter(tokenSummary, usageStatus);
+  return <CenteredModal theme={theme} width={width} height={height} title="Menu" footer={footer} lines={lines} minWidth={48} />;
 }

--- a/packages/client-ink/src/tui/modals/modals.test.tsx
+++ b/packages/client-ink/src/tui/modals/modals.test.tsx
@@ -400,6 +400,66 @@ describe("GameMenu", () => {
     expect(frame).toContain("0/0/0 | 2k/0/15k | 5k/200/40k");
   });
 
+  it("appends remaining-usage percentage to footer when a primary percentage segment is present", () => {
+    const usageStatus = {
+      segments: [{
+        id: "primary",
+        label: "5-hour window",
+        kind: "percentage" as const,
+        usedPercent: 42,
+        status: "warning" as const,
+      }],
+      snapshotAt: 1,
+      fresh: true,
+    };
+    const { lastFrame } = render(
+      <Box width={60} height={24}>
+        <GameMenu
+          theme={theme}
+          width={60}
+          height={24}
+          tokenSummary="0/0/0 | 2k/0/15k | 5k/200/40k"
+          usageStatus={usageStatus}
+          onSelect={noop}
+          onDismiss={noop}
+        />
+      </Box>,
+    );
+    // 42% used → 58% remaining, matching the gauge semantics.
+    expect(lastFrame()).toContain("0/0/0 | 2k/0/15k | 5k/200/40k | 58%");
+  });
+
+  it("omits usage percentage when there is no primary segment", () => {
+    const usageStatus = {
+      segments: [{
+        id: "credits",
+        label: "Credit balance",
+        kind: "balance" as const,
+        used: 0,
+        total: 100,
+        status: "ok" as const,
+      }],
+      snapshotAt: 1,
+      fresh: true,
+    };
+    const { lastFrame } = render(
+      <Box width={60} height={24}>
+        <GameMenu
+          theme={theme}
+          width={60}
+          height={24}
+          tokenSummary="0/0/0"
+          usageStatus={usageStatus}
+          onSelect={noop}
+          onDismiss={noop}
+        />
+      </Box>,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain("0/0/0");
+    expect(frame).not.toMatch(/0\/0\/0\s*\|/);
+  });
+
   it("highlights first item by default", () => {
     const { lastFrame } = render(
       <Box width={40} height={24}>

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -14,6 +14,7 @@ import type {
   StateSnapshot,
   CampaignConfig,
   GameState,
+  UsageStatus,
 } from "@machine-violet/shared";
 import { GameEngine } from "../agents/game-engine.js";
 import { RollbackCompleteError } from "@machine-violet/shared/types/errors.js";
@@ -82,6 +83,13 @@ export class SessionManager {
    *  Used by management routes (e.g. usage queries) that need to find a
    *  live provider instance for a specific connection. */
   private providersByConnectionId = new Map<string, LLMProvider>();
+  /** Unsubscribe callbacks for active provider usage subscriptions.
+   *  Drained at endSession so the listeners don't leak across sessions. */
+  private usageUnsubscribers: (() => void)[] = [];
+  /** Latest UsageStatus broadcast for the DM tier, replayed to newly
+   *  connecting clients so the gauge / Esc menu show data immediately
+   *  instead of waiting for the next codex response. */
+  private lastUsageStatus: UsageStatus | null = null;
   private currentMode: "play" | "ooc" | "dev" | "setup" = "play";
   private persistedUI: { themeName?: string; variant?: string; keyColor?: string | null; modelines?: Record<string, string> | null } = {};
   /** One-shot recap payload: set during sessionResume, emitted in the next
@@ -155,6 +163,12 @@ export class SessionManager {
         type: "state:snapshot",
         data: snapshot,
       });
+      // Replay the latest provider usage so the bottom-right gauge / Esc
+      // menu percentage render immediately instead of waiting for the
+      // next codex response.
+      if (this.lastUsageStatus) {
+        this.sendTo(ws, { type: "usage:update", data: this.lastUsageStatus });
+      }
     }
   }
 
@@ -466,6 +480,26 @@ export class SessionManager {
     // The DM uses the large tier; keep `provider` as a local alias for the
     // many downstream sites in this method that still reference it directly.
     const provider = tierProviders.large.provider;
+
+    // Wire usage broadcasts for the DM-tier provider. Currently only
+    // openai-chatgpt exposes a usage concept; other providers omit
+    // `subscribeUsage` and this block is a no-op for them. Seeded with the
+    // current snapshot (if any) so clients connecting before the first
+    // codex response still get something to render.
+    this.lastUsageStatus = null;
+    this.usageUnsubscribers = [];
+    if (provider.subscribeUsage) {
+      const seed = provider.getUsageStatus?.() ?? null;
+      if (seed) {
+        this.lastUsageStatus = seed;
+        this.broadcast({ type: "usage:update", data: seed });
+      }
+      const unsub = provider.subscribeUsage((status) => {
+        this.lastUsageStatus = status;
+        this.broadcast({ type: "usage:update", data: status });
+      });
+      this.usageUnsubscribers.push(unsub);
+    }
 
     // --- Debug: set context dump directory ---
     const { setContextDumpDir } = await import("../config/context-dump.js");
@@ -1144,6 +1178,15 @@ export class SessionManager {
         stack: err instanceof Error ? err.stack : undefined,
       });
     }
+
+    // Drain usage subscriptions before disposing providers so the
+    // unsubscribe callback (which removes from the provider's listener
+    // set) can't race with subprocess teardown.
+    for (const unsub of this.usageUnsubscribers) {
+      try { unsub(); } catch { /* best-effort */ }
+    }
+    this.usageUnsubscribers = [];
+    this.lastUsageStatus = null;
 
     // Dispose stateful providers (openai-chatgpt subprocess teardown).
     // Each provider's dispose is idempotent and best-effort — errors are

--- a/packages/shared/src/protocol/events.ts
+++ b/packages/shared/src/protocol/events.ts
@@ -6,6 +6,7 @@
  */
 import { Type, type Static } from "@sinclair/typebox";
 import { TurnContribution, Turn } from "./turn.js";
+import { UsageStatus } from "./usage.js";
 
 // --- Narrative ---
 
@@ -153,6 +154,13 @@ export const DiscordPresenceEvent = Type.Object({
   ]),
 });
 
+// --- Provider usage (remaining session quota) ---
+
+export const UsageUpdateEvent = Type.Object({
+  type: Type.Literal("usage:update"),
+  data: UsageStatus,
+});
+
 // --- Error ---
 
 export const ErrorEvent = Type.Object({
@@ -182,6 +190,7 @@ export const ServerEvent = Type.Union([
   SessionEndedEvent,
   SessionTransitionEvent,
   DiscordPresenceEvent,
+  UsageUpdateEvent,
   ErrorEvent,
 ]);
 
@@ -200,5 +209,6 @@ export type SessionModeEvent = Static<typeof SessionModeEvent>;
 export type SessionEndedEvent = Static<typeof SessionEndedEvent>;
 export type SessionTransitionEvent = Static<typeof SessionTransitionEvent>;
 export type DiscordPresenceEvent = Static<typeof DiscordPresenceEvent>;
+export type UsageUpdateEvent = Static<typeof UsageUpdateEvent>;
 export type ErrorEvent = Static<typeof ErrorEvent>;
 export type ServerEvent = Static<typeof ServerEvent>;


### PR DESCRIPTION
## Summary

Closes #470 and #471. Both surface the user's remaining ChatGPT-session quota using the existing `UsageStatus` abstraction, without needing the user to leave the app.

- **#470 — Conversation-pane gauge.** New 5-cell gem indicator in the bottom-right of the conversation pane. 25 buckets total (4% per tick), leftmost cell depletes first. Each cell passes through `◆` (light-blue diamond) → `⬢` (red hexagon, "ruby") → `■` (brown square, "garnet") → `*` (grey asterisk) → space. Reads only the primary 5-hour window; the secondary 7-day window is intentionally ignored. Mutually exclusive with the existing `scroll (N) more` indicator — only one mounts at a time, so the scroll indicator cleanly overlays the gauge with no bleed-through.

- **#471 — Esc-menu percentage.** GameMenu footer now appends ` | <remaining>%` after the token tier stats whenever a primary percentage segment is present. Width grows with the number (`5%` → `100%`); modal `minWidth` bumped 40→48 to fit. Inverts the provider's `usedPercent` so the displayed value matches the gauge semantics — how much headroom is left, not how much has been spent.

Plumbing:
- New `usage:update` `ServerEvent` carrying a `UsageStatus` payload.
- `SessionManager` subscribes to the DM-tier provider's `subscribeUsage`, broadcasts each update, caches the latest snapshot for replay to late-connecting clients, and drains the subscription on session end. No-op for providers without a usage concept (currently only openai-chatgpt has one).
- Client `ClientState` and `GameContextValue` gain a `usageStatus` field. Receiving a `usage:update` counts as forward-progress evidence (clears any recoverable retry overlay). `session:transition` clears the snapshot so it doesn't bleed across sessions.

## Test plan

- [x] `npm run check` — 2530/2530 tests pass, lint clean.
- [x] Unit tests for `gaugeCells` covering full / empty / mid-depletion / edge clamping / leftmost-first ordering.
- [x] Render tests for `<UsageGauge />` — null/non-percentage-segment skip path, primary-only consumption.
- [x] Event-handler tests for `usage:update` — captures snapshot, clears on `session:transition`, counts as progress for retry overlay.
- [x] GameMenu footer tests — appends `<remaining>%` when primary segment present, omits when absent.
- [ ] Manual: live ChatGPT session — confirm gauge updates on each codex response and percentage matches the bottom-right gauge state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)