### PR TITLE
Stream reasoning summaries from ChatGPT codex provider

### DIFF
--- a/packages/engine/src/providers/openai-chatgpt/protocol.ts
+++ b/packages/engine/src/providers/openai-chatgpt/protocol.ts
@@ -150,6 +150,7 @@ export interface ModelListResult {
 export type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
 export type ApprovalPolicy = "untrusted" | "on-failure" | "on-request" | "never";
 export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ReasoningSummary = "auto" | "concise" | "detailed" | "none";
 
 /** A custom tool registered with the thread. Wire-supported but absent from generated schema. */
 export interface DynamicToolSpec {
@@ -202,6 +203,15 @@ export interface TurnStartParams {
   input: UserInputItem[];
   model?: string;
   effort?: ReasoningEffort;
+  /**
+   * Per-turn override for reasoning-summary verbosity. When unset, codex
+   * falls back to its config default, which for the ChatGPT-account /
+   * app-server flow is effectively "none" — meaning no
+   * `item/reasoning/summaryTextDelta` notifications fire and our
+   * `thinkingText` stays empty even though reasoning tokens are billed.
+   * Set this explicitly to opt into streamed summaries.
+   */
+  summary?: ReasoningSummary;
 }
 
 export interface TurnStartResult {

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -523,11 +523,18 @@ export class OpenAIChatGptProvider implements LLMProvider {
       const turnInput: TurnStartParams["input"] = lastUserText
         ? [{ type: "text", text: lastUserText }]
         : [{ type: "text", text: "(continue)" }];
+      // Request detailed reasoning summaries whenever we're asking for any
+      // reasoning effort. Without this, codex defaults to summary="none" for
+      // chatgpt-account flows and our thinkingText never gets populated even
+      // though reasoning tokens are billed — see protocol.ts:TurnStartParams.
       const turnReq: TurnStartParams = {
         threadId,
         input: turnInput,
         ...(params.thinking?.effort
-          ? { effort: mapEffort(params.thinking.effort) }
+          ? {
+              effort: mapEffort(params.thinking.effort),
+              summary: "detailed",
+            }
           : {}),
       };
       log.turnStart({ threadId, effort: turnReq.effort });


### PR DESCRIPTION
## Summary
- Pass `summary: "detailed"` on `turn/start` whenever a reasoning effort is set, so codex asks OpenAI for streamed reasoning summaries
- Without this, codex defaults to `summary="none"` for chatgpt-account / app-server flows, so `item/reasoning/summaryTextDelta` notifications never fire — `thinkingText` stays empty and `dumpThinking` is never called, even though reasoning tokens are billed
- Verified the notification names and `TurnStartParams.summary` shape against the schema generated from the bundled `@openai/codex` (`app-server generate-json-schema`)

The `onReasoningDelta` handler in [provider.ts](packages/engine/src/providers/openai-chatgpt/provider.ts) was already wired up correctly; it just had nothing to consume. Gated on `params.thinking?.effort` so text-only / no-reasoning calls don't request a summary the model isn't producing.

## Test plan
- [x] `tsc -b` passes
- [ ] Manual: run a session against a ChatGPT-account connection with thinking enabled, confirm `context-dump`s now contain a `_thinking_trace` block
- [ ] Manual: verify text-only paths still work (no `effort` → no `summary` → no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)