### PR TITLE
Stop the frame composer from silently dropping rows on title/footer overflow

### DIFF
--- a/packages/client-ink/src/tui/components/ThemedFrame.test.tsx
+++ b/packages/client-ink/src/tui/components/ThemedFrame.test.tsx
@@ -83,6 +83,29 @@ describe("ThemedHorizontalBorder", () => {
       s.replace(new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g"), "");
     expect(stripAnsi(framWithGrad()!)).toBe(stripAnsi(framNoGrad()!));
   });
+
+  it("renders both head and continuation chunks when given a title array", () => {
+    // A short continuation under a long head: the composer centers the
+    // short chunk inside the wider slot by inserting extra padding spaces.
+    // The previous ` ${rowText} ` lookup wouldn't find the chunk in that
+    // case and the continuation would silently render in the border color
+    // — see the matching composer-level coverage in composer.test.ts that
+    // asserts the chunk is locatable via indexOf(rowText).
+    const head = "Warranty Void | Processing Cycles 1/10 | Coherence 4/10";
+    const cont = "Connections 3/5";
+    const { lastFrame } = render(
+      <ThemedHorizontalBorder
+        theme={noGrad}
+        width={80}
+        position="top"
+        centerText={[head, cont]}
+        centerTextColor="#ffffff"
+      />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain(head);
+    expect(frame).toContain(cont);
+  });
 });
 
 describe("ThemedSideFrame", () => {

--- a/packages/client-ink/src/tui/components/ThemedFrame.tsx
+++ b/packages/client-ink/src/tui/components/ThemedFrame.tsx
@@ -93,12 +93,16 @@ export const ThemedHorizontalBorder = React.memo(function ThemedHorizontalBorder
     <Box flexDirection="column">
       {frame.rows.map((row, i) => {
         const rowText = position === "top" ? centerLines[i] : (i === frame.rows.length - 1 ? centerLines[0] : undefined);
-        // If there's center text on this row and a distinct title color, render in parts
+        // If there's center text on this row and a distinct title color, render in parts.
+        // The composer centers shorter continuation lines inside the (wider) longest-line
+        // slot by inserting extra spaces around the text, so the ` ${rowText} ` substring
+        // we used to match no longer exists in that case. Search for rowText directly —
+        // the surrounding pad spaces stay border-colored, which is invisible.
         if (rowText && titleColor && titleColor !== borderColor) {
-          const textIdx = row.indexOf(` ${rowText} `);
+          const textIdx = row.indexOf(rowText);
           if (textIdx >= 0) {
             const before = row.slice(0, textIdx);
-            const middle = ` ${rowText} `;
+            const middle = rowText;
             const after = row.slice(textIdx + middle.length);
 
             if (gradient && borderColor) {

--- a/packages/client-ink/src/tui/components/ThemedFrame.tsx
+++ b/packages/client-ink/src/tui/components/ThemedFrame.tsx
@@ -50,7 +50,12 @@ interface ThemedHorizontalBorderProps {
   theme: ResolvedTheme;
   width: number;
   position: "top" | "bottom";
-  centerText?: string;
+  /**
+   * Center text on the frame's title row(s). Pass an array of strings on
+   * `position="top"` to place a continuation chunk on each subsequent
+   * row of the top frame (used when the title overflows the head slot).
+   */
+  centerText?: string | string[];
   centerTextColor?: string;
 }
 
@@ -68,22 +73,32 @@ export const ThemedHorizontalBorder = React.memo(function ThemedHorizontalBorder
   const frame =
     position === "top"
       ? composeTopFrame(theme.asset, width, centerText)
-      : composeBottomFrame(theme.asset, width, centerText);
+      : composeBottomFrame(theme.asset, width, typeof centerText === "string" ? centerText : centerText?.[0]);
 
   const borderColor = themeColor(theme, "border");
   const titleColor = centerTextColor ?? themeColor(theme, "title");
 
   const gradient = theme.gradient;
 
+  // Per-row lookup of which text chunk is on which row. The composer
+  // also centers shorter continuations within the longest line's slot,
+  // so we trim each chunk to find its actual span in the row string.
+  const centerLines: (string | undefined)[] = Array.isArray(centerText)
+    ? centerText
+    : centerText
+      ? [centerText]
+      : [];
+
   return (
     <Box flexDirection="column">
       {frame.rows.map((row, i) => {
-        // If there's center text and a distinct title color, render in parts
-        if (centerText && titleColor && titleColor !== borderColor) {
-          const textIdx = row.indexOf(` ${centerText} `);
+        const rowText = position === "top" ? centerLines[i] : (i === frame.rows.length - 1 ? centerLines[0] : undefined);
+        // If there's center text on this row and a distinct title color, render in parts
+        if (rowText && titleColor && titleColor !== borderColor) {
+          const textIdx = row.indexOf(` ${rowText} `);
           if (textIdx >= 0) {
             const before = row.slice(0, textIdx);
-            const middle = ` ${centerText} `;
+            const middle = ` ${rowText} `;
             const after = row.slice(textIdx + middle.length);
 
             if (gradient && borderColor) {

--- a/packages/client-ink/src/tui/layout.test.tsx
+++ b/packages/client-ink/src/tui/layout.test.tsx
@@ -82,6 +82,41 @@ describe("Layout", () => {
     expect(frame).toContain("Loc: The Shattered Hall");
   });
 
+  it("wraps an overflowing title onto a continuation row inside the top frame", () => {
+    // Real campaign repro: "Warranty Void" with four resources blows past
+    // the title slot and used to vanish the entire top edge. The fix
+    // splits the title at ` | ` and renders the spillover on row 1 of the
+    // top frame (gothic's previously-blank second row), so no blank row
+    // appears between the head and the continuation.
+    const { lastFrame } = render(
+      <Layout
+        {...baseProps}
+        campaignName="Warranty Void"
+        resources={[
+          "Processing Cycles 1/10",
+          "Coherence 4/10",
+          "Connections 3/5",
+          "Memory Integrity 6/10",
+        ]}
+      />,
+    );
+    const frame = lastFrame()!;
+    // Top edge corners survive — without wrapping, composeTopFrame would
+    // drop them along with the title.
+    expect(frame).toContain("╔");
+    expect(frame).toContain("╗");
+    // Both halves of the wrapped title render somewhere on screen.
+    expect(frame).toContain("Warranty Void");
+    expect(frame).toContain("Memory Integrity 6/10");
+    // The continuation sits on the very next line below the head row —
+    // no blank intervening row in the frame. (Splitting on \n and reading
+    // adjacent rows is the most direct check.)
+    const lines = frame.split("\n");
+    const headIdx = lines.findIndex((l) => l.includes("Warranty Void"));
+    expect(headIdx).toBeGreaterThanOrEqual(0);
+    expect(lines[headIdx + 1]).toContain("Memory Integrity 6/10");
+  });
+
   it("playerPaneOverlay replaces modeline at standard tier", () => {
     const overlay = <Text>OVERLAY CONTENT</Text>;
     const { lastFrame } = render(

--- a/packages/client-ink/src/tui/layout.tsx
+++ b/packages/client-ink/src/tui/layout.tsx
@@ -16,6 +16,7 @@ import {
   NarrativeArea,
   KeyHints,
 } from "./components/index.js";
+import { splitTitle, topFrameTitleBudget } from "./title.js";
 import type { KeyHint } from "./components/index.js";
 import {
   ThemedHorizontalBorder,
@@ -145,13 +146,26 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
   const modelineDisplay = buildModelineDisplay(modelineText, actGlyph);
   const modelineLines = splitModeline(modelineDisplay, width);
 
-  // Build resource string for top frame title
+  // Build resource string for top frame title, then split into chunks at
+  // ` | ` boundaries. The head sits in the title slot on row 0 and any
+  // continuation chunks render on rows 1+ of the top frame itself — for
+  // multi-row themes (gothic, arcane) the first continuation fills the
+  // frame's existing blank row 1, so a single overflow row costs nothing.
+  // Without wrapping, a long title silently drops the entire top edge:
+  // composeTopFrame renders just a bare edge tile when fillWidth < 0.
   const titleText = resources.length > 0
     ? `${campaignName} | ${resources.join(" | ")}`
     : campaignName;
+  const titleBudget = elements.topFrame ? topFrameTitleBudget(theme.asset, width) : 0;
+  const titleChunks = elements.topFrame ? splitTitle(titleText, titleBudget) : [titleText];
+  // Rows the top frame grows by beyond its native asset.height. Each extra
+  // row costs one narrative row; chunks that fit within asset.height are
+  // free (they fill rows that were previously blank).
+  const topFrameExtraRows = Math.max(0, titleChunks.length - theme.asset.height);
 
-  // Calculate narrative rows (accounting for themed border heights)
-  const narRows = narrativeRows(
+  // Calculate narrative rows (accounting for themed border heights), then
+  // subtract any extra top-frame rows the title wrap added.
+  const narRowsBase = narrativeRows(
     dimensions.rows,
     elements,
     hideInputLine,
@@ -159,11 +173,13 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
     players.length,
     playerPaneExtraHeight,
   );
+  const narRows = Math.max(1, narRowsBase - topFrameExtraRows);
 
   // Fixed content height inside the Player Pane (between top/bottom borders)
   const playerPaneContentHeight = PLAYER_PANE_HEIGHT + elements.playerPaneExtraRows + playerPaneExtraHeight - 2;
 
-  // Height of the middle section (narrative + activity) for side frames
+  // Height of the middle section (narrative + activity) for side frames.
+  // Wrap rows live inside the top frame, so they don't affect middleHeight.
   const middleHeight = narRows + (elements.activityLine ? 1 : 0);
   const sidePadding = elements.sideFrames ? 1 : 0;
   const innerWidth = elements.sideFrames ? width - 2 * sideFrameWidth - 2 * sidePadding : width;
@@ -172,10 +188,15 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
 
   const topFrame = useMemo(
     () => elements.topFrame ? (
-      <ThemedHorizontalBorder theme={theme} width={width} position="top" centerText={titleText} />
+      <ThemedHorizontalBorder theme={theme} width={width} position="top" centerText={titleChunks} />
     ) : null,
-    [elements.topFrame, theme, width, titleText],
+    // titleChunks is a fresh array each render; key on its joined content.
+    [elements.topFrame, theme, width, titleChunks.join(" ")],
   );
+
+  // Wrap rows used to render below the top frame as standalone Text rows;
+  // they now live inside the top frame itself via composeTopFrame's
+  // multi-line title support.
 
   const bottomFrame = useMemo(
     () => elements.lowerFrame ? (

--- a/packages/client-ink/src/tui/modals/CenteredModal.tsx
+++ b/packages/client-ink/src/tui/modals/CenteredModal.tsx
@@ -3,7 +3,7 @@ import { useInput, Box, Text } from "ink";
 import { ScrollView } from "ink-scroll-view";
 import type { ScrollViewRef } from "ink-scroll-view";
 import type { FormattingNode } from "@machine-violet/shared/types/tui.js";
-import type { ResolvedTheme } from "../themes/types.js";
+import type { ResolvedTheme, ThemeAsset, ThemeComponent } from "../themes/types.js";
 import { ThemedHorizontalBorder, ThemedSideFrame } from "../components/ThemedFrame.js";
 import { themeColor, deriveModalTheme } from "../themes/color-resolve.js";
 import { stringWidth } from "../frames/index.js";
@@ -14,6 +14,19 @@ import type { ScrollHandle } from "../hooks/useScrollHandle.js";
 import { scrollAmount } from "../components/NarrativeArea.js";
 
 export type CenteredModalHandle = ScrollHandle;
+
+/**
+ * Bottom-row width of the bottom-frame fixed parts (corners + separators).
+ * Used to size the modal so a long `footer` doesn't overflow — `composeBottomFrame`
+ * silently drops the entire bottom border (corners and centerText alike) when the
+ * fill region would go negative, so we expand the modal to keep the footer visible.
+ */
+function bottomFrameOverhead(asset: ThemeAsset): number {
+  const lastRowWidth = (c: ThemeComponent): number => stringWidth(c.rows[c.rows.length - 1] ?? "");
+  const { corner_bl, corner_br, separator_left_bottom, separator_right_bottom } = asset.components;
+  return lastRowWidth(corner_bl) + lastRowWidth(corner_br) +
+    lastRowWidth(separator_left_bottom) + lastRowWidth(separator_right_bottom);
+}
 
 /** Word-wrap a single plain-text line to fit within the given width. */
 function wrapPlainLine(text: string, width: number): string[] {
@@ -108,7 +121,14 @@ export const CenteredModal = forwardRef<CenteredModalHandle, CenteredModalProps>
     const borderHeight = theme.asset.height;
     const sidePadding = 1;
 
-    const modalWidth = Math.max(minWidth, Math.min(Math.floor(width * widthFraction), maxWidth));
+    // Floor on modal width: enough to fit the footer's centerText (text + 2
+     // padding spaces) plus the bottom frame's fixed overhead. Without this,
+     // composeBottomFrame would silently drop the corners and footer text.
+    const footerFloor = footer
+      ? stringWidth(footer) + 2 + bottomFrameOverhead(theme.asset)
+      : 0;
+    const baseModalWidth = Math.max(minWidth, Math.min(Math.floor(width * widthFraction), maxWidth));
+    const modalWidth = Math.min(width, Math.max(baseModalWidth, footerFloor));
     const innerWidth = modalWidth - 2 * sideWidth - 2 * sidePadding;
 
     // Word-wrap text content

--- a/packages/client-ink/src/tui/modals/modals.test.tsx
+++ b/packages/client-ink/src/tui/modals/modals.test.tsx
@@ -460,6 +460,41 @@ describe("GameMenu", () => {
     expect(frame).not.toMatch(/0\/0\/0\s*\|/);
   });
 
+  it("expands modal width to keep a long footer visible", () => {
+    // Real-session token summary (multi-tier with cumulative totals) plus
+    // the appended usage percentage easily exceeds the default 48-col
+    // minWidth on an 80-col terminal. composeBottomFrame silently drops
+    // the entire bottom border (corners and footer alike) when the
+    // centerText doesn't fit, so the modal must self-expand.
+    const usageStatus = {
+      segments: [{
+        id: "primary",
+        label: "5-hour window",
+        kind: "percentage" as const,
+        usedPercent: 5,
+        status: "ok" as const,
+      }],
+      snapshotAt: 1,
+      fresh: true,
+    };
+    const longSummary = "200k/30k/300k | 100k/10k/180k | 25k/220/240k";
+    const { lastFrame } = render(
+      <Box width={80} height={25}>
+        <GameMenu
+          theme={theme}
+          width={80}
+          height={25}
+          tokenSummary={longSummary}
+          usageStatus={usageStatus}
+          onSelect={noop}
+          onDismiss={noop}
+        />
+      </Box>,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain(`${longSummary} | 95%`);
+  });
+
   it("highlights first item by default", () => {
     const { lastFrame } = render(
       <Box width={40} height={24}>

--- a/packages/client-ink/src/tui/themes/composer.test.ts
+++ b/packages/client-ink/src/tui/themes/composer.test.ts
@@ -180,6 +180,50 @@ describe("composeTopFrame", () => {
     expect(frame.rows[0]).not.toContain("[");
     expect(frame.rows[0]).not.toContain("]");
   });
+
+  it("renders an array of titles across rows, sizing each row to width", () => {
+    const asset = parseThemeAsset(H2_THEME);
+    const frame = composeTopFrame(asset, 50, ["HEAD", "WRAP"]);
+    expect(frame.height).toBe(2);
+    expect(frame.rows[0]).toContain("HEAD");
+    expect(frame.rows[1]).toContain("WRAP");
+    for (const row of frame.rows) expect(row.length).toBe(50);
+  });
+
+  it("extends past asset.height when there are more title lines than rows", () => {
+    const asset = parseThemeAsset(H1_THEME); // height 1
+    const frame = composeTopFrame(asset, 50, ["HEAD", "WRAP1", "WRAP2"]);
+    expect(frame.height).toBe(3);
+    expect(frame.rows[0]).toContain("HEAD");
+    expect(frame.rows[1]).toContain("WRAP1");
+    expect(frame.rows[2]).toContain("WRAP2");
+  });
+
+  it("each row's text chunk is locatable via indexOf for downstream coloring", () => {
+    // ThemedHorizontalBorder uses row.indexOf(rowText) to color the title
+    // span in its own color. With a shorter continuation centered inside
+    // a wider slot, the chunk must still be findable as a contiguous
+    // substring — i.e. the composer must not split it with embedded padding.
+    const asset = parseThemeAsset(H2_THEME);
+    const frame = composeTopFrame(asset, 60, ["LONG HEAD TEXT", "SHORT"]);
+    expect(frame.rows[0].indexOf("LONG HEAD TEXT")).toBeGreaterThanOrEqual(0);
+    expect(frame.rows[1].indexOf("SHORT")).toBeGreaterThanOrEqual(0);
+  });
+
+  it("truncates an over-long title instead of dropping the entire row", () => {
+    // Title of 100 chars on a 30-char frame would push fillWidth negative
+    // under the old code and collapse to a bare edge tile. Now we clamp
+    // the slot and ellipsis-truncate the line so the corners survive.
+    const asset = parseThemeAsset(H1_THEME);
+    const longTitle = "X".repeat(100);
+    const frame = composeTopFrame(asset, 30, longTitle);
+    expect(frame.height).toBe(1);
+    expect(frame.rows[0].length).toBe(30);
+    // Corners survive and an ellipsis marks the truncation.
+    expect(frame.rows[0][0]).toBe("+");
+    expect(frame.rows[0][29]).toBe("+");
+    expect(frame.rows[0]).toContain("…");
+  });
 });
 
 describe("composeBottomFrame", () => {

--- a/packages/client-ink/src/tui/themes/composer.ts
+++ b/packages/client-ink/src/tui/themes/composer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ThemeAsset, ThemeComponent, PlayerPaneFrame } from "./types.js";
+import { stringWidth, truncateToWidth } from "../frames/index.js";
 
 /** A composed frame: an array of string rows ready for rendering. */
 export interface ComposedFrame {
@@ -50,10 +51,26 @@ export function composeTopFrame(
     asset.components;
 
   const titleLines = Array.isArray(title) ? title : title ? [title] : [];
-  const longestLen = titleLines.reduce((m, l) => Math.max(m, l.length), 0);
-  const titleWidth = longestLen > 0 ? longestLen + 2 : 0; // +2 for padding spaces
-  const totalRows = Math.max(asset.height, titleLines.length);
+  // All column math goes through `stringWidth` so wide Unicode (CJK / emoji)
+  // doesn't lie about how many cells a title or border glyph occupies.
+  const longestLen = titleLines.reduce((m, l) => Math.max(m, stringWidth(l)), 0);
 
+  // Worst-case row overhead: row 0 carries the corners + separators (their
+  // largest configuration, given separators are only painted when titleWidth>0).
+  // Clamping titleWidth against this floor guarantees `fillWidth >= 0` on
+  // every row, so the frame never falls through to the bare-edge fallback.
+  const row0Fixed = stringWidth(corner_tl.rows[0] ?? "")
+    + stringWidth(corner_tr.rows[0] ?? "")
+    + (longestLen > 0 ? stringWidth(separator_left_top.rows[0] ?? "") : 0)
+    + (longestLen > 0 ? stringWidth(separator_right_top.rows[0] ?? "") : 0);
+  const maxTitleSlot = Math.max(0, width - row0Fixed);
+  const titleWidth = longestLen > 0 ? Math.min(longestLen + 2, maxTitleSlot) : 0;
+  // Available room inside the title slot for the line text (excluding the
+  // 2 padding spaces). A line longer than this is hard-truncated with an
+  // ellipsis to preserve the surrounding frame.
+  const lineMaxWidth = Math.max(0, titleWidth - 2);
+
+  const totalRows = Math.max(asset.height, titleLines.length);
   const rows: string[] = [];
 
   for (let r = 0; r < totalRows; r++) {
@@ -74,12 +91,14 @@ export function composeTopFrame(
     // title sits centered on a clean blank between the side edges.
     const edge = insideAsset ? (edge_top.rows[r] ?? "") : " ";
 
-    const fixedWidth = ctl.length + ctr.length + slt.length + srt.length;
+    const fixedWidth = stringWidth(ctl) + stringWidth(ctr) + stringWidth(slt) + stringWidth(srt);
     const centerWidth = titleWidth > 0 ? titleWidth : 0;
     const fillWidth = width - fixedWidth - centerWidth;
 
     if (fillWidth < 0) {
-      // Degenerate: width too narrow, just tile everything
+      // Safety net — titleWidth was clamped against row 0's worst case, so
+      // we shouldn't land here in practice. Fall back to a bare edge tile
+      // rather than emit a malformed row.
       rows.push(tileToWidth(edge, width));
       continue;
     }
@@ -87,19 +106,23 @@ export function composeTopFrame(
     const leftFill = Math.floor(fillWidth / 2);
     const rightFill = fillWidth - leftFill;
 
-    // Center the row's title line inside the (wider) slot, so a short
-    // continuation under a long head aligns visually under it.
+    // Truncate any per-row line that would overflow the (possibly clamped)
+    // slot, then center it inside the slot so a short continuation under
+    // a long head aligns visually under it.
     const lineForRow = titleLines[r] ?? "";
+    const fittedLine = stringWidth(lineForRow) > lineMaxWidth
+      ? truncateToWidth(lineForRow, lineMaxWidth)
+      : lineForRow;
     let centerPart: string;
     if (titleWidth === 0) {
       centerPart = "";
-    } else if (lineForRow.length === 0) {
+    } else if (fittedLine.length === 0) {
       centerPart = " ".repeat(titleWidth);
     } else {
-      const innerPad = titleWidth - 2 - lineForRow.length;
+      const innerPad = titleWidth - 2 - stringWidth(fittedLine);
       const innerLeft = Math.floor(innerPad / 2);
       const innerRight = innerPad - innerLeft;
-      centerPart = ` ${" ".repeat(innerLeft)}${lineForRow}${" ".repeat(innerRight)} `;
+      centerPart = ` ${" ".repeat(innerLeft)}${fittedLine}${" ".repeat(innerRight)} `;
     }
 
     rows.push(

--- a/packages/client-ink/src/tui/themes/composer.ts
+++ b/packages/client-ink/src/tui/themes/composer.ts
@@ -30,27 +30,49 @@ export function tileToWidth(pattern: string, targetWidth: number): string {
  * Compose the top frame (Conversation Pane top border).
  * Each row: corner_tl[r] + tile(edge_top[r]) + sep_lt[r] + title_or_space + sep_rt[r] + tile(edge_top[r]) + corner_tr[r]
  *
- * Title text appears on row 0 only; other rows get spaces.
+ * `title` may be a single string (head only, on row 0) or an array of
+ * strings (head on row 0, continuation chunks on rows 1, 2, …). When
+ * there are more title lines than `asset.height`, the frame's height
+ * grows to fit; extra rows reuse the last available row's corner / edge
+ * components so the side edges stay continuous. The separator decoration
+ * around the title slot still only appears on rows where the source
+ * `separator_*_top` component defines content (typically row 0).
+ *
+ * The title slot is sized to the longest line + 2 padding spaces, so a
+ * short continuation centered under a long head still fits cleanly.
  */
 export function composeTopFrame(
   asset: ThemeAsset,
   width: number,
-  title?: string,
+  title?: string | string[],
 ): ComposedFrame {
-  const { corner_tl, corner_tr, edge_top, separator_left_top, separator_right_top } =
+  const { corner_tl, corner_tr, edge_top, edge_left, edge_right, separator_left_top, separator_right_top } =
     asset.components;
 
-  const titleText = title ?? "";
-  const titleWidth = titleText.length > 0 ? titleText.length + 2 : 0; // +2 for padding spaces
+  const titleLines = Array.isArray(title) ? title : title ? [title] : [];
+  const longestLen = titleLines.reduce((m, l) => Math.max(m, l.length), 0);
+  const titleWidth = longestLen > 0 ? longestLen + 2 : 0; // +2 for padding spaces
+  const totalRows = Math.max(asset.height, titleLines.length);
 
   const rows: string[] = [];
 
-  for (let r = 0; r < asset.height; r++) {
-    const ctl = corner_tl.rows[r] ?? "";
-    const ctr = corner_tr.rows[r] ?? "";
-    const slt = titleWidth > 0 ? (separator_left_top.rows[r] ?? "") : "";
-    const srt = titleWidth > 0 ? (separator_right_top.rows[r] ?? "") : "";
-    const edge = edge_top.rows[r] ?? "";
+  for (let r = 0; r < totalRows; r++) {
+    // For rows inside the native asset.height, use the corner component's
+    // row — multi-row themes (gothic, arcane) design row 1+ of the corner
+    // to look like a side-frame char. Beyond that, switch to edge_left /
+    // edge_right so single-row themes (clean) don't repeat their corners.
+    const insideAsset = r < asset.height;
+    const ctl = insideAsset
+      ? (corner_tl.rows[r] ?? "")
+      : (edge_left.rows[0] ?? "");
+    const ctr = insideAsset
+      ? (corner_tr.rows[r] ?? "")
+      : (edge_right.rows[0] ?? "");
+    const slt = titleWidth > 0 && insideAsset ? (separator_left_top.rows[r] ?? "") : "";
+    const srt = titleWidth > 0 && insideAsset ? (separator_right_top.rows[r] ?? "") : "";
+    // Extension rows have no edge_top equivalent — fill with spaces so the
+    // title sits centered on a clean blank between the side edges.
+    const edge = insideAsset ? (edge_top.rows[r] ?? "") : " ";
 
     const fixedWidth = ctl.length + ctr.length + slt.length + srt.length;
     const centerWidth = titleWidth > 0 ? titleWidth : 0;
@@ -65,12 +87,20 @@ export function composeTopFrame(
     const leftFill = Math.floor(fillWidth / 2);
     const rightFill = fillWidth - leftFill;
 
-    const centerPart =
-      r === 0 && titleText.length > 0
-        ? ` ${titleText} `
-        : titleWidth > 0
-          ? " ".repeat(titleWidth)
-          : "";
+    // Center the row's title line inside the (wider) slot, so a short
+    // continuation under a long head aligns visually under it.
+    const lineForRow = titleLines[r] ?? "";
+    let centerPart: string;
+    if (titleWidth === 0) {
+      centerPart = "";
+    } else if (lineForRow.length === 0) {
+      centerPart = " ".repeat(titleWidth);
+    } else {
+      const innerPad = titleWidth - 2 - lineForRow.length;
+      const innerLeft = Math.floor(innerPad / 2);
+      const innerRight = innerPad - innerLeft;
+      centerPart = ` ${" ".repeat(innerLeft)}${lineForRow}${" ".repeat(innerRight)} `;
+    }
 
     rows.push(
       ctl +

--- a/packages/client-ink/src/tui/title.test.ts
+++ b/packages/client-ink/src/tui/title.test.ts
@@ -39,6 +39,19 @@ describe("splitTitle", () => {
     // or producing empty lines.
     expect(splitTitle("Campaign | Foo", 0)).toEqual(["Campaign | Foo"]);
   });
+
+  it("measures width via stringWidth, not raw .length", () => {
+    // stringWidth strips ANSI; raw .length would mismeasure when ANSI is
+    // embedded. (CJK / emoji width is the same as .length under this
+    // codebase's stringWidth, but the ANSI-stripping behavior is what
+    // ensures wide-Unicode robustness once stringWidth gains EAW support.)
+    const ansi = String.fromCharCode(0x1b) + "[31m";
+    const reset = String.fromCharCode(0x1b) + "[0m";
+    const text = `${ansi}Campaign${reset} | A 1/1 | B 2/2`;
+    // Visible content is 23 chars; ANSI sequences would push raw .length
+    // far above. With stringWidth-based sizing, this fits at maxWidth=30.
+    expect(splitTitle(text, 30)).toEqual([text]);
+  });
 });
 
 describe("topFrameTitleBudget", () => {

--- a/packages/client-ink/src/tui/title.test.ts
+++ b/packages/client-ink/src/tui/title.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { splitTitle, topFrameTitleBudget } from "./title.js";
+import { resolveTheme } from "./themes/resolver.js";
+import { resetThemeCache } from "./themes/loader.js";
+import { BUILTIN_DEFINITIONS } from "./themes/builtin-definitions.js";
+
+describe("splitTitle", () => {
+  it("returns the original text when it fits", () => {
+    expect(splitTitle("Warranty Void", 80)).toEqual(["Warranty Void"]);
+  });
+
+  it("packs segments greedily up to maxWidth", () => {
+    const text = "Campaign | Resource A 1/10 | Resource B 5/5 | Resource C 0/3";
+    // Fits comfortably on one line.
+    expect(splitTitle(text, 80)).toEqual([text]);
+  });
+
+  it("wraps onto a new line when adding a segment would overflow", () => {
+    const text = "Warranty Void | Processing Cycles 1/10 | Coherence 4/10 | Connections 3/5 | Memory Integrity 6/10";
+    const lines = splitTitle(text, 70);
+    // Each line must stay within budget.
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(70);
+    }
+    // Joining the lines back with the same separator reconstructs the input.
+    expect(lines.join(" | ")).toBe(text);
+  });
+
+  it("emits a single oversize line when one segment exceeds maxWidth", () => {
+    const text = "Campaign | This Single Resource Has An Inordinately Long Name 1/10";
+    const lines = splitTitle(text, 30);
+    // The oversized segment lands on its own line; truncation isn't this
+    // helper's job.
+    expect(lines).toContain("This Single Resource Has An Inordinately Long Name 1/10");
+  });
+
+  it("returns the input unchanged when maxWidth <= 0", () => {
+    // Degenerate input — degenerate output. Better than infinite-looping
+    // or producing empty lines.
+    expect(splitTitle("Campaign | Foo", 0)).toEqual(["Campaign | Foo"]);
+  });
+});
+
+describe("topFrameTitleBudget", () => {
+  it("subtracts corners + separators + 2 padding spaces from total width", () => {
+    resetThemeCache();
+    const gothic = resolveTheme(BUILTIN_DEFINITIONS["gothic"], "exploration", "#cc4444");
+    // Gothic row 0: corner_tl="╔═"(2) + corner_tr="═╗"(2) + sep_lt="═╡"(2) + sep_rt="╞═"(2) = 8.
+    // 80 - 8 - 2 = 70.
+    expect(topFrameTitleBudget(gothic.asset, 80)).toBe(70);
+  });
+
+  it("clamps to 0 when the row can't even hold an empty title", () => {
+    resetThemeCache();
+    const gothic = resolveTheme(BUILTIN_DEFINITIONS["gothic"], "exploration", "#cc4444");
+    expect(topFrameTitleBudget(gothic.asset, 5)).toBe(0);
+  });
+});

--- a/packages/client-ink/src/tui/title.ts
+++ b/packages/client-ink/src/tui/title.ts
@@ -10,6 +10,7 @@
  * layout inserts above the narrative area.
  */
 import type { ThemeAsset } from "./themes/types.js";
+import { stringWidth } from "./frames/index.js";
 
 /**
  * Maximum title length (in display columns) that fits in the top frame's
@@ -17,26 +18,30 @@ import type { ThemeAsset } from "./themes/types.js";
  * corners + two separators) and the two padding spaces around the
  * centerText. Falls back to 0 if the slot can't accommodate even an
  * empty title (extremely narrow terminal).
+ *
+ * Uses `stringWidth` rather than `.length` so wide Unicode glyphs in a
+ * theme's corner / separator (or in a future title) don't undercount.
  */
 export function topFrameTitleBudget(asset: ThemeAsset, width: number): number {
   const { corner_tl, corner_tr, separator_left_top, separator_right_top } = asset.components;
   // Row 0 is what holds the title; the +2 accounts for ` ${title} ` padding.
   const fixedWidth =
-    (corner_tl.rows[0]?.length ?? 0) +
-    (corner_tr.rows[0]?.length ?? 0) +
-    (separator_left_top.rows[0]?.length ?? 0) +
-    (separator_right_top.rows[0]?.length ?? 0);
+    stringWidth(corner_tl.rows[0] ?? "") +
+    stringWidth(corner_tr.rows[0] ?? "") +
+    stringWidth(separator_left_top.rows[0] ?? "") +
+    stringWidth(separator_right_top.rows[0] ?? "");
   return Math.max(0, width - fixedWidth - 2);
 }
 
 /**
  * Greedily pack ` | `-separated segments into lines of at most `maxWidth`
- * columns. The separator is consumed at the break, mirroring splitModeline's
- * behavior. A segment that alone exceeds maxWidth occupies its own line —
- * truncation isn't this function's job; the renderer does that.
+ * display columns. The separator is consumed at the break, mirroring
+ * splitModeline's behavior. A segment that alone exceeds maxWidth occupies
+ * its own line — truncation isn't this function's job; the renderer does
+ * that.
  */
 export function splitTitle(text: string, maxWidth: number): string[] {
-  if (maxWidth <= 0 || text.length <= maxWidth) return [text];
+  if (maxWidth <= 0 || stringWidth(text) <= maxWidth) return [text];
 
   const segments = text.split(" | ");
   const lines: string[] = [];
@@ -44,7 +49,7 @@ export function splitTitle(text: string, maxWidth: number): string[] {
 
   for (let i = 1; i < segments.length; i++) {
     const candidate = current + " | " + segments[i];
-    if (candidate.length <= maxWidth) {
+    if (stringWidth(candidate) <= maxWidth) {
       current = candidate;
     } else {
       lines.push(current);

--- a/packages/client-ink/src/tui/title.ts
+++ b/packages/client-ink/src/tui/title.ts
@@ -1,0 +1,56 @@
+/**
+ * Title-wrapping helpers for the conversation pane top frame.
+ *
+ * The title slot in `composeTopFrame` lives between the corners and
+ * separators on row 0. When the title is longer than the slot can fit,
+ * the composer silently drops the entire row (corners and title alike) —
+ * see composer.ts. To keep all four resources visible without losing the
+ * frame, we split the title at ` | ` boundaries and let the head chunk
+ * sit in the title slot while remaining chunks wrap onto extra rows the
+ * layout inserts above the narrative area.
+ */
+import type { ThemeAsset } from "./themes/types.js";
+
+/**
+ * Maximum title length (in display columns) that fits in the top frame's
+ * title slot at row 0: total width minus the row's fixed parts (two
+ * corners + two separators) and the two padding spaces around the
+ * centerText. Falls back to 0 if the slot can't accommodate even an
+ * empty title (extremely narrow terminal).
+ */
+export function topFrameTitleBudget(asset: ThemeAsset, width: number): number {
+  const { corner_tl, corner_tr, separator_left_top, separator_right_top } = asset.components;
+  // Row 0 is what holds the title; the +2 accounts for ` ${title} ` padding.
+  const fixedWidth =
+    (corner_tl.rows[0]?.length ?? 0) +
+    (corner_tr.rows[0]?.length ?? 0) +
+    (separator_left_top.rows[0]?.length ?? 0) +
+    (separator_right_top.rows[0]?.length ?? 0);
+  return Math.max(0, width - fixedWidth - 2);
+}
+
+/**
+ * Greedily pack ` | `-separated segments into lines of at most `maxWidth`
+ * columns. The separator is consumed at the break, mirroring splitModeline's
+ * behavior. A segment that alone exceeds maxWidth occupies its own line —
+ * truncation isn't this function's job; the renderer does that.
+ */
+export function splitTitle(text: string, maxWidth: number): string[] {
+  if (maxWidth <= 0 || text.length <= maxWidth) return [text];
+
+  const segments = text.split(" | ");
+  const lines: string[] = [];
+  let current = segments[0];
+
+  for (let i = 1; i < segments.length; i++) {
+    const candidate = current + " | " + segments[i];
+    if (candidate.length <= maxWidth) {
+      current = candidate;
+    } else {
+      lines.push(current);
+      current = segments[i];
+    }
+  }
+  lines.push(current);
+  return lines;
+}


### PR DESCRIPTION
## Summary

Two bugs in the same composer fail-mode, both surfaced by the warranty-void campaign.

`composeTopFrame` and `composeBottomFrame` both have an `if (fillWidth < 0) tileToWidth(edge, width)` branch — when the title/footer plus its frame overhead would exceed the modal/pane width, the entire row collapses to a bare edge tile, taking the corners and centerText with it. Two visible places this happens in practice:

- **Esc menu modal:** the usage-counter PR (#471) appended ` | <n>%` to the token stats footer, pushing real-session summaries past the 48-col `minWidth`. The footer (and bottom corners) vanished.
- **Conversation pane top edge:** a campaign with a 13-char name plus four resources produces a ~97-char title, which overflows any 80–110 col terminal. The top edge renders as a flat `═══…` strip with no corners or title.

This PR fixes both at the call site:

- **`CenteredModal`** computes a `footerFloor` from the actual footer length plus the theme's bottom-row corner/separator widths, and clamps `modalWidth` between that floor and the terminal width. Lives in `CenteredModal` rather than `GameMenu` so any modal with a wide footer benefits.
- **`composeTopFrame`** accepts `title: string | string[]`. Layout splits the campaign-plus-resources string at ` | ` boundaries via a new `splitTitle` helper and passes the chunks straight to the composer. Continuation chunks render on rows 1+ of the frame itself — for multi-row themes (gothic, arcane) the first continuation fills the frame's previously-blank second row, so a single overflow row costs zero narrative budget. Single-row themes (clean) extend the frame by one row and switch the left/right edges from corner glyphs to `edge_left`/`edge_right` so the side frame stays continuous instead of repeating `┌...┐`. `ThemedHorizontalBorder` accepts the same array form and does per-row title coloring.

### Before / after

Top edge (gothic, 80 cols), warranty-void campaign:

Before:
```
══════════════════════════════════════════════════════════════════════════════
║                                                                            ║
```

After:
```
╔═════════╡ Warranty Void | Processing Cycles 1/10 | Coherence 4/10 ╞══════════╗
║                   Connections 3/5 | Memory Integrity 6/10                    ║
║ <narrative...>                                                               ║
```

Esc menu footer, real-session summary:

Before — bottom border collapsed; stats gone.

After:
```
╚═- - -═╡ 200k/30k/300k | 100k/10k/180k | 25k/220/240k | 95% ╞═- - - ═╝
```

## Test plan
- [x] `npm run check` — lint + 2555 tests pass
- [x] New `Layout > wraps an overflowing title onto a continuation row inside the top frame` asserts the continuation sits on `lines[headIdx + 1]` (locks in the no-blank-row behavior)
- [x] New `GameMenu > expands modal width to keep a long footer visible` asserts the full footer string + percentage survives
- [x] New `splitTitle` / `topFrameTitleBudget` unit tests in `title.test.ts`
- [ ] Manual: open the warranty-void campaign with `npm run dev`, confirm the top edge renders with corners + wrapped resources, and that the Esc menu footer is visible after a few DM turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)