### PR TITLE
Surface PC theme color in DM active state

### DIFF
--- a/packages/engine/src/agents/scene-manager.test.ts
+++ b/packages/engine/src/agents/scene-manager.test.ts
@@ -556,6 +556,61 @@ describe("SceneManager", () => {
     expect(sessionState.activeState).not.toContain("(also:");
   });
 
+  it("contextRefresh appends theme color to PC summary when set in frontmatter", async () => {
+    const fileIO = mockFileIO();
+    files["/tmp/test-campaign/characters/aldric.md"] =
+      "# Aldric\n\n**Type:** PC\n**Theme Color:** #cc55aa\n\nA paladin.\n";
+
+    const sessionState = mockSessionState();
+    const mgr = new SceneManager(
+      mockState(),
+      mockScene(),
+      new ConversationManager({ retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 }),
+      sessionState,
+      fileIO,
+    );
+
+    await mgr.contextRefresh();
+    expect(sessionState.activeState).toContain("Aldric [theme color: #cc55aa]");
+  });
+
+  it("contextRefresh combines aliases and theme color on one line", async () => {
+    const fileIO = mockFileIO();
+    files["/tmp/test-campaign/characters/aldric.md"] =
+      "# Aldric\n\n**Type:** PC\n**Additional Names:** The Hooded Figure\n**Theme Color:** #4488cc\n\nA paladin.\n";
+
+    const sessionState = mockSessionState();
+    const mgr = new SceneManager(
+      mockState(),
+      mockScene(),
+      new ConversationManager({ retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 }),
+      sessionState,
+      fileIO,
+    );
+
+    await mgr.contextRefresh();
+    expect(sessionState.activeState).toContain("Aldric (also: The Hooded Figure) [theme color: #4488cc]");
+  });
+
+  it("contextRefresh ignores invalid theme color values", async () => {
+    const fileIO = mockFileIO();
+    files["/tmp/test-campaign/characters/aldric.md"] =
+      "# Aldric\n\n**Type:** PC\n**Theme Color:** mauve and gold\n\nA paladin.\n";
+
+    const sessionState = mockSessionState();
+    const mgr = new SceneManager(
+      mockState(),
+      mockScene(),
+      new ConversationManager({ retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 }),
+      sessionState,
+      fileIO,
+    );
+
+    await mgr.contextRefresh();
+    expect(sessionState.activeState).toContain("Aldric");
+    expect(sessionState.activeState).not.toContain("theme color:");
+  });
+
   it("buildAliasContext returns formatted alias lines across entity types", async () => {
     const fileIO = mockFileIO();
     files["/tmp/test-campaign/characters/mysterious-stranger.md"] =

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -927,6 +927,10 @@ export class SceneManager {
           if (aliases?.trim()) {
             line += ` (also: ${aliases.trim()})`;
           }
+          const themeColor = typeof frontMatter.theme_color === "string" ? frontMatter.theme_color.trim() : "";
+          if (themeColor) {
+            line += ` [theme color: ${themeColor}]`;
+          }
         }
       } catch { /* non-critical — fall back to bare name */ }
       summaries.push(line);

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -928,7 +928,7 @@ export class SceneManager {
             line += ` (also: ${aliases.trim()})`;
           }
           const themeColor = typeof frontMatter.theme_color === "string" ? frontMatter.theme_color.trim() : "";
-          if (themeColor) {
+          if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(themeColor)) {
             line += ` [theme color: ${themeColor}]`;
           }
         }


### PR DESCRIPTION
## Summary
- The DM directive (`packages/engine/src/prompts/dm-directives.md:85`) tells the model: *"PCs are highlighted in their theme color."*
- But `loadPCSummaries` in `scene-manager.ts` only included the character name and aliases — it never read the `theme_color` frontmatter field, so the DM had the rule but no values to apply.
- Append `[theme color: #hex]` to each PC summary line when the character file declares one. PCs without a `theme_color` get the bare line, same as before.

Example active-state block after this change:
```
PCs:
  Aldric (also: the Wanderer) [theme color: #cc55aa]
  Rook [theme color: #4488cc]
```

## Test plan
- [x] `npx vitest run packages/engine/src/agents/scene-manager.test.ts` — 71/71 pass
- [x] `npx tsc -b` clean
- [ ] Live: start a session with a PC whose character file has `theme_color` set, confirm the DM renders the PC name in that color

🤖 Generated with [Claude Code](https://claude.com/claude-code)