### PR TITLE
Expand TUI theme library: 11 frame families, 31 new themes

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -283,12 +283,24 @@ An optional `keyColor` (hex) shifts the swatch hue to center on that color, allo
 
 ### Built-in themes
 
-| Theme | Genre tags | Height | Feel |
+35 themes ship in `assets/`, grouped by the underlying ASCII frame family:
+
+| Frame family | Themes | Height | Feel |
 |---|---|---|---|
-| `gothic` | grimdark, horror, dark_fantasy | 2 | Double-line box-drawing, muted colors |
-| `arcane` | high_fantasy, epic | 2 | Ornate Unicode flourishes |
-| `terminal` | sci-fi, cyberpunk | 1 | Single-line ASCII |
-| `clean` | modern, freeform | 1 | Minimal borders |
+| `clean` | `clean` | 1 | Minimal borders |
+| `terminal` | `terminal`, `cold_steel`, `bio_lab`, `klaxon`, `neon_grid`, `soft_machine` | 1 | Single-line ASCII / circuit boards |
+| `noir` | `whiskey_neon`, `cold_open`, `wet_pavement` | 1 | Thin cinematic single-line |
+| `arcane` | `arcane` | 2 | Ornate Unicode flourishes |
+| `gothic` | `gothic` | 2 | Double-line box-drawing, muted |
+| `scriptorium` | `scriptorium`, `palimpsest`, `bonfire_letter`, `field_notes`, `glitched_margin` | 2 | Illuminated manuscript / loose-leaf |
+| `tendrils` | `forest_fey`, `bloom_horror`, `wild_growth`, `congregation` | 2 | Vines, fey woods, choking growth |
+| `rune` | `old_oaths`, `salt_throne`, `elder_stone` | 2 | Runestone, angular, weighty |
+| `bone` | `mortuary`, `wraithlight`, `inner_dark` | 2 | Skeletal, broken, dust |
+| `starlight` | `void`, `nebula`, `signal_noise` | 2 | Sparse star drift, deep space |
+| `brass` | `clockwork`, `corporate_dread` | 2 | Brass plate, gears, ledger |
+| `woven` | `hearth`, `autumn_market`, `sunday_morning` | 2 | Basket weave, quilt, slice-of-life |
+
+Each theme files its own `@genre_tags` and may override `[colors]`, `[variant_combat]`, `[variant_ooc]`, etc. for mood. Run `node --import tsx/esm tools/theme-editor/scripts/validate.mjs` after editing to confirm a theme still parses and resolves all variants.
 
 ### Location-scoped themes
 

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -300,7 +300,7 @@ An optional `keyColor` (hex) shifts the swatch hue to center on that color, allo
 | `brass` | `clockwork`, `corporate_dread` | 2 | Brass plate, gears, ledger |
 | `woven` | `hearth`, `autumn_market`, `sunday_morning` | 2 | Basket weave, quilt, slice-of-life |
 
-Each theme files its own `@genre_tags` and may override `[colors]`, `[variant_combat]`, `[variant_ooc]`, etc. for mood. Run `node --import tsx/esm tools/theme-editor/scripts/validate.mjs` after editing to confirm a theme still parses and resolves all variants.
+Each theme declares its own `@genre_tags` and may override `[colors]`, `[variant_combat]`, `[variant_ooc]`, etc. for mood. Run `node --import tsx/esm tools/theme-editor/scripts/validate.mjs` after editing to confirm a theme still parses and resolves all variants.
 
 ### Location-scoped themes
 

--- a/packages/client-ink/src/tui/frames/renderer.ts
+++ b/packages/client-ink/src/tui/frames/renderer.ts
@@ -3,6 +3,9 @@ import { Text } from "ink";
 import type { FormattingNode, FrameStyleVariant } from "@machine-violet/shared/types/tui.js";
 import { toPlainText, parseFormatting } from "../formatting.js";
 import { renderNodes } from "../render-nodes.js";
+import { stringWidth, truncateToWidth } from "./string-width.js";
+
+export { stringWidth, truncateToWidth };
 
 /** ASCII fallback for terminals that can't render Unicode box-drawing */
 const ASCII_VARIANT: FrameStyleVariant = {
@@ -198,25 +201,6 @@ export function renderVerticalFrame(
   }
   // Width 2: border char + padding space (inside edge)
   return side === "left" ? `${v.vertical} ` : ` ${v.vertical}`;
-}
-
-/**
- * Approximate string width (handles most common cases).
- * Does not handle full Unicode width detection — just counts characters.
- */
-export function stringWidth(str: string): number {
-  // Strip ANSI escape codes
-  // eslint-disable-next-line no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, "").length;
-}
-
-/**
- * Truncate a string to a maximum display width.
- */
-export function truncateToWidth(str: string, maxWidth: number): string {
-  if (stringWidth(str) <= maxWidth) return str;
-  if (maxWidth <= 1) return str.slice(0, maxWidth);
-  return str.slice(0, maxWidth - 1) + "…";
 }
 
 /**

--- a/packages/client-ink/src/tui/frames/string-width.ts
+++ b/packages/client-ink/src/tui/frames/string-width.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure string-width helpers used by the frame renderer and the .theme composer.
+ * Kept in their own module so the composer doesn't pull in the ink/React-laden
+ * renderer when imported from browser tools (e.g. the theme editor).
+ */
+
+/**
+ * Approximate string width (handles most common cases).
+ * Does not handle full Unicode width detection — just counts characters.
+ */
+export function stringWidth(str: string): number {
+  // Strip ANSI escape codes
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, "").length;
+}
+
+/**
+ * Truncate a string to a maximum display width.
+ */
+export function truncateToWidth(str: string, maxWidth: number): string {
+  if (stringWidth(str) <= maxWidth) return str;
+  if (maxWidth <= 1) return str.slice(0, maxWidth);
+  return str.slice(0, maxWidth - 1) + "…";
+}

--- a/packages/client-ink/src/tui/themes/assets/autumn_market.theme
+++ b/packages/client-ink/src/tui/themes/assets/autumn_market.theme
@@ -1,0 +1,100 @@
+<!-- Autumn Market Theme
+     Woven frame set, autumn-recolored. Same diamond-weave border, but
+     ember/split-complementary/shimmer turns it into pumpkin and persimmon
+     with cool teal piping in the seams — a stall canopy at the harvest
+     fair, a knit scarf on a folding chair, jam jars catching October light.
+
+     Suited to: Customer Support, The Roommate, HOA from Hell — suburban
+     comedy where neighbors run feuds the way armies run wars, but with
+     casseroles instead of campaigns.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: autumn_market
+@genre_tags: cozy, comedy, suburb, slice_of_life, community
+@height: 2
+
+[colors]
+preset: ember
+harmony: split-complementary
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- The neighborhood meeting boils over -->
+border: 6
+corner: 7
+gradient: vignette
+
+[variant_ooc]
+<!-- Friendly aside — pull to cool anchor 1 -->
+border: 102
+corner: 103
+gradient: none
+
+[variant_dev]
+<!-- The HOA bylaws spreadsheet — anchor 2 -->
+border: 202
+corner: 203
+gradient: shimmer
+
+[corner_tl]
+╭◇
+│
+
+[corner_tr]
+◇╮
+ │
+
+[corner_bl]
+│
+╰◇
+
+[corner_br]
+ │
+◇╯
+
+[edge_top]
+◇◈
+··
+
+[edge_bottom]
+··
+◇◈
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+─╋
+ ·
+
+[separator_right_top]
+╋─
+·
+
+[separator_left_bottom]
+ ·
+─╋
+
+[separator_right_bottom]
+·
+╋─
+
+[turn_separator]
+◇◈◇── ✦ ──◇◈◇

--- a/packages/client-ink/src/tui/themes/assets/bio_lab.theme
+++ b/packages/client-ink/src/tui/themes/assets/bio_lab.theme
@@ -1,0 +1,90 @@
+<!-- Bio Lab Theme
+     Circuit frame on living foliage. Same dashed PCB lines and bracket
+     separators as `neon_grid`, but the foliage preset roots them in
+     greenhouse chlorophyll, with split-complementary anchors pulling
+     into magenta-bloom and amber-rot directions. Shimmer keeps the
+     palette breathing, like a culture plate left under the warm lights.
+
+     Suited to: The Thaw, Good Soil, Decommissioned, splicer subcultures,
+     genelab incident reports, cryptids in petri dishes.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: bio_lab
+@genre_tags: sci_fi, biopunk, horror, lab, organic_tech
+
+@height: 1
+
+[colors]
+preset: foliage
+harmony: split-complementary
+gradient: shimmer
+border: 3
+corner: 5
+separator: 6
+title: 7
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Containment breach: split-comp anchor 1 (magenta bloom) -->
+border: 105
+corner: 107
+separator: 106
+gradient: vignette
+
+[variant_ooc]
+<!-- Quiet lab: base anchor, no gradient -->
+border: 2
+corner: 4
+gradient: none
+
+[variant_levelup]
+<!-- Successful splice: anchor 2 warm bloom, shimmer -->
+border: 205
+corner: 207
+gradient: shimmer
+
+[corner_tl]
+┌
+
+[corner_tr]
+┐
+
+[corner_bl]
+└
+
+[corner_br]
+┘
+
+[edge_top]
+─┈
+
+[edge_bottom]
+┈─
+
+[edge_left]
+│
+
+[edge_right]
+│
+
+[separator_left_top]
+┤
+
+[separator_right_top]
+├
+
+[separator_left_bottom]
+┤
+
+[separator_right_bottom]
+├
+
+[turn_separator]
+┈─┤ ❀ ├─┈

--- a/packages/client-ink/src/tui/themes/assets/bloom_horror.theme
+++ b/packages/client-ink/src/tui/themes/assets/bloom_horror.theme
@@ -1,0 +1,94 @@
+<!-- Bloom Horror Theme
+     Tendrils frame set, recolored. Beautiful-apocalypse palette: ember
+     hot in the petals, sickly secondaries in the curl. For campaigns
+     where something is blooming that shouldn't be.
+
+     Use for: The Bloom, Red Tide — the world is in flower, and the
+     flowers are wrong.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: bloom_horror
+@genre_tags: horror, body_horror, apocalypse, fantasy, bloom
+@height: 2
+
+[colors]
+preset: ember
+harmony: split-complementary
+gradient: vignette
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- Outbreak: lean into the split-complementary teal -->
+preset: ember
+harmony: split-complementary
+border: 104
+corner: 106
+gradient: hueShift
+
+[variant_ooc]
+<!-- Dormant spores: cool and quiet -->
+border: 202
+corner: 203
+gradient: none
+
+[corner_tl]
+╭~
+│
+
+[corner_tr]
+~╮
+ │
+
+[corner_bl]
+│
+╰~
+
+[corner_br]
+ │
+~╯
+
+[edge_top]
+~╌
+ ❀
+
+[edge_bottom]
+ ❀
+~╌
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+~❦
+ ·
+
+[separator_right_top]
+❦~
+·
+
+[separator_left_bottom]
+ ·
+~❦
+
+[separator_right_bottom]
+·
+❦~
+
+[turn_separator]
+~~╌╌── ✾ ──╌╌~~

--- a/packages/client-ink/src/tui/themes/assets/bonfire_letter.theme
+++ b/packages/client-ink/src/tui/themes/assets/bonfire_letter.theme
@@ -1,0 +1,94 @@
+<!-- Bonfire Letter Theme
+     Paper frame set. Torn loose-leaf edge with ragged corners, dashed
+     runs, and small ink-blot accents — letters spread on a kitchen
+     table by lamplight, a confession written then almost burned.
+     Ember/analogous/shimmer warms the page like firelight through
+     yellowed pulp.
+
+     Suited to: Heirloom, The Debt — wills and ledgers, hand-written
+     accusations, family secrets sealed in wax and opened too late.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: bonfire_letter
+@genre_tags: mystery, drama, family, period, melodrama
+@height: 2
+
+[colors]
+preset: ember
+harmony: analogous
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- The reveal — paper goes orange, ink darker -->
+border: 6
+corner: 7
+gradient: vignette
+
+[variant_ooc]
+<!-- Reading aloud, lamp low, palette quieted -->
+border: 102
+corner: 103
+gradient: none
+
+[corner_tl]
+╱┄
+│
+
+[corner_tr]
+┄╲
+ │
+
+[corner_bl]
+│
+╲┄
+
+[corner_br]
+ │
+┄╱
+
+[edge_top]
+┄·
+··
+
+[edge_bottom]
+··
+┄·
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+┄*
+ ·
+
+[separator_right_top]
+*┄
+·
+
+[separator_left_bottom]
+ ·
+┄*
+
+[separator_right_bottom]
+·
+*┄
+
+[turn_separator]
+╱┄·── ✦ ──·┄╲

--- a/packages/client-ink/src/tui/themes/assets/clockwork.theme
+++ b/packages/client-ink/src/tui/themes/assets/clockwork.theme
@@ -1,0 +1,103 @@
+<!-- Clockwork Theme
+     Brass frame for bureaucratic retrofuture. Round riveted corners,
+     double-line edges with a quiet shaded row underneath, and gear-disc
+     separators evoke a leatherbound ledger sitting on the desk of an
+     overworked clerk at the Department of Compliance. Ember preset in
+     warm analogous harmony with a soft vignette — the lamp on the desk
+     is the only light in the room.
+
+     Suited to: Customer Support, The Gravity Tax, Closing Time, paper
+     trails, filing-cabinet horror, the slow grind of process.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: clockwork
+@genre_tags: sci_fi, retrofuture, bureaucracy, steampunk, mystery
+
+@height: 2
+
+[colors]
+preset: ember
+harmony: analogous
+gradient: vignette
+border: 3
+corner: 5
+separator: 6
+title: 7
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Audit triggered: punch the ember saturation up, hueShift -->
+border: 5
+corner: 7
+separator: 6
+gradient: hueShift
+
+[variant_ooc]
+<!-- After hours: cool analogous anchor, lights low -->
+border: 102
+corner: 104
+gradient: none
+
+[variant_levelup]
+<!-- Promotion granted: warm anchor, ribbon-cutting glow -->
+border: 205
+corner: 207
+gradient: shimmer
+
+[corner_tl]
+◯═
+║·
+
+[corner_tr]
+═◯
+·║
+
+[corner_bl]
+║·
+◯═
+
+[corner_br]
+·║
+═◯
+
+[edge_top]
+══
+··
+
+[edge_bottom]
+··
+══
+
+[edge_left]
+║
+▓
+
+[edge_right]
+║
+▓
+
+[separator_left_top]
+═⊙
+ ·
+
+[separator_right_top]
+⊙═
+·
+
+[separator_left_bottom]
+ ·
+═⊙
+
+[separator_right_bottom]
+·
+⊙═
+
+[turn_separator]
+═══◍═── ⊛ ──═◍═══

--- a/packages/client-ink/src/tui/themes/assets/cold_open.theme
+++ b/packages/client-ink/src/tui/themes/assets/cold_open.theme
@@ -1,0 +1,83 @@
+<!-- Cold Open Theme
+     Noir frame set, recolored. Same minimal cinematic line, but pulled
+     toward bluish moonlight and pre-dawn fog instead of bar-sign amber.
+     Ethereal/analogous/vignette gives a quiet, dimmed palette — the
+     first sixty seconds of a thriller before the title card hits.
+
+     Suited to: Cold Open, The Hound and the Fox — espionage, dead-drops,
+     a body before the first commercial break, a chase you join already
+     in progress.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: cold_open
+@genre_tags: noir, espionage, thriller, mystery, modern
+@height: 1
+
+[colors]
+preset: ethereal
+harmony: analogous
+gradient: vignette
+border: 2
+corner: 4
+separator: 3
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- The chase — sharper, brighter, eyes wide -->
+border: 5
+corner: 6
+separator: 5
+gradient: hueShift
+
+[variant_ooc]
+<!-- Debrief: shift to the warmer analogous anchor -->
+border: 102
+corner: 103
+gradient: none
+
+[corner_tl]
+╭┄
+
+[corner_tr]
+┄╮
+
+[corner_bl]
+╰┄
+
+[corner_br]
+┄╯
+
+[edge_top]
+┄┈
+
+[edge_bottom]
+┈┄
+
+[edge_left]
+│
+
+[edge_right]
+│
+
+[separator_left_top]
+┄◦
+
+[separator_right_top]
+◦┄
+
+[separator_left_bottom]
+┄◦
+
+[separator_right_bottom]
+◦┄
+
+[turn_separator]
+┈┄┈── ◯ ──┈┄┈

--- a/packages/client-ink/src/tui/themes/assets/cold_steel.theme
+++ b/packages/client-ink/src/tui/themes/assets/cold_steel.theme
@@ -1,0 +1,91 @@
+<!-- Cold Steel Theme
+     Circuit frame stripped down to bone. Thin square corners, a single
+     hairline dashed run, and the ethereal preset on a complementary
+     two-anchor split — a cool steel-blue against a single warning
+     accent. Vignette pulls the periphery dark; what's left is the
+     readout, the cursor, and whatever you brought into the room.
+
+     Suited to: Cold Open, Floor 14 (sci-fi side), corporate-noir interrogations,
+     midnight server-room thefts, the side of cyberpunk that doesn't shout.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: cold_steel
+@genre_tags: sci_fi, noir, cyberpunk, minimal, thriller
+
+@height: 1
+
+[colors]
+preset: ethereal
+harmony: complementary
+gradient: vignette
+border: 2
+corner: 4
+separator: 5
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Move to the complement: warm accent ignites -->
+border: 105
+corner: 107
+separator: 106
+gradient: hueShift
+
+[variant_ooc]
+<!-- Damp everything down -->
+border: 1
+corner: 2
+gradient: none
+
+[variant_dev]
+<!-- Engineering layer: cyberpunk for diagnostics -->
+preset: cyberpunk
+border: 4
+corner: 6
+gradient: none
+
+[corner_tl]
+┌
+
+[corner_tr]
+┐
+
+[corner_bl]
+└
+
+[corner_br]
+┘
+
+[edge_top]
+╴╶
+
+[edge_bottom]
+╶╴
+
+[edge_left]
+│
+
+[edge_right]
+│
+
+[separator_left_top]
+┤
+
+[separator_right_top]
+├
+
+[separator_left_bottom]
+┤
+
+[separator_right_bottom]
+├
+
+[turn_separator]
+╶── ▪ ──╴

--- a/packages/client-ink/src/tui/themes/assets/congregation.theme
+++ b/packages/client-ink/src/tui/themes/assets/congregation.theme
@@ -1,0 +1,95 @@
+<!-- Congregation Theme
+     Tendrils frame set, recolored with cyberpunk palette. Organic
+     curls in saturated neon — the cult's flowers are alive in a
+     way they shouldn't be. Horror crossed with the wrong kind of
+     ecstasy.
+
+     Use for: Congregation, The Docent, Apocrypha — communion
+     with something that should have stayed buried.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: congregation
+@genre_tags: horror, cult, occult, ritual, body_horror
+@height: 2
+
+[colors]
+preset: cyberpunk
+harmony: split-complementary
+gradient: vignette
+border: 3
+corner: 5
+separator: 4
+title: 7
+turn_indicator: 106
+side_frame: 1
+
+[variant_combat]
+<!-- Rapture: lean to one split-complementary anchor with hueShift -->
+preset: cyberpunk
+harmony: split-complementary
+border: 106
+corner: 108
+gradient: hueShift
+
+[variant_ooc]
+<!-- Apostasy: cool secondary, flat -->
+border: 203
+corner: 204
+gradient: none
+
+[corner_tl]
+╭~
+│
+
+[corner_tr]
+~╮
+ │
+
+[corner_bl]
+│
+╰~
+
+[corner_br]
+ │
+~╯
+
+[edge_top]
+~╌
+ ❀
+
+[edge_bottom]
+ ❀
+~╌
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+~❦
+ ·
+
+[separator_right_top]
+❦~
+·
+
+[separator_left_bottom]
+ ·
+~❦
+
+[separator_right_bottom]
+·
+❦~
+
+[turn_separator]
+~~╌╌── ✺ ──╌╌~~

--- a/packages/client-ink/src/tui/themes/assets/corporate_dread.theme
+++ b/packages/client-ink/src/tui/themes/assets/corporate_dread.theme
@@ -1,0 +1,104 @@
+<!-- Corporate Dread Theme
+     Brass frame, but the brass has been replaced by injection-molded
+     polymer with a corporate logo embossed on it. Same riveted round
+     corners and gear-disc separators as `clockwork`, repainted in
+     cyberpunk triadic — three saturated brand anchors fighting for
+     dominance, with a vignette darkening the periphery the way a
+     well-lit boardroom darkens everything beyond the glass.
+
+     Suited to: Terms and Conditions, The Debt, Warranty Void, the
+     megacorp campaign, signing things you should not be signing.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: corporate_dread
+@genre_tags: sci_fi, cyberpunk, megacorp, dystopia, bureaucracy
+
+@height: 2
+
+[colors]
+preset: cyberpunk
+harmony: triadic
+gradient: vignette
+border: 3
+corner: 6
+separator: 7
+title: 8
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- Legal escalation: jump to triadic anchor 1, hueShift -->
+border: 106
+corner: 108
+separator: 107
+gradient: hueShift
+
+[variant_ooc]
+<!-- Breakroom: triadic anchor 2, dimmer -->
+border: 203
+corner: 205
+gradient: none
+
+[variant_dev]
+<!-- Sysadmin console: foliage green, no gradient -->
+preset: foliage
+border: 4
+corner: 6
+gradient: none
+
+[corner_tl]
+◯═
+║·
+
+[corner_tr]
+═◯
+·║
+
+[corner_bl]
+║·
+◯═
+
+[corner_br]
+·║
+═◯
+
+[edge_top]
+══
+··
+
+[edge_bottom]
+··
+══
+
+[edge_left]
+║
+▓
+
+[edge_right]
+║
+▓
+
+[separator_left_top]
+═◐
+ ·
+
+[separator_right_top]
+◑═
+·
+
+[separator_left_bottom]
+ ·
+═◐
+
+[separator_right_bottom]
+·
+◑═
+
+[turn_separator]
+══◍▓══ ▣ ══▓◍══

--- a/packages/client-ink/src/tui/themes/assets/elder_stone.theme
+++ b/packages/client-ink/src/tui/themes/assets/elder_stone.theme
@@ -1,0 +1,94 @@
+<!-- Elder Stone Theme
+     Rune frame set, recolored. Ethereal split-complementary with
+     shimmer — pale moon on grey monoliths. Slow, ancient, the
+     mountain has been here longer than language.
+
+     Use for: Teeth of the World, The Second Labyrinth — vast
+     places where time runs sideways.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: elder_stone
+@genre_tags: fantasy, mythic, ancient, dungeon, cosmic
+@height: 2
+
+[colors]
+preset: ethereal
+harmony: split-complementary
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Awakening: warm hueShift, the stone notices you -->
+preset: ember
+harmony: split-complementary
+border: 4
+corner: 6
+gradient: hueShift
+
+[variant_ooc]
+<!-- Stillness: secondary anchor, flat -->
+border: 202
+corner: 203
+gradient: none
+
+[corner_tl]
+◤━
+┃
+
+[corner_tr]
+━◥
+ ┃
+
+[corner_bl]
+┃
+◣━
+
+[corner_br]
+ ┃
+━◢
+
+[edge_top]
+━━
+··
+
+[edge_bottom]
+··
+━━
+
+[edge_left]
+┃
+┃
+
+[edge_right]
+┃
+┃
+
+[separator_left_top]
+━╋
+ ┃
+
+[separator_right_top]
+╋━
+┃
+
+[separator_left_bottom]
+ ┃
+━╋
+
+[separator_right_bottom]
+┃
+╋━
+
+[turn_separator]
+━━┳━── ✶ ──━┳━━

--- a/packages/client-ink/src/tui/themes/assets/field_notes.theme
+++ b/packages/client-ink/src/tui/themes/assets/field_notes.theme
@@ -1,0 +1,94 @@
+<!-- Field Notes Theme
+     Paper frame set, greened. Same torn page with margin-doodle asterisks,
+     but foliage/analogous/shimmer dyes the palette through moss, ink,
+     and damp lichen — a naturalist's journal carried in an oilcloth
+     pocket, smudged with rain and pressed leaves.
+
+     Suited to: Inkblot, Night Mail, Mise en Place — quiet observation,
+     small towns, recipes and route-numbers, the comfort of writing things
+     down as if they could be sorted by description alone.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: field_notes
+@genre_tags: cozy, slice_of_life, mystery, naturalist, journal
+@height: 2
+
+[colors]
+preset: foliage
+harmony: analogous
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- Storm on the trail — darker, vignette closer -->
+border: 5
+corner: 6
+gradient: vignette
+
+[variant_ooc]
+<!-- Around the kitchen table — soften to anchor 1 -->
+border: 102
+corner: 103
+gradient: none
+
+[corner_tl]
+╱┄
+│
+
+[corner_tr]
+┄╲
+ │
+
+[corner_bl]
+│
+╲┄
+
+[corner_br]
+ │
+┄╱
+
+[edge_top]
+┄·
+··
+
+[edge_bottom]
+··
+┄·
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+┄*
+ ·
+
+[separator_right_top]
+*┄
+·
+
+[separator_left_bottom]
+ ·
+┄*
+
+[separator_right_bottom]
+·
+*┄
+
+[turn_separator]
+··┄── ✿ ──┄··

--- a/packages/client-ink/src/tui/themes/assets/forest_fey.theme
+++ b/packages/client-ink/src/tui/themes/assets/forest_fey.theme
@@ -1,0 +1,94 @@
+<!-- Forest Fey Theme
+     Tendrils frame set. Organic vine-and-leaf borders for fey forests,
+     overgrown ruins, and old-magic wilderness campaigns. Rounded corners
+     unwind into curling tendrils; flourishes sprout small flowers.
+
+     Use for: Root and Ruin, The Shepherds, Hollowdeep — places where
+     the woods have something to say.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: forest_fey
+@genre_tags: fantasy, fey, druidic, wilderness, nature
+@height: 2
+
+[colors]
+preset: foliage
+harmony: analogous
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Brambles tighten: shift toward the hot-leaf secondary -->
+preset: foliage
+harmony: analogous
+border: 105
+corner: 106
+gradient: vignette
+
+[variant_ooc]
+<!-- Cool moss: pull to the cool secondary anchor -->
+border: 202
+corner: 203
+gradient: none
+
+[corner_tl]
+╭~
+│
+
+[corner_tr]
+~╮
+ │
+
+[corner_bl]
+│
+╰~
+
+[corner_br]
+ │
+~╯
+
+[edge_top]
+~╌
+ ❀
+
+[edge_bottom]
+ ❀
+~╌
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+~❦
+ ·
+
+[separator_right_top]
+❦~
+·
+
+[separator_left_bottom]
+ ·
+~❦
+
+[separator_right_bottom]
+·
+❦~
+
+[turn_separator]
+~~╌╌── ❀ ──╌╌~~

--- a/packages/client-ink/src/tui/themes/assets/glitched_margin.theme
+++ b/packages/client-ink/src/tui/themes/assets/glitched_margin.theme
@@ -1,0 +1,103 @@
+<!-- Glitched Margin Theme
+     Paper frame set, signal-corrupted. The torn loose-leaf line is still
+     there but cyberpunk/complementary/hueShift recasts every margin-doodle
+     as a CRT artifact — apocrypha photocopied past legibility, drafts of
+     a script the showrunner doesn't want you to read, footnotes that
+     argue with the manuscript.
+
+     Suited to: Apocrypha, Season Finale, The Understudies, Cartomancy —
+     metafiction, fourth-wall hijinks, comedy bits that get a little too
+     real, characters reading their own stage directions.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: glitched_margin
+@genre_tags: meta, comedy, surreal, metafiction, theatre
+@height: 2
+
+[colors]
+preset: cyberpunk
+harmony: complementary
+gradient: hueShift
+border: 3
+corner: 6
+separator: 5
+title: 8
+turn_indicator: 7
+side_frame: 1
+
+[variant_combat]
+<!-- The bit goes off the rails — flip to complement -->
+border: 105
+corner: 107
+gradient: vignette
+
+[variant_ooc]
+<!-- Notes-on-the-script: dim and ethereal -->
+preset: ethereal
+border: 2
+corner: 3
+gradient: shimmer
+
+[variant_dev]
+<!-- The writers' room is open — foliage green-screen -->
+preset: foliage
+border: 4
+corner: 5
+gradient: none
+
+[corner_tl]
+╱┄
+│
+
+[corner_tr]
+┄╲
+ │
+
+[corner_bl]
+│
+╲┄
+
+[corner_br]
+ │
+┄╱
+
+[edge_top]
+┄·
+··
+
+[edge_bottom]
+··
+┄·
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+┄*
+ ·
+
+[separator_right_top]
+*┄
+·
+
+[separator_left_bottom]
+ ·
+┄*
+
+[separator_right_bottom]
+·
+*┄
+
+[turn_separator]
+··┄·── ‹§› ──·┄··

--- a/packages/client-ink/src/tui/themes/assets/hearth.theme
+++ b/packages/client-ink/src/tui/themes/assets/hearth.theme
@@ -1,0 +1,100 @@
+<!-- Hearth Theme
+     Woven frame set. Basket-weave / quilt edges with alternating diamond
+     glyphs and small cross accents — like a hand-stitched border on a
+     café apron, or the trim on a winter blanket. Foliage/analogous/shimmer
+     keeps everything in the sage-and-moss family with a faint glow.
+
+     Suited to: The Coffee Shop, The Bake-Off — small businesses, regulars
+     who know your order, the comfort of a place that smells like flour
+     and steamed milk and someone's grandmother's perfume.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: hearth
+@genre_tags: cozy, slice_of_life, comedy, community, food
+@height: 2
+
+[colors]
+preset: foliage
+harmony: analogous
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- Lunch rush — push to brighter foliage anchors -->
+border: 5
+corner: 6
+gradient: vignette
+
+[variant_ooc]
+<!-- Closing time — settle to anchor 2 -->
+border: 202
+corner: 203
+gradient: none
+
+[variant_levelup]
+<!-- New recipe perfected — brighten -->
+border: 6
+corner: 7
+gradient: shimmer
+
+[corner_tl]
+╭◇
+│
+
+[corner_tr]
+◇╮
+ │
+
+[corner_bl]
+│
+╰◇
+
+[corner_br]
+ │
+◇╯
+
+[edge_top]
+◇◈
+··
+
+[edge_bottom]
+··
+◇◈
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+─╋
+ ·
+
+[separator_right_top]
+╋─
+·
+
+[separator_left_bottom]
+ ·
+─╋
+
+[separator_right_bottom]
+·
+╋─
+
+[turn_separator]
+◇◈◇── ❀ ──◇◈◇

--- a/packages/client-ink/src/tui/themes/assets/inner_dark.theme
+++ b/packages/client-ink/src/tui/themes/assets/inner_dark.theme
@@ -1,0 +1,94 @@
+<!-- Inner Dark Theme
+     Bone frame set, recolored. Cyberpunk complementary with
+     deep vignette — psychological horror, claustrophobia, the
+     room you can't leave because the room is your head.
+
+     Use for: The Tenant, Floor 14, Deep Tenancy — apartment
+     hauntings of the self.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: inner_dark
+@genre_tags: horror, psychological, urban, claustrophobic, modern
+@height: 2
+
+[colors]
+preset: cyberpunk
+harmony: complementary
+gradient: vignette
+border: 2
+corner: 5
+separator: 4
+title: 7
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- Break: complementary anchor explodes -->
+preset: cyberpunk
+harmony: complementary
+border: 105
+corner: 108
+gradient: hueShift
+
+[variant_ooc]
+<!-- Sedation: low chroma, flat -->
+border: 2
+corner: 3
+gradient: none
+
+[corner_tl]
+╷╌
+┊
+
+[corner_tr]
+╌╷
+ ┊
+
+[corner_bl]
+┊
+╵╌
+
+[corner_br]
+ ┊
+╌╵
+
+[edge_top]
+╌╌
+··
+
+[edge_bottom]
+··
+╌╌
+
+[edge_left]
+┊
+┊
+
+[edge_right]
+┊
+┊
+
+[separator_left_top]
+╌†
+ ·
+
+[separator_right_top]
+†╌
+·
+
+[separator_left_bottom]
+ ·
+╌†
+
+[separator_right_bottom]
+·
+†╌
+
+[turn_separator]
+··╌╌── ╳ ──╌╌··

--- a/packages/client-ink/src/tui/themes/assets/klaxon.theme
+++ b/packages/client-ink/src/tui/themes/assets/klaxon.theme
@@ -1,0 +1,90 @@
+<!-- Klaxon Theme
+     Circuit frame lit by emergency-bay lighting. Heavy single-line
+     borders, double-dash edges, and chevron-style separators evoke a
+     ship damage-control panel mid-incident: amber primary, with the
+     triadic alarm-red and warning-yellow anchors waiting to flash.
+
+     Suited to: Ember Protocol, Signal Lost, life-support failures,
+     reactor breach drills, anything where the lights are about to go red.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: klaxon
+@genre_tags: sci_fi, survival, emergency, horror, station
+
+@height: 1
+
+[colors]
+preset: ember
+harmony: triadic
+gradient: vignette
+border: 3
+corner: 5
+separator: 6
+title: 7
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- Hull breach: full red across the board -->
+border: 6
+corner: 7
+separator: 5
+gradient: hueShift
+
+[variant_ooc]
+<!-- Lights up, alarms off: swing to the second triadic anchor -->
+border: 103
+corner: 104
+separator: 102
+gradient: shimmer
+
+[variant_levelup]
+<!-- Repair-bay: third anchor, cooler tone -->
+border: 203
+corner: 205
+gradient: shimmer
+
+[corner_tl]
+┏
+
+[corner_tr]
+┓
+
+[corner_bl]
+┗
+
+[corner_br]
+┛
+
+[edge_top]
+━╾
+
+[edge_bottom]
+╼━
+
+[edge_left]
+┃
+
+[edge_right]
+┃
+
+[separator_left_top]
+┫
+
+[separator_right_top]
+┣
+
+[separator_left_bottom]
+┫
+
+[separator_right_bottom]
+┣
+
+[turn_separator]
+╾━━┫ ◈ ┣━━╼

--- a/packages/client-ink/src/tui/themes/assets/mortuary.theme
+++ b/packages/client-ink/src/tui/themes/assets/mortuary.theme
@@ -1,0 +1,94 @@
+<!-- Mortuary Theme
+     Bone frame set. Broken-line borders with skeletal cross
+     separators — fragmented strokes, daggers, dust. For
+     museum-after-dark and grave-keeper campaigns.
+
+     Use for: Taxidermy, Graveyard Shift — quiet rooms full of
+     things that used to be alive.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: mortuary
+@genre_tags: horror, gothic, death, museum, occult
+@height: 2
+
+[colors]
+preset: ember
+harmony: analogous
+gradient: vignette
+border: 2
+corner: 4
+separator: 3
+title: 5
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Reanimation: warm secondary, the dust stirs -->
+preset: ember
+harmony: analogous
+border: 105
+corner: 106
+gradient: vignette
+
+[variant_ooc]
+<!-- Cold storage: cool secondary, flat -->
+border: 202
+corner: 203
+gradient: none
+
+[corner_tl]
+╷╌
+┊
+
+[corner_tr]
+╌╷
+ ┊
+
+[corner_bl]
+┊
+╵╌
+
+[corner_br]
+ ┊
+╌╵
+
+[edge_top]
+╌╌
+··
+
+[edge_bottom]
+··
+╌╌
+
+[edge_left]
+┊
+┊
+
+[edge_right]
+┊
+┊
+
+[separator_left_top]
+╌†
+ ·
+
+[separator_right_top]
+†╌
+·
+
+[separator_left_bottom]
+ ·
+╌†
+
+[separator_right_bottom]
+·
+†╌
+
+[turn_separator]
+╌╌··── † ──··╌╌

--- a/packages/client-ink/src/tui/themes/assets/nebula.theme
+++ b/packages/client-ink/src/tui/themes/assets/nebula.theme
@@ -1,0 +1,102 @@
+<!-- Nebula Theme
+     Starlight frame in soft triad. Same sparse slash-corners and dotted
+     stellar drift as `void`, but recolored: the ethereal preset spreads
+     pastel violets, mints, and rose-tints across three triadic anchors,
+     with shimmer keeping the colors slowly breathing. The view is no
+     longer a cold cabin window — it's a wondrous unknown.
+
+     Suited to: The Interstitial, The Cartographer's Error, exploratory
+     surveys, encounters with phenomena nobody has named yet.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: nebula
+@genre_tags: sci_fi, exploration, mystery, wonder, space
+
+@height: 2
+
+[colors]
+preset: ethereal
+harmony: triadic
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Phenomenon turns hostile: triadic anchor 1 (sharper) -->
+border: 105
+corner: 107
+separator: 106
+gradient: vignette
+
+[variant_ooc]
+<!-- Tone down to base anchor, no gradient -->
+border: 2
+corner: 3
+gradient: none
+
+[variant_levelup]
+<!-- Revelation: anchor 2 (third triadic), brighter -->
+border: 205
+corner: 207
+gradient: shimmer
+
+[corner_tl]
+╲·
+ ⋅
+
+[corner_tr]
+·╱
+⋅
+
+[corner_bl]
+ ⋅
+╱·
+
+[corner_br]
+⋅
+·╲
+
+[edge_top]
+·⋅
+⋅·
+
+[edge_bottom]
+⋅·
+·⋅
+
+[edge_left]
+╎
+⋅
+
+[edge_right]
+╎
+⋅
+
+[separator_left_top]
+·✧
+ ⋅
+
+[separator_right_top]
+✧·
+⋅
+
+[separator_left_bottom]
+ ⋅
+·✧
+
+[separator_right_bottom]
+⋅
+✧·
+
+[turn_separator]
+⋅ · ✧ · ✦ · ✧ · ⋅

--- a/packages/client-ink/src/tui/themes/assets/neon_grid.theme
+++ b/packages/client-ink/src/tui/themes/assets/neon_grid.theme
@@ -1,0 +1,90 @@
+<!-- Neon Grid Theme
+     Circuit frame for high-saturation tech dystopia campaigns.
+     Square corners, dashed edges, and bracket separators evoke an IDE,
+     command-line tool, or PCB schematic. The cyberpunk preset with
+     complementary harmony lights up like neon under glass.
+
+     Suited to: The Algorithm, Severance Package, dataspike heists,
+     corp-net infiltration runs.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: neon_grid
+@genre_tags: sci_fi, cyberpunk, dystopia, hacking, tech
+@height: 1
+
+[colors]
+preset: cyberpunk
+harmony: complementary
+gradient: hueShift
+border: 3
+corner: 6
+separator: 7
+title: 8
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Alarm: shove everything to the complement and brighten -->
+border: 105
+corner: 107
+separator: 108
+gradient: vignette
+
+[variant_ooc]
+<!-- Dim the grid for OOC -->
+preset: ethereal
+border: 2
+corner: 3
+gradient: shimmer
+
+[variant_dev]
+<!-- Dev console: green-on-black terminal vibe via foliage -->
+preset: foliage
+border: 3
+corner: 5
+gradient: none
+
+[corner_tl]
+┌
+
+[corner_tr]
+┐
+
+[corner_bl]
+└
+
+[corner_br]
+┘
+
+[edge_top]
+─┄
+
+[edge_bottom]
+┄─
+
+[edge_left]
+│
+
+[edge_right]
+│
+
+[separator_left_top]
+┤
+
+[separator_right_top]
+├
+
+[separator_left_bottom]
+┤
+
+[separator_right_bottom]
+├
+
+[turn_separator]
+┄─┤ ▣ ├─┄

--- a/packages/client-ink/src/tui/themes/assets/old_oaths.theme
+++ b/packages/client-ink/src/tui/themes/assets/old_oaths.theme
@@ -1,0 +1,93 @@
+<!-- Old Oaths Theme
+     Rune frame set. Heavy angular runestone borders with chiseled
+     diagonal corners and bound-cross separators. For campaigns about
+     binding pacts, knightly orders, and oaths that cannot be unsaid.
+
+     Use for: Iron Saints, The Oath Eaters — promises with teeth.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: old_oaths
+@genre_tags: fantasy, grimdark, knightly, pact, oath
+@height: 2
+
+[colors]
+preset: ember
+harmony: analogous
+gradient: vignette
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Blood pact: deeper ember, lean to warm secondary -->
+preset: ember
+harmony: analogous
+border: 106
+corner: 107
+gradient: vignette
+
+[variant_ooc]
+<!-- Cold council: cool analogous anchor -->
+border: 202
+corner: 203
+gradient: none
+
+[corner_tl]
+◤━
+┃
+
+[corner_tr]
+━◥
+ ┃
+
+[corner_bl]
+┃
+◣━
+
+[corner_br]
+ ┃
+━◢
+
+[edge_top]
+━━
+··
+
+[edge_bottom]
+··
+━━
+
+[edge_left]
+┃
+┃
+
+[edge_right]
+┃
+┃
+
+[separator_left_top]
+━╋
+ ┃
+
+[separator_right_top]
+╋━
+┃
+
+[separator_left_bottom]
+ ┃
+━╋
+
+[separator_right_bottom]
+┃
+╋━
+
+[turn_separator]
+━━┳━── ✦ ──━┳━━

--- a/packages/client-ink/src/tui/themes/assets/palimpsest.theme
+++ b/packages/client-ink/src/tui/themes/assets/palimpsest.theme
@@ -1,0 +1,100 @@
+<!-- Palimpsest Theme
+     Paper frame set, ethereally recolored. Same torn loose-leaf edges,
+     but ethereal/triadic/shimmer drifts the palette across cool blues,
+     dusty lavenders, and pale gold — a manuscript scraped and rewritten,
+     three texts visible through the parchment when held to candle.
+
+     Suited to: Palimpsest, Cartomancy, The Bureau of Forgotten Things —
+     archives where the indexes don't agree, files that disappear when
+     read aloud, a draft beneath every draft.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: palimpsest
+@genre_tags: mystery, occult, bureaucracy, archive, meta
+@height: 2
+
+[colors]
+preset: ethereal
+harmony: triadic
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- The third text surfaces — pull to anchor 1 -->
+border: 105
+corner: 107
+gradient: hueShift
+
+[variant_ooc]
+<!-- Out-of-character: pull to triadic anchor 2 -->
+border: 202
+corner: 204
+gradient: shimmer
+
+[variant_levelup]
+<!-- A page reveals itself — brighten anchor 0 -->
+border: 6
+corner: 7
+gradient: shimmer
+
+[corner_tl]
+╱┄
+│
+
+[corner_tr]
+┄╲
+ │
+
+[corner_bl]
+│
+╲┄
+
+[corner_br]
+ │
+┄╱
+
+[edge_top]
+┄·
+··
+
+[edge_bottom]
+··
+┄·
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+┄*
+ ·
+
+[separator_right_top]
+*┄
+·
+
+[separator_left_bottom]
+ ·
+┄*
+
+[separator_right_bottom]
+·
+*┄
+
+[turn_separator]
+··┄── ✧ ──┄··

--- a/packages/client-ink/src/tui/themes/assets/salt_throne.theme
+++ b/packages/client-ink/src/tui/themes/assets/salt_throne.theme
@@ -1,0 +1,94 @@
+<!-- Salt Throne Theme
+     Rune frame set, recolored. Triadic ember with hueShift —
+     brutal kingdoms, salt-crusted crowns, hot blood under cold
+     iron. The throne is heavy and tastes of the sea.
+
+     Use for: A Throne of Salt, The Shattered Crown — power that
+     corrodes everything it touches.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: salt_throne
+@genre_tags: fantasy, grimdark, kingdom, political, ruin
+@height: 2
+
+[colors]
+preset: ember
+harmony: triadic
+gradient: hueShift
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 105
+side_frame: 1
+
+[variant_combat]
+<!-- War council: tighter analogous warmth -->
+preset: ember
+harmony: analogous
+border: 106
+corner: 107
+gradient: vignette
+
+[variant_ooc]
+<!-- Salt and slate: cool triadic anchor -->
+border: 203
+corner: 204
+gradient: none
+
+[corner_tl]
+◤━
+┃
+
+[corner_tr]
+━◥
+ ┃
+
+[corner_bl]
+┃
+◣━
+
+[corner_br]
+ ┃
+━◢
+
+[edge_top]
+━━
+··
+
+[edge_bottom]
+··
+━━
+
+[edge_left]
+┃
+┃
+
+[edge_right]
+┃
+┃
+
+[separator_left_top]
+━╋
+ ┃
+
+[separator_right_top]
+╋━
+┃
+
+[separator_left_bottom]
+ ┃
+━╋
+
+[separator_right_bottom]
+┃
+╋━
+
+[turn_separator]
+━━┳━── ♛ ──━┳━━

--- a/packages/client-ink/src/tui/themes/assets/scriptorium.theme
+++ b/packages/client-ink/src/tui/themes/assets/scriptorium.theme
@@ -1,0 +1,91 @@
+<!-- Scriptorium Theme
+     Illuminated-manuscript style for scripture, mystery, and prophecy campaigns.
+     Rounded double-line frame with diamond-rosette flourishes — like a page
+     of an old book inked in iron-gall and gold leaf.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: scriptorium
+@genre_tags: scripture, mystery, prophecy, fantasy, meta
+@height: 2
+
+[colors]
+preset: ember
+harmony: split-complementary
+gradient: shimmer
+border: 2
+corner: 4
+separator: 5
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Burning wrath: tighter ember palette, darker vignette -->
+preset: ember
+harmony: analogous
+border: 5
+corner: 6
+gradient: vignette
+
+[variant_ooc]
+<!-- Quiet vellum: pull the colors toward the cool secondary anchor -->
+border: 102
+corner: 103
+gradient: none
+
+[corner_tl]
+╭═
+║
+
+[corner_tr]
+═╮
+ ║
+
+[corner_bl]
+║
+╰═
+
+[corner_br]
+ ║
+═╯
+
+[edge_top]
+══
+··
+
+[edge_bottom]
+··
+══
+
+[edge_left]
+║
+║
+
+[edge_right]
+║
+║
+
+[separator_left_top]
+═◇
+ ·
+
+[separator_right_top]
+◇═
+·
+
+[separator_left_bottom]
+ ·
+═◇
+
+[separator_right_bottom]
+·
+◇═
+
+[turn_separator]
+══··── ❦ ──··══

--- a/packages/client-ink/src/tui/themes/assets/signal_noise.theme
+++ b/packages/client-ink/src/tui/themes/assets/signal_noise.theme
@@ -1,0 +1,103 @@
+<!-- Signal Noise Theme
+     Starlight frame tuned for a distressed transmission. Same diagonal
+     slash corners and dotted starfield as `void` and `nebula`, but the
+     ember preset crashes a warm amber carrier signal against two cool
+     split-complementary anchors — like a hailing frequency riding on a
+     bed of static. The hueShift gradient drifts the colors as the
+     signal degrades.
+
+     Suited to: Jettison, The Copernicus Mandate, contact with hostile
+     transmitters, encrypted channels going dark mid-sentence.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: signal_noise
+@genre_tags: sci_fi, horror, thriller, transmission, space
+
+@height: 2
+
+[colors]
+preset: ember
+harmony: split-complementary
+gradient: hueShift
+border: 3
+corner: 5
+separator: 6
+title: 7
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Carrier breaks — push to the second split-comp anchor (cool) -->
+border: 205
+corner: 207
+separator: 206
+gradient: vignette
+
+[variant_ooc]
+<!-- Channel stable: damped ember, no gradient -->
+border: 2
+corner: 3
+gradient: none
+
+[variant_levelup]
+<!-- Decoded: ride the first split-comp anchor -->
+border: 105
+corner: 107
+gradient: shimmer
+
+[corner_tl]
+╲⋅
+ ·
+
+[corner_tr]
+⋅╱
+·
+
+[corner_bl]
+ ·
+╱⋅
+
+[corner_br]
+·
+⋅╲
+
+[edge_top]
+⋅·
+·⋅
+
+[edge_bottom]
+·⋅
+⋅·
+
+[edge_left]
+╎
+·
+
+[edge_right]
+╎
+·
+
+[separator_left_top]
+⋅⊹
+ ·
+
+[separator_right_top]
+⊹⋅
+·
+
+[separator_left_bottom]
+ ·
+⋅⊹
+
+[separator_right_bottom]
+·
+⊹⋅
+
+[turn_separator]
+· ⋅ ⊹ · ◬ · ⊹ ⋅ ·

--- a/packages/client-ink/src/tui/themes/assets/soft_machine.theme
+++ b/packages/client-ink/src/tui/themes/assets/soft_machine.theme
@@ -1,0 +1,89 @@
+<!-- Soft Machine Theme
+     Circuit frame with the edges sanded down. Rounded corners, light
+     dotted runs, and a quiet shimmer through the ethereal preset turn
+     the IDE/PCB look into something gentler — a friendly companion app,
+     a domestic robot's status screen, a barista's order ticket.
+
+     Suited to: Skinjob, Known Issue, The Coffee Shop, slice-of-life
+     sci-fi, downtime episodes, conversations with helpful machines.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: soft_machine
+@genre_tags: sci_fi, slice_of_life, cozy, modern, ai_companion
+
+@height: 1
+
+[colors]
+preset: ethereal
+harmony: analogous
+gradient: shimmer
+border: 2
+corner: 4
+separator: 3
+title: 5
+turn_indicator: 4
+side_frame: 1
+
+[variant_combat]
+<!-- Even soft machines have edges. Just a touch more saturation. -->
+preset: cyberpunk
+border: 4
+corner: 6
+gradient: vignette
+
+[variant_ooc]
+<!-- Lean further into the cool secondary analogous anchor -->
+border: 103
+corner: 104
+gradient: none
+
+[variant_levelup]
+<!-- Warm milestone tint via the warm analogous anchor -->
+border: 203
+corner: 205
+gradient: shimmer
+
+[corner_tl]
+╭
+
+[corner_tr]
+╮
+
+[corner_bl]
+╰
+
+[corner_br]
+╯
+
+[edge_top]
+╴·
+
+[edge_bottom]
+·╶
+
+[edge_left]
+╎
+
+[edge_right]
+╎
+
+[separator_left_top]
+┤
+
+[separator_right_top]
+├
+
+[separator_left_bottom]
+┤
+
+[separator_right_bottom]
+├
+
+[turn_separator]
+··╴── ◌ ──╶··

--- a/packages/client-ink/src/tui/themes/assets/sunday_morning.theme
+++ b/packages/client-ink/src/tui/themes/assets/sunday_morning.theme
@@ -1,0 +1,101 @@
+<!-- Sunday Morning Theme
+     Woven frame set, sky-light recolored. The diamond weave under
+     ethereal/triadic/shimmer reads pale and bright — robin's-egg blue,
+     daffodil yellow, blush — the kitchen at 9am with the radio low,
+     no agenda but coffee and the crossword.
+
+     Suited to: Middle Management of Doom, The Bake-Off, Library Card —
+     stories where the stakes are mid and the texture is everything:
+     office politics, hobby rivalries, a library overdue notice that
+     spirals into ontological crisis.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: sunday_morning
+@genre_tags: cozy, comedy, slice_of_life, mundane, office
+@height: 2
+
+[colors]
+preset: ethereal
+harmony: triadic
+gradient: shimmer
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- The status meeting — push to anchor 1 -->
+border: 104
+corner: 106
+gradient: hueShift
+
+[variant_ooc]
+<!-- Note-from-the-author: anchor 2 -->
+border: 202
+corner: 203
+gradient: shimmer
+
+[variant_levelup]
+<!-- Promotion / reorg / new title -->
+border: 6
+corner: 7
+gradient: shimmer
+
+[corner_tl]
+╭◇
+│
+
+[corner_tr]
+◇╮
+ │
+
+[corner_bl]
+│
+╰◇
+
+[corner_br]
+ │
+◇╯
+
+[edge_top]
+◇◈
+··
+
+[edge_bottom]
+··
+◇◈
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+─╋
+ ·
+
+[separator_right_top]
+╋─
+·
+
+[separator_left_bottom]
+ ·
+─╋
+
+[separator_right_bottom]
+·
+╋─
+
+[turn_separator]
+◇◈◇── ✺ ──◇◈◇

--- a/packages/client-ink/src/tui/themes/assets/void.theme
+++ b/packages/client-ink/src/tui/themes/assets/void.theme
@@ -1,0 +1,103 @@
+<!-- Void Theme
+     Starlight frame on cold complement. Diagonal slash corners and a
+     sparse star/dot edge run frame the conversation in negative space —
+     the cabin window of a long-haul ship, the observation deck of an
+     abandoned outpost. Vignette pulls the eye inward; the cyberpunk
+     complement pairs an icy cyan signal with a distant orange anomaly.
+
+     Suited to: Lighthouse, Ghosts of Station Proxima, Deep Tenancy,
+     derelict-vessel boardings, long silences between transmissions.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: void
+@genre_tags: sci_fi, horror, space, isolation, derelict
+
+@height: 2
+
+[colors]
+preset: cyberpunk
+harmony: complementary
+gradient: vignette
+border: 2
+corner: 5
+separator: 4
+title: 7
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- The anomaly arrives: shift to the complement, brighter -->
+border: 106
+corner: 108
+separator: 107
+gradient: hueShift
+
+[variant_ooc]
+<!-- Drift: lower contrast, no gradient -->
+preset: ethereal
+border: 1
+corner: 3
+gradient: none
+
+[variant_levelup]
+<!-- Encounter with the unknown — push to the complement -->
+border: 107
+corner: 109
+gradient: shimmer
+
+[corner_tl]
+╲·
+ ⋅
+
+[corner_tr]
+·╱
+⋅
+
+[corner_bl]
+ ⋅
+╱·
+
+[corner_br]
+⋅
+·╲
+
+[edge_top]
+·⋅
+⋅·
+
+[edge_bottom]
+⋅·
+·⋅
+
+[edge_left]
+╎
+⋅
+
+[edge_right]
+╎
+⋅
+
+[separator_left_top]
+·✦
+ ⋅
+
+[separator_right_top]
+✦·
+⋅
+
+[separator_left_bottom]
+ ⋅
+·✦
+
+[separator_right_bottom]
+⋅
+✦·
+
+[turn_separator]
+·  ⋅  ·  ✦  ·  ⋅  ·

--- a/packages/client-ink/src/tui/themes/assets/wet_pavement.theme
+++ b/packages/client-ink/src/tui/themes/assets/wet_pavement.theme
@@ -1,0 +1,83 @@
+<!-- Wet Pavement Theme
+     Noir frame set, cyberpunk-recolored. The thin line and bead glyphs
+     stay, but cyberpunk/split-complementary/hueShift drags the palette
+     through magentas, sodium-vapor yellows, and rain-slick teals — the
+     reflection of a neon sign in a puddle on the wrong side of town.
+
+     Suited to: Route 0, Exit Wounds — long highway nights, somebody
+     bleeding in the passenger seat, the radio losing signal, the city
+     glowing on the horizon for hours before you reach it.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: wet_pavement
+@genre_tags: noir, cyberpunk, horror, urban, thriller
+@height: 1
+
+[colors]
+preset: cyberpunk
+harmony: split-complementary
+gradient: hueShift
+border: 3
+corner: 5
+separator: 4
+title: 7
+turn_indicator: 6
+side_frame: 1
+
+[variant_combat]
+<!-- Tail lights vanishing — push to anchor 1 hard -->
+border: 105
+corner: 107
+separator: 106
+gradient: vignette
+
+[variant_ooc]
+<!-- Idling at the stoplight: pull to anchor 2, settle -->
+border: 202
+corner: 204
+gradient: shimmer
+
+[corner_tl]
+╭┄
+
+[corner_tr]
+┄╮
+
+[corner_bl]
+╰┄
+
+[corner_br]
+┄╯
+
+[edge_top]
+┄┈
+
+[edge_bottom]
+┈┄
+
+[edge_left]
+│
+
+[edge_right]
+│
+
+[separator_left_top]
+┄◦
+
+[separator_right_top]
+◦┄
+
+[separator_left_bottom]
+┄◦
+
+[separator_right_bottom]
+◦┄
+
+[turn_separator]
+┄┈┄── ◉ ──┄┈┄

--- a/packages/client-ink/src/tui/themes/assets/whiskey_neon.theme
+++ b/packages/client-ink/src/tui/themes/assets/whiskey_neon.theme
@@ -1,0 +1,84 @@
+<!-- Whiskey Neon Theme
+     Noir frame set. Thin lines, single-row, with a dashed horizon and a
+     small bead at every interruption — like a fluorescent sign humming
+     in the rain, or condensation tracking down a glass of bourbon.
+
+     Ember/complementary/vignette burns amber for the sign and pulls
+     cyan-teal for the wet asphalt outside.
+
+     Suited to: Last Call, Blackwater Bay — bar at 2am, the night that
+     wouldn't end, a stranger with too many questions.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: whiskey_neon
+@genre_tags: noir, crime, mystery, modern, urban
+@height: 1
+
+[colors]
+preset: ember
+harmony: complementary
+gradient: vignette
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 5
+side_frame: 1
+
+[variant_combat]
+<!-- Bar fight: amber hot, vignette tighter -->
+border: 6
+corner: 7
+separator: 5
+gradient: vignette
+
+[variant_ooc]
+<!-- Back booth, low light — cool complement -->
+border: 102
+corner: 103
+gradient: none
+
+[corner_tl]
+╭┄
+
+[corner_tr]
+┄╮
+
+[corner_bl]
+╰┄
+
+[corner_br]
+┄╯
+
+[edge_top]
+┄┈
+
+[edge_bottom]
+┈┄
+
+[edge_left]
+│
+
+[edge_right]
+│
+
+[separator_left_top]
+┄◦
+
+[separator_right_top]
+◦┄
+
+[separator_left_bottom]
+┄◦
+
+[separator_right_bottom]
+◦┄
+
+[turn_separator]
+┄┈┄── ◯ ──┄┈┄

--- a/packages/client-ink/src/tui/themes/assets/wild_growth.theme
+++ b/packages/client-ink/src/tui/themes/assets/wild_growth.theme
@@ -1,0 +1,93 @@
+<!-- Wild Growth Theme
+     Tendrils frame set, recolored. Triadic foliage with hueShift —
+     old magic returning, seasons turning, soil remembering. Vines
+     curl through ruins as colors drift across the spectrum.
+
+     Use for: Fallow, Petrichor, Good Soil — the green coming back.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: wild_growth
+@genre_tags: fantasy, druidic, nature, ritual, mythic
+@height: 2
+
+[colors]
+preset: foliage
+harmony: triadic
+gradient: hueShift
+border: 4
+corner: 5
+separator: 3
+title: 6
+turn_indicator: 105
+side_frame: 1
+
+[variant_combat]
+<!-- Thorn season: pull to the warm triadic anchor -->
+preset: foliage
+harmony: triadic
+border: 105
+corner: 106
+gradient: vignette
+
+[variant_ooc]
+<!-- Long winter: cool triadic anchor, flat -->
+border: 203
+corner: 204
+gradient: none
+
+[corner_tl]
+╭~
+│
+
+[corner_tr]
+~╮
+ │
+
+[corner_bl]
+│
+╰~
+
+[corner_br]
+ │
+~╯
+
+[edge_top]
+~╌
+ ❀
+
+[edge_bottom]
+ ❀
+~╌
+
+[edge_left]
+│
+│
+
+[edge_right]
+│
+│
+
+[separator_left_top]
+~❦
+ ·
+
+[separator_right_top]
+❦~
+·
+
+[separator_left_bottom]
+ ·
+~❦
+
+[separator_right_bottom]
+·
+❦~
+
+[turn_separator]
+~~╌╌── ⚘ ──╌╌~~

--- a/packages/client-ink/src/tui/themes/assets/wraithlight.theme
+++ b/packages/client-ink/src/tui/themes/assets/wraithlight.theme
@@ -1,0 +1,94 @@
+<!-- Wraithlight Theme
+     Bone frame set, recolored. Ethereal complementary with
+     hueShift — pale, cold, drifting colors. Subtle horror, the
+     kind where you're not sure what you saw.
+
+     Use for: The Replacement, Beneath the Skin — wrongness you
+     can't quite name.
+
+     Configuration keys:
+       preset       — swatch preset (ember, ethereal, cyberpunk, foliage)
+       harmony      — color harmony (analogous, complementary, triadic, ...)
+       gradient     — gradient preset (vignette, shimmer, hueShift, none)
+       border/corner/separator/title/turn_indicator/side_frame — swatch indices
+-->
+
+@name: wraithlight
+@genre_tags: horror, paranormal, subtle_horror, uncanny, ghost
+@height: 2
+
+[colors]
+preset: ethereal
+harmony: complementary
+gradient: hueShift
+border: 3
+corner: 5
+separator: 4
+title: 6
+turn_indicator: 105
+side_frame: 1
+
+[variant_combat]
+<!-- Manifestation: lean to complementary anchor -->
+preset: ethereal
+harmony: complementary
+border: 104
+corner: 106
+gradient: vignette
+
+[variant_ooc]
+<!-- Settled: cool key arc, no shift -->
+border: 2
+corner: 3
+gradient: none
+
+[corner_tl]
+╷╌
+┊
+
+[corner_tr]
+╌╷
+ ┊
+
+[corner_bl]
+┊
+╵╌
+
+[corner_br]
+ ┊
+╌╵
+
+[edge_top]
+╌╌
+··
+
+[edge_bottom]
+··
+╌╌
+
+[edge_left]
+┊
+┊
+
+[edge_right]
+┊
+┊
+
+[separator_left_top]
+╌†
+ ·
+
+[separator_right_top]
+†╌
+·
+
+[separator_left_bottom]
+ ·
+╌†
+
+[separator_right_bottom]
+·
+†╌
+
+[turn_separator]
+··╌╌── ✟ ──╌╌··

--- a/packages/client-ink/src/tui/themes/composer.ts
+++ b/packages/client-ink/src/tui/themes/composer.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ThemeAsset, ThemeComponent, PlayerPaneFrame } from "./types.js";
-import { stringWidth, truncateToWidth } from "../frames/index.js";
+import { stringWidth, truncateToWidth } from "../frames/string-width.js";
 
 /** A composed frame: an array of string rows ready for rendering. */
 export interface ComposedFrame {

--- a/packages/client-ink/src/tui/themes/loader.test.ts
+++ b/packages/client-ink/src/tui/themes/loader.test.ts
@@ -53,7 +53,6 @@ describe("loader", () => {
     expect(themes).toContain("arcane");
     expect(themes).toContain("terminal");
     expect(themes).toContain("clean");
-    expect(themes).toHaveLength(4);
   });
 
   it("resetThemeCache clears cache", () => {

--- a/tools/theme-editor/scripts/validate.mjs
+++ b/tools/theme-editor/scripts/validate.mjs
@@ -38,6 +38,11 @@ const frames = readdirSync(assetsDir)
 let failures = 0;
 const VARIANTS = ["exploration", "combat", "ooc", "levelup", "dev"];
 
+function formatError(err) {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 console.log(`\n=== Themes (${themes.length}) ===`);
 for (const name of themes) {
   try {
@@ -52,7 +57,7 @@ for (const name of themes) {
     console.log(`  ok   ${name.padEnd(28)} h=${asset.height} tile=${cw}x${ch} tags=${tags}`);
   } catch (err) {
     failures++;
-    console.error(`  FAIL ${name}: ${err.message ?? err}`);
+    console.error(`  FAIL ${name}: ${formatError(err)}`);
   }
 }
 
@@ -64,13 +69,15 @@ for (const name of frames) {
     console.log(`  ok   ${name.padEnd(28)} corner_tl=${cw}w`);
   } catch (err) {
     failures++;
-    console.error(`  FAIL ${name}: ${err.message ?? err}`);
+    console.error(`  FAIL ${name}: ${formatError(err)}`);
   }
 }
 
 if (failures > 0) {
   console.error(`\n${failures} file(s) failed validation`);
-  process.exit(failures);
+  // POSIX exit codes are 0-255; clamp so a triple-digit failure count
+  // doesn't wrap and look like success.
+  process.exit(Math.min(failures, 255));
 } else {
   console.log(`\nAll ${themes.length} themes + ${frames.length} frames validated cleanly.`);
 }

--- a/tools/theme-editor/scripts/validate.mjs
+++ b/tools/theme-editor/scripts/validate.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Validate every .theme and .player-frame in packages/client-ink/src/tui/themes/assets/.
+ * Parses + resolves each so we surface broken art, bad config keys, and unknown
+ * presets/gradients/harmonies before the TUI tries to render them.
+ *
+ * Usage: node --import tsx/esm tools/theme-editor/scripts/validate.mjs
+ * Exit code is the number of files that failed.
+ */
+import { readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+const assetsDir = resolve(repoRoot, "packages/client-ink/src/tui/themes/assets");
+
+// Windows-safe dynamic import: must convert path to file:// URL.
+const loaderUrl = pathToFileURL(
+  resolve(repoRoot, "packages/client-ink/src/tui/themes/loader.ts"),
+).href;
+const resolverUrl = pathToFileURL(
+  resolve(repoRoot, "packages/client-ink/src/tui/themes/resolver.ts"),
+).href;
+
+const { loadBuiltinTheme, loadBuiltinPlayerFrame, loadThemeDefinition } = await import(loaderUrl);
+const { resolveTheme } = await import(resolverUrl);
+
+const themes = readdirSync(assetsDir)
+  .filter((f) => f.endsWith(".theme"))
+  .map((f) => f.replace(/\.theme$/, ""))
+  .sort();
+const frames = readdirSync(assetsDir)
+  .filter((f) => f.endsWith(".player-frame"))
+  .map((f) => f.replace(/\.player-frame$/, ""))
+  .sort();
+
+let failures = 0;
+const VARIANTS = ["exploration", "combat", "ooc", "levelup", "dev"];
+
+console.log(`\n=== Themes (${themes.length}) ===`);
+for (const name of themes) {
+  try {
+    const asset = loadBuiltinTheme(name);
+    const def = loadThemeDefinition(name);
+    for (const v of VARIANTS) {
+      resolveTheme(def, v, "#8a6cff");
+    }
+    const cw = asset.components.edge_top.width;
+    const ch = asset.components.edge_left.height;
+    const tags = asset.genreTags.join(",") || "(none)";
+    console.log(`  ok   ${name.padEnd(28)} h=${asset.height} tile=${cw}x${ch} tags=${tags}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}: ${err.message ?? err}`);
+  }
+}
+
+console.log(`\n=== Player frames (${frames.length}) ===`);
+for (const name of frames) {
+  try {
+    const frame = loadBuiltinPlayerFrame(name);
+    const cw = frame.components.corner_tl.width;
+    console.log(`  ok   ${name.padEnd(28)} corner_tl=${cw}w`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}: ${err.message ?? err}`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} file(s) failed validation`);
+  process.exit(failures);
+} else {
+  console.log(`\nAll ${themes.length} themes + ${frames.length} frames validated cleanly.`);
+}

--- a/tools/theme-editor/vite.config.ts
+++ b/tools/theme-editor/vite.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
       "@engine-src": resolve(__dirname, "../../packages/client-ink/src"),
     },
   },
+  // ink and yoga-layout (transitively pulled via @engine-src/tui/frames) use
+  // top-level await, which only es2022+ supports. Both the dev pre-bundler
+  // and the production build need the bumped target.
+  optimizeDeps: {
+    esbuildOptions: { target: "es2022" },
+  },
+  build: { target: "es2022" },
   server: {
     port: 5198,
     proxy: {


### PR DESCRIPTION
## Summary

Grows the built-in theme library from 4 themes to 35, organized into 11 ASCII frame families and tuned to the campaign-seed catalog.

**Frame families added (10 new + 1 demo):**

| Family | Themes | Vibe |
|---|---|---|
| `scriptorium` | scriptorium, palimpsest, bonfire_letter, field_notes, glitched_margin | Illuminated manuscript / loose-leaf |
| `tendrils` | forest_fey, bloom_horror, wild_growth, congregation | Vines, fey woods, choking growth |
| `rune` | old_oaths, salt_throne, elder_stone | Runestone, angular, weighty |
| `bone` | mortuary, wraithlight, inner_dark | Skeletal, broken, dust |
| `circuit` | cold_steel, bio_lab, klaxon, neon_grid, soft_machine | PCB / CLI dashed lines |
| `starlight` | void, nebula, signal_noise | Sparse star drift, deep space |
| `brass` | clockwork, corporate_dread | Riveted plate, gears (quiet stitched horizontals) |
| `noir` | whiskey_neon, cold_open, wet_pavement | Thin cinematic single-line |
| `paper` | (lives in scriptorium family) | Torn margin, doodles |
| `woven` | hearth, autumn_market, sunday_morning | Basket weave, quilt, slice-of-life |

**Mechanics changes that landed alongside the asset work:**

- Split `stringWidth` / `truncateToWidth` into `packages/client-ink/src/tui/frames/string-width.ts` so the composer's import chain no longer drags `ink` + `yoga-layout` (with their top-level await) into browser tooling. The Theme Editor now renders correctly.
- Bump `tools/theme-editor/vite.config.ts` esbuild target to `es2022` for any remaining TLA in engine source.
- New gate: `node --import tsx/esm tools/theme-editor/scripts/validate.mjs` — parses every `.theme` and resolves all 5 variants. Use it after editing themes.
- `loader.test.ts`: replace hard-coded `toHaveLength(4)` with presence checks so the test doesn't fail every time a theme is added.
- Docs: `docs/tui-design.md` Built-in themes section now groups all 35 themes by frame family.

## Test plan

- [x] `npm run check` — 150 test files, 2594/2594 passing, lint clean
- [x] `node --import tsx/esm tools/theme-editor/scripts/validate.mjs` — 35/35 themes resolve cleanly across all 5 variants
- [x] Theme Editor (`npm run dev` in `tools/theme-editor`) renders representative samples without errors: scriptorium, forest_fey, void, whiskey_neon, clockwork, corporate_dread, wraithlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)