### PR TITLE
Move "Enter your own" to top of ChoiceOverlay; grow downward

### DIFF
--- a/docs/game-initialization.md
+++ b/docs/game-initialization.md
@@ -6,7 +6,7 @@ Game initialization takes the player from first launch to gameplay. After a one-
 
 - **Single conversational path.** There is one "New Campaign" entry point, with the setup agent offering Quick Start or Full Setup within the conversation. No separate code paths.
 - **Options, not interrogation.** Each decision point offers 2-10 choices via `present_choices`, plus freeform input via "Enter your own". The player picks one or types something else. When fewer than 5 options are shown, focus defaults to "Enter your own" so the player can freely type.
-- **"Show me more ideas" is always available.** Every `present_choices` call includes this as the last option. The app automatically appends "Enter your own" below it.
+- **"Show me more ideas" is always available.** Every `present_choices` call includes this as the last option. The app automatically prepends "Enter your own" above the list as the first option.
 - **Pre-finalize review is mandatory.** Before calling `finalize_setup`, the agent reads back the full configuration in natural language and asks the player to confirm or request changes.
 - **Setup is dramatic.** The setup agent has personality — it's not a form wizard, it's the opening act. It sets the tone before the DM (Opus) takes over.
 - **Mechanical work is delegated.** PDF imports, file creation, rule parsing, and chargen mechanics run on Haiku or in code.

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -337,10 +337,10 @@ A core UX element. The DM (or the engine) presents the player with structured op
 
 ```
 The passage forks ahead.
-▲  > ◆ Left — you hear running water
-▼    ◆ Right — a draft smells of smoke
+▲    ◆ Enter your own...
+▼  > ◆ Left — you hear running water
+     ◆ Right — a draft smells of smoke
      ◆ Listen carefully first
-     ◆ Enter your own...
 
                             ESC dismiss
 ```

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -394,7 +394,6 @@ export function PlayingPhase() {
       choices={activeChoices.choices ?? []}
       descriptions={activeChoices.descriptions}
       maxChoiceRows={choiceRowBudget(visibleElements, 1, hasDescriptions, DESCRIPTION_ROWS)}
-      initialIndex={1}
       onSelect={handleChoiceSelect}
       onNarrativeScroll={handleNarrativeScroll}
       isActive={!menuOpen && !activeModal && !apiErrorModalActive}

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -394,7 +394,7 @@ export function PlayingPhase() {
       choices={activeChoices.choices ?? []}
       descriptions={activeChoices.descriptions}
       maxChoiceRows={choiceRowBudget(visibleElements, 1, hasDescriptions, DESCRIPTION_ROWS)}
-      initialIndex={0}
+      initialIndex={1}
       onSelect={handleChoiceSelect}
       onNarrativeScroll={handleNarrativeScroll}
       isActive={!menuOpen && !activeModal && !apiErrorModalActive}

--- a/packages/client-ink/src/tui/components/InlineTextInput.tsx
+++ b/packages/client-ink/src/tui/components/InlineTextInput.tsx
@@ -125,6 +125,10 @@ export interface InlineTextInputProps {
   placeholder?: string;
   /** When true, text wraps to multiple lines instead of scrolling horizontally. Requires availableWidth. */
   wrap?: boolean;
+  /** Cap on visible wrap lines. When the text wraps past this many lines, the
+   *  rendered window scrolls vertically to keep the cursor line in view.
+   *  Only applies in wrap mode. */
+  maxLines?: number;
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
 }
@@ -134,7 +138,7 @@ export interface InlineTextInputProps {
  * Supports: left/right arrows, Home/End, Ctrl+A/E, backspace.
  * Clear by changing the React `key` prop.
  */
-export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled = false, defaultValue = "", availableWidth, placeholder, wrap, onChange, onSubmit }: InlineTextInputProps) {
+export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled = false, defaultValue = "", availableWidth, placeholder, wrap, maxLines, onChange, onSubmit }: InlineTextInputProps) {
   const initialState: State = {
     value: defaultValue,
     cursorOffset: defaultValue.length,
@@ -385,7 +389,20 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
     const cursorLine = Math.floor(cursorOffset / w);
     const cursorCol = cursorOffset % w;
 
-    return textLines.map((line, lineIdx) => {
+    // When the wrapped lines exceed maxLines, scroll the window vertically
+    // so the cursor line stays in view. Show the last maxLines lines that
+    // still include the cursor — typically a tail-anchored window.
+    let viewStartLine = 0;
+    let viewLines = textLines;
+    if (maxLines != null && maxLines > 0 && textLines.length > maxLines) {
+      // Keep cursorLine within [viewStartLine, viewStartLine + maxLines - 1].
+      viewStartLine = Math.max(0, cursorLine - maxLines + 1);
+      viewStartLine = Math.min(viewStartLine, textLines.length - maxLines);
+      viewLines = textLines.slice(viewStartLine, viewStartLine + maxLines);
+    }
+
+    return viewLines.map((line, idx) => {
+      const lineIdx = viewStartLine + idx;
       let styled: string;
       if (lineIdx === cursorLine) {
         if (cursorCol >= line.length) {
@@ -399,7 +416,7 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
       }
       return styled + " ".repeat(Math.max(0, w - line.length));
     });
-  }, [useWrap, isDisabled, renderState.value, renderState.cursorOffset, availableWidth, placeholder]);
+  }, [useWrap, isDisabled, renderState.value, renderState.cursorOffset, availableWidth, placeholder, maxLines]);
 
   if (wrappedLines) {
     return (

--- a/packages/client-ink/src/tui/components/InlineTextInput.tsx
+++ b/packages/client-ink/src/tui/components/InlineTextInput.tsx
@@ -130,6 +130,10 @@ export interface InlineTextInputProps {
    *  Only applies in wrap mode. */
   maxLines?: number;
   onChange?: (value: string) => void;
+  /** Fired whenever the cursor offset changes. Lets a parent that mirrors
+   *  the input's value also mirror cursor position (e.g. to replicate the
+   *  atEnd-only wrap-boundary line rule in wrap mode). */
+  onCursorOffsetChange?: (offset: number) => void;
   onSubmit?: (value: string) => void;
 }
 
@@ -138,7 +142,7 @@ export interface InlineTextInputProps {
  * Supports: left/right arrows, Home/End, Ctrl+A/E, backspace.
  * Clear by changing the React `key` prop.
  */
-export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled = false, defaultValue = "", availableWidth, placeholder, wrap, maxLines, onChange, onSubmit }: InlineTextInputProps) {
+export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled = false, defaultValue = "", availableWidth, placeholder, wrap, maxLines, onChange, onCursorOffsetChange, onSubmit }: InlineTextInputProps) {
   const initialState: State = {
     value: defaultValue,
     cursorOffset: defaultValue.length,
@@ -152,6 +156,8 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
 
   // Track last value reported to onChange to avoid duplicate callbacks.
   const lastReportedValueRef = useRef(defaultValue);
+  // Same pattern for cursor offset reporting.
+  const lastReportedCursorRef = useRef(defaultValue.length);
 
   const viewStartRef = useRef(0);
 
@@ -219,6 +225,14 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
       onChange?.(renderState.value);
     }
   }, [renderState.value, onChange]);
+
+  // Fire onCursorOffsetChange when cursor moves.
+  useEffect(() => {
+    if (renderState.cursorOffset !== lastReportedCursorRef.current) {
+      lastReportedCursorRef.current = renderState.cursorOffset;
+      onCursorOffsetChange?.(renderState.cursorOffset);
+    }
+  }, [renderState.cursorOffset, onCursorOffsetChange]);
 
   // Bracketed paste: pasted text arrives as one string and is never forwarded
   // to useInput, so embedded "\r" characters can't trigger a premature submit.

--- a/packages/client-ink/src/tui/modals/ChoiceModal.tsx
+++ b/packages/client-ink/src/tui/modals/ChoiceModal.tsx
@@ -111,10 +111,14 @@ export function ChoiceOverlay({
   const [selectedIndex, setSelectedIndex] = useState(defaultIndex);
   const [customInputActive, setCustomInputActive] = useState(defaultIndex === 0);
   const [customInputResetKey, setCustomInputResetKey] = useState(0);
-  // Mirrors the InlineTextInput's current value so the parent can size the
-  // custom-active row to its actual wrapped height (and the scroll/budget
-  // logic can count those lines).
+  // Mirrors the InlineTextInput's current value + cursor offset so the
+  // parent can size the custom-active row to its actual wrapped height
+  // (and the scroll/budget logic can count those lines). Tracking the
+  // cursor lets us match InlineTextInput's "extra empty wrap line only
+  // when atEnd" rule exactly — without this, moving the cursor mid-text
+  // would leave the parent's count one line too high.
   const [customInputValue, setCustomInputValue] = useState("");
+  const [customCursorOffset, setCustomCursorOffset] = useState(0);
   const scrollStartRef = useRef(0);
 
   // Reset state when choices change (e.g. choice-generator replaces DM-provided choices).
@@ -126,16 +130,24 @@ export function ChoiceOverlay({
     setCustomInputActive(idx === 0);
     setCustomInputResetKey((k) => k + 1);
     setCustomInputValue("");
+    setCustomCursorOffset(0);
     scrollStartRef.current = 0;
   }, [choicesKey, initialIndex, choices.length]);
 
   useInput((input, key) => {
     if (customInputActive) {
-      if (key.escape) { setCustomInputActive(false); return; }
+      if (key.escape) {
+        setCustomInputActive(false);
+        setCustomInputResetKey((k) => k + 1);
+        setCustomInputValue("");
+        setCustomCursorOffset(0);
+        return;
+      }
       if (key.downArrow) {
         setCustomInputActive(false);
         setCustomInputResetKey((k) => k + 1);
         setCustomInputValue("");
+        setCustomCursorOffset(0);
         setSelectedIndex(choices.length > 0 ? 1 : 0);
         return;
       }
@@ -193,16 +205,17 @@ export function ChoiceOverlay({
   //   - Idle (input not active): always 1 line ("Enter your own...").
   //   - Active and empty: 1 line (cursor + placeholder).
   //   - Active with text: ceil(len / w), plus an extra empty wrap line when
-  //     the value lands on a wrap boundary so the cursor has somewhere to sit.
-  //   Mirrors the textLines computation inside InlineTextInput so the
-  //   parent's budget matches what gets drawn. Capped at `choiceRows` so
-  //   long input scrolls *inside* the InlineTextInput (via maxLines) rather
-  //   than spilling past the bottom of the overlay.
+  //     the cursor sits at the end *and* the value lands on a wrap boundary
+  //     (matches InlineTextInput's `atEnd && len % w === 0` rule — without
+  //     the cursor check, moving off the end would over-count by 1 line).
+  // Capped at `choiceRows` so long input scrolls *inside* the InlineTextInput
+  // (via maxLines) rather than spilling past the bottom of the overlay.
   let customLineCount = 1;
   if (customInputActive && customInputValue.length > 0) {
     const w = customInputWidth;
     const len = customInputValue.length;
-    customLineCount = Math.ceil(len / w) + (len % w === 0 ? 1 : 0);
+    const atEnd = customCursorOffset === len;
+    customLineCount = Math.ceil(len / w) + (atEnd && len % w === 0 ? 1 : 0);
   }
   const customLineCap = Math.max(1, choiceRows);
   customLineCount = Math.min(customLineCount, customLineCap);
@@ -399,6 +412,7 @@ export function ChoiceOverlay({
                 maxLines={customLineCap}
                 placeholder="Enter your own..."
                 onChange={setCustomInputValue}
+                onCursorOffsetChange={setCustomCursorOffset}
                 onSubmit={handleCustomInputSubmit}
               />
             </Box>

--- a/packages/client-ink/src/tui/modals/ChoiceModal.tsx
+++ b/packages/client-ink/src/tui/modals/ChoiceModal.tsx
@@ -46,7 +46,7 @@ interface ChoiceOverlayProps {
   accentColor?: string;
   /** Max visual rows for choice items. Defaults to MAX_CHOICE_ROWS (5). */
   maxChoiceRows?: number;
-  /** Initial selection index (e.g. choices.length to start on "Enter your own"). */
+  /** Initial selection index. 0 = "Enter your own" (always at the top); 1..choices.length = regular choices. */
   initialIndex?: number;
   /** Called when the player selects a choice (text) or submits custom input. */
   onSelect: (choice: string) => void;
@@ -65,6 +65,11 @@ const MAX_CHOICE_ROWS = 5;
 
 /**
  * Frameless choice list for embedding inside the Player Pane.
+ *
+ * "Enter your own" always sits at the top of the choice list (index 0).
+ * Choices are top-anchored: as items wrap to more visual rows, the list
+ * extends downward (pushing later options down) while the freeform row
+ * stays put.
  *
  * Without descriptions — 7-row layout:
  *   Row 0: prompt text
@@ -98,31 +103,40 @@ export function ChoiceOverlay({
     : [];
 
   const showCustomInput = true;
-  const totalOptions = choices.length + 1; // +1 for "Enter your own"
-  const defaultIndex = initialIndex ?? (choices.length < 5 ? choices.length : 0);
+  const totalOptions = choices.length + 1; // +1 for "Enter your own" (index 0)
+  // "Enter your own" sits at index 0. For short lists, default focus there
+  // so the player can type without navigating; for long lists, default to
+  // the first real choice (index 1).
+  const defaultIndex = initialIndex ?? (choices.length < 5 ? 0 : 1);
   const [selectedIndex, setSelectedIndex] = useState(defaultIndex);
-  const [customInputActive, setCustomInputActive] = useState(defaultIndex === choices.length);
+  const [customInputActive, setCustomInputActive] = useState(defaultIndex === 0);
   const [customInputResetKey, setCustomInputResetKey] = useState(0);
+  // Mirrors the InlineTextInput's current value so the parent can size the
+  // custom-active row to its actual wrapped height (and the scroll/budget
+  // logic can count those lines).
+  const [customInputValue, setCustomInputValue] = useState("");
   const scrollStartRef = useRef(0);
 
   // Reset state when choices change (e.g. choice-generator replaces DM-provided choices).
   // Keyed on the serialized choices array so we only reset when actual options change.
   const choicesKey = rawChoices.join("\0");
   useEffect(() => {
-    const idx = initialIndex ?? (choices.length < 5 ? choices.length : 0);
+    const idx = initialIndex ?? (choices.length < 5 ? 0 : 1);
     setSelectedIndex(idx);
-    setCustomInputActive(idx === choices.length);
+    setCustomInputActive(idx === 0);
     setCustomInputResetKey((k) => k + 1);
+    setCustomInputValue("");
     scrollStartRef.current = 0;
   }, [choicesKey, initialIndex, choices.length]);
 
   useInput((input, key) => {
     if (customInputActive) {
       if (key.escape) { setCustomInputActive(false); return; }
-      if (key.upArrow) {
+      if (key.downArrow) {
         setCustomInputActive(false);
         setCustomInputResetKey((k) => k + 1);
-        setSelectedIndex(choices.length - 1);
+        setCustomInputValue("");
+        setSelectedIndex(choices.length > 0 ? 1 : 0);
         return;
       }
       if (key.pageUp || key.pageDown) {
@@ -132,21 +146,24 @@ export function ChoiceOverlay({
       return;
     }
 
-    if (key.upArrow) { setSelectedIndex((i) => Math.max(0, i - 1)); return; }
-    if (key.downArrow) {
+    if (key.upArrow) {
       setSelectedIndex((i) => {
-        const next = Math.min(totalOptions - 1, i + 1);
-        if (next === choices.length) setCustomInputActive(true);
+        const next = Math.max(0, i - 1);
+        if (next === 0) setCustomInputActive(true);
         return next;
       });
       return;
     }
+    if (key.downArrow) {
+      setSelectedIndex((i) => Math.min(totalOptions - 1, i + 1));
+      return;
+    }
     if (key.return) {
-      if (selectedIndex === choices.length) {
+      if (selectedIndex === 0) {
         setCustomInputActive(true);
         return;
       }
-      const chosen = stripLeadingBullet(stripFormatting(choices[selectedIndex]));
+      const chosen = stripLeadingBullet(stripFormatting(choices[selectedIndex - 1]));
       onSelect(chosen);
       return;
     }
@@ -170,9 +187,38 @@ export function ChoiceOverlay({
   // Prefix layout: [arrow 1ch][gap 1ch][cursor 1ch][space 1ch] = 4 chars
   const prefixWidth = 4;
   const labelWidth = Math.max(1, width - prefixWidth);
+  const customInputWidth = Math.max(1, width - prefixWidth);
+
+  // Visual line count for the custom-input row.
+  //   - Idle (input not active): always 1 line ("Enter your own...").
+  //   - Active and empty: 1 line (cursor + placeholder).
+  //   - Active with text: ceil(len / w), plus an extra empty wrap line when
+  //     the value lands on a wrap boundary so the cursor has somewhere to sit.
+  //   Mirrors the textLines computation inside InlineTextInput so the
+  //   parent's budget matches what gets drawn. Capped at `choiceRows` so
+  //   long input scrolls *inside* the InlineTextInput (via maxLines) rather
+  //   than spilling past the bottom of the overlay.
+  let customLineCount = 1;
+  if (customInputActive && customInputValue.length > 0) {
+    const w = customInputWidth;
+    const len = customInputValue.length;
+    customLineCount = Math.ceil(len / w) + (len % w === 0 ? 1 : 0);
+  }
+  const customLineCap = Math.max(1, choiceRows);
+  customLineCount = Math.min(customLineCount, customLineCap);
 
   interface WrappedItem { index: number; isCustom: boolean; lines: FormattingNode[][] }
   const allItems: WrappedItem[] = [];
+  if (showCustomInput) {
+    const customLines: FormattingNode[][] = customInputActive
+      ? Array.from({ length: customLineCount }, () => [] as FormattingNode[])
+      : [["Enter your own..."]];
+    allItems.push({
+      index: 0,
+      isCustom: true,
+      lines: customLines,
+    });
+  }
   for (let i = 0; i < choices.length; i++) {
     const nodes = parseFormatting(choices[i]);
     const lines = wrapNodes(nodes, labelWidth);
@@ -182,14 +228,7 @@ export function ChoiceOverlay({
       const lastLine = lines[MAX_CHOICE_ROWS - 1];
       lines[MAX_CHOICE_ROWS - 1] = [...lastLine, "…"];
     }
-    allItems.push({ index: i, isCustom: false, lines });
-  }
-  if (showCustomInput) {
-    allItems.push({
-      index: choices.length,
-      isCustom: true,
-      lines: [["Enter your own..."]],
-    });
+    allItems.push({ index: i + 1, isCustom: false, lines });
   }
 
   // Find visible window: fit items within choiceRows visual rows,
@@ -256,9 +295,10 @@ export function ChoiceOverlay({
       ? prompt.slice(0, width - 1) + "…"
       : prompt;
 
-  // Description for highlighted choice (word-wrapped to fixed rows)
-  const descText = hasDescriptions && selectedIndex < (descriptions?.length ?? 0)
-    ? (descriptions ?? [])[selectedIndex] ?? ""
+  // Description for highlighted choice (word-wrapped to fixed rows).
+  // selectedIndex 0 = "Enter your own" (no description); 1..N = choices[i-1].
+  const descText = hasDescriptions && selectedIndex > 0 && (selectedIndex - 1) < (descriptions?.length ?? 0)
+    ? (descriptions ?? [])[selectedIndex - 1] ?? ""
     : "";
   const descLines: FormattingNode[][] = hasDescriptions ? wrapToFixedRows(descText, width, DESCRIPTION_ROWS) : [];
 
@@ -267,17 +307,12 @@ export function ChoiceOverlay({
     ? "↵ submit  ESC back"
     : "↵ select";
 
-  const customInputWidth = Math.max(1, width - prefixWidth);
-
   return (
     <Box flexDirection="column" flexGrow={1} width={width}>
       {/* Row 0: prompt text */}
       <Box>
         <Text>{displayPrompt}</Text>
       </Box>
-
-      {/* Growth space: empty area between prompt and bottom-justified choices */}
-      <Box flexGrow={1} />
 
       {/* Description region (fixed height, only when descriptions provided) */}
       {hasDescriptions && (
@@ -292,6 +327,13 @@ export function ChoiceOverlay({
 
       {/* Choice rows — arrow column (col 0) + cursor column (col 1) */}
       {visualRows.map((row, rowIdx) => {
+        // The active custom input renders all its visual lines from a single
+        // InlineTextInput placed on the first row. Drop the placeholder rows
+        // for lines 1..N-1 so they don't double-count vertically.
+        if (row.isCustom && customInputActive && !row.isItemFirstLine) {
+          return null;
+        }
+
         const isSelected = row.itemIndex === selectedIndex;
 
         // Arrow column: ▲ on row 0, ▼ on row 1 — bright when scrollable, dimmed otherwise
@@ -318,17 +360,45 @@ export function ChoiceOverlay({
           ? <Text color={accentColor}>{" " + cursorStr + " "}</Text>
           : <Text>{" " + cursorStr + " "}</Text>;
 
-        // Special rendering for active custom input — wraps to multiple lines
+        // Special rendering for active custom input — wraps to multiple lines.
+        // The arrow and cursor columns are rendered as their own N-tall
+        // columns so they line up row-by-row with the InlineTextInput's
+        // wrapped lines (in particular, ▼ stays visible on the second visual
+        // line when the input has wrapped).
         if (row.isCustom && customInputActive && row.isItemFirstLine) {
+          const arrowColumn = Array.from({ length: customLineCount }, (_, i) => {
+            if (i === 0) {
+              return canScrollUp
+                ? <Text key={i} color="#aaff00">▲</Text>
+                : <Text key={i} dimColor>▲</Text>;
+            }
+            if (i === 1) {
+              return canScrollDown
+                ? <Text key={i} color="#aaff00">▼</Text>
+                : <Text key={i} dimColor>▼</Text>;
+            }
+            return <Text key={i}> </Text>;
+          });
+          const cursorColumn = Array.from({ length: customLineCount }, (_, i) => {
+            if (i === 0) {
+              return accentColor
+                ? <Text key={i} color={accentColor}>{" > "}</Text>
+                : <Text key={i}>{" > "}</Text>;
+            }
+            return <Text key={i}>{"   "}</Text>;
+          });
           return (
             <Box key="custom-active">
-              {arrowElement}{cursorElement}
+              <Box flexDirection="column">{arrowColumn}</Box>
+              <Box flexDirection="column">{cursorColumn}</Box>
               <InlineTextInput
                 key={customInputResetKey}
                 isDisabled={!isActive}
                 availableWidth={customInputWidth}
                 wrap
+                maxLines={customLineCap}
                 placeholder="Enter your own..."
+                onChange={setCustomInputValue}
                 onSubmit={handleCustomInputSubmit}
               />
             </Box>
@@ -342,6 +412,10 @@ export function ChoiceOverlay({
           </Box>
         );
       })}
+
+      {/* Growth space: pushes help to the bottom while choices stay top-anchored,
+        * so wrapped choices expand downward (not upward) into the empty area. */}
+      <Box flexGrow={1} />
 
       {/* Bottom row: right-aligned help */}
       <Box justifyContent="flex-end">

--- a/packages/client-ink/src/tui/modals/modals.test.tsx
+++ b/packages/client-ink/src/tui/modals/modals.test.tsx
@@ -132,7 +132,7 @@ describe("ChoiceOverlay", () => {
         width={60}
         prompt="What do you do?"
         choices={["Attack", "Flee", "Negotiate"]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );
@@ -152,7 +152,7 @@ describe("ChoiceOverlay", () => {
         width={60}
         prompt="Pick one"
         choices={["A", "B", "C", "D", "E", "F", "G"]}
-        initialIndex={5}
+        initialIndex={6}
         onSelect={noop}
       />,
     );
@@ -170,7 +170,7 @@ describe("ChoiceOverlay", () => {
         width={60}
         prompt="Pick one"
         choices={["A", "B", "C", "D", "E", "F", "G"]}
-        initialIndex={6}
+        initialIndex={7}
         onSelect={noop}
       />,
     );
@@ -207,7 +207,7 @@ describe("ChoiceOverlay", () => {
         width={60}
         prompt="Pick one"
         choices={["A", "B"]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );
@@ -223,7 +223,7 @@ describe("ChoiceOverlay", () => {
         width={60}
         prompt="Pick one"
         choices={["A", "B"]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );
@@ -238,21 +238,40 @@ describe("ChoiceOverlay", () => {
         width={60}
         prompt="What do you do?"
         choices={["Attack", "Flee"]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );
     expect(lastFrame()!).toContain("Enter your own...");
   });
 
+  it("shows Enter your own at the top of the list", () => {
+    const { lastFrame } = render(
+      <ChoiceOverlay
+        width={60}
+        prompt="What do you do?"
+        choices={["Attack", "Flee"]}
+        initialIndex={1}
+        onSelect={noop}
+      />,
+    );
+    const lines = lastFrame()!.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+    const customRow = lines.findIndex((l) => l.includes("Enter your own"));
+    const attackRow = lines.findIndex((l) => l.includes("Attack"));
+    const fleeRow = lines.findIndex((l) => l.includes("Flee"));
+    expect(customRow).toBeGreaterThanOrEqual(0);
+    expect(customRow).toBeLessThan(attackRow);
+    expect(attackRow).toBeLessThan(fleeRow);
+  });
+
   it("shows submit/back help text when custom input is active", () => {
-    // initialIndex = choices.length activates custom input mode
+    // initialIndex = 0 activates custom input mode (custom is at the top now)
     const { lastFrame } = render(
       <ChoiceOverlay
         width={60}
         prompt="What do you do?"
         choices={["Attack"]}
-        initialIndex={1}
+        initialIndex={0}
         onSelect={noop}
       />,
     );
@@ -270,7 +289,7 @@ describe("ChoiceOverlay", () => {
           "<color=#cc4444>Dread and Horror</color> — Slow burn",
           "<b>Grim Survival</b> — Desperate",
         ]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );
@@ -291,7 +310,7 @@ describe("ChoiceOverlay", () => {
         width={60}
         prompt="Pick"
         choices={["A", "B", "C"]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );
@@ -309,7 +328,7 @@ describe("ChoiceOverlay", () => {
           "A <b>dark</b> and <color=#22aa44>mossy</color> trail",
           "Echoing <i>whispers</i> from within",
         ]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );
@@ -332,7 +351,8 @@ describe("ChoiceOverlay", () => {
         width={40}
         prompt="What next?"
         choices={[longChoice, "◆ Rest"]}
-        initialIndex={0}
+        initialIndex={1}
+        maxChoiceRows={10}
         onSelect={noop}
       />,
     );
@@ -351,7 +371,7 @@ describe("ChoiceOverlay", () => {
         width={30}
         prompt="Pick"
         choices={[longChoice, "◆ Short"]}
-        initialIndex={0}
+        initialIndex={1}
         onSelect={noop}
       />,
     );


### PR DESCRIPTION
## Summary

- "Enter your own" now sits at the top of the choice list (index 0). Choice indices shift to 1..N. The overlay is top-anchored: wrapping a choice pushes following options downward, and the freeform row stays put.
- Custom-input wrap is layout-aware. `ChoiceOverlay` mirrors the `InlineTextInput` value via `onChange` and sizes the custom row to its actual wrapped line count, so the existing scroll-budget logic correctly hides choices as the input grows. ▼ stays visible on the second wrap line via column-direction arrow/cursor columns aligned with the wrapped input.
- `InlineTextInput` gained a `maxLines` prop for wrap mode — when the text wraps past the cap, the visible window slides to keep the cursor line in view. `ChoiceOverlay` passes the choice-row budget as the cap, so typing past available height scrolls the input internally instead of disappearing off the bottom of the overlay.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc -b` clean
- [x] `npx vitest run --changed` (153 passed)
- [x] `npx vitest run packages/client-ink/src/tui/modals/modals.test.tsx` (36 passed)
- [ ] Manual: open a `present_choices` overlay, confirm "Enter your own" appears first and choices stay anchored when it's selected.
- [ ] Manual: type into the freeform input past one line — choices should push downward, then scroll out of view as the input fills the choice budget.
- [ ] Manual: keep typing past the cap — input should scroll internally with the cursor on the bottom-most visible line, no content drawn below the help row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)