### PR TITLE
Preserve DM continuations after deferred TUI tools (#485)

### DIFF
--- a/packages/engine/src/agents/agent-loop.test.ts
+++ b/packages/engine/src/agents/agent-loop.test.ts
@@ -227,14 +227,13 @@ describe("agentLoop", () => {
       mockConfig({ provider }),
     );
 
-    // Last-non-empty-round-wins: only the final assistant message's text is
-    // returned, mirroring `finalAssistantText` in the game engine and the
-    // conversation history. This was changed from accumulation in PR/commit
-    // for the duplicate-DM bug — Claude re-narrates after deferred TUI
-    // tool_results often enough that accumulation produced verbatim
-    // doubling in long campaigns. See agent-loop-bridge.test.ts for the
-    // round-boundary cases.
-    expect(result.text).toBe("A natural 20!");
+    // Preface + continuation: round 1 sets the stage ("Let me roll for you...")
+    // before a tool call, round 2 lands the result ("A natural 20!"). The two
+    // are a legitimate continuation, not a regeneration, so the bridge
+    // concatenates them. See agent-loop-bridge.test.ts for the regen path,
+    // which collapses identical/near-identical text across rounds and emits
+    // a corrective rollback to the client.
+    expect(result.text).toBe("Let me roll for you... A natural 20!");
   });
 
   it("accumulates usage across rounds", async () => {

--- a/packages/engine/src/providers/agent-loop-bridge.test.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.test.ts
@@ -565,7 +565,11 @@ describe("runProviderLoop round-boundary rollback", () => {
     expect(callCount).toBe(2);
   });
 
-  it("fires onRollback between rounds when the prior round emitted text", async () => {
+  it("fires a post-loop corrective onRollback when the model regenerates", async () => {
+    // Regen case: the model emits the same narrative both before and after
+    // the deferred tool_result, despite the "narrative delivered" suffix.
+    // The bridge collapses to one canonical copy (last-wins) and tells the
+    // client to discard the doubled stream + replay the canonical text.
     let callCount = 0;
     const provider: LLMProvider = {
       providerId: "test",
@@ -573,11 +577,55 @@ describe("runProviderLoop round-boundary rollback", () => {
       stream: vi.fn(async (_params, onDelta) => {
         callCount++;
         if (callCount === 1) {
-          const r = textPlusToolResult("Round one text.", "scribe");
+          const r = textPlusToolResult("Round one narrative.", "scribe");
           onDelta(r.text);
           return r;
         }
-        const r = textResult("Round two text.");
+        const r = textResult("Round one narrative.");
+        onDelta(r.text);
+        return r;
+      }),
+      healthCheck: vi.fn(),
+    };
+
+    const onRollback = vi.fn();
+    const deltas: string[] = [];
+    const result = await runProviderLoop(provider, "system", [
+      { role: "user", content: "hello" },
+    ], {
+      name: "test",
+      model: "test-model",
+      maxTokens: 100,
+      stream: true,
+      onTextDelta: (d) => deltas.push(d),
+      onRollback,
+      toolHandler: () => ({ content: "ok" }),
+    });
+
+    expect(result.text).toBe("Round one narrative.");
+    expect(onRollback).toHaveBeenCalledOnce();
+    // After the rollback, the canonical text is replayed as a single delta so
+    // the client redraws what we actually persist.
+    expect(deltas.at(-1)).toBe("Round one narrative.");
+  });
+
+  it("concatenates a genuine continuation across rounds (#485)", async () => {
+    // Continuation case: the model takes the "unless you have new narrative
+    // to add" hint at face value and writes a coda after the deferred tool.
+    // The bridge must concatenate (not discard) — that's the entire reason
+    // we replaced the old last-wins-always rule.
+    let callCount = 0;
+    const provider: LLMProvider = {
+      providerId: "test",
+      chat: vi.fn(),
+      stream: vi.fn(async (_params, onDelta) => {
+        callCount++;
+        if (callCount === 1) {
+          const r = textPlusToolResult("Round one narrative.", "scribe");
+          onDelta(r.text);
+          return r;
+        }
+        const r = textResult("Round two coda.");
         onDelta(r.text);
         return r;
       }),
@@ -598,10 +646,10 @@ describe("runProviderLoop round-boundary rollback", () => {
       toolHandler: () => ({ content: "ok" }),
     });
 
-    expect(result.text).toBe("Round two text.");
-    // Exactly one rollback at the round boundary — clears round-1's "Round
-    // one text." from the client before round 2's deltas arrive.
-    expect(onRollback).toHaveBeenCalledOnce();
+    expect(result.text).toBe("Round one narrative.Round two coda.");
+    // No rollback — the client's accumulated stream already matches the
+    // persisted text, so a corrective snapshot would be a pointless flash.
+    expect(onRollback).not.toHaveBeenCalled();
   });
 
   it("does NOT fire onRollback when the prior round emitted no text", async () => {
@@ -802,7 +850,11 @@ describe("runProviderLoop round-boundary rollback", () => {
     expect(toolResultBlock?.content).toBe("Scribe failed: invalid update");
   });
 
-  it("fires both per-attempt and inter-round rollbacks when both apply", async () => {
+  it("fires both per-attempt and post-loop rollbacks when both apply", async () => {
+    // Same round-1 retry path as before, but round 2 regenerates round 1's
+    // text (instead of continuing) so the post-loop corrective rollback also
+    // fires. The two rollbacks address distinct duplication sources: a
+    // failed mid-stream attempt vs. the model re-narrating after the tool.
     let callCount = 0;
     const provider: LLMProvider = {
       providerId: "test",
@@ -820,8 +872,8 @@ describe("runProviderLoop round-boundary rollback", () => {
           onDelta(r.text);
           return r;
         }
-        // Round 2: final narration → triggers inter-round rollback before it streams.
-        const r = textResult("Round two final.");
+        // Round 2: model re-narrates verbatim → post-loop corrective rollback.
+        const r = textResult("Round one narrative.");
         onDelta(r.text);
         return r;
       }),
@@ -845,10 +897,10 @@ describe("runProviderLoop round-boundary rollback", () => {
     await vi.advanceTimersByTimeAsync(1000);
     const result = await promise;
 
-    expect(result.text).toBe("Round two final.");
-    // One for the failed attempt's partial leak, one for the round-1 → round-2
-    // boundary. Both are necessary: the first protects against retry duplication,
-    // the second against re-narration duplication.
+    expect(result.text).toBe("Round one narrative.");
+    // One for the failed attempt's partial leak, one for the post-loop
+    // regen collapse. Both are necessary: the first protects against retry
+    // duplication, the second against re-narration duplication.
     expect(onRollback).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -226,11 +226,13 @@ export async function runProviderLoop(
   };
   const tuiCommands: TuiCommand[] = [];
   let fullText = "";
+  // Concatenation of every round's emitted text, in the order the client saw
+  // it on screen. Compared against `fullText` after the loop: if regen-aware
+  // accumulation produced a shorter canonical text than what was streamed,
+  // we emit a corrective rollback + re-stream so the displayed narrative
+  // matches the persisted one.
+  let streamedText = "";
   let truncated = false;
-  // Tracks whether the round we just completed emitted any text deltas.
-  // Used to roll the client back at the boundary into the next round —
-  // see the inter-round rollback comment inside the loop.
-  let priorRoundEmittedText = false;
 
   const workingMessages = [...messages];
   const loopStartIndex = workingMessages.length;
@@ -239,19 +241,6 @@ export async function runProviderLoop(
   const priorAssistantCount = messages.filter((m) => m.role === "assistant").length;
 
   for (let round = 0; round < maxToolRounds; round++) {
-    // Inter-round rollback: when a round emitted narrative text alongside a
-    // tool call (typically a deferred TUI tool like scribe / scene_transition
-    // / dm_notes), Claude often re-narrates the same content in the next
-    // round after seeing the synthetic tool_result. The streamed deltas from
-    // round N are still in the client's narrative log; without a rollback,
-    // round N+1's stream is appended after them and the user sees the same
-    // text twice. Reuse the retry-rollback path so the bridge clears its
-    // delta buffer and the session-manager publishes a corrective snapshot
-    // before round N+1's deltas begin arriving.
-    if (priorRoundEmittedText) {
-      config.onRollback?.();
-    }
-
     // Tool dispatcher for providers that own tool dispatch internally
     // (currently openai-chatgpt). Wraps the same per-call logic the
     // bridge runs after this chat() returns for non-internal-dispatch
@@ -312,7 +301,6 @@ export async function runProviderLoop(
     });
 
     let result: ChatResult;
-    let roundEmittedDeltas: boolean;
     const apiStart = Date.now();
     for (let attempt = 0; ; attempt++) {
       // Per-attempt flag: did this attempt actually stream any text before
@@ -331,12 +319,6 @@ export async function runProviderLoop(
           // In non-streaming mode, emit the full text
           if (result.text) config.onTextDelta?.(result.text);
         }
-        // Successful attempt: capture whether deltas leaked so the
-        // inter-round rollback at the top of the next iteration knows
-        // whether a corrective snapshot is needed. Per-attempt rollbacks
-        // for retries already cleared the failed-attempt streams; this
-        // flag reflects only the surviving (successful) attempt.
-        roundEmittedDeltas = shouldStream ? attemptEmittedDeltas : !!result.text;
         break; // success — exit retry loop
       } catch (apiErr) {
         const status = extractStatus(apiErr);
@@ -411,22 +393,32 @@ export async function runProviderLoop(
       dumpThinking(config.name, priorAssistantCount + round, result.thinkingText);
     }
 
-    // Last-non-empty-round-wins: each round with text overwrites prior text.
-    // When the model emits text alongside a tool call and then re-narrates
-    // after the tool_result (Claude does this routinely with deferred TUI
-    // tools, see the inter-round rollback comment above), accumulating across
-    // rounds doubles the response in every downstream sink — display log,
-    // scene transcript, committed narrative, etc. Overwriting keeps
-    // `result.text` consistent with the final assistant message in
-    // `roundMessages`, which is what the conversation history already
-    // collapses to via `finalAssistantText` in game-engine.ts. The non-empty
-    // guard preserves the prior round's text for the unusual case where the
-    // model said its piece alongside a tool call and then end_turn'd in the
-    // next round without further narration.
+    // Regen-aware accumulation. The model can do one of two things after a
+    // deferred-TUI tool_result:
+    //   (a) Regenerate the prior round's narrative verbatim or near-verbatim
+    //       (it reads the synthetic "queue confirmation" ack ambiguously,
+    //       even with the "narrative delivered" suffix, especially under
+    //       deep context pressure). We must NOT concatenate, or the
+    //       persisted transcript doubles up.
+    //   (b) Add a genuine continuation — a coda, a follow-up beat, a "and
+    //       then the door creaked open." This is exactly what the
+    //       "end your turn unless you have new narrative to add" hint
+    //       invites, and the model does take that invitation. We must
+    //       concatenate, or the new narrative is silently dropped (#485).
+    // Distinguish by prefix overlap: a regen typically shares a long opening
+    // with the prior text; a continuation starts somewhere genuinely new.
+    // Both branches also drive the post-loop corrective rollback below —
+    // streamedText tracks what the client actually saw on screen, fullText
+    // tracks what should be persisted, and any divergence at the end of the
+    // turn means we need to re-stream the canonical text.
     if (result.text) {
-      fullText = result.text;
+      streamedText += result.text;
+      if (fullText && looksLikeRegeneration(fullText, result.text)) {
+        fullText = result.text;
+      } else {
+        fullText += result.text;
+      }
     }
-    priorRoundEmittedText = roundEmittedDeltas;
 
     // Process tool calls concurrently. Sync handlers still run sequentially
     // on the JS event loop; async handlers (subagent spawns, search) genuinely
@@ -489,6 +481,17 @@ export async function runProviderLoop(
     }
   }
 
+  // Post-loop corrective rollback: if regen detection collapsed multiple
+  // rounds into a shorter canonical text, the client's narrative log holds
+  // the un-collapsed stream (regen showed up twice on screen). Clear it via
+  // the snapshot path and re-stream the canonical text so what the player
+  // sees matches what we persist. No-op in the common case where every
+  // round was a genuine continuation, since streamedText === fullText.
+  if (shouldStream && streamedText !== fullText) {
+    config.onRollback?.();
+    if (fullText) config.onTextDelta?.(fullText);
+  }
+
   config.onComplete?.(totalUsage);
 
   return {
@@ -498,4 +501,30 @@ export async function runProviderLoop(
     truncated,
     roundMessages: workingMessages.slice(loopStartIndex),
   };
+}
+
+/**
+ * Heuristic: does `next` look like the model regenerating `prior`, as opposed
+ * to adding a continuation? Used at round boundaries to decide whether to
+ * overwrite (regen) or concatenate (continuation) accumulated text.
+ *
+ * Two strong signals:
+ *  - One text fully contains the other: clear regen (with possible extension).
+ *  - The two share a long common prefix (>= 64 chars): the model started the
+ *    new round by re-typing the prior round, almost always a regen.
+ *
+ * Tuned to favor false negatives (treat as continuation) over false positives
+ * (treat as regen). Wrongly treating a regen as continuation just duplicates
+ * text on screen — annoying but recoverable. Wrongly treating a continuation
+ * as regen silently drops narrative the player can never recover (#485).
+ */
+function looksLikeRegeneration(prior: string, next: string): boolean {
+  const p = prior.trim();
+  const n = next.trim();
+  if (!p || !n) return false;
+  if (n.includes(p) || p.includes(n)) return true;
+  const limit = Math.min(p.length, n.length);
+  let i = 0;
+  while (i < limit && p.charCodeAt(i) === n.charCodeAt(i)) i++;
+  return i >= 64;
 }


### PR DESCRIPTION
## Summary
- Fixes #485: DM response disappears while generating, screen stays blank until campaign is reloaded.
- The agent-loop bridge was treating *any* text after a deferred TUI tool (scribe / scene_transition / dm_notes / promote_character / session_end) as a re-narration: pre-emptive client rollback + last-non-empty-round-wins for `result.text`. Documented as a known trade-off in 23f511b (the "Let me roll… / A natural 20!" example), but it bit hard in the wild when the DM took the "end your turn unless you have new narrative to add" hint at face value and added a coda after scribe. The earlier full-page narrative was wiped from the screen, `display-log.md`, the scene transcript, and `conversation.json` — unrecoverable via reload because persistence was clobbered too.
- New `looksLikeRegeneration(prior, next)` heuristic: full-substring containment or a >= 64-char common prefix. Tuned to favor false negatives (treat as continuation) — wrongly calling a regen a continuation just duplicates text on screen, recoverable; wrongly calling a continuation a regen drops content permanently.
- Replaced the pre-emptive inter-round rollback with a single post-loop corrective rollback that fires only when regen actually collapsed the screen-text into a shorter canonical, then replays `fullText` as one delta. Continuations now just concatenate naturally.

## Trace from the warranty-void campaign
1. Round 0: `roll_dice` only, no text.
2. Round 1: full-page narrative + `scribe` + `update_modeline`.
3. Round 2: brief one-line coda, no tools.

Old behavior: rollback at start of round 2 cleared the page from the screen; last-wins replaced the page with the coda in `result.text`. Persistence and display both ended up with only the coda.

New behavior: round 2's coda is detected as a continuation (no prefix overlap with round 1) → concatenated. No rollback fires. Persisted = displayed = page + coda.

## Test plan
- [x] `npx vitest run packages/engine/src/providers/agent-loop-bridge.test.ts packages/engine/src/agents/agent-loop.test.ts` — 41/41
- [x] `npm run check` — 2563/2563, lint clean
- [x] Updated test "fires onRollback between rounds when the prior round emitted text" → "fires a post-loop corrective onRollback when the model regenerates" (uses identical text in both rounds so it's an actual regen; asserts the canonical text is replayed as the final delta after the rollback).
- [x] Updated "fires both per-attempt and inter-round rollbacks when both apply" → "fires both per-attempt and post-loop rollbacks when both apply" (round 2 now regenerates round 1's text verbatim so both paths fire).
- [x] New test "concatenates a genuine continuation across rounds (#485)" — locks in the fix.
- [x] Agent-loop level "text + tool_use" test now asserts the correct concatenated result; the "preface + continuation" case 23f511b explicitly called out as a known trade-off is now preserved.
- [ ] Manual: continue a `warranty-void`-style campaign through several deferred-TUI tool calls and confirm full-page DM responses no longer disappear when the DM adds a coda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)