### PR TITLE
Stop release-notes prompt linking PR numbers as issues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -301,11 +301,15 @@ jobs:
           - Describe user-facing bug fixes and features in plain,
             friendly language a player would understand.
           - A few concise bullet points in markdown. No heading, no preamble.
-          - If a PR's data includes a "Closes issues:" section, append
-            markdown links for those issues to the matching bullet, e.g.
-            "([#45](https://github.com/owner/repo/issues/45))". Use the
-            exact URL from the "Closes issues:" list. Only link issues
-            tied to user-facing changes — skip them for internal commits.
+          - Append issue links ONLY when that PR's context contains a
+            "Closes issues:" section. For each issue listed there, add a
+            markdown link in parens at the end of the matching bullet,
+            e.g. "([#45](https://github.com/owner/repo/issues/45))".
+            Copy the number and URL verbatim from "Closes issues:" —
+            never construct a URL, and never link a PR number. The
+            "## PR #N:" heading is context for you, NOT a link target;
+            if a PR has no "Closes issues:" section its bullet has no
+            trailing link.
           - If there are genuinely no player-facing changes, output exactly:
             "Internal improvements and maintenance."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,11 +274,15 @@ jobs:
           - Describe user-facing bug fixes and features in plain,
             friendly language a player would understand.
           - A few concise bullet points in markdown. No heading, no preamble.
-          - If a PR's data includes a "Closes issues:" section, append
-            markdown links for those issues to the matching bullet, e.g.
-            "([#45](https://github.com/owner/repo/issues/45))". Use the
-            exact URL from the "Closes issues:" list. Only link issues
-            tied to user-facing changes — skip them for internal commits.
+          - Append issue links ONLY when that PR's context contains a
+            "Closes issues:" section. For each issue listed there, add a
+            markdown link in parens at the end of the matching bullet,
+            e.g. "([#45](https://github.com/owner/repo/issues/45))".
+            Copy the number and URL verbatim from "Closes issues:" —
+            never construct a URL, and never link a PR number. The
+            "## PR #N:" heading is context for you, NOT a link target;
+            if a PR has no "Closes issues:" section its bullet has no
+            trailing link.
           - If there are genuinely no player-facing changes, output exactly:
             "Internal improvements and maintenance."
 


### PR DESCRIPTION
## Summary
Follow-up to #505. Today's nightly post linked `(#499)` and `(#501)` as if those were issues — but they're PR numbers, and neither PR closes any issue (`closingIssuesReferences.totalCount = 0` for both). Claude saw the `## PR #N:` heading in the context block and manufactured a link, ignoring the rule about using the supplied `Closes issues:` list.

This tightens the prompt rule to be unambiguous:
- Append issue links **only** when the PR's context contains a `Closes issues:` section.
- Copy number and URL verbatim from that section — never construct a URL.
- **Never link a PR number.** The `## PR #N:` heading is described explicitly as context, not a link target.
- PRs without a `Closes issues:` section get bullets with no trailing link.

## Test plan
- [ ] Next nightly: bullets for PRs that close issues end with `([#N](url))`; bullets for PRs that close none have no trailing link.
- [ ] Spot-check that the next tagged release behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)