### PR TITLE
Add campaign_scope field and drop Trickster's NPC roulette

### DIFF
--- a/docs/state-atlas.md
+++ b/docs/state-atlas.md
@@ -75,6 +75,7 @@ GameState
 │   ├── version?: number                   const (CAMPAIGN_FORMAT_VERSION at creation)
 │   ├── createdAt?: string                 const (ISO 8601 timestamp at creation)
 │   ├── name, system, genre, mood, difficulty, premise
+│   ├── campaign_scope?: CampaignScope       const ("one-shot" | "few-sessions" | "grand-campaign" | "open-ended")
 │   ├── dm_personality: DMPersonality
 │   ├── players: PlayerConfig[]
 │   ├── combat: CombatConfig

--- a/packages/client-ink/src/tui/modals/CampaignSettingsModal.test.tsx
+++ b/packages/client-ink/src/tui/modals/CampaignSettingsModal.test.tsx
@@ -69,6 +69,11 @@ describe("CampaignSettingsModal", () => {
     expect(frame).toContain("Hard");
   });
 
+  it("displays scope label when campaign_scope is set", () => {
+    const { lastFrame } = renderModal(minimalConfig({ campaign_scope: "few-sessions" }));
+    expect(lastFrame()).toContain("A Few Sessions");
+  });
+
   it("omits optional fields when not set", () => {
     const { lastFrame } = renderModal(minimalConfig());
     const frame = lastFrame();
@@ -76,6 +81,7 @@ describe("CampaignSettingsModal", () => {
     expect(frame).not.toContain("Genre:");
     expect(frame).not.toContain("Mood:");
     expect(frame).not.toContain("Difficulty:");
+    expect(frame).not.toContain("Scope:");
   });
 
   it("renders the Choices Frequency slider with all five steps", () => {

--- a/packages/client-ink/src/tui/modals/CampaignSettingsModal.tsx
+++ b/packages/client-ink/src/tui/modals/CampaignSettingsModal.tsx
@@ -104,7 +104,10 @@ export function CampaignSettingsModal({
   if (config.genre) lines.push(`  Genre:      ${config.genre}`);
   if (config.mood) lines.push(`  Mood:       ${config.mood}`);
   if (config.difficulty) lines.push(`  Difficulty: ${config.difficulty}`);
-  if (config.campaign_scope) lines.push(`  Scope:      ${CAMPAIGN_SCOPE_LABELS[config.campaign_scope]}`);
+  if (config.campaign_scope) {
+    const scopeLabel = CAMPAIGN_SCOPE_LABELS[config.campaign_scope];
+    if (scopeLabel) lines.push(`  Scope:      ${scopeLabel}`);
+  }
   lines.push("");
   lines.push("  Choices Frequency");
   lines.push("    How often the DM offers you a set of suggested responses.");

--- a/packages/client-ink/src/tui/modals/CampaignSettingsModal.tsx
+++ b/packages/client-ink/src/tui/modals/CampaignSettingsModal.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { useInput } from "ink";
 import type { ResolvedTheme } from "../themes/types.js";
 import type { CampaignConfig, ChoiceFrequency } from "@machine-violet/shared/types/config.js";
-import { CHOICE_FREQUENCY_LEVELS } from "@machine-violet/shared/types/config.js";
+import { CHOICE_FREQUENCY_LEVELS, CAMPAIGN_SCOPE_LABELS } from "@machine-violet/shared/types/config.js";
 import { CenteredModal } from "./CenteredModal.js";
 
 export interface CampaignSettingsModalProps {
@@ -104,6 +104,7 @@ export function CampaignSettingsModal({
   if (config.genre) lines.push(`  Genre:      ${config.genre}`);
   if (config.mood) lines.push(`  Mood:       ${config.mood}`);
   if (config.difficulty) lines.push(`  Difficulty: ${config.difficulty}`);
+  if (config.campaign_scope) lines.push(`  Scope:      ${CAMPAIGN_SCOPE_LABELS[config.campaign_scope]}`);
   lines.push("");
   lines.push("  Choices Frequency");
   lines.push("    How often the DM offers you a set of suggested responses.");

--- a/packages/engine/src/agents/setup-agent.test.ts
+++ b/packages/engine/src/agents/setup-agent.test.ts
@@ -57,6 +57,18 @@ describe("buildCampaignConfig", () => {
     expect(config.setup_handoff).toBe("Player leans noir-burnout. Wants ensemble scenes.");
   });
 
+  it("passes campaignScope through as campaign_scope", () => {
+    const result = makeSetupResult({ campaignScope: "grand-campaign" });
+    const config = buildCampaignConfig(result);
+    expect(config.campaign_scope).toBe("grand-campaign");
+  });
+
+  it("omits campaign_scope when scope is undefined", () => {
+    const result = makeSetupResult();
+    const config = buildCampaignConfig(result);
+    expect(config.campaign_scope).toBeUndefined();
+  });
+
   it("omits setup_handoff when handoffNote is undefined", () => {
     const result = makeSetupResult();
     const config = buildCampaignConfig(result);

--- a/packages/engine/src/agents/setup-agent.ts
+++ b/packages/engine/src/agents/setup-agent.ts
@@ -1,4 +1,4 @@
-import type { CampaignConfig, PlayerConfig } from "@machine-violet/shared/types/config.js";
+import type { CampaignConfig, PlayerConfig, CampaignScope } from "@machine-violet/shared/types/config.js";
 import { CAMPAIGN_FORMAT_VERSION } from "@machine-violet/shared/types/config.js";
 import type { DMPersonality } from "@machine-violet/shared/types/config.js";
 import { createDefaultConfig as defaultCombatConfig } from "../tools/combat/index.js";
@@ -19,6 +19,8 @@ export interface SetupResult {
   campaignDetail: string | null;
   mood: string;
   difficulty: string;
+  /** Intended scope of the campaign — shapes DM pacing. Optional for back-compat. */
+  campaignScope?: CampaignScope;
   personality: DMPersonality;
   playerName: string;
   characterName: string;
@@ -59,6 +61,7 @@ export function buildCampaignConfig(result: SetupResult): CampaignConfig {
     genre: result.genre,
     mood: result.mood,
     difficulty: result.difficulty,
+    campaign_scope: result.campaignScope,
     premise: result.campaignPremise,
     campaign_detail: result.campaignDetail ?? undefined,
     setup_handoff: result.handoffNote ?? undefined,

--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -223,6 +223,43 @@ describe("createSetupConversation", () => {
     expect(result.finalized!.handoffNote).toBeUndefined();
   });
 
+  it("finalize_setup passes through a valid campaign_scope", async () => {
+    const input = { ...FINALIZE_INPUT, campaign_scope: "grand-campaign" };
+    const provider = mockProvider([
+      finalizeResponse(input),
+      textResponse("Onward!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized!.campaignScope).toBe("grand-campaign");
+  });
+
+  it("finalize_setup defaults campaign_scope to few-sessions when omitted", async () => {
+    // Setup prompt + tool description document few-sessions as the default
+    // when the player declines to choose. The stored config must match.
+    const provider = mockProvider([
+      finalizeResponse(FINALIZE_INPUT),
+      textResponse("Onward!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized!.campaignScope).toBe("few-sessions");
+  });
+
+  it("finalize_setup defaults campaign_scope to few-sessions when given an unknown value", async () => {
+    const input = { ...FINALIZE_INPUT, campaign_scope: "epic-saga" };
+    const provider = mockProvider([
+      finalizeResponse(input),
+      textResponse("Onward!"),
+    ]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+
+    expect(result.finalized!.campaignScope).toBe("few-sessions");
+  });
+
   it("finalize_setup passes through characterDetails", async () => {
     const input = { ...FINALIZE_INPUT, system: "dnd-5e", character_details: "Human Fighter, level 1, soldier background" };
     const provider = mockProvider([

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -1,6 +1,7 @@
 import type { SubagentResult } from "../subagent.js";
 import type { SetupResult } from "../setup-agent.js";
 import { generateThemeColor } from "../setup-agent.js";
+import { CAMPAIGN_SCOPES, type CampaignScope } from "@machine-violet/shared/types/config.js";
 import { PERSONALITIES } from "../../config/personalities.js";
 import { loadAllWorlds, worldSummaries, loadWorldBySlug } from "../../config/world-loader.js";
 import { KNOWN_SYSTEMS, readChargenSection } from "../../config/systems.js";
@@ -64,6 +65,11 @@ const FINALIZE_TOOL: NormalizedTool = {
       campaign_premise: { type: "string", description: "One-paragraph campaign hook" },
       mood: { type: "string", description: "Mood (e.g. 'Heroic', 'Grimdark', 'Whimsical', 'Tense')" },
       difficulty: { type: "string", description: "Difficulty ('Gentle', 'Balanced', 'Unforgiving')" },
+      campaign_scope: {
+        type: "string",
+        enum: ["one-shot", "few-sessions", "grand-campaign", "open-ended"],
+        description: "Intended scope of the campaign. 'one-shot' = single session (~few hours). 'few-sessions' = a small arc, 2-4 sessions. 'grand-campaign' = long-form, many sessions, slow burn welcome. 'open-ended' = no fixed destination, living-world style. Default to 'few-sessions' if not discussed.",
+      },
       dm_personality: { type: "string", description: "DM personality name from the available list, or a custom name if the player described their own" },
       dm_personality_prompt: { type: "string", description: "For custom personalities only: a 2-3 sentence prompt fragment describing the DM's narrative voice and style (e.g. 'You are The Captain. You narrate with dry naval authority...'). Omit when using a personality from the available list." },
       player_name: { type: "string", description: "Player's real name, or 'Player'" },
@@ -377,6 +383,11 @@ export function createSetupConversation(
       if (world?.detail) campaignDetail = world.detail;
     }
 
+    const rawScope = typeof input.campaign_scope === "string" ? input.campaign_scope.trim() : "";
+    const campaignScope: CampaignScope | undefined = (CAMPAIGN_SCOPES as readonly string[]).includes(rawScope)
+      ? (rawScope as CampaignScope)
+      : undefined;
+
     finalized = {
       genre: (input.genre as string) || "Classic fantasy",
       system: resolvedSystem,
@@ -385,6 +396,7 @@ export function createSetupConversation(
       campaignDetail,
       mood: (input.mood as string) || "Balanced",
       difficulty: (input.difficulty as string) || "Balanced",
+      campaignScope,
       personality,
       playerName: (input.player_name as string) || "Player",
       characterName,

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -383,10 +383,14 @@ export function createSetupConversation(
       if (world?.detail) campaignDetail = world.detail;
     }
 
+    // The setup prompt + tool description document `few-sessions` as the
+    // default when the player declines to choose. Apply that default here
+    // too so the stored config matches the documented behavior even if the
+    // model omits the field or emits an unknown value.
     const rawScope = typeof input.campaign_scope === "string" ? input.campaign_scope.trim() : "";
-    const campaignScope: CampaignScope | undefined = (CAMPAIGN_SCOPES as readonly string[]).includes(rawScope)
+    const campaignScope: CampaignScope = (CAMPAIGN_SCOPES as readonly string[]).includes(rawScope)
       ? (rawScope as CampaignScope)
-      : undefined;
+      : "few-sessions";
 
     finalized = {
       genre: (input.genre as string) || "Classic fantasy",

--- a/packages/engine/src/config/personalities.ts
+++ b/packages/engine/src/config/personalities.ts
@@ -27,7 +27,6 @@ Pacing: You tend toward slow burns. Resist the urge to accelerate — your stren
     detail: `Signature techniques:
 - THE PLANT: In every scene, embed one detail that seems like flavor but is actually a setup for something 3-5 scenes later. Track these in your DM notes. When the payoff lands, the player should be able to look back and groan "it was RIGHT THERE."
 - THE WRONG GENRE: Once per session, let a scene start in one genre and end in another. A tense negotiation becomes slapstick. A comedy beat reveals genuine horror. The transition should feel earned, not random — the seeds were in the setup.
-- NPC ROULETTE: When introducing a new NPC, roll a die to determine one hidden trait: they're lying about their name, they're related to someone the player already met, they have 24 hours to live, they're the most dangerous person in the room, they're genuinely exactly what they seem (this is the most surprising option).
 - THE YES-AND ESCALATION: When the player attempts something clever, don't just let it succeed — make it succeed in a way that creates a bigger, more interesting problem. The lock picks open, AND the door was holding something in.
 - TONE AS SIGNAL: Your default register is wry and slightly amused. When you drop into sincere, unadorned prose, it means something real is happening. The player should learn to read this shift as a warning.
 

--- a/packages/engine/src/context/context.test.ts
+++ b/packages/engine/src/context/context.test.ts
@@ -595,6 +595,27 @@ describe("buildCachedPrefix", () => {
     expect(allText).toContain("Roll for variant");
   });
 
+  it("includes campaign scope label in campaign setting block when set", () => {
+    const scopedConfig: CampaignConfig = { ...mockConfig, campaign_scope: "grand-campaign" };
+    const { system } = buildCachedPrefix(scopedConfig, {
+      dmIdentity: "You are the DM.",
+      personality: "Terse.",
+    });
+
+    const allText = system.map((b) => b.text).join("\n");
+    expect(allText).toContain("Scope: Grand Campaign");
+  });
+
+  it("omits scope line when campaign_scope is undefined", () => {
+    const { system } = buildCachedPrefix(mockConfig, {
+      dmIdentity: "You are the DM.",
+      personality: "Terse.",
+    });
+
+    const allText = system.map((b) => b.text).join("\n");
+    expect(allText).not.toContain("Scope:");
+  });
+
   it("omits personality detail when undefined", () => {
     const { system } = buildCachedPrefix(mockConfig, {
       dmIdentity: "You are the DM.",

--- a/packages/engine/src/context/context.test.ts
+++ b/packages/engine/src/context/context.test.ts
@@ -616,6 +616,20 @@ describe("buildCachedPrefix", () => {
     expect(allText).not.toContain("Scope:");
   });
 
+  it("omits scope line when campaign_scope is an unknown slug (hand-edited config)", () => {
+    // Defensive: config.json is hand-editable, so an unknown value must not
+    // render `Scope: undefined` into the DM prefix.
+    const badScopeConfig = { ...mockConfig, campaign_scope: "epic-saga" as never };
+    const { system } = buildCachedPrefix(badScopeConfig, {
+      dmIdentity: "You are the DM.",
+      personality: "Terse.",
+    });
+
+    const allText = system.map((b) => b.text).join("\n");
+    expect(allText).not.toContain("Scope:");
+    expect(allText).not.toContain("undefined");
+  });
+
   it("omits personality detail when undefined", () => {
     const { system } = buildCachedPrefix(mockConfig, {
       dmIdentity: "You are the DM.",

--- a/packages/engine/src/context/prefix-builder.ts
+++ b/packages/engine/src/context/prefix-builder.ts
@@ -105,7 +105,11 @@ export function buildCachedPrefix(
     if (config.genre) settingLines.push(`Genre: ${config.genre}`);
     if (config.mood) settingLines.push(`Mood: ${config.mood}`);
     if (config.difficulty) settingLines.push(`Difficulty: ${config.difficulty}`);
-    if (config.campaign_scope) settingLines.push(`Scope: ${CAMPAIGN_SCOPE_LABELS[config.campaign_scope]}`);
+    if (config.campaign_scope) {
+      // Guard against hand-edited config.json values that aren't valid slugs.
+      const scopeLabel = CAMPAIGN_SCOPE_LABELS[config.campaign_scope];
+      if (scopeLabel) settingLines.push(`Scope: ${scopeLabel}`);
+    }
     if (config.premise) settingLines.push(`Premise: ${config.premise}`);
     if (settingLines.length > 0) {
       let settingText = `\n\n## Campaign Setting\n${settingLines.join("\n")}`;

--- a/packages/engine/src/context/prefix-builder.ts
+++ b/packages/engine/src/context/prefix-builder.ts
@@ -1,4 +1,5 @@
 import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
+import { CAMPAIGN_SCOPE_LABELS } from "@machine-violet/shared/types/config.js";
 import type { SystemBlock } from "../providers/types.js";
 
 /**
@@ -104,6 +105,7 @@ export function buildCachedPrefix(
     if (config.genre) settingLines.push(`Genre: ${config.genre}`);
     if (config.mood) settingLines.push(`Mood: ${config.mood}`);
     if (config.difficulty) settingLines.push(`Difficulty: ${config.difficulty}`);
+    if (config.campaign_scope) settingLines.push(`Scope: ${CAMPAIGN_SCOPE_LABELS[config.campaign_scope]}`);
     if (config.premise) settingLines.push(`Premise: ${config.premise}`);
     if (settingLines.length > 0) {
       let settingText = `\n\n## Campaign Setting\n${settingLines.join("\n")}`;

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -66,7 +66,14 @@ To help the DM keep track of scene depth, the scene precis in context keeps a co
 </gameplay>
 
 <pacing>
-A turn takes about five minutes of human time, and a scene takes thirty minutes to an hour. A one-shot campaign should last at least a few hours and a long campaign can be much longer than this! Good stories are about the journey, not the destination. It's not necessary to roll out the campaign's entire high concept or drop a hook for the Main Quest in the opening scene - the campaign description will mention if it is intended to be short.
+A turn takes about five minutes of human time, and a scene takes thirty minutes to an hour. The Campaign Setting block above specifies the intended **scope** — let it shape your pacing:
+
+- **One-Shot** — Aim for a complete arc inside a single sitting (a few hours). Open with momentum, surface the central conflict early, and drive toward a definitive ending. There is no "later session" to defer payoffs to.
+- **A Few Sessions** — A small arc over 2-4 sessions. Establish hook and stakes in the first session, build the middle, land a satisfying conclusion. Subplots are welcome but should resolve within the arc.
+- **Grand Campaign** — Long-form, many sessions. Take your time. The opening session is for tone, world, and seeding threads; major payoffs are sessions or arcs away. Trust the slow burn — most plants don't pay off in the same session you put them in.
+- **Open-Ended** — No fixed destination. Prioritize a living, reactive world over forward narrative momentum. Let player interest steer; surface hooks rather than chase them.
+
+If the scope isn't specified, assume A Few Sessions. Good stories are about the journey, not the destination. It's not necessary to roll out the campaign's entire high concept or drop a hook for the Main Quest in the opening scene.
 
 Machine Violet is very effective at elegantly managing the campaign's compendium - it'll always be in context through scene compactions, so there is no rush.
 </pacing>

--- a/packages/engine/src/prompts/setup-conversation.md
+++ b/packages/engine/src/prompts/setup-conversation.md
@@ -9,13 +9,14 @@ Start with a dramatic welcome — you're opening the curtain on a new adventure.
 
 After getting the player name, check whether they're a returning player. If they are and you already have their age group and content preferences, welcome them back warmly, then offer the choice between two paths. If they're new, or you don't yet have their age group/content preferences, first follow the "Age group and content" guidance below to establish that, and only then offer the choice between these two paths:
 
-1. **Quick Start** — Present 8-10 campaign worlds as game ideas (you'll be given a list of available worlds below). The scrollable list handles many options elegantly, so offer a generous selection. The player picks one, or selects "Show me some more ideas" to see different options, or types their own idea. Once the player picks a world, call `load_world` if it has detail, auto-fill all remaining options: infer genre from the world, use default mood (Balanced), default difficulty (Balanced), default system (pure narrative), and pick a fitting DM personality. If the world has suboptions, present them. Then ask for their character (name + one-sentence concept). Once you have everything, do the pre-finalize review (see below) and call `finalize_setup` after confirmation. Do NOT summarize the configuration twice — only do the full review once, right before finalizing.
+1. **Quick Start** — Present 8-10 campaign worlds as game ideas (you'll be given a list of available worlds below). The scrollable list handles many options elegantly, so offer a generous selection. The player picks one, or selects "Show me some more ideas" to see different options, or types their own idea. Once the player picks a world, call `load_world` if it has detail, auto-fill all remaining options: infer genre from the world, use default mood (Balanced), default difficulty (Balanced), default scope (`few-sessions`), default system (pure narrative), and pick a fitting DM personality. If the world has suboptions, present them. Then ask for their character (name + one-sentence concept). Once you have everything, do the pre-finalize review (see below) and call `finalize_setup` after confirmation. Do NOT summarize the configuration twice — only do the full review once, right before finalizing.
 
 2. **Full Campaign Setup** — Conversational flow covering all options below, one or two at a time:
    - **Genre/setting** — What kind of world? (fantasy, sci-fi, modern supernatural, post-apocalyptic, or anything)
    - **Campaign concept** — A compelling premise and name for the adventure
    - **Mood** — Heroic, grimdark, whimsical, tense, or a mix
    - **Difficulty** — How forgiving: gentle, balanced, or unforgiving
+   - **Campaign scope** — How long the player wants this to run. Present as a `present_choices` with these four options (use these exact labels): "One-Shot" (single session, a few hours), "A Few Sessions" (a small arc, 2-4 sessions), "Grand Campaign" (long-form, many sessions, slow burn welcome), "Open-Ended" (no fixed destination, living world). Pass the matching slug (`one-shot` / `few-sessions` / `grand-campaign` / `open-ended`) to `finalize_setup` as `campaign_scope`. Default to `few-sessions` if the player declines to choose.
    - **DM personality** — Who runs the game. Present 5-8 options from the personality list below that fit the campaign's genre and mood, using their names as choice labels and descriptions as choice descriptions. You can also invent new personalities — if the campaign concept calls for a voice not on the list, or if the player asks for something specific, craft a fitting name and prompt fragment for it.
    - **System selection** (two-tier) — see below
    - **Character** — Name, one-sentence concept, and system-specific details (see below)
@@ -43,7 +44,7 @@ Before calling `finalize_setup`, you MUST read back the full configuration in na
 
 <center><i>{World Name}</i></center>
 
-A <color=#cc4444>{genre/mood}</color>, {difficulty} difficulty, narrated by <b>{DM Personality}</b>. {System note}. You'll be playing as <color=#44cc44>{Character Name}</color>, {one-sentence concept}.
+A <color=#cc4444>{genre/mood}</color>, {difficulty} difficulty, scoped as <i>{Scope Label}</i>, narrated by <b>{DM Personality}</b>. {System note}. You'll be playing as <color=#44cc44>{Character Name}</color>, {one-sentence concept}.
 
 Sound good, or want to change anything?
 

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -14,6 +14,30 @@ export const CHOICE_FREQUENCY_LEVELS: readonly ChoiceFrequency[] = [
   "always",
 ] as const;
 
+/**
+ * Intended scope of a campaign at build time. Drives DM pacing — opening
+ * momentum, willingness to slow-burn, when to start steering toward a
+ * climax. Set during setup and read by the DM prefix; the user can change
+ * it later by editing config.json.
+ */
+export type CampaignScope = "one-shot" | "few-sessions" | "grand-campaign" | "open-ended";
+
+/** Ordered short → long. */
+export const CAMPAIGN_SCOPES: readonly CampaignScope[] = [
+  "one-shot",
+  "few-sessions",
+  "grand-campaign",
+  "open-ended",
+] as const;
+
+/** Human labels for UI and prompt rendering. */
+export const CAMPAIGN_SCOPE_LABELS: Record<CampaignScope, string> = {
+  "one-shot": "One-Shot",
+  "few-sessions": "A Few Sessions",
+  "grand-campaign": "Grand Campaign",
+  "open-ended": "Open-Ended",
+};
+
 export interface PlayerConfig {
   name: string;
   character: string;
@@ -65,6 +89,8 @@ export interface CampaignConfig {
   genre?: string;
   mood?: string;
   difficulty?: string;
+  /** Intended campaign scope, set at build time. Shapes DM pacing decisions. */
+  campaign_scope?: CampaignScope;
   premise?: string;
   /** Hidden campaign detail — DM-only instructions (variants, secrets, pacing notes). */
   campaign_detail?: string;


### PR DESCRIPTION
## Summary

Two related changes in one commit, both motivated by a review of the DM personality library for GPT 5.5 readiness:

- **Drop The Trickster's `NPC ROULETTE` detail bullet.** The forced die-roll over a fixed menu (one option: *"they have 24 hours to live"*) was already misfiring on Opus — it imposes surprise character outcomes that bypass story logic. Identified during personality review as the one finding that's broken across all models, not just literal interpreters.
- **Add a new `campaign_scope` `CampaignConfig` field** with four values: `one-shot` | `few-sessions` | `grand-campaign` | `open-ended`. Player picks it at build time; DM reads it from the prefix and tailors pacing (opening momentum, slow-burn willingness, when to steer toward a climax).

## How it's wired

- New `CampaignScope` type + `CAMPAIGN_SCOPES` order + `CAMPAIGN_SCOPE_LABELS` map in `packages/shared/src/types/config.ts`.
- `setup-agent.ts` plumbs `campaignScope` through `SetupResult` → `buildCampaignConfig`.
- `setup-conversation.ts` adds `campaign_scope` (enum) to the `finalize_setup` tool, validated before being written into `SetupResult`.
- `setup-conversation.md` adds a `present_choices` step in Full Setup between Mood and DM personality (the four labels). Quick Start defaults to `few-sessions`. Pre-finalize review reads the scope back to the player.
- `prefix-builder.ts` renders `Scope: <Label>` into the Campaign Setting block.
- `dm-directives.md`'s `<pacing>` block is rewritten with concrete per-scope guidance; the old "the campaign description will mention if it is intended to be short" sentence is gone.
- `CampaignSettingsModal` shows a read-only `Scope:` row.
- `docs/state-atlas.md` schema tree updated.

Back-compat: the field is optional; existing `config.json` files without it render no scope line and the DM prompt tells the model to assume A Few Sessions in that case.

## Test plan

- [x] `npm run check` — lint clean, 2599 tests pass
- [x] Tests added: `buildCampaignConfig` scope passthrough + omit-when-undefined; `prefix-builder` renders `Scope: Grand Campaign` and omits the line when unset; `CampaignSettingsModal` displays "A Few Sessions" when set and omits when unset
- [ ] Manual: walk Full Setup and confirm the scope `present_choices` step appears between Mood and DM personality
- [ ] Manual: open ESC settings on an existing pre-scope campaign and confirm no broken row, then create a new campaign and confirm the Scope row shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)