### PR TITLE
Thread runtime model ID through buildDMPrefix (fixes #483)

### DIFF
--- a/packages/engine/src/agents/dm-prompt.test.ts
+++ b/packages/engine/src/agents/dm-prompt.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { buildUIState, buildActiveState, buildHardStats } from "./dm-prompt.js";
+import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
+import { buildUIState, buildActiveState, buildHardStats, buildDMPrefix } from "./dm-prompt.js";
 import { resetPromptCache } from "../prompts/load-prompt.js";
+import { loadModelConfig } from "../config/models.js";
 
 beforeEach(() => {
   resetPromptCache();
+  loadModelConfig({ reset: true });
 });
 
 describe("buildUIState", () => {
@@ -133,5 +136,38 @@ describe("buildHardStats", () => {
       resourceValues: { Aldric: { HP: "24/30" } },
     });
     expect(result).toBe("Turn: Aldric\nResources:\n  Aldric: HP=24/30");
+  });
+});
+
+describe("buildDMPrefix model conditionals", () => {
+  // Regression guard for issue #483: the runtime tier-resolved model ID must
+  // reach loadPrompt so `<!--if:gpt-->` blocks in dm-directives.md resolve
+  // their if-branch when the DM is actually served by an OpenAI provider.
+  const mockConfig: CampaignConfig = {
+    name: "Test",
+    system: "D&D 5e",
+    dm_personality: { name: "grim", prompt_fragment: "You are terse." },
+    players: [{ name: "Alice", character: "Aldric", type: "human" }],
+    combat: { initiative_method: "d20_dex", round_structure: "individual", surprise_rules: false },
+    context: { retention_exchanges: 5, max_conversation_tokens: 4000, tool_result_stub_after: 200 },
+    recovery: { auto_commit_interval: 300, max_commits: 100, enable_git: false },
+    choices: { campaign_default: "never", player_overrides: {} },
+  } as CampaignConfig;
+
+  // Phrase from dm-directives.md's <!--if:gpt--> block. If the conditional
+  // body changes, update this string — the test asserts the conditional
+  // plumbing, not the specific wording.
+  const GPT_ONLY_PHRASE = `Not X, but Y`;
+
+  it("includes if:gpt block when a gpt-* model ID is threaded through", () => {
+    const { system } = buildDMPrefix(mockConfig, {}, "gpt-5.5");
+    const allText = system.map((b) => b.text).join("\n");
+    expect(allText).toContain(GPT_ONLY_PHRASE);
+  });
+
+  it("omits if:gpt block when a claude-* model ID is threaded through", () => {
+    const { system } = buildDMPrefix(mockConfig, {}, "claude-opus-4-6");
+    const allText = system.map((b) => b.text).join("\n");
+    expect(allText).not.toContain(GPT_ONLY_PHRASE);
   });
 });

--- a/packages/engine/src/agents/dm-prompt.ts
+++ b/packages/engine/src/agents/dm-prompt.ts
@@ -43,12 +43,21 @@ export interface DMSessionState {
  * Returns system blocks (Tier 1+2) and volatile context (Tier 3) separately.
  * Volatile context should be injected into the conversation, not the system prompt,
  * to avoid invalidating the tools cache (BP3) on every turn.
+ *
+ * `modelId` is the runtime tier-resolved model serving the DM, used by
+ * `<!--if:PREFIX-->` conditionals inside the prompt .md files. Callers should
+ * pass the same model ID they'll send the request with (typically
+ * `tierProviders.large.model`). When omitted, falls back to the static
+ * `getModel("large")` — preserves legacy behavior for callers that don't have
+ * tier routing wired up, but means conditionals won't reflect the actual
+ * runtime provider.
  */
 export function buildDMPrefix(
   config: CampaignConfig,
   sessionState: DMSessionState,
+  modelId?: string,
 ): CachedPrefixResult {
-  const model = getModel("large");
+  const model = modelId ?? getModel("large");
   const sections: PrefixSections = {
     dmIdentity: loadPrompt("dm-identity", model),
     dmDirectives: loadPrompt("dm-directives", model),

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -173,7 +173,12 @@ export class SceneManager {
     this.sessionState.playerRead = synthesizePlayerRead(this.scene.playerReads);
     this.sessionState.entityIndex = this.entityTreeSnapshot;
     this.sessionState.contentBoundaries = this.contentBoundariesSnapshot;
-    return buildDMPrefix(this.state.config, this.sessionState);
+    // Use the runtime tier-resolved model for prompt conditionals
+    // (`<!--if:gpt-->` etc.) so the DM prompt branches match the provider
+    // actually serving the request. Falls back to the static large default
+    // when tierProviders isn't supplied (legacy test paths).
+    const dmModelId = this.tierProviders?.large.model ?? getModel("large");
+    return buildDMPrefix(this.state.config, this.sessionState, dmModelId);
   }
 
   /** Append to the scene transcript */

--- a/packages/engine/src/agents/subagents/ooc-mode.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.ts
@@ -116,7 +116,7 @@ export function buildOOCPrompt(options: OOCPromptOptions): string | SystemBlock[
     return prompt;
   }
 
-  const prefix = buildDMPrefix(opts.config, opts.sessionState);
+  const prefix = buildDMPrefix(opts.config, opts.sessionState, opts.model);
 
   // OOC suffix — appended after all DM Tier 1+2 blocks. Uncached on purpose
   // (it varies per entry and is small), and sits past the last cache_control


### PR DESCRIPTION
## Summary

Fixes [#483](https://github.com/octopollux/machine-violet/issues/483). `<!--if:gpt-->` blocks in `dm-directives.md` (and any other DM prompt loaded via `buildDMPrefix`) never resolved to their if-branch at runtime, because `buildDMPrefix` was calling `getModel(\"large\")` — the **static** default from `dev-config.jsonc` — instead of the runtime tier-resolved model ID.

When a user assigned `gpt-5.5` (or any `gpt-*`) to the DM tier via a ChatGPT/OpenAI connection, the provider call correctly went to ChatGPT but the prompt was built against `claude-opus-4-6`, so the if:gpt branch always fell through to its else body.

## Changes

- **[packages/engine/src/agents/dm-prompt.ts](packages/engine/src/agents/dm-prompt.ts)** — `buildDMPrefix` takes an optional `modelId` and threads it into both `loadPrompt` calls. Falls back to `getModel(\"large\")` when omitted so legacy callers without tier routing keep working.
- **[packages/engine/src/agents/scene-manager.ts:176](packages/engine/src/agents/scene-manager.ts:176)** — `getSystemPrompt` passes `tierProviders?.large.model`, so the actual runtime DM model reaches the conditional preprocessor.
- **[packages/engine/src/agents/subagents/ooc-mode.ts:119](packages/engine/src/agents/subagents/ooc-mode.ts:119)** — `buildOOCPrompt` forwards its existing `opts.model` through to the DM prefix.
- **[packages/engine/src/agents/dm-prompt.test.ts](packages/engine/src/agents/dm-prompt.test.ts)** — regression test per the issue's suggested coverage: builds a DM prefix with a `gpt-*` model and asserts the if:gpt body is present; with a `claude-*` model, asserts it's absent.

## Test plan

- [x] `npm run check` passes (149 files / 2564 tests / lint clean)
- [x] New regression test fails on `main` and passes on this branch
- [ ] Manual: connect ChatGPT, assign `gpt-5.5` to DM tier, dump DM context, confirm the if:gpt body now appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)