### PR TITLE
Spawn codex native binary directly in SEA builds

### DIFF
--- a/packages/engine/src/providers/openai-chatgpt/binary.test.ts
+++ b/packages/engine/src/providers/openai-chatgpt/binary.test.ts
@@ -19,16 +19,22 @@ describe("resolveCodexBinary", () => {
   it("returns the bundled @openai/codex bin via Node when available", () => {
     // The bundled package is a workspace dependency installed at the repo
     // root. In dev/test, `process.execPath` is the user's Node binary
-    // (e.g. /usr/bin/node) which has no `codex/bin/codex.js` colocated,
+    // (e.g. /usr/bin/node) which has no `codex/vendor/...` tree colocated,
     // so the colocated probe naturally misses and we fall through to the
     // createRequire path which resolves `@openai/codex` from node_modules.
-    // Production SEA builds hit the colocated branch instead — the
-    // build-dist.js script vendors `codex/` next to the executable.
+    // Production SEA builds hit the colocated branch instead and spawn
+    // the native binary directly (see binary.ts).
     const r = resolveCodexBinary();
-    expect(["bundled", "colocated"]).toContain(r.source);
-    expect(r.path).toBe(process.execPath);
-    expect(r.prefixArgs).toHaveLength(1);
-    expect(r.prefixArgs[0]).toMatch(/codex.*\.js$/);
+    if (r.source === "bundled") {
+      expect(r.path).toBe(process.execPath);
+      expect(r.prefixArgs).toHaveLength(1);
+      expect(r.prefixArgs[0]).toMatch(/codex.*\.js$/);
+    } else {
+      // colocated — native binary, no script wrapper
+      expect(r.source).toBe("colocated");
+      expect(r.prefixArgs).toHaveLength(0);
+      expect(r.path).toMatch(/codex(?:\.exe)?$/);
+    }
   });
 
   it("caches the resolution across calls", () => {

--- a/packages/engine/src/providers/openai-chatgpt/binary.test.ts
+++ b/packages/engine/src/providers/openai-chatgpt/binary.test.ts
@@ -1,18 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import { tmpdir } from "node:os";
 import { resolveCodexBinary, resetCodexBinaryCache } from "./binary.js";
+import { norm } from "../../utils/paths.js";
 
 describe("resolveCodexBinary", () => {
   let savedEnv: string | undefined;
+  let savedExecPath: string;
 
   beforeEach(() => {
     resetCodexBinaryCache();
     savedEnv = process.env.CODEX_BIN;
     delete process.env.CODEX_BIN;
+    savedExecPath = process.execPath;
   });
 
   afterEach(() => {
     if (savedEnv === undefined) delete process.env.CODEX_BIN;
     else process.env.CODEX_BIN = savedEnv;
+    process.execPath = savedExecPath;
     resetCodexBinaryCache();
   });
 
@@ -41,5 +48,60 @@ describe("resolveCodexBinary", () => {
     const a = resolveCodexBinary();
     const b = resolveCodexBinary();
     expect(a).toBe(b);
+  });
+
+  it("resolves colocated native binary when SEA-style layout sits next to execPath", () => {
+    // Simulate the production SEA layout that build-dist.js produces:
+    //   <exeDir>/MachineViolet[.exe]
+    //   <exeDir>/codex/vendor/<triple>/codex/codex[.exe]
+    //   <exeDir>/codex/vendor/<triple>/path/             (for bundled rg)
+    // The resolver should pick the native binary directly (no script
+    // wrapper, prefixArgs empty) and prepend the path/ dir to PATH so
+    // the bundled `rg` is discoverable.
+    const root = mkdtempSync(join(tmpdir(), "mv-codex-test-"));
+    try {
+      const triple = "x86_64-pc-windows-msvc";
+      const exeName = process.platform === "win32" ? "codex.exe" : "codex";
+      const archDir = join(root, "codex", "vendor", triple);
+      const codexDir = join(archDir, "codex");
+      const pathDir = join(archDir, "path");
+      mkdirSync(codexDir, { recursive: true });
+      mkdirSync(pathDir, { recursive: true });
+      writeFileSync(join(codexDir, exeName), "");
+
+      process.execPath = join(root, process.platform === "win32" ? "MachineViolet.exe" : "MachineViolet");
+      resetCodexBinaryCache();
+
+      const r = resolveCodexBinary();
+      expect(r.source).toBe("colocated");
+      expect(r.prefixArgs).toEqual([]);
+      expect(norm(r.path)).toBe(norm(join(codexDir, exeName)));
+      expect(r.extraEnv?.PATH).toBeDefined();
+      expect(r.extraEnv!.PATH.split(delimiter)[0]).toBe(pathDir);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("omits PATH augmentation when colocated layout has no sibling path/ dir", () => {
+    // Defensive: an upstream codex release that ever drops the ripgrep
+    // sidecar would still resolve, just without PATH augmentation.
+    const root = mkdtempSync(join(tmpdir(), "mv-codex-test-"));
+    try {
+      const triple = "x86_64-pc-windows-msvc";
+      const exeName = process.platform === "win32" ? "codex.exe" : "codex";
+      const codexDir = join(root, "codex", "vendor", triple, "codex");
+      mkdirSync(codexDir, { recursive: true });
+      writeFileSync(join(codexDir, exeName), "");
+
+      process.execPath = join(root, process.platform === "win32" ? "MachineViolet.exe" : "MachineViolet");
+      resetCodexBinaryCache();
+
+      const r = resolveCodexBinary();
+      expect(r.source).toBe("colocated");
+      expect(r.extraEnv?.PATH).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/engine/src/providers/openai-chatgpt/binary.ts
+++ b/packages/engine/src/providers/openai-chatgpt/binary.ts
@@ -2,16 +2,20 @@
  * Resolve the `codex` binary path.
  *
  * Look up order:
- *   1. Colocated with the running executable: `<exeDir>/codex/bin/codex.js`
- *      with vendor binaries at `<exeDir>/codex/vendor/{triple}/...`. This is
- *      what production builds ship — see `scripts/build-dist.js`, which
- *      copies the platform-matching codex tree out of node_modules into
- *      `dist/codex/` next to the SEA executable. The codex.js wrapper's
- *      own fallback path (`../vendor/...` relative to bin/codex.js) finds
- *      the native binary without needing a sibling optional-dep package.
+ *   1. Colocated with the running executable: `<exeDir>/codex/vendor/{triple}/codex/codex[.exe]`,
+ *      vendored next to the SEA binary by `scripts/build-dist.js`. We spawn
+ *      the native Rust binary directly — NOT the `codex.js` wrapper —
+ *      because `process.execPath` in a Node SEA build is the SEA exe itself
+ *      (e.g. `MachineViolet.exe`), not a real `node` interpreter. A SEA
+ *      binary ignores its first script-path argv and always runs its
+ *      embedded main, so `MachineViolet.exe codex/bin/codex.js app-server`
+ *      would relaunch Machine Violet instead of running Codex.
+ *      We also prepend `vendor/{triple}/path` to PATH so the bundled
+ *      `rg.exe` is discoverable — that's what codex.js does too.
  *   2. The `@openai/codex` npm package resolved via `createRequire` —
  *      this is the path for `npm run dev` and tests, where node_modules
- *      lives next to the source.
+ *      lives next to the source and `process.execPath` IS real Node, so
+ *      running codex.js through it works.
  *   3. `process.env.CODEX_BIN` override — for local dev or experiments
  *      (accepts a `.js` script or a native exe).
  *   4. PATH lookup — fallback for environments where the user installed
@@ -20,8 +24,8 @@
  * If none resolves, callers will get a spawn EAGAIN/ENOENT and surface a
  * "Codex runtime not installed" error to the user.
  */
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
 import { createRequire } from "node:module";
 
 let cached: CodexBinaryResolution | null = null;
@@ -31,6 +35,8 @@ export interface CodexBinaryResolution {
   path: string;
   /** Arguments to prepend (e.g. ["bin/codex.js"] when path is "node"). */
   prefixArgs: string[];
+  /** Extra env vars to merge into the spawned child's environment (e.g. PATH augmentation for bundled `rg`). */
+  extraEnv?: Record<string, string>;
   source: "colocated" | "bundled" | "env" | "path";
 }
 
@@ -45,21 +51,41 @@ export function resolveCodexBinary(): CodexBinaryResolution {
   if (cached) return cached;
 
   // 1. Colocated with the running executable — production SEA builds ship
-  // `dist/codex/bin/codex.js` + `dist/codex/vendor/{triple}/...` next to
-  // MachineViolet[.exe]. We run codex.js through Node (the SEA process
-  // itself) so we don't need a separate Node install. codex.js's own
-  // bootstrap looks for `../vendor/...` next to itself and finds the
-  // native Rust binary without requiring sibling node_modules.
-  //
-  // In dev mode, `process.execPath` is the user's Node binary (e.g.
-  // /usr/bin/node) and the colocated probe naturally misses, falling
-  // through to the createRequire path.
+  // `dist/codex/vendor/{triple}/codex/codex[.exe]` next to MachineViolet[.exe].
+  // We spawn the native Rust binary directly; running codex.js through
+  // `process.execPath` would actually relaunch the SEA exe itself (the SEA
+  // ignores script-path argv and always runs its embedded main).
   try {
     const exeDir = dirname(process.execPath);
-    const colocated = join(exeDir, "codex", "bin", "codex.js");
-    if (existsSync(colocated)) {
-      cached = { path: process.execPath, prefixArgs: [colocated], source: "colocated" };
-      return cached;
+    const codexRoot = join(exeDir, "codex");
+    const vendorDir = join(codexRoot, "vendor");
+    if (existsSync(vendorDir)) {
+      // Each build vendors exactly one platform triple's subdir. Just take
+      // whatever's there rather than re-deriving the platform mapping.
+      const triples = readdirSync(vendorDir).filter((d) =>
+        statSync(join(vendorDir, d)).isDirectory(),
+      );
+      if (triples.length > 0) {
+        const triple = triples[0];
+        const exeName = process.platform === "win32" ? "codex.exe" : "codex";
+        const nativeBin = join(vendorDir, triple, "codex", exeName);
+        if (existsSync(nativeBin)) {
+          // Prepend the sibling `path/` dir to PATH so codex can find its
+          // bundled ripgrep, matching what codex.js does itself.
+          const pathDir = join(vendorDir, triple, "path");
+          const extraEnv: Record<string, string> = {};
+          if (existsSync(pathDir)) {
+            extraEnv.PATH = pathDir + delimiter + (process.env.PATH ?? "");
+          }
+          cached = {
+            path: nativeBin,
+            prefixArgs: [],
+            extraEnv,
+            source: "colocated",
+          };
+          return cached;
+        }
+      }
     }
   } catch { /* fall through */ }
 

--- a/packages/engine/src/providers/openai-chatgpt/rpc.ts
+++ b/packages/engine/src/providers/openai-chatgpt/rpc.ts
@@ -87,6 +87,7 @@ export class CodexRpcClient extends EventEmitter {
 
     this.proc = spawn(bin.path, [...bin.prefixArgs, "app-server", ...this.extraArgs], {
       stdio: ["pipe", "pipe", "inherit"],
+      env: bin.extraEnv ? { ...process.env, ...bin.extraEnv } : process.env,
       // `.cmd` shims on Windows (used by PATH-resolved global installs) need
       // shell resolution. Bundled-mode invokes node directly so shell is off.
       shell: process.platform === "win32" && bin.source === "path",


### PR DESCRIPTION
## Summary
- Fixes a Windows-installer-only crash where the ChatGPT-account provider failed to start its `codex app-server` subprocess.
- Root cause: in a Node SEA build, `process.execPath` is the SEA exe (`MachineViolet.exe`), not real `node`. The colocated resolution in `binary.ts` was spawning `process.execPath codex/bin/codex.js app-server`, which a SEA *ignores* (it always runs its embedded main and treats extra argv as `process.argv` for that main). The result was Machine Violet re-launching itself with `codex.js` as a campaign id, the RPC client reading non-JSON output, and login never completing.
- Fix: in the colocated branch, locate `vendor/{triple}/codex/codex[.exe]` and spawn it directly with no wrapper. Prepend `vendor/{triple}/path` to PATH so the bundled `rg` is reachable (matching what `codex.js` does internally). Dev/test path (createRequire-resolved `@openai/codex`) is unchanged — `process.execPath` is real Node there, so `codex.js` continues to work.

## Test plan
- [x] `npm run check` clean (one flaky unrelated `setup-conversation` test passes on rerun)
- [x] Locally built Velopack installer (`vpk pack` on the same channel format CI uses), installed over the existing `%LOCALAPPDATA%\MachineViolet`, ChatGPT-account provider now spawns codex cleanly and reaches the login flow
- [x] Manually verified `codex.exe app-server` responds to `initialize` over stdio JSON-RPC from the vendored install location
- [ ] Trigger `test-build` workflow on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)