### PR TITLE
Surface Anthropic cache-miss reasons inline

### DIFF
--- a/packages/engine/src/providers/agent-loop-bridge.ts
+++ b/packages/engine/src/providers/agent-loop-bridge.ts
@@ -279,6 +279,12 @@ export async function runProviderLoop(
     // ChatParams is a discriminated union: tools + dispatchTool are
     // either both present (this call uses tools) or both absent (text-only).
     // Build the variant that matches `config.tools`.
+    //
+    // conversationId = agent name: stable across the bridge's tool-use rounds
+    // and across subsequent player turns for the same agent, distinct between
+    // agents (DM vs scribe vs subagents). Providers that support cache
+    // diagnostics (currently Anthropic) thread `previous_message_id` along
+    // this key so divergence reasons are attributed to the right chain.
     const chatParams: ChatParams = config.tools
       ? {
           model: config.model,
@@ -288,6 +294,7 @@ export async function runProviderLoop(
           maxTokens: config.maxTokens,
           thinking,
           cacheHints: config.cacheHints,
+          conversationId: config.name,
           dispatchTool,
         }
       : {
@@ -297,6 +304,7 @@ export async function runProviderLoop(
           maxTokens: config.maxTokens,
           thinking,
           cacheHints: config.cacheHints,
+          conversationId: config.name,
         };
 
     // Context dump: log params before API call. `thinking` is captured so the
@@ -385,6 +393,14 @@ export async function runProviderLoop(
       reasoningTokens: result.usage.reasoningTokens,
       toolCalls: result.toolCalls.length,
       stopReason: result.stopReason,
+      ...(result.cacheDiagnostics
+        ? {
+            cacheMissReason: result.cacheDiagnostics.reasonType,
+            ...(result.cacheDiagnostics.missedInputTokens !== undefined
+              ? { cacheMissedInputTokens: result.cacheDiagnostics.missedInputTokens }
+              : {}),
+          }
+        : {}),
     });
 
     // Accumulate usage

--- a/packages/engine/src/providers/anthropic.test.ts
+++ b/packages/engine/src/providers/anthropic.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { toAnthropicParams } from "./anthropic.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+import { toAnthropicParams, extractCacheDiagnostics } from "./anthropic.js";
 import type { ChatParams, NormalizedMessage } from "./types.js";
+import * as engineLog from "../context/engine-log.js";
 
 /**
  * Exercise the BP4 (messages) cache-stamp logic — the single most important
@@ -104,5 +106,144 @@ describe("toAnthropicParams: messages cache stamp (BP4)", () => {
     ];
     const out = toAnthropicParams(baseParams({ messages }));
     expect(stampedIndexes(out.messages)).toEqual([false, false]);
+  });
+});
+
+describe("toAnthropicParams: orphan-patch wiring", () => {
+  it("inserts a synthetic tool_result user message and lands the BP4 stamp on it", () => {
+    // End-to-end: an orphan-trailing history with no clean stable tail.
+    // The synthetic stub IS the new stable tail, so the cache stamp should
+    // land on it (not on the original trailing assistant, which would be
+    // invalid both for the API and for cache purposes).
+    // Pure-function behavior is covered in orphan-patch.test.ts.
+    const messages: NormalizedMessage[] = [
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "roll_dice", input: {} }],
+      },
+    ];
+    const out = toAnthropicParams(baseParams({ messages }));
+    expect(out.messages).toHaveLength(3);
+    expect(out.messages[2].role).toBe("user");
+    expect(out.messages[2].content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "t1",
+        content: "[no tool result recorded]",
+        is_error: true,
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+    expect(stampedIndexes(out.messages)).toEqual([false, false, true]);
+  });
+});
+
+/**
+ * Exercise the four documented `diagnostics` states from the
+ * cache-diagnosis-2026-04-07 beta and verify that only the actionable
+ * `*_changed` reasons (the ones operators can fix) trigger the structured
+ * `cache:miss` engine-log entry. The other states are returned-or-omitted
+ * silently so the log doesn't fill up with non-bugs.
+ */
+describe("extractCacheDiagnostics", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  // Minimal Anthropic.Message stand-in: the function only reads `id`, `model`,
+  // and (via cast) `diagnostics`. Build a permissive cast so each test can
+  // attach whatever `diagnostics` shape it's exercising without re-listing
+  // all the unused Message fields.
+  function msg(diagnostics: unknown): Anthropic.Message {
+    return {
+      id: "msg_test",
+      model: "claude-test",
+      diagnostics,
+    } as unknown as Anthropic.Message;
+  }
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(engineLog, "logEvent").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("returns undefined when the diagnostics field is absent (beta not enabled)", () => {
+    const m = { id: "msg_x", model: "claude-test" } as unknown as Anthropic.Message;
+    expect(extractCacheDiagnostics(m)).toBeUndefined();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when diagnostics is null (first turn or no divergence)", () => {
+    expect(extractCacheDiagnostics(msg(null))).toBeUndefined();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when cache_miss_reason is null (comparison still pending)", () => {
+    expect(extractCacheDiagnostics(msg({ cache_miss_reason: null }))).toBeUndefined();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns the reasonType + token count for an actionable *_changed miss", () => {
+    const result = extractCacheDiagnostics(msg({
+      cache_miss_reason: { type: "system_changed", cache_missed_input_tokens: 41850 },
+    }));
+    expect(result).toEqual({ reasonType: "system_changed", missedInputTokens: 41850 });
+  });
+
+  it("emits a cache:miss engine-log entry for *_changed reasons", () => {
+    extractCacheDiagnostics(msg({
+      cache_miss_reason: { type: "tools_changed", cache_missed_input_tokens: 1234 },
+    }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith("cache:miss", expect.objectContaining({
+      messageId: "msg_test",
+      model: "claude-test",
+      reasonType: "tools_changed",
+      missedInputTokens: 1234,
+    }));
+  });
+
+  it("omits missedInputTokens from the result when the API didn't include it", () => {
+    const result = extractCacheDiagnostics(msg({
+      cache_miss_reason: { type: "model_changed" },
+    }));
+    expect(result).toEqual({ reasonType: "model_changed" });
+    // And the log entry omits missedInputTokens too rather than logging undefined.
+    const logged = logSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(logged).not.toHaveProperty("missedInputTokens");
+  });
+
+  it("returns previous_message_not_found but does NOT emit a cache:miss log", () => {
+    // Non-actionable: the prior request just wasn't on file (fingerprint
+    // expired, different workspace, beta header missing on the prior call).
+    // Surface it for the viewer's gray pill but don't pollute the log with
+    // a "miss" entry — there's nothing in our prompts to fix.
+    const result = extractCacheDiagnostics(msg({
+      cache_miss_reason: { type: "previous_message_not_found" },
+    }));
+    expect(result).toEqual({ reasonType: "previous_message_not_found" });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns unavailable but does NOT emit a cache:miss log", () => {
+    // Same rationale as previous_message_not_found — no comparison was
+    // produced, not a prompt-prefix bug.
+    const result = extractCacheDiagnostics(msg({
+      cache_miss_reason: { type: "unavailable" },
+    }));
+    expect(result).toEqual({ reasonType: "unavailable" });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for a malformed cache_miss_reason missing a type", () => {
+    // Defensive against future beta schema drift — if `type` is absent,
+    // treat the whole object as uninterpretable rather than emitting a
+    // pill with `reasonType: undefined`.
+    expect(extractCacheDiagnostics(msg({
+      cache_miss_reason: { cache_missed_input_tokens: 100 },
+    }))).toBeUndefined();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/engine/src/providers/anthropic.ts
+++ b/packages/engine/src/providers/anthropic.ts
@@ -358,8 +358,9 @@ function fromAnthropicResponse(
  * line on `*_changed` types so operators can grep engine.jsonl for divergence
  * causes without going through the dump viewer.
  *
+ * Exported for tests.
  */
-function extractCacheDiagnostics(response: Anthropic.Message): CacheDiagnostics | undefined {
+export function extractCacheDiagnostics(response: Anthropic.Message): CacheDiagnostics | undefined {
   const raw = (response as unknown as Record<string, unknown>).diagnostics;
   if (raw == null || typeof raw !== "object") return undefined;
 

--- a/packages/engine/src/providers/anthropic.ts
+++ b/packages/engine/src/providers/anthropic.ts
@@ -9,9 +9,18 @@ import Anthropic from "@anthropic-ai/sdk";
 import type {
   LLMProvider, ChatParams, ChatResult, HealthCheckResult,
   NormalizedMessage, NormalizedToolCall,
-  NormalizedUsage, ContentPart, StopReason,
+  NormalizedUsage, ContentPart, StopReason, CacheDiagnostics,
 } from "./types.js";
 import { getKnownModel } from "../config/model-registry.js";
+import { logEvent } from "../context/engine-log.js";
+
+/**
+ * Beta header for prompt-cache diagnostics (Anthropic API only). When set,
+ * the API returns a `diagnostics` field describing where the prompt prefix
+ * diverged from a previous request identified by `previous_message_id`.
+ * See https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics.
+ */
+const CACHE_DIAGNOSIS_BETA = "cache-diagnosis-2026-04-07";
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -23,10 +32,20 @@ export function createAnthropicProvider(apiKey?: string): LLMProvider {
     ...(apiKey ? { apiKey } : {}),
   });
 
+  /**
+   * Per-conversation cursor for cache diagnostics. Key is the caller's
+   * `conversationId` (typically the agent name); value is the `id` of the
+   * most recent successful response on that chain. Looked up on each call
+   * to populate `diagnostics.previous_message_id`. Lost on process restart,
+   * which is fine — the next call simply passes `null` and starts a new
+   * chain; the API treats it as a first turn.
+   */
+  const previousIdByConversation = new Map<string, string>();
+
   return {
     providerId: "anthropic",
-    chat: (params) => anthropicChat(client, params, false),
-    stream: (params, onDelta) => anthropicChat(client, params, true, onDelta),
+    chat: (params) => anthropicChat(client, params, false, undefined, previousIdByConversation),
+    stream: (params, onDelta) => anthropicChat(client, params, true, onDelta, previousIdByConversation),
     healthCheck: (model) => anthropicHealthCheck(client, model),
   };
 }
@@ -39,18 +58,48 @@ async function anthropicChat(
   client: Anthropic,
   params: ChatParams,
   streaming: boolean,
-  onDelta?: (text: string) => void,
+  onDelta: ((text: string) => void) | undefined,
+  previousIdByConversation: Map<string, string>,
 ): Promise<ChatResult> {
   const apiParams = toAnthropicParams(params);
 
+  // Cache diagnostics: thread the previous response id on this chain so the
+  // API can pinpoint cache divergence. Sent on every call when the caller
+  // supplied a conversationId; `null` on the first call of a fresh chain
+  // (per Anthropic docs, that's the opt-in signal — no comparison, but
+  // future turns can compare against this one). The SDK at 0.82.0 doesn't
+  // type `diagnostics` yet, so we attach it as an untyped extension.
+  const convoId = params.conversationId;
+  const diagnosticsParams = convoId !== undefined
+    ? { diagnostics: { previous_message_id: previousIdByConversation.get(convoId) ?? null } }
+    : {};
+
+  // Anthropic-beta header per request; doesn't disturb existing default headers.
+  const requestOptions = convoId !== undefined
+    ? { headers: { "anthropic-beta": CACHE_DIAGNOSIS_BETA } }
+    : undefined;
+
   let response: Anthropic.Message;
 
+  // Extension fields (`diagnostics`, `betas`) aren't typed by SDK 0.82.0; we
+  // attach them via an unknown cast that resolves to the same shape the
+  // typed methods accept. `as unknown as ...` keeps the overload resolution
+  // correctly disambiguating Message vs Stream return types.
+  const streamParams = { ...apiParams, ...diagnosticsParams } as unknown as Anthropic.MessageStreamParams;
+  const createParams = { ...apiParams, ...diagnosticsParams, stream: false } as unknown as Anthropic.MessageCreateParamsNonStreaming;
+
   if (streaming && onDelta) {
-    const stream = client.messages.stream(apiParams);
+    const stream = client.messages.stream(streamParams, requestOptions);
     stream.on("text", (delta) => onDelta(delta));
     response = await stream.finalMessage();
   } else {
-    response = await client.messages.create({ ...apiParams, stream: false });
+    response = await client.messages.create(createParams, requestOptions);
+  }
+
+  // Cursor advances on success only — a thrown error leaves the prior id in
+  // place so a retry-then-success doesn't break the chain.
+  if (convoId !== undefined && response.id) {
+    previousIdByConversation.set(convoId, response.id);
   }
 
   return fromAnthropicResponse(response, !streaming ? onDelta : undefined);
@@ -270,6 +319,8 @@ function fromAnthropicResponse(
     reasoningTokens: 0,
   };
 
+  const cacheDiagnostics = extractCacheDiagnostics(response);
+
   return {
     text,
     toolCalls,
@@ -277,7 +328,53 @@ function fromAnthropicResponse(
     stopReason,
     thinkingText: thinkingText || undefined,
     assistantContent,
+    ...(cacheDiagnostics ? { cacheDiagnostics } : {}),
   };
+}
+
+/**
+ * Parse Anthropic's `diagnostics.cache_miss_reason` (beta `cache-diagnosis-2026-04-07`)
+ * from a response. The field has four states per the docs:
+ *   - absent: feature not enabled.
+ *   - `null`: first turn (no prior to compare) or comparison ran and found no divergence.
+ *   - `{ cache_miss_reason: null }`: comparison still running when response serialized.
+ *   - `{ cache_miss_reason: { type, cache_missed_input_tokens? } }`: divergence located.
+ *
+ * Returns `undefined` for the first three (nothing actionable to surface) and a
+ * populated CacheDiagnostics only for the fourth. Also emits a structured log
+ * line on `*_changed` types so operators can grep engine.jsonl for divergence
+ * causes without going through the dump viewer.
+ */
+function extractCacheDiagnostics(response: Anthropic.Message): CacheDiagnostics | undefined {
+  const raw = (response as unknown as Record<string, unknown>).diagnostics;
+  if (raw == null || typeof raw !== "object") return undefined;
+
+  const reason = (raw as Record<string, unknown>).cache_miss_reason;
+  if (reason == null || typeof reason !== "object") return undefined;
+
+  const reasonObj = reason as Record<string, unknown>;
+  const reasonType = typeof reasonObj.type === "string" ? reasonObj.type : undefined;
+  if (!reasonType) return undefined;
+
+  const missedRaw = reasonObj.cache_missed_input_tokens;
+  const missedInputTokens = typeof missedRaw === "number" ? missedRaw : undefined;
+
+  // *_changed reasons indicate an actual prompt-prefix divergence the operator
+  // can fix; the other two (`previous_message_not_found`, `unavailable`) are
+  // "no comparison was produced" and not bugs in our code. Log only the
+  // actionable ones so the signal stays useful.
+  if (reasonType.endsWith("_changed")) {
+    logEvent("cache:miss", {
+      messageId: response.id,
+      model: response.model,
+      reasonType,
+      ...(missedInputTokens !== undefined ? { missedInputTokens } : {}),
+    });
+  }
+
+  return missedInputTokens !== undefined
+    ? { reasonType, missedInputTokens }
+    : { reasonType };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/providers/types.ts
+++ b/packages/engine/src/providers/types.ts
@@ -95,6 +95,26 @@ export interface NormalizedUsage {
 }
 
 // ---------------------------------------------------------------------------
+// Cache diagnostics
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider-reported reason a prompt-cache lookup diverged from the previous
+ * request. Currently sourced from Anthropic's `cache-diagnosis-2026-04-07`
+ * beta; future providers with comparable signals can populate the same shape.
+ *
+ * `reasonType` mirrors the Anthropic `cache_miss_reason.type` discriminant:
+ * `model_changed | system_changed | tools_changed | messages_changed |
+ *  previous_message_not_found | unavailable`. Kept as `string` so newly
+ * added types don't break parsing.
+ */
+export interface CacheDiagnostics {
+  reasonType: string;
+  /** Estimated input tokens that fell after the divergence point, when known. */
+  missedInputTokens?: number;
+}
+
+// ---------------------------------------------------------------------------
 // Chat request / response
 // ---------------------------------------------------------------------------
 
@@ -122,6 +142,15 @@ interface ChatParamsBase {
   maxTokens: number;
   thinking?: ThinkingConfig;
   cacheHints?: CacheHint[];
+  /**
+   * Opaque stable key identifying this chain of related calls (typically an
+   * agent name like "dm" or "scribe"). Providers that surface cache
+   * diagnostics use this to thread Anthropic's `previous_message_id` between
+   * consecutive calls in the same chain so the API can pinpoint where the
+   * cached prefix diverged. Optional — callers that don't set it just opt
+   * out of cache-miss attribution; the call itself behaves identically.
+   */
+  conversationId?: string;
 }
 
 interface ChatParamsToolless extends ChatParamsBase {
@@ -177,6 +206,15 @@ export interface ChatResult {
    * Thinking blocks are excluded (they must not be sent back).
    */
   assistantContent: ContentPart[];
+  /**
+   * Per-call cache divergence attribution, when the provider supports it and
+   * a comparison ran. `undefined` means the provider didn't surface
+   * diagnostics for this call (no beta enabled, no prior request to compare
+   * against, comparison still pending, or comparison unavailable). A present
+   * value carries the divergence point that caused (or would have caused)
+   * the prompt cache to miss — see {@link CacheDiagnostics}.
+   */
+  cacheDiagnostics?: CacheDiagnostics;
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
+++ b/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
@@ -10,10 +10,12 @@ interface ContextDumpViewerProps {
  * log lines may pre-date the cacheCreation addition.
  *
  * `cacheMissReason` / `cacheMissedInputTokens` come from Anthropic's
- * `cache-diagnosis-2026-04-07` beta and are present only on calls where the
- * API actually attributed a divergence. The "no divergence" / "comparison
- * pending" / "unavailable" cases are absent rather than null so the chip
- * stays uncluttered when caching is working.
+ * `cache-diagnosis-2026-04-07` beta. The engine surfaces any non-null
+ * `cache_miss_reason.type` here — including the non-actionable
+ * `previous_message_not_found` and `unavailable` cases (rendered in muted
+ * gray by `CacheMissPill`). The truly silent states — "no divergence" and
+ * "comparison still pending" — are omitted entirely so the chip stays
+ * uncluttered when caching is working.
  */
 interface ApiCallEvent {
   t?: number;

--- a/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
+++ b/tools/campaign-explorer/src/client/components/ContextDumpViewer.tsx
@@ -8,6 +8,12 @@ interface ContextDumpViewerProps {
 /**
  * One api:call event from engine.jsonl. Fields are optional because older
  * log lines may pre-date the cacheCreation addition.
+ *
+ * `cacheMissReason` / `cacheMissedInputTokens` come from Anthropic's
+ * `cache-diagnosis-2026-04-07` beta and are present only on calls where the
+ * API actually attributed a divergence. The "no divergence" / "comparison
+ * pending" / "unavailable" cases are absent rather than null so the chip
+ * stays uncluttered when caching is working.
  */
 interface ApiCallEvent {
   t?: number;
@@ -21,6 +27,8 @@ interface ApiCallEvent {
   reasoningTokens?: number;
   toolCalls?: number;
   stopReason?: string;
+  cacheMissReason?: string;
+  cacheMissedInputTokens?: number;
 }
 
 interface ThinkingTrace {
@@ -375,25 +383,77 @@ function TurnStatsChip({ round, event }: { round: number; event: ApiCallEvent })
       {(event.toolCalls ?? 0) > 0 && <span>tools {event.toolCalls}</span>}
       {event.durationMs != null && <span style={{ opacity: 0.6 }}>{event.durationMs}ms</span>}
       {event.stopReason && <span style={{ opacity: 0.6 }}>stop:{event.stopReason}</span>}
+      {event.cacheMissReason && <CacheMissPill reason={event.cacheMissReason} missed={event.cacheMissedInputTokens} />}
     </div>
+  );
+}
+
+/**
+ * Renders the Anthropic cache-diagnosis verdict for a single turn.
+ *
+ * Red tint for `*_changed` reasons — these are actionable: something in the
+ * prompt prefix moved and the cached prefix had to be rewritten from that
+ * point on. Muted gray for `previous_message_not_found` and `unavailable`,
+ * which mean "no comparison was produced" rather than "your prompt drifted"
+ * (e.g. fingerprint expired, parameters outside the comparable set changed).
+ * The distinction matters because the muted cases aren't bugs to fix.
+ */
+function CacheMissPill({ reason, missed }: { reason: string; missed?: number }) {
+  const actionable = reason.endsWith("_changed");
+  const bg = actionable ? "rgba(218,54,51,0.18)" : "rgba(128,128,128,0.18)";
+  const color = actionable ? "rgb(248, 81, 73)" : undefined;
+  return (
+    <span
+      title={
+        actionable
+          ? `Prompt prefix diverged at ${reason.replace("_changed", "")}; ${missed != null ? fmtK(missed) + " input tokens" : "tokens"} fell after the divergence`
+          : `No cache comparison was produced for this turn (${reason})`
+      }
+      style={{
+        background: bg,
+        color,
+        padding: "0 6px",
+        borderRadius: 3,
+        fontWeight: actionable ? 600 : 400,
+      }}
+    >
+      miss:{reason}{missed != null ? ` (${fmtK(missed)})` : ""}
+    </span>
   );
 }
 
 /** One-line aggregate across the loaded turn window. */
 function TurnsSummary({ events }: { events: ApiCallEvent[] }) {
   let totIn = 0, totRead = 0, totWrite = 0, totOut = 0;
+  // Tally actionable cache misses by reason. Non-actionable reasons
+  // (previous_message_not_found, unavailable) are skipped — they aren't
+  // prompt-prefix bugs and shouldn't inflate the headline number.
+  const missByReason = new Map<string, number>();
   for (const e of events) {
     totIn += e.inputTokens ?? 0;
     totRead += e.cacheRead ?? 0;
     totWrite += e.cacheCreation ?? 0;
     totOut += e.outputTokens ?? 0;
+    if (e.cacheMissReason && e.cacheMissReason.endsWith("_changed")) {
+      missByReason.set(e.cacheMissReason, (missByReason.get(e.cacheMissReason) ?? 0) + 1);
+    }
   }
   const denom = totIn + totRead + totWrite;
   const hitPct = denom > 0 ? ((totRead / denom) * 100).toFixed(1) : "—";
+  const totalMisses = [...missByReason.values()].reduce((a, b) => a + b, 0);
+  const missBreakdown = [...missByReason.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, n]) => `${reason}×${n}`)
+    .join(", ");
   return (
     <div style={{ fontSize: 11, marginBottom: 8, opacity: 0.85 }}>
       {events.length} turns — cache hit {hitPct}% · in {fmtK(totIn)} · read {fmtK(totRead)}
       {" · write "}{fmtK(totWrite)} · out {fmtK(totOut)}
+      {totalMisses > 0 && (
+        <span style={{ color: "rgb(248, 81, 73)", marginLeft: 8 }}>
+          · {totalMisses} {totalMisses === 1 ? "miss" : "misses"} ({missBreakdown})
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #484.

## Summary
- Enables Anthropic's `cache-diagnosis-2026-04-07` beta on the Anthropic provider so each prompt-cache miss is attributed to a specific divergence (`system_changed`, `tools_changed`, `messages_changed`, `model_changed`).
- Threads `previous_message_id` per-agent via an in-memory cursor on the Anthropic provider instance, keyed by a new optional `conversationId` on `ChatParams` (bridge sets it to the agent name).
- Emits `cacheMissReason` + `cacheMissedInputTokens` on `api:call` jsonl events; logs a separate structured `cache:miss` event for the actionable `*_changed` reasons.
- Renders the reason inline in the campaign-explorer context dump viewer: a red pill on each `TurnStatsChip` for actionable misses (gray for `previous_message_not_found` / `unavailable`), plus a per-window miss tally in `TurnsSummary`.

## Notes
- The installed `@anthropic-ai/sdk@0.82.0` doesn't type the `diagnostics` field yet; it's attached via the same untyped-cast pattern the file already uses for `cache_read_input_tokens`. Beta header is sent via per-request `headers`, so existing default headers are untouched.
- Cursor advances only on successful responses — a retry-then-success keeps the chain intact.
- No schema break in `engine.jsonl`: new fields are additive; older log rows render in the viewer without the pill.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 1641/1642 engine tests pass; the single failure (`openai-chatgpt/binary.test.ts`) reproduces on `main` and is unrelated.
- [ ] Live: run a session, confirm `cache:miss` lines appear in `engine.jsonl` when a system-prompt timestamp drifts; confirm the dump viewer shows the pill and tally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)