### PR TITLE
Tweak UsageGauge gem colors

### DIFF
--- a/packages/client-ink/src/tui/components/UsageGauge.tsx
+++ b/packages/client-ink/src/tui/components/UsageGauge.tsx
@@ -36,9 +36,9 @@ interface Cell {
   color?: string;
 }
 
-const FULL: Cell = { glyph: "◆", color: "#7AC7E8" };       // light-blue diamond
-const RUBY: Cell = { glyph: "⬢", color: "#D03A3A" };       // red hexagon
-const GARNET: Cell = { glyph: "■", color: "#8B4513" };     // brown square
+const FULL: Cell = { glyph: "◆", color: "#529EAB" };       // light-blue diamond
+const RUBY: Cell = { glyph: "⬢", color: "#781313" };       // red hexagon
+const GARNET: Cell = { glyph: "■", color: "#A87712" };     // brown square
 const TARNISHED: Cell = { glyph: "*", color: "gray" };     // grey asterisk
 const EMPTY: Cell = { glyph: " " };
 


### PR DESCRIPTION
## Summary
- Tweak the three hex colors in the bottom-right usage gauge: full diamond → `#529EAB`, ruby → `#781313`, garnet → `#A87712`.

## Test plan
- [ ] Eyeball the gauge in the TUI at various drain levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)