### PR TITLE
Stop ESC from clearing the choices overlay (#487/#488)

### DIFF
--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -249,8 +249,6 @@ export function PlayingPhase() {
     }
   }, [apiClient, setActiveChoices, activeChar, currentTurn, setNarrativeLines]);
 
-  const handleChoiceDismiss = useCallback(() => setActiveChoices(null), [setActiveChoices]);
-
   const handleNarrativeScroll = useCallback((direction: number) => {
     const step = scrollAmount(rows);
     narrativeRef.current?.scrollBy(direction < 0 ? -step : step);
@@ -387,7 +385,6 @@ export function PlayingPhase() {
       maxChoiceRows={choiceRowBudget(visibleElements, 1, hasDescriptions, DESCRIPTION_ROWS)}
       initialIndex={0}
       onSelect={handleChoiceSelect}
-      onDismiss={handleChoiceDismiss}
       onNarrativeScroll={handleNarrativeScroll}
     />
   ) : undefined;

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -321,7 +321,18 @@ export function PlayingPhase() {
       return;
     }
 
-    if (apiErrorModalActive || activeChoices || activeModal || menuOpen) return;
+    if (apiErrorModalActive || activeModal || menuOpen) return;
+
+    // ESC while choices are visible opens the menu without clearing them.
+    // The overlay's own input is disabled while the menu is open (isActive
+    // prop), so arrow keys/Enter don't drive both UIs at once.
+    if (key.escape && activeChoices) {
+      setMenuOpen(true);
+      apiClient.getCost().then(({ formatted }) => setTokenSummary(formatted)).catch(() => { /* no-op */ });
+      return;
+    }
+
+    if (activeChoices) return;
 
     // Tab: toggle character pane
     if (key.tab) {
@@ -386,6 +397,7 @@ export function PlayingPhase() {
       initialIndex={0}
       onSelect={handleChoiceSelect}
       onNarrativeScroll={handleNarrativeScroll}
+      isActive={!menuOpen && !activeModal && !apiErrorModalActive}
     />
   ) : undefined;
 

--- a/packages/client-ink/src/tui/modals/ChoiceModal.tsx
+++ b/packages/client-ink/src/tui/modals/ChoiceModal.tsx
@@ -52,6 +52,12 @@ interface ChoiceOverlayProps {
   onSelect: (choice: string) => void;
   /** Called for PageUp/PageDown to scroll the narrative area behind the overlay. */
   onNarrativeScroll?: (delta: number) => void;
+  /**
+   * When false, the overlay stops consuming keystrokes and the custom-input
+   * row is read-only. Use this when a modal/menu opens above the choices so
+   * arrow keys and Enter don't drive both UIs simultaneously. Defaults to true.
+   */
+  isActive?: boolean;
 }
 
 /** Maximum visual rows available for choice items. */
@@ -85,6 +91,7 @@ export function ChoiceOverlay({
   initialIndex,
   onSelect,
   onNarrativeScroll,
+  isActive = true,
 }: ChoiceOverlayProps) {
   const choices = Array.isArray(rawChoices)
     ? rawChoices.map((c) => (typeof c === "string" ? c : String(c)))
@@ -149,7 +156,7 @@ export function ChoiceOverlay({
     if (input === "+" || input === "-") {
       onNarrativeScroll?.(input === "-" ? -1 : 1);
     }
-  });
+  }, { isActive });
 
   const handleCustomInputSubmit = (value: string) => {
     if (!value.trim()) return;
@@ -318,7 +325,7 @@ export function ChoiceOverlay({
               {arrowElement}{cursorElement}
               <InlineTextInput
                 key={customInputResetKey}
-                isDisabled={false}
+                isDisabled={!isActive}
                 availableWidth={customInputWidth}
                 wrap
                 placeholder="Enter your own..."

--- a/packages/client-ink/src/tui/modals/ChoiceModal.tsx
+++ b/packages/client-ink/src/tui/modals/ChoiceModal.tsx
@@ -50,8 +50,6 @@ interface ChoiceOverlayProps {
   initialIndex?: number;
   /** Called when the player selects a choice (text) or submits custom input. */
   onSelect: (choice: string) => void;
-  /** Called when the player dismisses the overlay (ESC). */
-  onDismiss: () => void;
   /** Called for PageUp/PageDown to scroll the narrative area behind the overlay. */
   onNarrativeScroll?: (delta: number) => void;
 }
@@ -86,7 +84,6 @@ export function ChoiceOverlay({
   maxChoiceRows: maxChoiceRowsProp,
   initialIndex,
   onSelect,
-  onDismiss,
   onNarrativeScroll,
 }: ChoiceOverlayProps) {
   const choices = Array.isArray(rawChoices)
@@ -128,7 +125,6 @@ export function ChoiceOverlay({
       return;
     }
 
-    if (key.escape) { onDismiss(); return; }
     if (key.upArrow) { setSelectedIndex((i) => Math.max(0, i - 1)); return; }
     if (key.downArrow) {
       setSelectedIndex((i) => {
@@ -262,7 +258,7 @@ export function ChoiceOverlay({
   // Help text
   const helpText = customInputActive
     ? "↵ submit  ESC back"
-    : "ESC dismiss";
+    : "↵ select";
 
   const customInputWidth = Math.max(1, width - prefixWidth);
 

--- a/packages/client-ink/src/tui/modals/modals.test.tsx
+++ b/packages/client-ink/src/tui/modals/modals.test.tsx
@@ -134,7 +134,6 @@ describe("ChoiceOverlay", () => {
         choices={["Attack", "Flee", "Negotiate"]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const frame = lastFrame()!;
@@ -155,7 +154,6 @@ describe("ChoiceOverlay", () => {
         choices={["A", "B", "C", "D", "E", "F", "G"]}
         initialIndex={5}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const frame = lastFrame()!;
@@ -174,7 +172,6 @@ describe("ChoiceOverlay", () => {
         choices={["A", "B", "C", "D", "E", "F", "G"]}
         initialIndex={6}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
 
@@ -212,7 +209,6 @@ describe("ChoiceOverlay", () => {
         choices={["A", "B"]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const frame = lastFrame()!;
@@ -221,7 +217,7 @@ describe("ChoiceOverlay", () => {
     expect(frame).toContain("▼");
   });
 
-  it("shows ESC dismiss help text", () => {
+  it("shows select help text and does not advertise ESC dismiss", () => {
     const { lastFrame } = render(
       <ChoiceOverlay
         width={60}
@@ -229,10 +225,11 @@ describe("ChoiceOverlay", () => {
         choices={["A", "B"]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
-    expect(lastFrame()!).toContain("ESC dismiss");
+    const frame = lastFrame()!;
+    expect(frame).toContain("↵ select");
+    expect(frame).not.toContain("ESC dismiss");
   });
 
   it("always shows Enter your own row", () => {
@@ -243,7 +240,6 @@ describe("ChoiceOverlay", () => {
         choices={["Attack", "Flee"]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     expect(lastFrame()!).toContain("Enter your own...");
@@ -258,7 +254,6 @@ describe("ChoiceOverlay", () => {
         choices={["Attack"]}
         initialIndex={1}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const frame = lastFrame()!;
@@ -277,7 +272,6 @@ describe("ChoiceOverlay", () => {
         ]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const frame = lastFrame()!;
@@ -299,7 +293,6 @@ describe("ChoiceOverlay", () => {
         choices={["A", "B", "C"]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const lines = lastFrame()!.split("\n");
@@ -318,7 +311,6 @@ describe("ChoiceOverlay", () => {
         ]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const frame = lastFrame()!;
@@ -342,7 +334,6 @@ describe("ChoiceOverlay", () => {
         choices={[longChoice, "◆ Rest"]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const frame = lastFrame()!;
@@ -362,7 +353,6 @@ describe("ChoiceOverlay", () => {
         choices={[longChoice, "◆ Short"]}
         initialIndex={0}
         onSelect={noop}
-        onDismiss={noop}
       />,
     );
     const lines = lastFrame()!.split("\n");


### PR DESCRIPTION
## Summary

- Drop the ESC→`onDismiss` handler from `ChoiceOverlay` so single-ESC no longer wipes the choices for the turn ([#487](https://github.com/octopollux/machine-violet/issues/487)).
- Remove the now-dead `onDismiss` prop and the `handleChoiceDismiss` callback in `PlayingPhase`.
- Footer hint changes from "ESC dismiss" to "↵ select".
- ESC inside the custom-input row still steps back to the choice list, and triple-ESC remains the nuclear recovery path (clears choices along with menus/modals).

Closes [#488](https://github.com/octopollux/machine-violet/issues/488), fixes [#487](https://github.com/octopollux/machine-violet/issues/487).

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npx vitest run packages/client-ink/src/tui/modals/modals.test.tsx` — 34 passed (updated "ESC dismiss" assertion to verify the old footer text is gone and `↵ select` is shown).
- [ ] Manual: with choice frequency enabled, present a choice, press ESC — choices remain. Press ESC three times rapidly — choices clear (recovery path still works). Custom-input row: typing then ESC returns to the choice list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)