### PR TITLE
Reset mode state on session teardown (closes #486)

### DIFF
--- a/docs/websocket-api.md
+++ b/docs/websocket-api.md
@@ -244,6 +244,8 @@ The campaign session has ended.
 | `summary` | string? | End-of-session summary text. |
 | `cost`    | object? | Final token cost breakdown. |
 
+Immediately before `session:ended`, the server broadcasts a final `state:snapshot` carrying `mode: "play"` (and otherwise-empty campaign fields). This is the canonical "you are back in play mode" signal for clients that were in OOC/Dev mode — without it, paths that null the engine's mode session as part of teardown (e.g. OOC rollback) would leave clients believing they're still in a mode session, and the next ESC would call `/exit_mode` against a dead session.
+
 ---
 
 ### Discord Presence

--- a/packages/engine/src/server/command-handler.test.ts
+++ b/packages/engine/src/server/command-handler.test.ts
@@ -104,6 +104,32 @@ describe("handleCommand /rollback", () => {
   });
 });
 
+describe("handleCommand /exit_mode", () => {
+  it("with no active mode session: rebroadcasts session:mode play and surfaces no error", async () => {
+    // Regression: the client previously got a user-visible
+    // "Not in a mode session." system message when its mode state had drifted
+    // out of sync with the server, wedging it out of its own ESC menu.
+    // Now we silently realign the client to play mode.
+    const engine = makeMockEngine();
+    const broadcast = vi.fn();
+
+    const result = await handleCommand(
+      "exit_mode",
+      "",
+      engine,
+      makeMockGameState(),
+      broadcast,
+    );
+
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "session:mode",
+      data: { mode: "play", variant: "exploration" },
+    });
+    expect(result.message).toBeFalsy();
+    expect(result.error).toBeFalsy();
+  });
+});
+
 describe("handleCommand /ooc", () => {
   it("passes gameState into createOOCSession so DM-tier tools register", async () => {
     vi.mocked(createOOCSession).mockClear();

--- a/packages/engine/src/server/command-handler.ts
+++ b/packages/engine/src/server/command-handler.ts
@@ -215,7 +215,16 @@ function handleExitMode(
 ): CommandResult {
   const current = engine.getModeSession();
   if (!current) {
-    return { message: "Not in a mode session." };
+    // Defensive belt: if the client thought it was in a mode session but the
+    // server lost track (e.g. via a teardown path that didn't broadcast),
+    // re-broadcast play mode so the client realigns instead of seeing a
+    // confusing "Not in a mode session." error and getting wedged out of
+    // its own ESC menu.
+    broadcast({
+      type: "session:mode",
+      data: { mode: "play", variant: engine.getPreviousVariant() ?? "exploration" },
+    });
+    return {};
   }
 
   const label = current.label;

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -1222,6 +1222,14 @@ export class SessionManager {
       data: { action: "stop" },
     });
 
+    // Push a final snapshot so any client still tracking mode state sees the
+    // authoritative reset to "play" before the session winds down. Without
+    // this, paths that null the mode session as part of teardown (e.g. OOC
+    // rollback at line 801) leave clients believing they're still in OOC/Dev
+    // — the next ESC sends /exit_mode against a dead session and surfaces
+    // "Not in a mode session." instead of the menu.
+    this.broadcast({ type: "state:snapshot", data: this.buildStateSnapshot() });
+
     this.broadcast({
       type: "session:ended",
       data: { summary: "Session ended." },

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -1224,10 +1224,11 @@ export class SessionManager {
 
     // Push a final snapshot so any client still tracking mode state sees the
     // authoritative reset to "play" before the session winds down. Without
-    // this, paths that null the mode session as part of teardown (e.g. OOC
-    // rollback at line 801) leave clients believing they're still in OOC/Dev
-    // — the next ESC sends /exit_mode against a dead session and surfaces
-    // "Not in a mode session." instead of the menu.
+    // this, teardown paths that null the engine's mode session (e.g. the OOC
+    // rollback path that calls endSession("rollback") from the commit handler)
+    // leave clients believing they're still in OOC/Dev — the next ESC sends
+    // /exit_mode against a dead session and surfaces "Not in a mode session."
+    // instead of opening the menu.
     this.broadcast({ type: "state:snapshot", data: this.buildStateSnapshot() });
 
     this.broadcast({


### PR DESCRIPTION
## Summary
- `endSession()` now broadcasts a final `state:snapshot` (carrying `mode: "play"`) right before `session:ended`, following this codebase's "spray full state on ambiguity" convention. This is the canonical fix: any teardown path that nulls the engine's mode session now also tells the client to flip back to play mode.
- `handleExitMode()` with no active mode session now silently re-broadcasts `session:mode play` instead of surfacing `"Not in a mode session."` as a system message. Defensive belt: if anything else ever loses sync, the next ESC realigns the client instead of wedging the user out of their own menu.

## Diagnosis
Verified against the `.mvdiag` bundle attached to #486:

- The reporter was in OOC mode (logged `/ooc` at 19:42 UTC, then a 3-hour idle gap).
- No `session:end idle_timeout` ever fired — the TUI's WS keeps `hasNoPlayers()` false, so my initial guess (server-side idle teardown) was wrong.
- The accidental cat-on-keyboard input at 22:54 ran through the OOC handler; some path (most likely OOC rollback at [session-manager.ts:801](https://github.com/octopollux/machine-violet/blob/main/packages/engine/src/server/session-manager.ts#L801)) cleared the server's mode session without broadcasting.
- Client kept `mode === "ooc"`; ESC sent `/exit_mode`; server's `getModeSession()` returned null → `"Not in a mode session."` surfaced to the user, and the TUI never opened its menu.

The "DM text in input box" and `/diagnostics` as in-character symptoms both fit the same desync — they're not separate bugs.

## Test plan
- [x] `npm run check` — 148 files / 2546 tests pass, lint clean.
- [ ] Manual: enter OOC mode → `/rollback` → verify ESC opens the menu cleanly on the new session.
- [ ] Manual: enter OOC mode → end campaign (Save & Quit) → resume → verify TUI starts in play mode.

Companion issue #485 (DM response disappears) deferred — needs separate repro since the surviving `.mvdiag` URL on Discord is dead and the post-reload bundle doesn't carry rendering state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)