### PR TITLE
Fix character sheet data duplication on ChatGPT/codex path

### DIFF
--- a/packages/engine/src/agents/subagents/scribe.test.ts
+++ b/packages/engine/src/agents/subagents/scribe.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { buildScribeToolHandler, splitSections, mergeSectionBodies } from "./scribe.js";
+import { buildScribeToolHandler, splitSections, mergeSectionBodies, sanitizeFrontMatter } from "./scribe.js";
 import type { ScribeFileIO } from "./scribe.js";
 import { resetPromptCache } from "../../prompts/load-prompt.js";
 import { norm } from "../../utils/paths.js";
@@ -630,5 +630,59 @@ describe("mergeSectionBodies", () => {
     expect(result).toContain("## Stats");
     expect(result).toContain("### Substats");
     expect(result).toContain("STR: 10");
+  });
+});
+
+describe("sanitizeFrontMatter", () => {
+  // These cases all came from route-0 (gpt-5.4-mini scribe). Without the
+  // sanitizer they round-trip as `****Type:** character:** character` etc.
+  // and the file frontmatter is permanently corrupted.
+  it("passes well-formed keys through unchanged", () => {
+    const input = {
+      type: "character",
+      disposition: "friendly",
+      location: "[[The Shattered Hall]]",
+    };
+    expect(sanitizeFrontMatter(input)).toEqual(input);
+  });
+
+  it("recovers when the whole `**Key:** Value` line is the JSON key", () => {
+    const out = sanitizeFrontMatter({ "**Type:** character": "character" });
+    expect(out).toEqual({ type: "character" });
+  });
+
+  it("recovers when the value differs from the key fragment (prefers explicit value)", () => {
+    // Model sometimes passes the new value separately while still
+    // malforming the key — the explicit value should win.
+    const out = sanitizeFrontMatter({ "**Disposition:** old": "new" });
+    expect(out).toEqual({ disposition: "new" });
+  });
+
+  it("handles multiple malformed keys without dropping any", () => {
+    const out = sanitizeFrontMatter({
+      "**Type:** NPC": "NPC",
+      "**Location:** [[US-9]]": "[[US-9]]",
+    });
+    expect(out).toEqual({ type: "NPC", location: "[[US-9]]" });
+  });
+
+  it("lowercases and snake-cases recovered keys to match normalizeKey", () => {
+    const out = sanitizeFrontMatter({ "**Additional Names:** Foo, Bar": "Foo, Bar" });
+    expect(out).toEqual({ additional_names: "Foo, Bar" });
+  });
+
+  it("does not clobber an already-clean key with a malformed duplicate", () => {
+    // If both forms are present, the clean key arrives first in
+    // Object.entries order; sanitizer must not overwrite it.
+    const out = sanitizeFrontMatter({
+      type: "character",
+      "**Type:** NPC": "NPC",
+    });
+    expect(out).toEqual({ type: "character" });
+  });
+
+  it("preserves null sentinel for key deletion", () => {
+    const out = sanitizeFrontMatter({ placeholder: null });
+    expect(out).toEqual({ placeholder: null });
   });
 });

--- a/packages/engine/src/agents/subagents/scribe.test.ts
+++ b/packages/engine/src/agents/subagents/scribe.test.ts
@@ -685,4 +685,13 @@ describe("sanitizeFrontMatter", () => {
     const out = sanitizeFrontMatter({ placeholder: null });
     expect(out).toEqual({ placeholder: null });
   });
+
+  it("preserves null sentinel even when the malformed key carries an old value fragment", () => {
+    // Regression for the case Copilot flagged on #481: a model that
+    // means to delete a field but also malforms the key would silently
+    // resurrect the old value because the recovered fragment looks like
+    // information. `null` always means delete — never substitute.
+    const out = sanitizeFrontMatter({ "**Location:** [[Old]]": null });
+    expect(out).toEqual({ location: null });
+  });
 });

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -210,12 +210,17 @@ export function sanitizeFrontMatter(
     }
     const recoveredKey = m[1].trim().toLowerCase().replace(/\s+/g, "_");
     const recoveredValueFromKey = m[2].trim();
-    // Prefer the supplied value when it carries information; otherwise
-    // fall back to the trailing fragment of the malformed key.
+    // `null` is the deletion sentinel — preserve it regardless of any
+    // value fragment recovered from the malformed key. Otherwise a
+    // payload like `{ "**Location:** [[Old]]": null }` would silently
+    // become `{ location: "[[Old]]" }` and never actually delete the
+    // field (Copilot-flagged regression on #481).
     const value =
-      typeof rawValue === "string" && rawValue.trim() && rawValue.trim() !== recoveredValueFromKey
-        ? rawValue
-        : recoveredValueFromKey || rawValue;
+      rawValue === null
+        ? null
+        : typeof rawValue === "string" && rawValue.trim() && rawValue.trim() !== recoveredValueFromKey
+          ? rawValue
+          : recoveredValueFromKey || rawValue;
     if (!(recoveredKey in out)) {
       out[recoveredKey] = value;
     }

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -184,6 +184,45 @@ function unescapeNewlines(s: string): string {
   return s.replace(/\\n/g, "\n");
 }
 
+/**
+ * Repair front_matter objects produced by smaller models (gpt-5.4-mini in
+ * particular) that occasionally pass the entire on-disk markdown line as
+ * the JSON key — e.g. `{ "**Type:** character": "character" }` — instead of
+ * the documented `{ "type": "character" }` shape. Without this, the
+ * serializer round-trips the bad key as `****Type:** character:** character`
+ * and the file frontmatter is permanently corrupted on subsequent reads.
+ *
+ * Strategy: detect a `**Key:**` prefix in the key, extract the real key
+ * (lowercased + snake-cased to match {@link normalizeKey}), and use the
+ * trailing fragment as the value if no separate value was supplied or if
+ * the supplied value duplicates the trailing fragment.
+ */
+export function sanitizeFrontMatter(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const KEY_RE = /^\*+\s*([^*:]+?)\s*:\*+\s*(.*)$/;
+  for (const [rawKey, rawValue] of Object.entries(raw)) {
+    const m = KEY_RE.exec(rawKey);
+    if (!m) {
+      out[rawKey] = rawValue;
+      continue;
+    }
+    const recoveredKey = m[1].trim().toLowerCase().replace(/\s+/g, "_");
+    const recoveredValueFromKey = m[2].trim();
+    // Prefer the supplied value when it carries information; otherwise
+    // fall back to the trailing fragment of the malformed key.
+    const value =
+      typeof rawValue === "string" && rawValue.trim() && rawValue.trim() !== recoveredValueFromKey
+        ? rawValue
+        : recoveredValueFromKey || rawValue;
+    if (!(recoveredKey in out)) {
+      out[recoveredKey] = value;
+    }
+  }
+  return out;
+}
+
 /** Heading pattern: a `## ` at the start of a line (not `###` or deeper). */
 const H2_RE = /^## (?!#)/m;
 
@@ -361,7 +400,7 @@ export function buildScribeToolHandler(
 
             const fm: EntityFrontMatter = {
               type: entityType,
-              ...(input.front_matter as Record<string, unknown> ?? {}),
+              ...sanitizeFrontMatter((input.front_matter as Record<string, unknown> | undefined) ?? {}),
             };
             const body = input.body ? unescapeNewlines(input.body as string) : "";
             const changelog: string[] = [];
@@ -386,10 +425,12 @@ export function buildScribeToolHandler(
             const { frontMatter, body, changelog } = parseFrontMatter(raw);
             const title = (frontMatter._title ?? entityName) as string;
 
-            // Merge front matter
+            // Merge front matter (sanitize first to catch small-model
+            // mistakes that pass full `**Key:** Value` markdown lines as
+            // JSON keys — see sanitizeFrontMatter).
             const fmUpdates = input.front_matter as Record<string, unknown> | undefined;
             if (fmUpdates) {
-              for (const [key, value] of Object.entries(fmUpdates)) {
+              for (const [key, value] of Object.entries(sanitizeFrontMatter(fmUpdates))) {
                 if (value === null) {
                   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                   delete frontMatter[key];

--- a/packages/engine/src/prompts/scribe.md
+++ b/packages/engine/src/prompts/scribe.md
@@ -44,14 +44,39 @@ Never leave `**Placeholder:** true` on an entity that has been fleshed out. If y
 Entity files are **markdown**. The body field in `write_entity` is markdown text — use real line breaks between paragraphs, not literal `\n` sequences.
 
 ### Front matter format
-Each entity file starts with `**Key:** Value` lines (not YAML). Common keys:
-- `**Type:** character` (always include)
-- `**Class:** Rogue` (for characters)
-- `**Disposition:** friendly` (for NPCs)
-- `**Location:** [[The Shattered Hall]]` (current location)
-- `**Additional Names:** The Hooded Figure, Shadow` (aliases)
-- `**Color:** #cc4444` (highlight color for this entity)
-- `**Display Resources:** HP, Spell Slots` (for PC stat bar, array)
+Entity files store front matter as `**Key:** Value` lines on disk (not YAML), but **the `front_matter` argument to `write_entity` is a plain JSON object**, not a string of markdown lines.
+
+- Keys are short, lowercase, snake_case identifiers: `type`, `class`, `disposition`, `location`, `additional_names`, `color`, `display_resources`.
+- Values are plain strings. Do NOT wrap keys in `**…:**`. Do NOT include the key inside the value.
+- `null` deletes a key (use this in update mode to clear a field).
+
+**Correct (always do this):**
+```json
+"front_matter": {
+  "type": "character",
+  "disposition": "friendly",
+  "location": "[[The Shattered Hall]]",
+  "additional_names": "The Hooded Figure, Shadow",
+  "color": "#cc4444"
+}
+```
+
+**Wrong (NEVER do this — it corrupts the file with malformed keys like `****Type:** character:** character`):**
+```json
+"front_matter": {
+  "**Type:** character": "character",
+  "**Location:** [[The Shattered Hall]]": "[[The Shattered Hall]]"
+}
+```
+
+Common keys and their values:
+- `type`: `character`, `location`, `faction`, `item`, `lore`, `player` (always include on create)
+- `class`: e.g. `Rogue` (for characters)
+- `disposition`: e.g. `friendly`, `mysterious` (for NPCs)
+- `location`: wikilink to current location, e.g. `[[The Shattered Hall]]`
+- `additional_names`: comma-separated aliases, e.g. `The Hooded Figure, Shadow`
+- `color`: hex highlight color, e.g. `#cc4444`
+- `display_resources`: comma-separated, e.g. `HP, Spell Slots` (for PC stat bar)
 
 ### Item entities
 Not every item needs an entity file. Mundane gear (rations, rope, coins) stays as plain text on the character sheet. Create `item` entities only for objects with narrative significance — named weapons, quest items, magical artifacts, keys to locked plots.

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -463,6 +463,65 @@ describe("runProviderLoop retry", () => {
 // not the running concatenation, and (b) tell consumers to roll back the
 // streamed deltas from the prior round before the next round's stream
 // begins, so the live UI doesn't show the response twice.
+describe("runProviderLoop with internal-dispatch providers", () => {
+  // Codex (openai-chatgpt) dispatches tool calls in-band during the turn
+  // via params.dispatchTool. It MUST NOT re-surface those calls through
+  // ChatResult.toolCalls, or the bridge will run every write_entity /
+  // scribe write twice — the symptom that wrecked route-0's character
+  // sheets (duplicated changelog entries, duplicated body paragraphs,
+  // duplicated frontmatter mutations).
+  it("does not re-dispatch tool calls when provider used internal dispatch", async () => {
+    const handlerCalls: { name: string; input: Record<string, unknown> }[] = [];
+    const provider: LLMProvider = {
+      providerId: "test-internal-dispatch",
+      chat: vi.fn(async (params) => {
+        // Simulate codex's internal dispatch: provider invokes
+        // params.dispatchTool itself during the turn.
+        if (params.tools && params.dispatchTool) {
+          await params.dispatchTool({
+            id: "call_1",
+            name: "write_entity",
+            input: { name: "Janey" },
+          });
+        }
+        return {
+          text: "ok",
+          // Critical: an internal-dispatch provider returns no surfaced
+          // tool calls; the bridge would otherwise re-run the handler.
+          toolCalls: [],
+          usage: mockUsage(),
+          stopReason: "end" as const,
+          assistantContent: [
+            { type: "tool_use", id: "call_1", name: "write_entity", input: { name: "Janey" } },
+            { type: "text", text: "ok" },
+          ],
+        };
+      }),
+      stream: vi.fn(),
+      healthCheck: vi.fn(),
+    };
+
+    await runProviderLoop(provider, "system", [
+      { role: "user", content: "do it" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: false,
+      tools: [{ name: "write_entity", description: "", inputSchema: { type: "object", properties: {} } }],
+      toolHandler: (name, input) => {
+        handlerCalls.push({ name, input });
+        return { content: "wrote" };
+      },
+    });
+
+    // Exactly one invocation — the internal-dispatch call. If the bridge
+    // re-dispatched result.toolCalls, this would be 2.
+    expect(handlerCalls).toHaveLength(1);
+    expect(handlerCalls[0]).toEqual({ name: "write_entity", input: { name: "Janey" } });
+  });
+});
+
 describe("runProviderLoop round-boundary rollback", () => {
   beforeEach(() => { vi.useFakeTimers(); });
   afterEach(() => { vi.useRealTimers(); });

--- a/packages/engine/src/providers/openai-chatgpt/provider.test.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { TurnCollector } from "./provider.js";
+import type {
+  AgentMessageDeltaNotification, ItemCompletedNotification,
+  TurnCompletedNotification,
+} from "./protocol.js";
+
+function completedTurn(): TurnCompletedNotification {
+  return {
+    threadId: "t1",
+    turn: { id: "turn_1", status: "completed", durationMs: 100 },
+  } as TurnCompletedNotification;
+}
+
+function agentMessageCompleted(text: string): ItemCompletedNotification {
+  return {
+    threadId: "t1",
+    item: { id: "msg_1", type: "agentMessage", text },
+  } as ItemCompletedNotification;
+}
+
+function agentMessageDelta(delta: string): AgentMessageDeltaNotification {
+  return { threadId: "t1", itemId: "msg_1", delta } as AgentMessageDeltaNotification;
+}
+
+describe("TurnCollector", () => {
+  it("records assistant text from streaming deltas", () => {
+    const c = new TurnCollector();
+    c.onAgentMessageDelta(agentMessageDelta("Hello, "));
+    c.onAgentMessageDelta(agentMessageDelta("world."));
+    c.onItemCompleted(agentMessageCompleted("Hello, world."));
+    const result = c.toChatResult(completedTurn());
+
+    expect(result.text).toBe("Hello, world.");
+    expect(result.assistantContent).toEqual([{ type: "text", text: "Hello, world." }]);
+    expect(result.toolCalls).toEqual([]);
+  });
+
+  // Codex owns tool dispatch end-to-end. The bridge must not see surfaced
+  // tool calls or it re-runs every handler (the route-0 data corruption).
+  it("never surfaces tool calls through ChatResult.toolCalls", () => {
+    const c = new TurnCollector();
+    c.onToolCall({ id: "call_1", name: "write_entity", input: { name: "Janey" } });
+    const result = c.toChatResult(completedTurn());
+
+    expect(result.toolCalls).toEqual([]);
+    // But the assistant message still records what the model did, so
+    // downstream history reflects it.
+    expect(result.assistantContent).toContainEqual({
+      type: "tool_use",
+      id: "call_1",
+      name: "write_entity",
+      input: { name: "Janey" },
+    });
+  });
+
+  // Copilot regression on #481: an agentMessage that completes AFTER a
+  // tool_use in the same turn used to vanish, because the old branch
+  // only updated/appended text when the last block was text or the array
+  // was empty. tool_use as the last block silently dropped the prose.
+  it("appends final prose as a new text block when it arrives after a tool_use", () => {
+    const c = new TurnCollector();
+    c.onToolCall({ id: "call_1", name: "write_entity", input: {} });
+    c.onAgentMessageDelta(agentMessageDelta("Done."));
+    c.onItemCompleted(agentMessageCompleted("Done."));
+    const result = c.toChatResult(completedTurn());
+
+    expect(result.text).toBe("Done.");
+    expect(result.assistantContent).toEqual([
+      { type: "tool_use", id: "call_1", name: "write_entity", input: {} },
+      { type: "text", text: "Done." },
+    ]);
+  });
+
+  it("updates the existing text block in place when prose precedes the tool_use", () => {
+    const c = new TurnCollector();
+    c.onAgentMessageDelta(agentMessageDelta("Pre"));
+    c.onAgentMessageDelta(agentMessageDelta("amble."));
+    c.onItemCompleted(agentMessageCompleted("Preamble."));
+    c.onToolCall({ id: "call_1", name: "write_entity", input: {} });
+    const result = c.toChatResult(completedTurn());
+
+    expect(result.assistantContent).toEqual([
+      { type: "text", text: "Preamble." },
+      { type: "tool_use", id: "call_1", name: "write_entity", input: {} },
+    ]);
+  });
+
+  it("falls back to completed item text when no deltas streamed", () => {
+    const c = new TurnCollector();
+    c.onItemCompleted(agentMessageCompleted("Non-streamed reply."));
+    const result = c.toChatResult(completedTurn());
+
+    expect(result.text).toBe("Non-streamed reply.");
+    expect(result.assistantContent).toEqual([{ type: "text", text: "Non-streamed reply." }]);
+  });
+});

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -778,7 +778,8 @@ function messageToResponsesItems(msg: NormalizedMessage): unknown[] {
 // Per-turn notification accumulator
 // ---------------------------------------------------------------------------
 
-class TurnCollector {
+// Exported for unit tests — production callers go through OpenAIChatGptProvider.
+export class TurnCollector {
   private text = "";
   private reasoning: string[] = [];
   private assistantContent: ContentPart[] = [];
@@ -806,14 +807,23 @@ class TurnCollector {
       // item's full text supersedes them only if our accumulation is empty.
       // Otherwise the streaming sum is canonical.
       if (!this.text) this.text = params.item.text;
-      // The assistantContent for history must be the FINAL committed text.
-      if (this.assistantContent.length === 0 && this.text) {
+      if (!this.text) return;
+      // The assistantContent for history must include the FINAL committed
+      // text. Three cases (Copilot-flagged on #481 — case 3 used to drop
+      // the prose entirely):
+      //   1. Empty buffer → push the text block.
+      //   2. Last block is text → update it in place (streaming case).
+      //   3. Last block is a tool_use → append a new text block. Codex
+      //      can complete an agentMessage AFTER a tool_use item in the
+      //      same turn, and without this branch the assistant prose
+      //      vanishes from downstream history.
+      const last = this.assistantContent[this.assistantContent.length - 1];
+      if (!last) {
         this.assistantContent.push({ type: "text", text: this.text });
-      } else if (this.assistantContent.length > 0 && this.text) {
-        const last = this.assistantContent[this.assistantContent.length - 1];
-        if (last.type === "text") {
-          last.text = this.text;
-        }
+      } else if (last.type === "text") {
+        last.text = this.text;
+      } else {
+        this.assistantContent.push({ type: "text", text: this.text });
       }
     }
   }

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -781,7 +781,6 @@ function messageToResponsesItems(msg: NormalizedMessage): unknown[] {
 class TurnCollector {
   private text = "";
   private reasoning: string[] = [];
-  private toolCalls: NormalizedToolCall[] = [];
   private assistantContent: ContentPart[] = [];
   private latestUsage: TokenUsageUpdatedNotification["tokenUsage"] | null = null;
 
@@ -820,7 +819,12 @@ class TurnCollector {
   }
 
   onToolCall(call: NormalizedToolCall): void {
-    this.toolCalls.push(call);
+    // Codex owns tool dispatch end-to-end (the model gets the tool_result
+    // in-band during the same turn), so we deliberately do NOT surface
+    // calls back through ChatResult.toolCalls — the bridge would otherwise
+    // re-dispatch them after chat() returns, running every write_entity /
+    // scribe write twice. assistantContent keeps the tool_use block so the
+    // returned conversation history still reflects what the model did.
     this.assistantContent.push({
       type: "tool_use",
       id: call.id,
@@ -859,7 +863,9 @@ class TurnCollector {
 
     return {
       text: this.text,
-      toolCalls: this.toolCalls,
+      // Always empty — see onToolCall. Tool calls were dispatched in-band
+      // during the turn, so the bridge must not see them here.
+      toolCalls: [],
       usage,
       stopReason,
       thinkingText: this.reasoning.length > 0 ? this.reasoning.join("") : undefined,


### PR DESCRIPTION
## Summary

Two compounding bugs were corrupting campaign character files when the DM ran on the openai-chatgpt provider with `gpt-5.4-mini` as the scribe — duplicated changelog entries, duplicated body paragraphs, and malformed frontmatter keys like `****Type:** character:** character`.

### Bug 1 — Double tool-dispatch on the codex path

Codex owns tool dispatch end-to-end: model tool calls arrive as JSON-RPC server requests and the provider invokes `params.dispatchTool` in-band during the turn. But `TurnCollector` was also pushing each call into `ChatResult.toolCalls`, which the bridge then re-dispatched after `chat()` returned. Every `write_entity` ran twice with identical input.

Fix in `provider.ts`: collector records `tool_use` only on `assistantContent` (history needs it) and returns an empty `toolCalls`. The bridge sees nothing to dispatch and breaks cleanly.

### Bug 2 — Small models passing malformed `front_matter`

`gpt-5.4-mini` occasionally takes the on-disk markdown shape literally and sends `{ "**Type:** character": "character" }` instead of the documented `{ "type": "character" }`. The serializer then round-trips the bad key as `****Type:** character:** character` and the frontmatter is permanently corrupted.

Two-pronged fix:
- **Prompt** (`scribe.md`): explicit JSON example, an anti-example showing the exact corruption pattern, and a key glossary mapping on-disk display names to their snake_case JSON keys.
- **Defense** (`scribe.ts`): new `sanitizeFrontMatter()` recovers the real key and value from any `**Key:** Value` pattern, wired into both create and update paths. The prompt is the primary fix; the sanitizer is the belt for when smaller models still slip up.

## Regression coverage

- `agent-loop-bridge.test.ts`: a fake internal-dispatch provider that invokes `params.dispatchTool` then returns empty `toolCalls`. Asserts the handler is called exactly once — would catch any future re-introduction of the double-dispatch.
- `scribe.test.ts`: six `sanitizeFrontMatter` cases covering pass-through, single recovery, explicit-value-wins, multi-key, duplicate-with-clean-key, and the `null`-deletion sentinel.

## Test plan
- [ ] `npm run check` passes (one unrelated `server.test.ts` flake on parallel run; clean in isolation)
- [ ] Run a route-0-style scene on the ChatGPT provider with gpt-5.4-mini as the small model and verify each `write_entity` produces a single changelog line and a single body update
- [ ] Verify that even if the small model emits a malformed `front_matter` payload, the saved file has a clean `**Key:** Value` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)