### PR TITLE
Link resolved issues in release notes posted to Discord

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -232,7 +232,8 @@ jobs:
                 QUERY_FIELDS="${QUERY_FIELDS}
                   pr_${pr}: pullRequest(number: ${pr}) {
                     number title body
-                    closingIssuesReferences(first: 20) {
+                    closingIssuesReferences(first: 50) {
+                      totalCount
                       nodes { number title url }
                     }
                   }"
@@ -250,12 +251,17 @@ jobs:
                   | sort_by(.number)
                   | map(
                       "## PR #\(.number): \(.title)\n\(.body // "(no description)")"
-                      + (if (.closingIssuesReferences.nodes | length) > 0
-                         then "\n\nCloses issues:\n"
-                              + (.closingIssuesReferences.nodes
-                                 | map("- #\(.number) \(.title) — \(.url)")
-                                 | join("\n"))
-                         else "" end)
+                      + (.closingIssuesReferences as $cir
+                         | if ($cir.nodes | length) > 0
+                           then "\n\nCloses issues:\n"
+                                + ($cir.nodes
+                                   | sort_by(.number)
+                                   | map("- #\(.number) \(.title) — \(.url)")
+                                   | join("\n"))
+                                + (if $cir.totalCount > ($cir.nodes | length)
+                                   then "\n- …and \($cir.totalCount - ($cir.nodes | length)) more issue(s) not shown"
+                                   else "" end)
+                           else "" end)
                       + "\n---"
                     )
                   | join("\n")

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -230,7 +230,12 @@ jobs:
               QUERY_FIELDS=""
               for pr in $PR_NUMBERS; do
                 QUERY_FIELDS="${QUERY_FIELDS}
-                  pr_${pr}: pullRequest(number: ${pr}) { number title body }"
+                  pr_${pr}: pullRequest(number: ${pr}) {
+                    number title body
+                    closingIssuesReferences(first: 20) {
+                      nodes { number title url }
+                    }
+                  }"
               done
 
               PR_CONTEXT=$(gh api graphql \
@@ -243,7 +248,16 @@ jobs:
                   | to_entries
                   | map(select(.value != null) | .value)
                   | sort_by(.number)
-                  | map("## PR #\(.number): \(.title)\n\(.body // "(no description)")\n---")
+                  | map(
+                      "## PR #\(.number): \(.title)\n\(.body // "(no description)")"
+                      + (if (.closingIssuesReferences.nodes | length) > 0
+                         then "\n\nCloses issues:\n"
+                              + (.closingIssuesReferences.nodes
+                                 | map("- #\(.number) \(.title) — \(.url)")
+                                 | join("\n"))
+                         else "" end)
+                      + "\n---"
+                    )
                   | join("\n")
                 ')
             fi
@@ -281,6 +295,11 @@ jobs:
           - Describe user-facing bug fixes and features in plain,
             friendly language a player would understand.
           - A few concise bullet points in markdown. No heading, no preamble.
+          - If a PR's data includes a "Closes issues:" section, append
+            markdown links for those issues to the matching bullet, e.g.
+            "([#45](https://github.com/owner/repo/issues/45))". Use the
+            exact URL from the "Closes issues:" list. Only link issues
+            tied to user-facing changes — skip them for internal commits.
           - If there are genuinely no player-facing changes, output exactly:
             "Internal improvements and maintenance."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,8 @@ jobs:
                 QUERY_FIELDS="${QUERY_FIELDS}
                   pr_${pr}: pullRequest(number: ${pr}) {
                     number title body
-                    closingIssuesReferences(first: 20) {
+                    closingIssuesReferences(first: 50) {
+                      totalCount
                       nodes { number title url }
                     }
                   }"
@@ -225,12 +226,17 @@ jobs:
                   | sort_by(.number)
                   | map(
                       "## PR #\(.number): \(.title)\n\(.body // "(no description)")"
-                      + (if (.closingIssuesReferences.nodes | length) > 0
-                         then "\n\nCloses issues:\n"
-                              + (.closingIssuesReferences.nodes
-                                 | map("- #\(.number) \(.title) — \(.url)")
-                                 | join("\n"))
-                         else "" end)
+                      + (.closingIssuesReferences as $cir
+                         | if ($cir.nodes | length) > 0
+                           then "\n\nCloses issues:\n"
+                                + ($cir.nodes
+                                   | sort_by(.number)
+                                   | map("- #\(.number) \(.title) — \(.url)")
+                                   | join("\n"))
+                                + (if $cir.totalCount > ($cir.nodes | length)
+                                   then "\n- …and \($cir.totalCount - ($cir.nodes | length)) more issue(s) not shown"
+                                   else "" end)
+                           else "" end)
                       + "\n---"
                     )
                   | join("\n")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,12 @@ jobs:
               QUERY_FIELDS=""
               for pr in $PR_NUMBERS; do
                 QUERY_FIELDS="${QUERY_FIELDS}
-                  pr_${pr}: pullRequest(number: ${pr}) { number title body }"
+                  pr_${pr}: pullRequest(number: ${pr}) {
+                    number title body
+                    closingIssuesReferences(first: 20) {
+                      nodes { number title url }
+                    }
+                  }"
               done
 
               PR_CONTEXT=$(gh api graphql \
@@ -218,7 +223,16 @@ jobs:
                   | to_entries
                   | map(select(.value != null) | .value)
                   | sort_by(.number)
-                  | map("## PR #\(.number): \(.title)\n\(.body // "(no description)")\n---")
+                  | map(
+                      "## PR #\(.number): \(.title)\n\(.body // "(no description)")"
+                      + (if (.closingIssuesReferences.nodes | length) > 0
+                         then "\n\nCloses issues:\n"
+                              + (.closingIssuesReferences.nodes
+                                 | map("- #\(.number) \(.title) — \(.url)")
+                                 | join("\n"))
+                         else "" end)
+                      + "\n---"
+                    )
                   | join("\n")
                 ')
             fi
@@ -254,6 +268,11 @@ jobs:
           - Describe user-facing bug fixes and features in plain,
             friendly language a player would understand.
           - A few concise bullet points in markdown. No heading, no preamble.
+          - If a PR's data includes a "Closes issues:" section, append
+            markdown links for those issues to the matching bullet, e.g.
+            "([#45](https://github.com/owner/repo/issues/45))". Use the
+            exact URL from the "Closes issues:" list. Only link issues
+            tied to user-facing changes — skip them for internal commits.
           - If there are genuinely no player-facing changes, output exactly:
             "Internal improvements and maintenance."
 


### PR DESCRIPTION
## Summary
- Extends the GraphQL PR query in both release.yml and nightly.yml with `closingIssuesReferences`, so each PR's `Closes #N` / `Fixes #N` / `Resolves #N` links are fetched along with title and body.
- Formats those issues into the context block fed to Claude as a `Closes issues:` list with the real GitHub URL for each one.
- Adds a prompt rule telling Claude to append markdown issue links like `([#45](https://github.com/owner/repo/issues/45))` to the matching bullet, using the exact URL from the supplied list (so they can't be hallucinated). Discord and the GitHub release body both render that markdown as clickable links.

## Test plan
- [ ] Trigger a nightly run (or wait for the scheduled one) and confirm release notes posted to Discord include clickable issue links for PRs that close issues.
- [ ] On the next tagged release, confirm the same in `Release` workflow output and in the GitHub release body.
- [ ] Spot-check a release range with PRs that close *no* issues — bullets should still be present, just without trailing links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)