### PR TITLE
Rework entity tool surface around a unified store

### DIFF
--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -54,6 +54,8 @@ import { writeDebugDump } from "../tools/filesystem/debug-dump.js";
 import { styleTheme } from "./subagents/theme-styler.js";
 import { SCENE_TRACKER_CADENCE } from "./subagents/scene-tracker.js";
 import { ResolveSession } from "./resolve-session.js";
+import { EntityStore } from "../entities/store.js";
+import { buildEntityToolHandler, ENTITY_TOOL_NAME_SET } from "../entities/tools.js";
 import type { ActionDeclaration, StateDelta } from "@machine-violet/shared/types/resolve-session.js";
 
 // --- Types ---
@@ -95,6 +97,14 @@ export class GameEngine {
   private injectionRegistry: InjectionRegistry;
   private terminalDims: TerminalDims | undefined;
   private resolveSession: ResolveSession | null = null;
+  /**
+   * Entity store + dispatch handler — owns all file-backed entity I/O for
+   * this session. Constructed once because the store caches its index/drift
+   * scans and invalidates on writes. Lazy-init in `getEntityToolDispatcher`
+   * so test sites that bypass agent dispatch don't pay for it.
+   */
+  private entityStore: EntityStore | null = null;
+  private entityToolDispatcher: ((name: string, input: Record<string, unknown>) => Promise<import("./tool-registry.js").ToolResult | null>) | null = null;
 
   /** Tracks the last failed input so the player can press Enter to retry. */
   private lastFailedInput: { characterName: string; text: string; opts?: { fromAI?: boolean; skipTranscript?: boolean } } | null = null;
@@ -1446,11 +1456,37 @@ export class GameEngine {
     };
   }
 
+  /**
+   * Lazily build the entity-tool dispatcher. Stable across turns so the
+   * underlying store's scan/drift caches survive between calls.
+   */
+  private getEntityToolDispatcher(): (name: string, input: Record<string, unknown>) => Promise<import("./tool-registry.js").ToolResult | null> {
+    if (!this.entityToolDispatcher) {
+      this.entityStore = new EntityStore(this.gameState.campaignRoot, this.fileIO);
+      this.entityToolDispatcher = buildEntityToolHandler(this.entityStore, {
+        sceneNumber: this.sceneManager.getScene().sceneNumber,
+      });
+    }
+    return this.entityToolDispatcher;
+  }
+
+  /** Public accessor — used by OOC/Dev wiring that needs the live store. */
+  getEntityStore(): EntityStore {
+    this.getEntityToolDispatcher();
+    return this.entityStore as EntityStore;
+  }
+
   /** Handle tools that require async work (subagent spawning, I/O). */
   private async handleAsyncToolInternal(
     name: string,
     input: Record<string, unknown>,
   ): Promise<import("./tool-registry.js").ToolResult | null> {
+    // Entity tools — encapsulated dispatcher, owns the store, cache lives
+    // for the GameEngine's lifetime.
+    if (ENTITY_TOOL_NAME_SET.has(name)) {
+      return this.getEntityToolDispatcher()(name, input);
+    }
+
     if (name === "resolve_turn") {
       if (!this.resolveSession) {
         return {

--- a/packages/engine/src/agents/phase8.test.ts
+++ b/packages/engine/src/agents/phase8.test.ts
@@ -447,8 +447,10 @@ describe("new Phase 8 tools", () => {
     expect(registry.has("promote_character")).toBe(true);
   });
 
-  it("registry has 29 tools total", () => {
+  it("registry has 35 tools total", () => {
     const registry = createTestRegistry();
-    expect(registry.size).toBe(29);
+    // Bumped from 29 → 35 by the entity-tool rework: entity, describe_entity_type,
+    // list_entity_types, validate_entity, find_schema_drift, detect_orphans.
+    expect(registry.size).toBe(35);
   });
 });

--- a/packages/engine/src/agents/subagents/dev-mode.ts
+++ b/packages/engine/src/agents/subagents/dev-mode.ts
@@ -15,6 +15,8 @@ import { queryCommitLog, performRollback } from "../../tools/git/index.js";
 import { RollbackCompleteError } from "@machine-violet/shared/types/errors.js";
 import { registry as singletonRegistry } from "../tool-registry.js";
 import { findReferences, renameEntity, mergeEntities, resolveDeadLinks } from "../../tools/campaign-ops/index.js";
+import { EntityStore } from "../../entities/store.js";
+import { buildEntityToolHandler, RAW_ENTITY_IO_TOOL } from "../../entities/tools.js";
 import type { ModeSession } from "@machine-violet/shared/types/engine.js";
 import type { TuiCommand } from "../agent-loop.js";
 import { styleTheme } from "./theme-styler.js";
@@ -244,6 +246,11 @@ export function buildDevTools(): NormalizedTool[] {
     },
   ];
 
+  // Dev-only escape hatch — explicitly named so its appearance in transcripts
+  // stands out. The structured `entity` tool (inherited from the registry
+  // below) is the right surface for normal entity work.
+  devTools.push(RAW_ENTITY_IO_TOOL);
+
   // Append all DM tools, skipping any names already defined above
   const devNames = new Set(devTools.map((t) => t.name));
   for (const def of singletonRegistry.getDefinitions()) {
@@ -284,10 +291,48 @@ export function buildDevToolHandler(
 ): (name: string, input: Record<string, unknown>) => Promise<{ content: string; is_error?: boolean }> {
   const root = gameState.campaignRoot;
   const dmRegistry = singletonRegistry;
+  // Entity tools land on the per-session store. Shared with the rest of the
+  // engine via this handler — Dev gets structured CRUD on entities for free.
+  const entityStore = new EntityStore(root, fileIO);
+  const entityDispatch = buildEntityToolHandler(entityStore, {
+    sceneNumber: sceneManager?.getScene().sceneNumber ?? 0,
+  });
 
   return async (name: string, input: Record<string, unknown>) => {
+    // Entity tools first — structured surface beats raw file I/O.
+    const entityResult = await entityDispatch(name, input);
+    if (entityResult !== null) return entityResult;
+
     try {
       switch (name) {
+        case "raw_entity_io": {
+          const path = input.path as string | undefined;
+          const op = input.op as string | undefined;
+          if (!path || !op) {
+            return { content: "raw_entity_io requires `path` and `op`", is_error: true };
+          }
+          const abs = resolveDevPath(root, path);
+          switch (op) {
+            case "read": {
+              const content = await fileIO.readFile(abs);
+              return { content };
+            }
+            case "write": {
+              const body = input.body as string | undefined;
+              if (body === undefined) return { content: "raw_entity_io write requires `body`", is_error: true };
+              await fileIO.writeFile(abs, body);
+              return { content: `[raw_entity_io] wrote ${path}` };
+            }
+            case "delete": {
+              if (!fileIO.deleteFile) return { content: "Delete not supported", is_error: true };
+              await fileIO.deleteFile(abs);
+              return { content: `[raw_entity_io] deleted ${path}` };
+            }
+            default:
+              return { content: `Unknown op: ${op}. Use read | write | delete.`, is_error: true };
+          }
+        }
+
         case "read_file": {
           const abs = resolveDevPath(root, input.path as string);
           const content = await fileIO.readFile(abs);

--- a/packages/engine/src/agents/subagents/ooc-mode.test.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.test.ts
@@ -321,7 +321,7 @@ describe("enterOOC", () => {
     // truthful regardless of caller plumbing. They return recoverable errors
     // at dispatch time when their backing capability isn't wired up.
     expect(names).toEqual(expect.arrayContaining([
-      "read_file", "find_references", "validate_campaign", "get_commit_log",
+      "find_references", "validate_campaign", "get_commit_log",
     ]));
     // No DM tools without a registry.
     expect(names).not.toContain("roll_dice");
@@ -389,9 +389,12 @@ describe("enterOOC with gameState + DM registry", () => {
     expect(names).not.toContain("enter_ooc");
     expect(names).toContain("rollback");
     expect(names).toContain("show_character_sheet");
-    expect(names).toContain("read_file");
+    // Entity surface replaces raw read_file in OOC.
+    expect(names).toContain("entity");
+    expect(names).toContain("describe_entity_type");
     expect(names).toContain("find_references");
     expect(names).toContain("validate_campaign");
+    expect(names).not.toContain("read_file");
 
     // Smoke: representative DM tools are present.
     expect(names).toContain("roll_dice");
@@ -408,7 +411,7 @@ describe("buildOOCTools", () => {
   it("returns just the OOC-only extras when given an empty registry", () => {
     const tools = buildOOCTools({ getDefinitions: () => [] } as unknown as Parameters<typeof buildOOCTools>[0]);
     const names = tools.map((t) => t.name);
-    expect(names).toEqual(["read_file", "find_references", "validate_campaign", "get_commit_log"]);
+    expect(names).toEqual(["find_references", "validate_campaign", "get_commit_log"]);
   });
 
   it("returns all DM tools (minus enter_ooc) plus extras with the real registry", () => {
@@ -419,7 +422,9 @@ describe("buildOOCTools", () => {
     expect(names).toContain("roll_dice");
     expect(names).toContain("scribe");
     expect(names).toContain("rollback");
-    expect(names).toContain("read_file");
+    // Structured entity surface replaces the old read_file extra.
+    expect(names).toContain("entity");
+    expect(names).not.toContain("read_file");
     expect(names).toContain("get_commit_log");
   });
 });
@@ -439,30 +444,9 @@ describe("buildOOCToolHandler — OOC-only extras", () => {
     expect(result.content).toContain("Dragon's Lair");
   });
 
-  it("read_file reads a campaign file", async () => {
-    const fio = mockFileIO({ "/camp/characters/kael.md": "# Kael\n**Type:** PC" });
-    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined, undefined, "/camp", fio);
-
-    const result = await handler("read_file", { path: "characters/kael.md" });
-    expect(result.is_error).toBeUndefined();
-    expect(result.content).toBe("# Kael\n**Type:** PC");
-  });
-
-  it("read_file rejects path traversal", async () => {
-    const fio = mockFileIO();
-    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined, undefined, "/camp", fio);
-
-    const result = await handler("read_file", { path: "../etc/passwd" });
-    expect(result.is_error).toBe(true);
-    expect(result.content).toContain("Path traversal not allowed");
-  });
-
-  it("read_file errors when fileIO is missing", async () => {
-    const handler = buildOOCToolHandler(singletonRegistry, mockGameState(), undefined);
-    const result = await handler("read_file", { path: "characters/kael.md" });
-    expect(result.is_error).toBe(true);
-    expect(result.content).toContain("File I/O not available");
-  });
+  // OOC no longer surfaces `read_file`; entity reads route through the
+  // `entity` tool dispatched by GameEngine.handleAsyncTool. See
+  // packages/engine/src/entities/tools.test.ts for the structured surface.
 
   it("find_references finds wikilinks", async () => {
     const fio = mockFileIO(

--- a/packages/engine/src/agents/subagents/ooc-mode.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.ts
@@ -18,7 +18,6 @@ import type { MapData } from "@machine-violet/shared/types/maps.js";
 import type { ClocksState } from "@machine-violet/shared/types/clocks.js";
 import { findReferences } from "../../tools/campaign-ops/index.js";
 import { validateCampaign } from "../../tools/validation/index.js";
-import { resolveCampaignPath } from "../../utils/paths.js";
 import { runProviderLoop } from "../../providers/agent-loop-bridge.js";
 import type { ModeSession } from "@machine-violet/shared/types/engine.js";
 
@@ -35,9 +34,10 @@ export type EngineAsyncToolHandler = (
   input: Record<string, unknown>,
 ) => Promise<ToolResult | null>;
 
-/** Tools that exist only in OOC — file/git inspection. Layered on top of the
- *  full DM toolset; not present in the singleton registry. */
-const OOC_ONLY_TOOL_NAMES = ["read_file", "find_references", "validate_campaign", "get_commit_log"] as const;
+/** Tools that exist only in OOC — git/validation extras. Layered on top of the
+ *  full DM toolset; not present in the singleton registry. Entity reads use
+ *  the new `entity` tool, so `read_file` is no longer surfaced here. */
+const OOC_ONLY_TOOL_NAMES = ["find_references", "validate_campaign", "get_commit_log"] as const;
 const OOC_ONLY_TOOL_SET = new Set<string>(OOC_ONLY_TOOL_NAMES);
 
 /** Tools deliberately excluded from OOC's view of the registry.
@@ -151,17 +151,6 @@ export function buildOOCTools(registry: ToolRegistry): NormalizedTool[] {
 
   tools.push(
     {
-      name: "read_file",
-      description: "Read a campaign file by relative path (e.g. 'characters/kael.md').",
-      inputSchema: {
-        type: "object" as const,
-        properties: {
-          path: { type: "string", description: "Relative path within the campaign directory" },
-        },
-        required: ["path"],
-      },
-    },
-    {
       name: "find_references",
       description: "Find all wikilinks pointing to an entity. Returns file, display text, and line number for each reference.",
       inputSchema: {
@@ -254,20 +243,6 @@ async function dispatchOOCExtra(
   clocks: ClocksState | undefined,
 ): Promise<ToolResult> {
   switch (name) {
-    case "read_file": {
-      if (!fileIO || !campaignRoot) {
-        return { content: "File I/O not available", is_error: true };
-      }
-      let abs: string;
-      try {
-        abs = resolveCampaignPath(campaignRoot, input.path as string);
-      } catch {
-        return { content: "Path traversal not allowed", is_error: true };
-      }
-      const content = await fileIO.readFile(abs);
-      return { content };
-    }
-
     case "find_references": {
       if (!fileIO || !campaignRoot) {
         return { content: "File I/O not available", is_error: true };

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -4,14 +4,16 @@ import type { SubagentResult } from "../subagent.js";
 import type { UsageStats } from "../agent-loop.js";
 import { getMaxOutput } from "../../config/model-registry.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
-import { join, dirname } from "node:path";
-import { campaignPaths, machinePaths } from "../../tools/filesystem/index.js";
+import { dirname } from "node:path";
+import { machinePaths } from "../../tools/filesystem/index.js";
 import { parseFrontMatter, serializeEntity } from "../../tools/filesystem/index.js";
 import { formatChangelogEntry } from "../../tools/filesystem/index.js";
 import type { EntityFrontMatter, EntityTree } from "@machine-violet/shared/types/entities.js";
 import { renderEntityTree } from "../../tools/filesystem/index.js";
 import { norm } from "../../utils/paths.js";
 import { renameEntity as renameEntityOp } from "../../tools/campaign-ops/rename-entity.js";
+import { EntityStore } from "../../entities/store.js";
+import { isFileBackedEntityType } from "@machine-violet/shared/schemas/entities/index.js";
 import type { FileIO } from "../scene-manager.js";
 
 // Re-export slugify from world-builder so the game engine doesn't need a separate import
@@ -319,35 +321,33 @@ export function buildScribeToolHandler(
   removedSlugs: string[] = [],
   homeDir?: string,
 ) {
-  const paths = campaignPaths(campaignRoot);
   const mPaths = homeDir ? machinePaths(homeDir) : undefined;
+  // EntityStore owns disk I/O for the five file-backed types. Scribe still
+  // handles `player` itself because players are machine-scope, not
+  // campaign-scope, and don't fit the store's campaign-rooted model.
+  const store = new EntityStore(campaignRoot, fileIO);
+
+  function playerPath(slug: string): string {
+    if (!mPaths) throw new Error("player entity type requires homeDir");
+    return mPaths.player(slug);
+  }
 
   function entityPath(entityType: string, slug: string): string {
-    switch (entityType) {
-      case "character": return paths.character(slug);
-      case "location": return paths.location(slug);
-      case "faction": return paths.faction(slug);
-      case "lore": return paths.lore(slug);
-      case "item": return paths.item(slug);
-      case "player":
-        if (!mPaths) throw new Error("player entity type requires homeDir");
-        return mPaths.player(slug);
-      default: return paths.lore(slug);
+    if (isFileBackedEntityType(entityType)) {
+      return store.pathFor(entityType, slug).abs;
     }
+    if (entityType === "player") return playerPath(slug);
+    // Unknown type — fall back to lore for back-compat with prior behavior.
+    return store.pathFor("lore", slug).abs;
   }
 
   function entityDir(entityType: string): string {
-    switch (entityType) {
-      case "character": return join(campaignRoot, "characters");
-      case "location": return join(campaignRoot, "locations");
-      case "faction": return join(campaignRoot, "factions");
-      case "lore": return join(campaignRoot, "lore");
-      case "item": return join(campaignRoot, "items");
-      case "player":
-        if (!mPaths) throw new Error("player entity type requires homeDir");
-        return mPaths.playersDir;
-      default: return join(campaignRoot, "lore");
+    if (isFileBackedEntityType(entityType)) return store.dirFor(entityType);
+    if (entityType === "player") {
+      if (!mPaths) throw new Error("player entity type requires homeDir");
+      return mPaths.playersDir;
     }
+    return store.dirFor("lore");
   }
 
   return async (name: string, input: Record<string, unknown>): Promise<{ content: string; is_error?: boolean }> => {
@@ -355,20 +355,26 @@ export function buildScribeToolHandler(
       case "list_entities": {
         const entityType = input.entity_type as string;
         const dir = entityDir(entityType);
+        // Probe the directory directly so we can distinguish "no entities of
+        // this type yet" (dir doesn't exist) from "dir exists but is empty"
+        // — the prompt relies on the wording. For file-backed types, route
+        // the actual enumeration through the store so the location-subdir
+        // quirk + skip-files behaviour is unified.
         try {
-          const entries = await fileIO.listDir(dir);
-          const names = entries
-            .filter(e => e.endsWith(".md"))
-            .map(e => e.replace(/\.md$/, ""));
-          // For locations, list subdirectories instead
-          if (entityType === "location") {
-            const dirEntries = entries.filter(e => !e.includes("."));
-            return { content: dirEntries.length > 0 ? dirEntries.join("\n") : "(none)" };
-          }
-          return { content: names.length > 0 ? names.join("\n") : "(none)" };
+          await fileIO.listDir(dir);
         } catch {
           return { content: "(directory not found — no entities of this type yet)" };
         }
+        if (isFileBackedEntityType(entityType)) {
+          const entries = await store.list(entityType);
+          return { content: entries.length > 0 ? entries.map(e => e.id).join("\n") : "(none)" };
+        }
+        // Player (machine-scope) — flat .md listing.
+        const entries = await fileIO.listDir(dir);
+        const names = entries
+          .filter(e => e.endsWith(".md"))
+          .map(e => e.replace(/\.md$/, ""));
+        return { content: names.length > 0 ? names.join("\n") : "(none)" };
       }
 
       case "read_entity": {

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -187,48 +187,13 @@ function unescapeNewlines(s: string): string {
 }
 
 /**
- * Repair front_matter objects produced by smaller models (gpt-5.4-mini in
- * particular) that occasionally pass the entire on-disk markdown line as
- * the JSON key — e.g. `{ "**Type:** character": "character" }` — instead of
- * the documented `{ "type": "character" }` shape. Without this, the
- * serializer round-trips the bad key as `****Type:** character:** character`
- * and the file frontmatter is permanently corrupted on subsequent reads.
- *
- * Strategy: detect a `**Key:**` prefix in the key, extract the real key
- * (lowercased + snake-cased to match {@link normalizeKey}), and use the
- * trailing fragment as the value if no separate value was supplied or if
- * the supplied value duplicates the trailing fragment.
+ * Re-export sanitizeFrontMatter from its canonical home. EntityStore.create
+ * /update use the same repair, so the implementation moved to the shared
+ * frontmatter module — this re-export keeps existing scribe.ts imports
+ * stable.
  */
-export function sanitizeFrontMatter(
-  raw: Record<string, unknown>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  const KEY_RE = /^\*+\s*([^*:]+?)\s*:\*+\s*(.*)$/;
-  for (const [rawKey, rawValue] of Object.entries(raw)) {
-    const m = KEY_RE.exec(rawKey);
-    if (!m) {
-      out[rawKey] = rawValue;
-      continue;
-    }
-    const recoveredKey = m[1].trim().toLowerCase().replace(/\s+/g, "_");
-    const recoveredValueFromKey = m[2].trim();
-    // `null` is the deletion sentinel — preserve it regardless of any
-    // value fragment recovered from the malformed key. Otherwise a
-    // payload like `{ "**Location:** [[Old]]": null }` would silently
-    // become `{ location: "[[Old]]" }` and never actually delete the
-    // field (Copilot-flagged regression on #481).
-    const value =
-      rawValue === null
-        ? null
-        : typeof rawValue === "string" && rawValue.trim() && rawValue.trim() !== recoveredValueFromKey
-          ? rawValue
-          : recoveredValueFromKey || rawValue;
-    if (!(recoveredKey in out)) {
-      out[recoveredKey] = value;
-    }
-  }
-  return out;
-}
+export { sanitizeFrontMatter } from "../../tools/filesystem/frontmatter.js";
+import { sanitizeFrontMatter } from "../../tools/filesystem/frontmatter.js";
 
 /** Heading pattern: a `## ` at the start of a line (not `###` or deeper). */
 const H2_RE = /^## (?!#)/m;

--- a/packages/engine/src/agents/tool-registry.test.ts
+++ b/packages/engine/src/agents/tool-registry.test.ts
@@ -35,8 +35,11 @@ function mockState(): GameState {
 describe("ToolRegistry", () => {
   it("registers all T1 tools", () => {
     const reg = createTestRegistry();
-    // Map (3) + Dice (1) + Deck (1) + Clocks (2) + Combat (4) + TUI (6) + Scene (3) + Entity (5) + Objectives (1) + Search (2) + Player (1) = 29
-    expect(reg.size).toBe(29);
+    // Map (3) + Dice (1) + Deck (1) + Clocks (2) + Combat (4) + TUI (6) + Scene (3)
+    //   + Entity-narrative (5: scribe/dm_notes/resolve_turn/promote_character/search)
+    //   + Entity-CRUD (6: entity/describe_entity_type/list_entity_types/validate_entity/find_schema_drift/detect_orphans)
+    //   + Objectives (1) + Search (2) + Player (1) = 35
+    expect(reg.size).toBe(35);
   });
 
   it("generates API-compatible tool definitions", () => {

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -52,6 +52,7 @@ import {
 } from "../tools/combat/index.js";
 import { manageObjectives } from "../tools/objectives/index.js";
 import type { ManageObjectivesInput } from "../tools/objectives/index.js";
+import { ENTITY_TOOLS } from "../entities/tools.js";
 
 // --- Helpers ---
 
@@ -898,6 +899,15 @@ const TOOL_DEFS: RegisteredTool[] = [
       };
     },
   },
+
+  // ====== ENTITIES ======
+  // Definitions only — actual dispatch lives in GameEngine.handleAsyncToolInternal,
+  // which owns the per-session EntityStore. If a caller ever invokes these
+  // through the sync registry path, the stub returns an explicit error.
+  ...ENTITY_TOOLS.map((def): RegisteredTool => ({
+    definition: def,
+    handler: () => err(`${def.name} requires async handler`),
+  })),
 
   // ====== OBJECTIVES ======
   {

--- a/packages/engine/src/entities/store.test.ts
+++ b/packages/engine/src/entities/store.test.ts
@@ -199,6 +199,46 @@ describe("EntityStore CRUD roundtrip", () => {
   });
 });
 
+describe("EntityStore type safety", () => {
+  it("pins type to the directory category on create even if patch tries to override", async () => {
+    const io = inMemoryFileIO();
+    const store = new EntityStore(ROOT, io);
+    const rec = await store.create("character", {
+      displayName: "Arvid",
+      // Adversarial patch trying to mislabel the entity.
+      frontMatter: { type: "location" },
+    });
+    expect(rec.frontMatter.type).toBe("character");
+  });
+
+  it("pins type on update even when patch tries to delete or change it", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+    });
+    const store = new EntityStore(ROOT, io);
+    await store.update("character", "arvid", { frontMatter: { type: null } });
+    const rec = await store.read("character", "arvid");
+    expect(rec.frontMatter.type).toBe("character");
+  });
+
+  it("repairs malformed `**Type:** character` keys via sanitizeFrontMatter", async () => {
+    // Reproduces the small-model corruption pattern that scribe's
+    // sanitizeFrontMatter was added for. The store must apply the same
+    // repair — otherwise the file rounds-trips to `****Type:** ...`.
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+    });
+    const store = new EntityStore(ROOT, io);
+    await store.update("character", "arvid", {
+      frontMatter: { "**Location:** [[Town]]": "[[Town]]" },
+    });
+    const rec = await store.read("character", "arvid");
+    expect(rec.frontMatter.location).toBe("[[Town]]");
+    // No corrupted key sneaks through.
+    expect(Object.keys(rec.frontMatter)).not.toContain("**Location:** [[Town]]");
+  });
+});
+
 describe("EntityStore.delete + wikilink sweep", () => {
   it("deletes the file and surfaces inbound refs as dead", async () => {
     const io = inMemoryFileIO({

--- a/packages/engine/src/entities/store.test.ts
+++ b/packages/engine/src/entities/store.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { EntityStore, EntityNotFoundError, EntityValidationError } from "./store.js";
+import type { EntityFileIO } from "./store.js";
+import { norm } from "../utils/paths.js";
+
+// --- In-memory FileIO ---
+
+/**
+ * Stateful in-memory FileIO. Tracks file content keyed by normalized path.
+ * Directory listings are derived from the file set, so a write under
+ * `/root/locations/foo/index.md` makes `/root/locations` list `["foo"]` and
+ * `/root/locations/foo` list `["index.md"]`.
+ */
+function inMemoryFileIO(initial: Record<string, string> = {}): EntityFileIO & { _files: Map<string, string> } {
+  const files = new Map<string, string>();
+  for (const [k, v] of Object.entries(initial)) files.set(norm(k), v);
+
+  function dirOf(path: string): string {
+    const idx = path.lastIndexOf("/");
+    return idx < 0 ? "" : path.slice(0, idx);
+  }
+  function nameOf(path: string): string {
+    const idx = path.lastIndexOf("/");
+    return idx < 0 ? path : path.slice(idx + 1);
+  }
+
+  return {
+    _files: files,
+    async readFile(p) {
+      const k = norm(p);
+      const v = files.get(k);
+      if (v === undefined) throw new Error(`ENOENT: ${k}`);
+      return v;
+    },
+    async writeFile(p, content) { files.set(norm(p), content); },
+    async mkdir() { /* directories are implicit */ },
+    async exists(p) {
+      const k = norm(p);
+      if (files.has(k)) return true;
+      // Treat as dir if any file path starts with `k/`
+      for (const existing of files.keys()) {
+        if (existing.startsWith(k + "/")) return true;
+      }
+      return false;
+    },
+    async listDir(p) {
+      const k = norm(p);
+      const seen = new Set<string>();
+      for (const existing of files.keys()) {
+        if (existing === k) continue;
+        if (existing.startsWith(k + "/")) {
+          const rest = existing.slice(k.length + 1);
+          const slash = rest.indexOf("/");
+          seen.add(slash === -1 ? rest : rest.slice(0, slash));
+        }
+      }
+      if (seen.size === 0) {
+        // Mirror real fs behavior: listDir on non-existent path throws.
+        // Tests that target empty dirs should preload a placeholder.
+        throw new Error(`ENOENT: ${k}`);
+      }
+      return [...seen];
+    },
+    async deleteFile(p) {
+      const k = norm(p);
+      if (!files.delete(k)) throw new Error(`ENOENT: ${k}`);
+    },
+    async rmdir(p) {
+      const k = norm(p);
+      for (const existing of files.keys()) {
+        if (existing.startsWith(k + "/")) throw new Error(`ENOTEMPTY: ${k}`);
+      }
+    },
+    // Suppress unused-helper lint when callers happen to not use them.
+    ...{ _dirOf: dirOf, _nameOf: nameOf },
+  } as EntityFileIO & { _files: Map<string, string> };
+}
+
+// --- Fixtures ---
+
+const ROOT = "/root";
+
+function character(name: string, body = "", extra: Record<string, string> = {}): string {
+  const lines = [`# ${name}`, ""];
+  lines.push(`**Type:** character`);
+  for (const [k, v] of Object.entries(extra)) lines.push(`**${k}:** ${v}`);
+  if (body) { lines.push("", body); }
+  return lines.join("\n") + "\n";
+}
+
+function location(name: string, body = ""): string {
+  const lines = [`# ${name}`, "", "**Type:** location"];
+  if (body) { lines.push("", body); }
+  return lines.join("\n") + "\n";
+}
+
+// --- Tests ---
+
+describe("EntityStore path resolution", () => {
+  it("resolves flat entity types to <dir>/<slug>.md", () => {
+    const store = new EntityStore(ROOT, inMemoryFileIO());
+    const p = store.pathFor("character", "Arvid the Pale");
+    expect(p.rel).toBe("characters/arvid-the-pale.md");
+    expect(p.abs).toBe("/root/characters/arvid-the-pale.md");
+  });
+
+  it("resolves locations to <dir>/<slug>/index.md", () => {
+    const store = new EntityStore(ROOT, inMemoryFileIO());
+    const p = store.pathFor("location", "The Crooked Coin");
+    expect(p.rel).toBe("locations/crooked-coin/index.md");
+  });
+
+  it("is idempotent for already-slugified ids", () => {
+    const store = new EntityStore(ROOT, inMemoryFileIO());
+    expect(store.pathFor("character", "arvid-the-pale").rel)
+      .toBe("characters/arvid-the-pale.md");
+  });
+});
+
+describe("EntityStore CRUD roundtrip", () => {
+  let io: ReturnType<typeof inMemoryFileIO>;
+  let store: EntityStore;
+
+  beforeEach(() => {
+    io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid the Pale", "Retired soldier."),
+    });
+    store = new EntityStore(ROOT, io);
+  });
+
+  it("reads an existing character", async () => {
+    const rec = await store.read("character", "arvid");
+    expect(rec.displayName).toBe("Arvid the Pale");
+    expect(rec.frontMatter.type).toBe("character");
+    expect(rec.body).toContain("Retired soldier");
+    expect(rec.schema.version).toBe("0.1");
+  });
+
+  it("throws EntityNotFoundError for missing entity", async () => {
+    await expect(store.read("character", "ghost")).rejects.toBeInstanceOf(EntityNotFoundError);
+  });
+
+  it("creates a new character", async () => {
+    const rec = await store.create("character", {
+      displayName: "Mira",
+      frontMatter: { disposition: "wary" },
+      body: "Bardic scout.",
+    });
+    expect(rec.id).toBe("mira");
+    expect(rec.frontMatter.disposition).toBe("wary");
+    expect(rec.body).toContain("Bardic scout");
+    expect(io._files.has("/root/characters/mira.md")).toBe(true);
+  });
+
+  it("refuses to create over an existing entity", async () => {
+    // The seeded file's slug is `arvid`; a displayName that slugifies to the
+    // same value must collide.
+    await expect(store.create("character", { displayName: "Arvid" }))
+      .rejects.toBeInstanceOf(EntityValidationError);
+  });
+
+  it("creates location at index.md path", async () => {
+    const rec = await store.create("location", { displayName: "North Keep", body: "An old keep." });
+    expect(rec.id).toBe("north-keep");
+    expect(io._files.has("/root/locations/north-keep/index.md")).toBe(true);
+  });
+
+  it("updates frontmatter — null deletes a key", async () => {
+    await store.update("character", "arvid", {
+      frontMatter: { disposition: "grim", location: "[North Keep](../locations/north-keep/index.md)" },
+    });
+    const after = await store.read("character", "arvid");
+    expect(after.frontMatter.disposition).toBe("grim");
+    expect(after.frontMatter.location).toContain("North Keep");
+
+    await store.update("character", "arvid", { frontMatter: { disposition: null } });
+    const cleaned = await store.read("character", "arvid");
+    expect(cleaned.frontMatter.disposition).toBeUndefined();
+  });
+
+  it("appends changelog entries with scene numbers", async () => {
+    await store.update("character", "arvid", { changelogEntry: "Fled north", body: "Retired soldier." }, 7);
+    const rec = await store.read("character", "arvid");
+    expect(rec.changelog).toHaveLength(1);
+    expect(rec.changelog[0]).toBe("**Scene 007**: Fled north");
+  });
+
+  it("preserves unknown frontmatter keys round-trip and flags them as drift", async () => {
+    await store.update("character", "arvid", { frontMatter: { mood_today: "tense" } });
+    const rec = await store.read("character", "arvid");
+    expect(rec.frontMatter.mood_today).toBe("tense");
+    expect(rec.drift.unknownFields).toContain("mood_today");
+  });
+
+  it("create/update preserves H1 display name on update without explicit displayName", async () => {
+    await store.update("character", "arvid", { body: "Updated body" });
+    const rec = await store.read("character", "arvid");
+    expect(rec.displayName).toBe("Arvid the Pale");
+  });
+});
+
+describe("EntityStore.delete + wikilink sweep", () => {
+  it("deletes the file and surfaces inbound refs as dead", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+      "/root/lore/fall-of-arvid.md":
+        "# Fall of Arvid\n\n**Type:** lore\n\nWhen [Arvid](../characters/arvid.md) fell, the keep emptied.\n",
+      "/root/characters/mira.md":
+        "# Mira\n\n**Type:** character\n\nMira recalls [her old friend](../characters/arvid.md).\n",
+    });
+    const store = new EntityStore(ROOT, io);
+
+    const del = await store.delete("character", "arvid");
+    expect(del.path).toBe("characters/arvid.md");
+    expect(del.deadReferences).toHaveLength(2);
+    const files = del.deadReferences.map(r => r.file).sort();
+    expect(files).toEqual(["characters/mira.md", "lore/fall-of-arvid.md"]);
+    expect(io._files.has("/root/characters/arvid.md")).toBe(false);
+  });
+
+  it("deletes location subdir entry and reports it gone", async () => {
+    const io = inMemoryFileIO({
+      "/root/locations/north-keep/index.md": location("North Keep"),
+    });
+    const store = new EntityStore(ROOT, io);
+    const del = await store.delete("location", "north-keep");
+    expect(del.path).toBe("locations/north-keep/index.md");
+    expect(io._files.has("/root/locations/north-keep/index.md")).toBe(false);
+  });
+
+  it("refuses to delete missing entity", async () => {
+    const io = inMemoryFileIO();
+    const store = new EntityStore(ROOT, io);
+    await expect(store.delete("character", "ghost")).rejects.toBeInstanceOf(EntityNotFoundError);
+  });
+});
+
+describe("EntityStore index + list", () => {
+  it("scans all entity types and reports their slugs", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+      "/root/characters/mira.md": character("Mira"),
+      "/root/factions/red-hand.md": "# Red Hand\n\n**Type:** faction\n",
+      "/root/locations/north-keep/index.md": location("North Keep"),
+      "/root/lore/fall.md": "# The Fall\n\n**Type:** lore\n",
+      "/root/items/cursed-blade.md": "# Cursed Blade\n\n**Type:** item\n",
+    });
+    const store = new EntityStore(ROOT, io);
+    const tree = await store.scanIndex();
+    expect(Object.keys(tree).sort()).toEqual([
+      "arvid", "cursed-blade", "fall", "mira", "north-keep", "red-hand",
+    ]);
+    expect(tree["north-keep"].type).toBe("location");
+    expect(tree["north-keep"].path).toBe("locations/north-keep/index.md");
+  });
+
+  it("lists entities of a single type", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid the Pale", "", { "Additional Names": "Pale One, Pale" }),
+      "/root/characters/mira.md": character("Mira"),
+    });
+    const store = new EntityStore(ROOT, io);
+    const list = await store.list("character");
+    expect(list).toHaveLength(2);
+    const arvid = list.find(e => e.id === "arvid");
+    expect(arvid?.displayName).toBe("Arvid the Pale");
+    expect(arvid?.aliases).toEqual(["Pale One", "Pale"]);
+  });
+
+  it("skips conventional non-entity files (party.md, notes.md)", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+      "/root/characters/party.md": "# The Party\nList of PCs.\n",
+      "/root/characters/notes.md": "# Notes\n",
+    });
+    const store = new EntityStore(ROOT, io);
+    const list = await store.list("character");
+    expect(list.map(e => e.id)).toEqual(["arvid"]);
+  });
+});
+
+describe("EntityStore observed-field scanner", () => {
+  it("tallies frontmatter keys across all entities of a type", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid", "", { Disposition: "grim", "Mood Today": "tense" }),
+      "/root/characters/mira.md":  character("Mira",  "", { Disposition: "wry", "Mood Today": "merry" }),
+      "/root/characters/thane.md": character("Thane", "", { "Mood Today": "stoic" }),
+    });
+    const store = new EntityStore(ROOT, io);
+    const observed = await store.scanObservedFields("character");
+    expect(observed.mood_today.occursIn).toBe(3);
+    expect(observed.mood_today.examples.sort()).toEqual(["arvid", "mira", "thane"]);
+    expect(observed.disposition.occursIn).toBe(2);
+    // declared key (type) shows up too
+    expect(observed.type.occursIn).toBe(3);
+  });
+
+  it("scans all types in one call", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+      "/root/factions/red-hand.md": "# Red Hand\n\n**Type:** faction\n**Stance:** hostile\n",
+    });
+    const store = new EntityStore(ROOT, io);
+    const all = await store.scanAllObservedFields();
+    expect(all.character.type.occursIn).toBe(1);
+    expect(all.faction.stance.occursIn).toBe(1);
+    expect(all.lore).toEqual({});
+  });
+});
+
+describe("EntityStore.read references", () => {
+  it("classifies outbound links as resolved or dead", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md":
+        "# Arvid\n\n**Type:** character\n\nMember of [Red Hand](../factions/red-hand.md). Knows of [Ghost Hand](../factions/ghost-hand.md).\n",
+      "/root/factions/red-hand.md": "# Red Hand\n\n**Type:** faction\n",
+    });
+    const store = new EntityStore(ROOT, io);
+    const rec = await store.read("character", "arvid");
+    expect(rec.references.outbound).toContain("faction:red-hand");
+    expect(rec.references.dead).toContain("factions/ghost-hand.md");
+  });
+
+  it("collects inbound references from other entities", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+      "/root/lore/fall-of-arvid.md":
+        "# Fall of Arvid\n\n**Type:** lore\n\n[Arvid](../characters/arvid.md) fell.\n",
+    });
+    const store = new EntityStore(ROOT, io);
+    const rec = await store.read("character", "arvid");
+    expect(rec.references.inbound).toContain("lore:fall-of-arvid");
+  });
+
+  it("flags dead outbound refs in validation warnings", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md":
+        "# Arvid\n\n**Type:** character\n\nFollows [Dead Faction](../factions/dead.md).\n",
+    });
+    const store = new EntityStore(ROOT, io);
+    const rec = await store.read("character", "arvid");
+    expect(rec.validation.status).toBe("warnings");
+    expect(rec.validation.issues.some(i => i.msg.includes("does not resolve"))).toBe(true);
+  });
+});
+
+describe("EntityStore.detectOrphans", () => {
+  it("returns entities with no inbound references", async () => {
+    const io = inMemoryFileIO({
+      "/root/characters/arvid.md": character("Arvid"),
+      "/root/characters/mira.md":
+        "# Mira\n\n**Type:** character\n\nKnows [Arvid](../characters/arvid.md).\n",
+      "/root/lore/orphan.md": "# Orphan Lore\n\n**Type:** lore\n",
+    });
+    const store = new EntityStore(ROOT, io);
+    const orphans = await store.detectOrphans();
+    const ids = orphans.map(o => o.id).sort();
+    expect(ids).toEqual(["mira", "orphan"]);
+  });
+});

--- a/packages/engine/src/entities/store.ts
+++ b/packages/engine/src/entities/store.ts
@@ -13,11 +13,10 @@
  */
 
 import { join, dirname } from "node:path";
-import { parseFrontMatter, serializeEntity } from "../tools/filesystem/frontmatter.js";
+import { parseFrontMatter, serializeEntity, sanitizeFrontMatter } from "../tools/filesystem/frontmatter.js";
 import { formatChangelogEntry } from "../tools/filesystem/changelog.js";
 import { campaignPaths } from "../tools/filesystem/scaffold.js";
-import { findReferences } from "../tools/campaign-ops/find-references.js";
-import { walkCampaignFiles } from "../tools/campaign-ops/walk-campaign.js";
+import { walkCampaignFiles, type CampaignFile } from "../tools/campaign-ops/walk-campaign.js";
 import { extractWikilinks } from "../tools/filesystem/wikilinks.js";
 import { resolveRelativePath } from "../tools/filesystem/validation.js";
 import { norm } from "../utils/paths.js";
@@ -165,6 +164,14 @@ export class EntityStore {
   private observedCache = new Map<FileBackedEntityType, ObservedFields>();
   /** Cached entity tree. Cleared on writes. */
   private treeCache: EntityTree | null = null;
+  /**
+   * Cached campaign-file walk + the derived inbound-reference index.
+   * Both invalidated on writes. Lazy because the first call is the expensive
+   * one (reads every campaign file); subsequent calls within the same session
+   * keep entity reads cheap, which the prompt advertises.
+   */
+  private walkedFilesCache: CampaignFile[] | null = null;
+  private inboundIndexCache: Map<string, { file: string; line: number; display: string }[]> | null = null;
 
   constructor(
     public readonly campaignRoot: string,
@@ -212,6 +219,40 @@ export class EntityStore {
   private invalidateCaches(): void {
     this.observedCache.clear();
     this.treeCache = null;
+    this.walkedFilesCache = null;
+    this.inboundIndexCache = null;
+  }
+
+  /**
+   * Walk every campaign file once and cache the result. Used by reference
+   * resolution + orphan detection; without this, every `entity("read")`
+   * re-walks the whole campaign.
+   */
+  private async getWalkedFiles(): Promise<CampaignFile[]> {
+    if (this.walkedFilesCache) return this.walkedFilesCache;
+    this.walkedFilesCache = await walkCampaignFiles(this.campaignRoot, this.fileIO as Parameters<typeof walkCampaignFiles>[1]);
+    return this.walkedFilesCache;
+  }
+
+  /**
+   * Build a `targetRelativePath → references[]` index from the cached walk.
+   * Inbound-ref lookups become O(1) per entity after the first walk.
+   */
+  private async getInboundIndex(): Promise<Map<string, { file: string; line: number; display: string }[]>> {
+    if (this.inboundIndexCache) return this.inboundIndexCache;
+    const files = await this.getWalkedFiles();
+    const index = new Map<string, { file: string; line: number; display: string }[]>();
+    for (const file of files) {
+      const links = extractWikilinks(file.content);
+      for (const link of links) {
+        const resolved = resolveRelativePath(file.relativePath, link.target);
+        const bucket = index.get(resolved) ?? [];
+        bucket.push({ file: file.relativePath, line: link.line, display: link.display });
+        index.set(resolved, bucket);
+      }
+    }
+    this.inboundIndexCache = index;
+    return index;
   }
 
   // ── Index / list ──
@@ -367,10 +408,13 @@ export class EntityStore {
 
     await this.fileIO.mkdir(dirname(abs));
 
-    const fm: EntityFrontMatter = {
-      type,
-      ...(patch.frontMatter ?? {}),
-    };
+    // Sanitize first to catch small-model corruption like
+    // `{ "**Type:** character": "character" }` keys — without this they
+    // round-trip as `****Type:** character:** character` and permanently
+    // corrupt the file. Then pin `type` last so a patch can never override
+    // the category marker the directory is committed to.
+    const sanitized = sanitizeFrontMatter(patch.frontMatter ?? {});
+    const fm: EntityFrontMatter = { ...sanitized, type };
     const changelog: string[] = [];
     if (patch.changelogEntry) {
       changelog.push(formatChangelogEntry(sceneNumber, patch.changelogEntry));
@@ -407,7 +451,9 @@ export class EntityStore {
     const fm: EntityFrontMatter = { ...parsed.frontMatter };
     delete (fm as Record<string, unknown>)._title;
     if (patch.frontMatter) {
-      for (const [k, v] of Object.entries(patch.frontMatter)) {
+      // Sanitize before merge — see sanitizeFrontMatter for why.
+      const sanitized = sanitizeFrontMatter(patch.frontMatter);
+      for (const [k, v] of Object.entries(sanitized)) {
         if (v === null) {
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
           delete (fm as Record<string, unknown>)[k];
@@ -416,6 +462,10 @@ export class EntityStore {
         }
       }
     }
+    // Pin `type` to the directory's canonical category. Patches that try to
+    // change or null it are silently overridden — the on-disk type is the
+    // contract validateEntityFile checks and many other places assume.
+    fm.type = type;
 
     const body = patch.body !== undefined ? patch.body : parsed.body;
     const changelog = [...parsed.changelog];
@@ -449,8 +499,10 @@ export class EntityStore {
 
     // Capture inbound refs BEFORE deletion — once the file is gone, the next
     // `walk` won't see it as a target, but the caller still wants to know
-    // which links now dangle.
-    const refResult = await findReferences(this.campaignRoot, this.fileIO as Parameters<typeof findReferences>[1], rel);
+    // which links now dangle. Uses the cached link index when it's been
+    // populated this session.
+    const inboundIndex = await this.getInboundIndex();
+    const deadReferences = (inboundIndex.get(rel) ?? []).filter(r => r.file !== rel);
 
     await this.fileIO.deleteFile(abs);
 
@@ -468,11 +520,7 @@ export class EntityStore {
       type,
       id: slug,
       path: rel,
-      deadReferences: refResult.references.map(r => ({
-        file: r.file,
-        line: r.line,
-        display: r.display,
-      })),
+      deadReferences,
     };
   }
 
@@ -528,24 +576,13 @@ export class EntityStore {
   /** Find files in the campaign with no inbound wikilinks. */
   async detectOrphans(): Promise<{ type: FileBackedEntityType; id: string; path: string }[]> {
     const tree = await this.scanIndex();
-    const walked = await walkCampaignFiles(this.campaignRoot, this.fileIO as Parameters<typeof walkCampaignFiles>[1]);
-
-    // Build inbound count by resolving every link.
-    const inbound = new Map<string, number>();
-    for (const file of walked) {
-      const links = extractWikilinks(file.content);
-      for (const link of links) {
-        const resolved = resolveRelativePath(file.relativePath, link.target);
-        // Don't count self-references as inbound.
-        if (resolved === file.relativePath) continue;
-        inbound.set(resolved, (inbound.get(resolved) ?? 0) + 1);
-      }
-    }
+    const inboundIndex = await this.getInboundIndex();
 
     const orphans: { type: FileBackedEntityType; id: string; path: string }[] = [];
     for (const [slug, entry] of Object.entries(tree)) {
       if (!isFileBackedEntityType(entry.type)) continue;
-      if ((inbound.get(entry.path) ?? 0) === 0) {
+      const refs = (inboundIndex.get(entry.path) ?? []).filter(r => r.file !== entry.path);
+      if (refs.length === 0) {
         orphans.push({ type: entry.type, id: slug, path: entry.path });
       }
     }
@@ -585,9 +622,9 @@ export class EntityStore {
       else dead.push(resolved);
     }
 
-    const refResult = await findReferences(this.campaignRoot, this.fileIO as Parameters<typeof findReferences>[1], rel);
+    const inboundIndex = await this.getInboundIndex();
     const inbound: string[] = [];
-    for (const ref of refResult.references) {
+    for (const ref of inboundIndex.get(rel) ?? []) {
       // Skip self-references.
       if (ref.file === rel) continue;
       const labeled = pathToTypeSlug.get(ref.file) ?? ref.file;
@@ -609,19 +646,14 @@ export class EntityStore {
     for (const [name, field] of Object.entries(schema.fields)) {
       if (field.source === "frontmatter") declaredFmKeys.add(name);
     }
-    // `aliases` is sourced from frontmatter under the on-disk key
-    // `additional_names`, not the logical name `aliases`. Map it.
-    declaredFmKeys.delete("aliases");
-    declaredFmKeys.add("additional_names");
 
     const unknownFields = Object.keys(frontMatter).filter(k => !declaredFmKeys.has(k));
     const missingFields: string[] = [];
     for (const [name, field] of Object.entries(schema.fields)) {
       if (!field.required) continue;
       // displayName is sourced from h1, not frontmatter — checked separately.
-      if (field.source === "frontmatter") {
-        const key = name === "aliases" ? "additional_names" : name;
-        if (!(key in frontMatter)) missingFields.push(name);
+      if (field.source === "frontmatter" && !(name in frontMatter)) {
+        missingFields.push(name);
       }
     }
     return { unknownFields, missingFields };
@@ -639,11 +671,8 @@ export class EntityStore {
       if (field.source === "h1" && !displayName.trim()) {
         issues.push({ level: "error", field: name, msg: `Missing H1 heading (${name})` });
       }
-      if (field.source === "frontmatter") {
-        const key = name === "aliases" ? "additional_names" : name;
-        if (!(key in frontMatter)) {
-          issues.push({ level: "error", field: name, msg: `Missing required field: ${name}` });
-        }
+      if (field.source === "frontmatter" && !(name in frontMatter)) {
+        issues.push({ level: "error", field: name, msg: `Missing required field: ${name}` });
       }
     }
     for (const dead of refs.dead) {

--- a/packages/engine/src/entities/store.ts
+++ b/packages/engine/src/entities/store.ts
@@ -1,0 +1,686 @@
+/**
+ * Entity store — the single owner of file I/O for file-backed entities.
+ *
+ * Everything that reads, writes, indexes, or deletes an entity file should
+ * route through here. Scribe, the new `entity` tool, and the campaign-ops
+ * refactor tools (rename/merge/resolve-dead-links) all sit on top of this.
+ *
+ * Encapsulates:
+ *   - The location-subdir quirk (`locations/<slug>/index.md` vs flat `.md`)
+ *   - Frontmatter parse/serialize
+ *   - Wikilink-aware delete (surfaces inbound refs that become dead)
+ *   - Observed-field scanning for schema drift
+ */
+
+import { join, dirname } from "node:path";
+import { parseFrontMatter, serializeEntity } from "../tools/filesystem/frontmatter.js";
+import { formatChangelogEntry } from "../tools/filesystem/changelog.js";
+import { campaignPaths } from "../tools/filesystem/scaffold.js";
+import { findReferences } from "../tools/campaign-ops/find-references.js";
+import { walkCampaignFiles } from "../tools/campaign-ops/walk-campaign.js";
+import { extractWikilinks } from "../tools/filesystem/wikilinks.js";
+import { resolveRelativePath } from "../tools/filesystem/validation.js";
+import { norm } from "../utils/paths.js";
+import { slugify } from "@machine-violet/shared/utils/slug.js";
+import {
+  FILE_BACKED_ENTITY_TYPES,
+  getEntitySchema,
+  isFileBackedEntityType,
+  type FileBackedEntityType,
+  type EntitySchema,
+} from "@machine-violet/shared/schemas/entities/index.js";
+import type {
+  EntityFrontMatter,
+  EntityTree,
+} from "@machine-violet/shared/types/entities.js";
+
+// --- I/O surface ---
+
+/**
+ * Minimal FileIO subset the store needs. Matches the structural shape of
+ * `scene-manager`'s FileIO so production callers can pass that straight in,
+ * but pulls in only what we touch so tests don't have to mock the rest.
+ */
+export interface EntityFileIO {
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, content: string): Promise<void>;
+  mkdir(path: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  listDir(path: string): Promise<string[]>;
+  /** Required for delete + rename-after-delete cleanup. */
+  deleteFile?(path: string): Promise<void>;
+  /** Optional cleanup of the location subdir on delete. Tolerates non-empty dirs. */
+  rmdir?(path: string): Promise<void>;
+}
+
+// --- Public types ---
+
+/**
+ * Rich entity record returned by `read`. Verbose by design — agents learn the
+ * data shape from these responses, so we don't truncate or hide fields.
+ */
+export interface EntityRecord {
+  type: FileBackedEntityType;
+  id: string;
+  displayName: string;
+  aliases: string[];
+
+  /** The on-disk markdown, verbatim, for round-trip safety. */
+  raw: string;
+  /** Parsed body (everything between front matter and `## Changelog`). */
+  body: string;
+  /** Parsed front-matter, with `_title` stripped. */
+  frontMatter: Record<string, unknown>;
+  /** Parsed `## Changelog` entries, one per line, leading `- ` stripped. */
+  changelog: string[];
+
+  schema: {
+    version: string;
+    knownFields: string[];
+    required: string[];
+    /** Pointer agents can quote to learn more. */
+    source: string;
+  };
+
+  validation: {
+    status: "ok" | "warnings" | "errors";
+    issues: ValidationIssue[];
+  };
+
+  references: {
+    /** Wikilink targets emitted from this entity's body, resolved to `type:slug` when possible. */
+    outbound: string[];
+    /** Other entities (and other files) that link to this entity. */
+    inbound: string[];
+    /** Outbound targets that don't resolve to an existing entity. */
+    dead: string[];
+  };
+
+  drift: {
+    /** Front-matter keys present in the file but not in the declared schema. */
+    unknownFields: string[];
+    /** Declared required fields absent from this entity. */
+    missingFields: string[];
+  };
+}
+
+export interface ValidationIssue {
+  level: "warning" | "error";
+  field?: string;
+  msg: string;
+}
+
+export interface ListEntry {
+  id: string;
+  displayName: string;
+  aliases: string[];
+  /** Path relative to campaign root (forward slashes). */
+  path: string;
+}
+
+/**
+ * Payload accepted by create/update. Lightly typed — entity contents are
+ * markdown-shaped, so the tool surface stays close to the underlying file.
+ */
+export interface EntityPatch {
+  /** Display name. Required on create; ignored on update unless explicitly set. */
+  displayName?: string;
+  /** Front-matter merge (per update semantics — `null` deletes a key). */
+  frontMatter?: Record<string, unknown>;
+  /** Body markdown. On update, section-aware replacement is delegated to the caller. */
+  body?: string;
+  /** Changelog entry (formatted with scene number by the store). */
+  changelogEntry?: string;
+}
+
+export interface DeleteResult {
+  type: FileBackedEntityType;
+  id: string;
+  /** Path that was removed (relative). */
+  path: string;
+  /** Inbound references that are now dead (were valid before delete). */
+  deadReferences: { file: string; line: number; display: string }[];
+}
+
+export interface ObservedField {
+  /** How many entities of this type have the field set. */
+  occursIn: number;
+  /** Up to five example slugs (deterministic order). */
+  examples: string[];
+}
+
+/** Per-type observed-field summary. */
+export type ObservedFields = Record<string, ObservedField>;
+
+// --- Store ---
+
+export class EntityStore {
+  /**
+   * Skip these filenames when scanning entity dirs — they're conventional
+   * non-entity files (party roster, scratch notes) that share the directory.
+   */
+  private static readonly SKIP_FILES = new Set(["party.md", "notes.md"]);
+
+  /** Cached scan results, keyed by entity type. Cleared on writes. */
+  private observedCache = new Map<FileBackedEntityType, ObservedFields>();
+  /** Cached entity tree. Cleared on writes. */
+  private treeCache: EntityTree | null = null;
+
+  constructor(
+    public readonly campaignRoot: string,
+    private readonly fileIO: EntityFileIO,
+  ) {}
+
+  // ── Path encapsulation ──
+
+  /**
+   * Resolve `<type>/<id>` to absolute and relative paths. Encapsulates the
+   * location-subdir quirk; nothing outside this class needs to know about it.
+   */
+  pathFor(type: FileBackedEntityType, id: string): { abs: string; rel: string } {
+    const paths = campaignPaths(this.campaignRoot);
+    const slug = slugify(id);
+    let abs: string;
+    switch (type) {
+      case "character": abs = paths.character(slug); break;
+      case "location":  abs = paths.location(slug);  break;
+      case "faction":   abs = paths.faction(slug);   break;
+      case "lore":      abs = paths.lore(slug);      break;
+      case "item":      abs = paths.item(slug);      break;
+    }
+    const normRoot = norm(this.campaignRoot);
+    const normAbs = norm(abs);
+    const rel = normAbs.startsWith(normRoot + "/")
+      ? normAbs.slice(normRoot.length + 1)
+      : normAbs;
+    return { abs: normAbs, rel };
+  }
+
+  /** Resolve the directory that holds all entities of a type. */
+  dirFor(type: FileBackedEntityType): string {
+    return norm(join(this.campaignRoot, getEntitySchema(type).storage.dir));
+  }
+
+  /** True if the entity exists on disk. */
+  async exists(type: FileBackedEntityType, id: string): Promise<boolean> {
+    const { abs } = this.pathFor(type, id);
+    return this.fileIO.exists(abs);
+  }
+
+  // ── Cache management ──
+
+  private invalidateCaches(): void {
+    this.observedCache.clear();
+    this.treeCache = null;
+  }
+
+  // ── Index / list ──
+
+  /**
+   * Build the campaign-wide entity tree by scanning all entity directories.
+   * Replaces the standalone `buildEntityTree` from `entity-tree.ts`.
+   */
+  async scanIndex(): Promise<EntityTree> {
+    if (this.treeCache) return this.treeCache;
+
+    const tree: EntityTree = {};
+
+    for (const type of FILE_BACKED_ENTITY_TYPES) {
+      const entries = await this.listSlugsOnDisk(type);
+      for (const slug of entries) {
+        try {
+          const { abs, rel } = this.pathFor(type, slug);
+          const raw = await this.fileIO.readFile(abs);
+          const parsed = parseFrontMatter(raw);
+          const name = (parsed.frontMatter._title as string | undefined) ?? slug;
+          const aliases = this.parseAliases(parsed.frontMatter.additional_names);
+          tree[slug] = { name, aliases, type, path: rel };
+        } catch {
+          // Skip unreadable / malformed files; validate_entity will surface them.
+        }
+      }
+    }
+
+    this.treeCache = tree;
+    return tree;
+  }
+
+  /** List on-disk entities of a type. */
+  async list(type: FileBackedEntityType): Promise<ListEntry[]> {
+    const slugs = await this.listSlugsOnDisk(type);
+    const out: ListEntry[] = [];
+    for (const slug of slugs) {
+      try {
+        const { abs, rel } = this.pathFor(type, slug);
+        const raw = await this.fileIO.readFile(abs);
+        const parsed = parseFrontMatter(raw);
+        out.push({
+          id: slug,
+          displayName: (parsed.frontMatter._title as string | undefined) ?? slug,
+          aliases: this.parseAliases(parsed.frontMatter.additional_names),
+          path: rel,
+        });
+      } catch {
+        // Malformed file — still surface it so the caller knows it's there.
+        const { rel } = this.pathFor(type, slug);
+        out.push({ id: slug, displayName: slug, aliases: [], path: rel });
+      }
+    }
+    return out;
+  }
+
+  /** Lower-level: enumerate the slugs on disk without reading files. */
+  private async listSlugsOnDisk(type: FileBackedEntityType): Promise<string[]> {
+    const schema = getEntitySchema(type);
+    const dir = this.dirFor(type);
+
+    // Skip the exists() precheck — it's racy and not all FileIO impls report
+    // directories as "exists". The listDir try/catch handles the
+    // missing-directory case directly.
+    let entries: string[];
+    try {
+      entries = await this.fileIO.listDir(dir);
+    } catch { return []; }
+
+    const slugs: string[] = [];
+    for (const entry of entries) {
+      if (EntityStore.SKIP_FILES.has(entry)) continue;
+      if (schema.storage.subdirs && !entry.endsWith(".md")) {
+        // Subdir-per-entity: confirm index.md is present
+        const indexPath = norm(join(dir, entry, "index.md"));
+        if (await this.fileIO.exists(indexPath)) slugs.push(entry);
+      } else if (!schema.storage.subdirs && entry.endsWith(".md")) {
+        slugs.push(entry.replace(/\.md$/, ""));
+      }
+    }
+    slugs.sort();
+    return slugs;
+  }
+
+  // ── Read ──
+
+  async read(type: FileBackedEntityType, id: string): Promise<EntityRecord> {
+    const slug = slugify(id);
+    const { abs, rel } = this.pathFor(type, slug);
+    if (!(await this.fileIO.exists(abs))) {
+      throw new EntityNotFoundError(type, slug);
+    }
+    const raw = await this.fileIO.readFile(abs);
+    const parsed = parseFrontMatter(raw);
+    const schema = getEntitySchema(type);
+
+    // Clean frontmatter — strip internal `_title` which we expose via displayName.
+    const cleanFm: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(parsed.frontMatter)) {
+      if (!k.startsWith("_")) cleanFm[k] = v;
+    }
+    const displayName = (parsed.frontMatter._title as string | undefined) ?? slug;
+    const aliases = this.parseAliases(cleanFm.additional_names);
+
+    const refs = await this.collectReferences(type, slug, rel, parsed.body);
+    const drift = this.computeDrift(schema, cleanFm);
+    const validation = this.runValidation(schema, displayName, cleanFm, refs);
+
+    return {
+      type,
+      id: slug,
+      displayName,
+      aliases,
+      raw,
+      body: parsed.body,
+      frontMatter: cleanFm,
+      changelog: parsed.changelog,
+      schema: {
+        version: schema.version,
+        knownFields: Object.keys(schema.fields),
+        required: Object.entries(schema.fields).filter(([, f]) => f.required).map(([k]) => k),
+        source: `describe_entity_type('${type}')`,
+      },
+      validation,
+      references: refs,
+      drift,
+    };
+  }
+
+  // ── Create / update ──
+
+  /**
+   * Create a new entity. `id` is derived from `patch.displayName` (slugified).
+   * Throws if the entity already exists.
+   *
+   * `sceneNumber` is woven into the changelog entry if provided. Tests and
+   * out-of-scene callers can pass 0 (renders as `Scene 000`).
+   */
+  async create(
+    type: FileBackedEntityType,
+    patch: EntityPatch,
+    sceneNumber = 0,
+  ): Promise<EntityRecord> {
+    if (!patch.displayName || !patch.displayName.trim()) {
+      throw new EntityValidationError("create requires a displayName");
+    }
+    const slug = slugify(patch.displayName);
+    const { abs } = this.pathFor(type, slug);
+    if (await this.fileIO.exists(abs)) {
+      throw new EntityValidationError(`Entity already exists: ${type}/${slug}`);
+    }
+
+    await this.fileIO.mkdir(dirname(abs));
+
+    const fm: EntityFrontMatter = {
+      type,
+      ...(patch.frontMatter ?? {}),
+    };
+    const changelog: string[] = [];
+    if (patch.changelogEntry) {
+      changelog.push(formatChangelogEntry(sceneNumber, patch.changelogEntry));
+    }
+    const content = serializeEntity(patch.displayName, fm, patch.body ?? "", changelog);
+    await this.fileIO.writeFile(abs, content);
+    this.invalidateCaches();
+    return this.read(type, slug);
+  }
+
+  /**
+   * Partial update. Front-matter values of `null` delete the corresponding
+   * key. Body is replaced wholesale by `patch.body` if provided — callers
+   * that want section-aware merging should compose the body first (see
+   * `mergeSectionBodies` in scribe).
+   */
+  async update(
+    type: FileBackedEntityType,
+    id: string,
+    patch: EntityPatch,
+    sceneNumber = 0,
+  ): Promise<EntityRecord> {
+    const slug = slugify(id);
+    const { abs } = this.pathFor(type, slug);
+    if (!(await this.fileIO.exists(abs))) {
+      throw new EntityNotFoundError(type, slug);
+    }
+    const raw = await this.fileIO.readFile(abs);
+    const parsed = parseFrontMatter(raw);
+    const title = patch.displayName?.trim()
+      || (parsed.frontMatter._title as string | undefined)
+      || slug;
+
+    const fm: EntityFrontMatter = { ...parsed.frontMatter };
+    delete (fm as Record<string, unknown>)._title;
+    if (patch.frontMatter) {
+      for (const [k, v] of Object.entries(patch.frontMatter)) {
+        if (v === null) {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete (fm as Record<string, unknown>)[k];
+        } else {
+          (fm as Record<string, unknown>)[k] = v;
+        }
+      }
+    }
+
+    const body = patch.body !== undefined ? patch.body : parsed.body;
+    const changelog = [...parsed.changelog];
+    if (patch.changelogEntry) {
+      changelog.push(formatChangelogEntry(sceneNumber, patch.changelogEntry));
+    }
+    const content = serializeEntity(title, fm, body, changelog);
+    await this.fileIO.writeFile(abs, content);
+    this.invalidateCaches();
+    return this.read(type, slug);
+  }
+
+  // ── Delete ──
+
+  /**
+   * Delete an entity. Returns the inbound references that just became dead.
+   *
+   * We don't auto-rewrite or stub anything — that's the job of
+   * `resolve_dead_links` or an explicit `rename`. Surfacing the orphaned
+   * refs lets the caller decide.
+   */
+  async delete(type: FileBackedEntityType, id: string): Promise<DeleteResult> {
+    if (!this.fileIO.deleteFile) {
+      throw new EntityValidationError("delete requires fileIO.deleteFile");
+    }
+    const slug = slugify(id);
+    const { abs, rel } = this.pathFor(type, slug);
+    if (!(await this.fileIO.exists(abs))) {
+      throw new EntityNotFoundError(type, slug);
+    }
+
+    // Capture inbound refs BEFORE deletion — once the file is gone, the next
+    // `walk` won't see it as a target, but the caller still wants to know
+    // which links now dangle.
+    const refResult = await findReferences(this.campaignRoot, this.fileIO as Parameters<typeof findReferences>[1], rel);
+
+    await this.fileIO.deleteFile(abs);
+
+    // Best-effort cleanup of the location subdir. Leaves it in place if a
+    // map JSON is still parked there.
+    const schema = getEntitySchema(type);
+    if (schema.storage.subdirs && this.fileIO.rmdir) {
+      const subdir = abs.replace(/\/index\.md$/, "");
+      try { await this.fileIO.rmdir(subdir); } catch { /* still has siblings */ }
+    }
+
+    this.invalidateCaches();
+
+    return {
+      type,
+      id: slug,
+      path: rel,
+      deadReferences: refResult.references.map(r => ({
+        file: r.file,
+        line: r.line,
+        display: r.display,
+      })),
+    };
+  }
+
+  // ── Schema observation ──
+
+  /**
+   * Scan all entities of a type and tally which frontmatter keys appear.
+   * Used by `describe_entity_type` to report drift between declared schema
+   * and reality.
+   */
+  async scanObservedFields(type: FileBackedEntityType): Promise<ObservedFields> {
+    const cached = this.observedCache.get(type);
+    if (cached) return cached;
+
+    const slugs = await this.listSlugsOnDisk(type);
+    const tally: Record<string, { count: number; examples: string[] }> = {};
+
+    for (const slug of slugs) {
+      try {
+        const { abs } = this.pathFor(type, slug);
+        const raw = await this.fileIO.readFile(abs);
+        const { frontMatter } = parseFrontMatter(raw);
+        for (const key of Object.keys(frontMatter)) {
+          if (key.startsWith("_")) continue;
+          const bucket = tally[key] ?? (tally[key] = { count: 0, examples: [] });
+          bucket.count++;
+          if (bucket.examples.length < 5) bucket.examples.push(slug);
+        }
+      } catch {
+        // Skip unreadable
+      }
+    }
+
+    const observed: ObservedFields = {};
+    for (const [key, { count, examples }] of Object.entries(tally)) {
+      observed[key] = { occursIn: count, examples };
+    }
+    this.observedCache.set(type, observed);
+    return observed;
+  }
+
+  /** Schema drift across all types in one shot (handy for `find_schema_drift`). */
+  async scanAllObservedFields(): Promise<Record<FileBackedEntityType, ObservedFields>> {
+    const out: Partial<Record<FileBackedEntityType, ObservedFields>> = {};
+    for (const type of FILE_BACKED_ENTITY_TYPES) {
+      out[type] = await this.scanObservedFields(type);
+    }
+    return out as Record<FileBackedEntityType, ObservedFields>;
+  }
+
+  // ── References ──
+
+  /** Find files in the campaign with no inbound wikilinks. */
+  async detectOrphans(): Promise<{ type: FileBackedEntityType; id: string; path: string }[]> {
+    const tree = await this.scanIndex();
+    const walked = await walkCampaignFiles(this.campaignRoot, this.fileIO as Parameters<typeof walkCampaignFiles>[1]);
+
+    // Build inbound count by resolving every link.
+    const inbound = new Map<string, number>();
+    for (const file of walked) {
+      const links = extractWikilinks(file.content);
+      for (const link of links) {
+        const resolved = resolveRelativePath(file.relativePath, link.target);
+        // Don't count self-references as inbound.
+        if (resolved === file.relativePath) continue;
+        inbound.set(resolved, (inbound.get(resolved) ?? 0) + 1);
+      }
+    }
+
+    const orphans: { type: FileBackedEntityType; id: string; path: string }[] = [];
+    for (const [slug, entry] of Object.entries(tree)) {
+      if (!isFileBackedEntityType(entry.type)) continue;
+      if ((inbound.get(entry.path) ?? 0) === 0) {
+        orphans.push({ type: entry.type, id: slug, path: entry.path });
+      }
+    }
+    return orphans;
+  }
+
+  // ── Internals ──
+
+  private parseAliases(raw: unknown): string[] {
+    if (typeof raw !== "string" || !raw.trim()) return [];
+    return raw.split(",").map(a => a.trim()).filter(Boolean);
+  }
+
+  /**
+   * Outbound + inbound refs for a single entity. Outbound are resolved to
+   * `type:slug` when they land on a known file; dead targets are surfaced
+   * as the raw resolved path for diagnostics.
+   */
+  private async collectReferences(
+    type: FileBackedEntityType,
+    slug: string,
+    rel: string,
+    body: string,
+  ): Promise<{ outbound: string[]; inbound: string[]; dead: string[] }> {
+    const tree = await this.scanIndex();
+    const pathToTypeSlug = new Map<string, string>();
+    for (const [s, entry] of Object.entries(tree)) {
+      pathToTypeSlug.set(entry.path, `${entry.type}:${s}`);
+    }
+
+    const outbound: string[] = [];
+    const dead: string[] = [];
+    for (const link of extractWikilinks(body)) {
+      const resolved = resolveRelativePath(rel, link.target);
+      const labeled = pathToTypeSlug.get(resolved);
+      if (labeled) outbound.push(labeled);
+      else dead.push(resolved);
+    }
+
+    const refResult = await findReferences(this.campaignRoot, this.fileIO as Parameters<typeof findReferences>[1], rel);
+    const inbound: string[] = [];
+    for (const ref of refResult.references) {
+      // Skip self-references.
+      if (ref.file === rel) continue;
+      const labeled = pathToTypeSlug.get(ref.file) ?? ref.file;
+      inbound.push(labeled);
+    }
+    // Dedupe both sides — multiple mentions of the same target collapse.
+    return {
+      outbound: dedupeKeepOrder(outbound),
+      inbound: dedupeKeepOrder(inbound),
+      dead: dedupeKeepOrder(dead),
+    };
+  }
+
+  private computeDrift(
+    schema: EntitySchema,
+    frontMatter: Record<string, unknown>,
+  ): { unknownFields: string[]; missingFields: string[] } {
+    const declaredFmKeys = new Set<string>();
+    for (const [name, field] of Object.entries(schema.fields)) {
+      if (field.source === "frontmatter") declaredFmKeys.add(name);
+    }
+    // `aliases` is sourced from frontmatter under the on-disk key
+    // `additional_names`, not the logical name `aliases`. Map it.
+    declaredFmKeys.delete("aliases");
+    declaredFmKeys.add("additional_names");
+
+    const unknownFields = Object.keys(frontMatter).filter(k => !declaredFmKeys.has(k));
+    const missingFields: string[] = [];
+    for (const [name, field] of Object.entries(schema.fields)) {
+      if (!field.required) continue;
+      // displayName is sourced from h1, not frontmatter — checked separately.
+      if (field.source === "frontmatter") {
+        const key = name === "aliases" ? "additional_names" : name;
+        if (!(key in frontMatter)) missingFields.push(name);
+      }
+    }
+    return { unknownFields, missingFields };
+  }
+
+  private runValidation(
+    schema: EntitySchema,
+    displayName: string,
+    frontMatter: Record<string, unknown>,
+    refs: { dead: string[] },
+  ): EntityRecord["validation"] {
+    const issues: ValidationIssue[] = [];
+    for (const [name, field] of Object.entries(schema.fields)) {
+      if (!field.required) continue;
+      if (field.source === "h1" && !displayName.trim()) {
+        issues.push({ level: "error", field: name, msg: `Missing H1 heading (${name})` });
+      }
+      if (field.source === "frontmatter") {
+        const key = name === "aliases" ? "additional_names" : name;
+        if (!(key in frontMatter)) {
+          issues.push({ level: "error", field: name, msg: `Missing required field: ${name}` });
+        }
+      }
+    }
+    for (const dead of refs.dead) {
+      issues.push({ level: "warning", msg: `Outbound wikilink does not resolve: ${dead}` });
+    }
+    const hasError = issues.some(i => i.level === "error");
+    const hasWarn  = issues.some(i => i.level === "warning");
+    return {
+      status: hasError ? "errors" : hasWarn ? "warnings" : "ok",
+      issues,
+    };
+  }
+}
+
+// --- Errors ---
+
+export class EntityNotFoundError extends Error {
+  constructor(public type: string, public id: string) {
+    super(`Entity not found: ${type}/${id}`);
+    this.name = "EntityNotFoundError";
+  }
+}
+
+export class EntityValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EntityValidationError";
+  }
+}
+
+// --- Helpers ---
+
+function dedupeKeepOrder<T>(arr: T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const item of arr) {
+    if (!seen.has(item)) { seen.add(item); out.push(item); }
+  }
+  return out;
+}

--- a/packages/engine/src/entities/tools.test.ts
+++ b/packages/engine/src/entities/tools.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { EntityStore, type EntityFileIO } from "./store.js";
+import { buildEntityToolHandler } from "./tools.js";
+import { norm } from "../utils/paths.js";
+
+// --- In-memory FileIO (same shape as store.test.ts) ---
+
+function inMemoryFileIO(initial: Record<string, string> = {}): EntityFileIO & { _files: Map<string, string> } {
+  const files = new Map<string, string>();
+  for (const [k, v] of Object.entries(initial)) files.set(norm(k), v);
+  return {
+    _files: files,
+    async readFile(p) {
+      const v = files.get(norm(p));
+      if (v === undefined) throw new Error(`ENOENT: ${p}`);
+      return v;
+    },
+    async writeFile(p, content) { files.set(norm(p), content); },
+    async mkdir() { /* implicit */ },
+    async exists(p) {
+      const k = norm(p);
+      if (files.has(k)) return true;
+      for (const existing of files.keys()) {
+        if (existing.startsWith(k + "/")) return true;
+      }
+      return false;
+    },
+    async listDir(p) {
+      const k = norm(p);
+      const seen = new Set<string>();
+      for (const existing of files.keys()) {
+        if (existing.startsWith(k + "/")) {
+          const rest = existing.slice(k.length + 1);
+          const slash = rest.indexOf("/");
+          seen.add(slash === -1 ? rest : rest.slice(0, slash));
+        }
+      }
+      if (seen.size === 0) throw new Error(`ENOENT: ${k}`);
+      return [...seen];
+    },
+    async deleteFile(p) {
+      const k = norm(p);
+      if (!files.delete(k)) throw new Error(`ENOENT: ${k}`);
+    },
+    async rmdir() { /* ok */ },
+  };
+}
+
+const ROOT = "/root";
+
+function makeStore(initial: Record<string, string> = {}): {
+  store: EntityStore;
+  io: ReturnType<typeof inMemoryFileIO>;
+  handler: ReturnType<typeof buildEntityToolHandler>;
+} {
+  const io = inMemoryFileIO(initial);
+  const store = new EntityStore(ROOT, io);
+  const handler = buildEntityToolHandler(store, { sceneNumber: 3 });
+  return { store, io, handler };
+}
+
+// --- Tests ---
+
+describe("entity tool — CRUD facade", () => {
+  let stuff: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    stuff = makeStore({
+      "/root/characters/arvid.md": "# Arvid\n\n**Type:** character\n\nA grim soldier.\n",
+    });
+  });
+
+  it("returns null for unknown tool names", async () => {
+    const out = await stuff.handler("not_a_tool", {});
+    expect(out).toBeNull();
+  });
+
+  it("read returns the rich record", async () => {
+    const out = await stuff.handler("entity", { op: "read", type: "character", id: "arvid" });
+    expect(out?.is_error).toBeUndefined();
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.displayName).toBe("Arvid");
+    expect(parsed.schema.knownFields).toContain("displayName");
+    expect(parsed.references.outbound).toEqual([]);
+  });
+
+  it("read surfaces EntityNotFoundError as is_error", async () => {
+    const out = await stuff.handler("entity", { op: "read", type: "character", id: "ghost" });
+    expect(out?.is_error).toBe(true);
+    expect(out?.content).toContain("Entity not found");
+  });
+
+  it("create writes a new entity and returns the record", async () => {
+    const out = await stuff.handler("entity", {
+      op: "create",
+      type: "lore",
+      patch: { displayName: "Fall of Arvid", body: "It happened long ago." },
+    });
+    expect(out?.is_error).toBeUndefined();
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.id).toBe("fall-of-arvid");
+    expect(stuff.io._files.has("/root/lore/fall-of-arvid.md")).toBe(true);
+  });
+
+  it("create errors when displayName is missing", async () => {
+    const out = await stuff.handler("entity", { op: "create", type: "lore", patch: {} });
+    expect(out?.is_error).toBe(true);
+  });
+
+  it("update merges patch and writes scene-numbered changelog", async () => {
+    const out = await stuff.handler("entity", {
+      op: "update",
+      type: "character",
+      id: "arvid",
+      patch: { frontMatter: { disposition: "wary" }, changelogEntry: "Lost his sword" },
+    });
+    expect(out?.is_error).toBeUndefined();
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.frontMatter.disposition).toBe("wary");
+    expect(parsed.changelog[0]).toBe("**Scene 003**: Lost his sword");
+  });
+
+  it("delete reports inbound dead refs", async () => {
+    stuff = makeStore({
+      "/root/characters/arvid.md": "# Arvid\n\n**Type:** character\n",
+      "/root/lore/echoes.md": "# Echoes\n\n**Type:** lore\n\n[Arvid](../characters/arvid.md) walked here.\n",
+    });
+    const out = await stuff.handler("entity", { op: "delete", type: "character", id: "arvid" });
+    expect(out?.is_error).toBeUndefined();
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.deadReferences).toHaveLength(1);
+    expect(parsed.deadReferences[0].file).toBe("lore/echoes.md");
+  });
+
+  it("list returns all entities of a type", async () => {
+    stuff = makeStore({
+      "/root/characters/arvid.md": "# Arvid\n\n**Type:** character\n",
+      "/root/characters/mira.md": "# Mira\n\n**Type:** character\n",
+    });
+    const out = await stuff.handler("entity", { op: "list", type: "character" });
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.map((e: { id: string }) => e.id).sort()).toEqual(["arvid", "mira"]);
+  });
+
+  it("rejects unknown op", async () => {
+    const out = await stuff.handler("entity", { op: "drop", type: "character", id: "arvid" });
+    expect(out?.is_error).toBe(true);
+  });
+
+  it("rejects unknown type", async () => {
+    const out = await stuff.handler("entity", { op: "read", type: "spaceship", id: "x" });
+    expect(out?.is_error).toBe(true);
+  });
+});
+
+describe("describe_entity_type tool", () => {
+  it("merges declared schema with observed drift", async () => {
+    const { handler } = makeStore({
+      "/root/characters/arvid.md":
+        "# Arvid\n\n**Type:** character\n**Mood Today:** tense\n",
+      "/root/characters/mira.md":
+        "# Mira\n\n**Type:** character\n**Mood Today:** merry\n",
+    });
+    const out = await handler("describe_entity_type", { type: "character" });
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.fields.displayName).toBeDefined();
+    expect(parsed.observedDrift.mood_today.occursIn).toBe(2);
+    // Declared `type` field should not show up as drift
+    expect(parsed.observedDrift.type).toBeUndefined();
+    expect(parsed.examples).toContain("characters/arvid.md");
+  });
+});
+
+describe("list_entity_types tool", () => {
+  it("returns counts per type", async () => {
+    const { handler } = makeStore({
+      "/root/characters/arvid.md": "# Arvid\n\n**Type:** character\n",
+      "/root/factions/red-hand.md": "# Red Hand\n\n**Type:** faction\n",
+      "/root/factions/black-rose.md": "# Black Rose\n\n**Type:** faction\n",
+    });
+    const out = await handler("list_entity_types", {});
+    const parsed = JSON.parse(out!.content) as { type: string; count: number }[];
+    const byType = Object.fromEntries(parsed.map(p => [p.type, p.count]));
+    expect(byType.character).toBe(1);
+    expect(byType.faction).toBe(2);
+    expect(byType.lore).toBe(0);
+  });
+});
+
+describe("validate_entity tool", () => {
+  it("flags dead outbound refs as warnings", async () => {
+    const { handler } = makeStore({
+      "/root/characters/arvid.md":
+        "# Arvid\n\n**Type:** character\n\nKnows [Gone](../characters/gone.md).\n",
+    });
+    const out = await handler("validate_entity", { type: "character", id: "arvid" });
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.validation.status).toBe("warnings");
+    expect(parsed.validation.issues.some((i: { msg: string }) => i.msg.includes("does not resolve"))).toBe(true);
+  });
+
+  it("succeeds on a clean entity", async () => {
+    const { handler } = makeStore({
+      "/root/characters/arvid.md": "# Arvid\n\n**Type:** character\n",
+    });
+    const out = await handler("validate_entity", { type: "character", id: "arvid" });
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.validation.status).toBe("ok");
+  });
+});
+
+describe("find_schema_drift tool", () => {
+  it("returns drift keyed by type when no type given", async () => {
+    const { handler } = makeStore({
+      "/root/characters/arvid.md":
+        "# Arvid\n\n**Type:** character\n**Mood Today:** tense\n",
+      "/root/factions/red-hand.md":
+        "# Red Hand\n\n**Type:** faction\n**Stance:** hostile\n",
+    });
+    const out = await handler("find_schema_drift", {});
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.character.mood_today.occursIn).toBe(1);
+    expect(parsed.faction.stance.occursIn).toBe(1);
+    expect(parsed.lore).toEqual({});
+  });
+
+  it("scopes to a single type when given", async () => {
+    const { handler } = makeStore({
+      "/root/characters/arvid.md":
+        "# Arvid\n\n**Type:** character\n**Mood Today:** tense\n",
+      "/root/factions/red-hand.md":
+        "# Red Hand\n\n**Type:** faction\n**Stance:** hostile\n",
+    });
+    const out = await handler("find_schema_drift", { type: "character" });
+    const parsed = JSON.parse(out!.content);
+    expect(parsed.character.mood_today.occursIn).toBe(1);
+    expect(parsed.faction).toBeUndefined();
+  });
+});
+
+describe("detect_orphans tool", () => {
+  it("lists entities with no inbound refs", async () => {
+    const { handler } = makeStore({
+      "/root/characters/arvid.md": "# Arvid\n\n**Type:** character\n",
+      "/root/characters/mira.md":
+        "# Mira\n\n**Type:** character\n\nKnows [Arvid](../characters/arvid.md).\n",
+      "/root/lore/orphan.md": "# Orphan Lore\n\n**Type:** lore\n",
+    });
+    const out = await handler("detect_orphans", {});
+    const parsed = JSON.parse(out!.content) as { id: string }[];
+    expect(parsed.map(o => o.id).sort()).toEqual(["mira", "orphan"]);
+  });
+});

--- a/packages/engine/src/entities/tools.ts
+++ b/packages/engine/src/entities/tools.ts
@@ -236,7 +236,7 @@ async function handleDescribe(
   const declaredFmKeys = new Set<string>();
   for (const [name, field] of Object.entries(schema.fields)) {
     if (field.source === "frontmatter") {
-      declaredFmKeys.add(name === "aliases" ? "additional_names" : name);
+      declaredFmKeys.add(name);
     }
   }
   const observedDrift: Record<string, { occursIn: number; examples: string[] }> = {};
@@ -303,7 +303,7 @@ async function handleFindDrift(
     const declaredFmKeys = new Set<string>();
     for (const [name, field] of Object.entries(schema.fields)) {
       if (field.source === "frontmatter") {
-        declaredFmKeys.add(name === "aliases" ? "additional_names" : name);
+        declaredFmKeys.add(name);
       }
     }
     const drift: Record<string, { occursIn: number; examples: string[] }> = {};

--- a/packages/engine/src/entities/tools.ts
+++ b/packages/engine/src/entities/tools.ts
@@ -1,0 +1,346 @@
+/**
+ * Agent-facing tools for the entity store.
+ *
+ * Two layers:
+ *  - Tool definitions (NormalizedTool[]) — the JSON-schema-shaped tool surface
+ *    that agents see in their tool list.
+ *  - Tool handler (dispatchEntityTool) — given a store, runs the requested op
+ *    and returns a {content, is_error} payload.
+ *
+ * Both are stateless w.r.t. session — agents register a single store per
+ * session and the handler closes over it.
+ */
+
+import type { NormalizedTool } from "../providers/types.js";
+import type { ToolResult } from "../agents/tool-registry.js";
+import {
+  EntityStore,
+  EntityNotFoundError,
+  EntityValidationError,
+  type EntityPatch,
+} from "./store.js";
+import {
+  FILE_BACKED_ENTITY_TYPES,
+  getEntitySchema,
+  isFileBackedEntityType,
+  type FileBackedEntityType,
+} from "@machine-violet/shared/schemas/entities/index.js";
+
+// --- Tool name list (single source of truth) ---
+
+export const ENTITY_TOOL_NAMES = [
+  "entity",
+  "describe_entity_type",
+  "list_entity_types",
+  "validate_entity",
+  "find_schema_drift",
+  "detect_orphans",
+] as const;
+
+export type EntityToolName = (typeof ENTITY_TOOL_NAMES)[number];
+
+export const ENTITY_TOOL_NAME_SET: ReadonlySet<string> = new Set(ENTITY_TOOL_NAMES);
+
+// --- Tool definitions ---
+
+const TYPE_ENUM = FILE_BACKED_ENTITY_TYPES as readonly string[];
+
+export const ENTITY_TOOLS: NormalizedTool[] = [
+  {
+    name: "entity",
+    description:
+      "CRUD on file-backed entities — characters, locations, factions, lore, items. " +
+      "Replaces direct file editing for entity work. " +
+      "Operations: read | create | update | delete | list. " +
+      "`read` returns the full record (frontmatter + body + refs + schema + drift) — verbose by design so you learn the data shape. " +
+      "`update` patch values of null delete a frontmatter key. " +
+      "`delete` removes the file and reports inbound wikilinks that just became dead. " +
+      "For map placement, use map_entity instead. For narrative writes, use scribe.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        op: { type: "string", enum: ["read", "create", "update", "delete", "list"] },
+        type: { type: "string", enum: [...TYPE_ENUM] },
+        id: { type: "string", description: "Entity slug or display name. Required for read/update/delete." },
+        patch: {
+          type: "object",
+          description: "For create/update. Shape: { displayName?, frontMatter?, body?, changelogEntry? }. On update, frontMatter values of null delete the key.",
+          properties: {
+            displayName: { type: "string" },
+            frontMatter: { type: "object" },
+            body: { type: "string" },
+            changelogEntry: { type: "string" },
+          },
+        },
+      },
+      required: ["op", "type"],
+    },
+  },
+  {
+    name: "describe_entity_type",
+    description:
+      "Describe the data shape of a file-backed entity type: declared schema, observed drift, storage layout, conventions, examples. " +
+      "Call this when you want to learn what fields an entity supports or what people actually put in it — declared schema is canonical; observed-drift fields are real data that haven't been formally adopted yet.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: { type: "string", enum: [...TYPE_ENUM] },
+      },
+      required: ["type"],
+    },
+  },
+  {
+    name: "list_entity_types",
+    description:
+      "List all file-backed entity types with their on-disk counts. Cheap inventory pass — use this before describe_entity_type to see what's available.",
+    inputSchema: { type: "object" as const, properties: {}, required: [] },
+  },
+  {
+    name: "validate_entity",
+    description:
+      "Validate a single entity: missing required fields, dead outbound wikilinks, schema conformance. Returns the validation block from the entity record.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: { type: "string", enum: [...TYPE_ENUM] },
+        id: { type: "string" },
+      },
+      required: ["type", "id"],
+    },
+  },
+  {
+    name: "find_schema_drift",
+    description:
+      "List frontmatter fields present on disk but not in the declared schema. Optionally scope to a single entity type.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: { type: "string", enum: [...TYPE_ENUM], description: "Optional. Omit to scan all types." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "detect_orphans",
+    description:
+      "List file-backed entities with zero inbound wikilinks across the campaign. Useful for spotting forgotten characters or locations that nothing references.",
+    inputSchema: { type: "object" as const, properties: {}, required: [] },
+  },
+];
+
+// --- Handler ---
+
+/** Whether to expose the dev-only raw escape hatch. */
+export interface EntityToolHandlerOptions {
+  /** Current scene number to weave into changelog entries (defaults to 0). */
+  sceneNumber?: number;
+}
+
+/**
+ * Build an async handler that dispatches the entity tool surface against
+ * a store. Returns `null` when the tool isn't ours (caller falls through).
+ */
+export function buildEntityToolHandler(
+  store: EntityStore,
+  options: EntityToolHandlerOptions = {},
+): (name: string, input: Record<string, unknown>) => Promise<ToolResult | null> {
+  return async (name, input) => {
+    if (!ENTITY_TOOL_NAME_SET.has(name)) return null;
+    try {
+      switch (name as EntityToolName) {
+        case "entity":              return await handleEntity(store, input, options.sceneNumber ?? 0);
+        case "describe_entity_type": return await handleDescribe(store, input);
+        case "list_entity_types":   return await handleListTypes(store);
+        case "validate_entity":     return await handleValidate(store, input);
+        case "find_schema_drift":   return await handleFindDrift(store, input);
+        case "detect_orphans":      return await handleDetectOrphans(store);
+      }
+    } catch (e) {
+      if (e instanceof EntityNotFoundError || e instanceof EntityValidationError) {
+        return { content: e.message, is_error: true };
+      }
+      const msg = e instanceof Error ? e.message : String(e);
+      return { content: `${name} failed: ${msg}`, is_error: true };
+    }
+  };
+}
+
+// --- Individual handlers ---
+
+async function handleEntity(
+  store: EntityStore,
+  input: Record<string, unknown>,
+  sceneNumber: number,
+): Promise<ToolResult> {
+  const op = input.op as string;
+  const type = input.type as string;
+  if (!isFileBackedEntityType(type)) {
+    return { content: `Unknown entity type: ${type}. Try one of ${FILE_BACKED_ENTITY_TYPES.join(", ")}.`, is_error: true };
+  }
+
+  switch (op) {
+    case "read": {
+      const id = input.id as string | undefined;
+      if (!id) return { content: "read requires `id`", is_error: true };
+      const rec = await store.read(type, id);
+      return { content: JSON.stringify(rec, null, 2) };
+    }
+
+    case "list": {
+      const list = await store.list(type);
+      return { content: JSON.stringify(list, null, 2) };
+    }
+
+    case "create": {
+      const patch = (input.patch as EntityPatch | undefined) ?? {};
+      if (!patch.displayName?.trim()) {
+        return { content: "create requires patch.displayName", is_error: true };
+      }
+      const rec = await store.create(type, patch, sceneNumber);
+      return { content: JSON.stringify(rec, null, 2) };
+    }
+
+    case "update": {
+      const id = input.id as string | undefined;
+      if (!id) return { content: "update requires `id`", is_error: true };
+      const patch = (input.patch as EntityPatch | undefined) ?? {};
+      const rec = await store.update(type, id, patch, sceneNumber);
+      return { content: JSON.stringify(rec, null, 2) };
+    }
+
+    case "delete": {
+      const id = input.id as string | undefined;
+      if (!id) return { content: "delete requires `id`", is_error: true };
+      const result = await store.delete(type, id);
+      return { content: JSON.stringify(result, null, 2) };
+    }
+
+    default:
+      return { content: `Unknown op: ${op}. Use read | create | update | delete | list.`, is_error: true };
+  }
+}
+
+async function handleDescribe(
+  store: EntityStore,
+  input: Record<string, unknown>,
+): Promise<ToolResult> {
+  const type = input.type as string;
+  if (!isFileBackedEntityType(type)) {
+    return { content: `Unknown entity type: ${type}.`, is_error: true };
+  }
+  const schema = getEntitySchema(type);
+  const observed = await store.scanObservedFields(type);
+  const list = await store.list(type);
+  const examples = list.slice(0, 3).map(e => e.path);
+
+  const declaredFmKeys = new Set<string>();
+  for (const [name, field] of Object.entries(schema.fields)) {
+    if (field.source === "frontmatter") {
+      declaredFmKeys.add(name === "aliases" ? "additional_names" : name);
+    }
+  }
+  const observedDrift: Record<string, { occursIn: number; examples: string[] }> = {};
+  for (const [k, v] of Object.entries(observed)) {
+    if (!declaredFmKeys.has(k)) observedDrift[k] = v;
+  }
+
+  const out = {
+    type,
+    schemaVersion: schema.version,
+    storage: schema.storage,
+    fields: schema.fields,
+    observedDrift,
+    conventions: schema.conventions,
+    examples,
+  };
+  return { content: JSON.stringify(out, null, 2) };
+}
+
+async function handleListTypes(store: EntityStore): Promise<ToolResult> {
+  const result: { type: FileBackedEntityType; count: number; dir: string }[] = [];
+  for (const type of FILE_BACKED_ENTITY_TYPES) {
+    const list = await store.list(type);
+    result.push({ type, count: list.length, dir: getEntitySchema(type).storage.dir });
+  }
+  return { content: JSON.stringify(result, null, 2) };
+}
+
+async function handleValidate(
+  store: EntityStore,
+  input: Record<string, unknown>,
+): Promise<ToolResult> {
+  const type = input.type as string;
+  const id = input.id as string;
+  if (!isFileBackedEntityType(type)) {
+    return { content: `Unknown entity type: ${type}.`, is_error: true };
+  }
+  if (!id) return { content: "validate_entity requires `id`", is_error: true };
+  const rec = await store.read(type, id);
+  return {
+    content: JSON.stringify({
+      type: rec.type,
+      id: rec.id,
+      validation: rec.validation,
+      drift: rec.drift,
+      references: rec.references,
+    }, null, 2),
+  };
+}
+
+async function handleFindDrift(
+  store: EntityStore,
+  input: Record<string, unknown>,
+): Promise<ToolResult> {
+  const type = input.type as string | undefined;
+  const types: FileBackedEntityType[] = type && isFileBackedEntityType(type)
+    ? [type]
+    : [...FILE_BACKED_ENTITY_TYPES];
+
+  const out: Record<string, Record<string, { occursIn: number; examples: string[] }>> = {};
+  for (const t of types) {
+    const observed = await store.scanObservedFields(t);
+    const schema = getEntitySchema(t);
+    const declaredFmKeys = new Set<string>();
+    for (const [name, field] of Object.entries(schema.fields)) {
+      if (field.source === "frontmatter") {
+        declaredFmKeys.add(name === "aliases" ? "additional_names" : name);
+      }
+    }
+    const drift: Record<string, { occursIn: number; examples: string[] }> = {};
+    for (const [k, v] of Object.entries(observed)) {
+      if (!declaredFmKeys.has(k)) drift[k] = v;
+    }
+    out[t] = drift;
+  }
+  return { content: JSON.stringify(out, null, 2) };
+}
+
+async function handleDetectOrphans(store: EntityStore): Promise<ToolResult> {
+  const orphans = await store.detectOrphans();
+  return { content: JSON.stringify(orphans, null, 2) };
+}
+
+// --- Dev-only raw escape hatch ---
+
+/**
+ * Raw byte-level entity I/O. Dev-only. Mirrors the old read_file/write_file/
+ * delete_file shape but explicitly named so it stands out in transcripts —
+ * if you see `raw_entity_io` in a turn, it means the agent bypassed the
+ * structured surface, which is almost always wrong outside debugging.
+ */
+export const RAW_ENTITY_IO_TOOL: NormalizedTool = {
+  name: "raw_entity_io",
+  description:
+    "DEV-ONLY. Raw byte-level read/write/delete on an entity file path. " +
+    "Bypasses schema validation and the wikilink-aware delete sweep. " +
+    "Prefer `entity` for everything except recovery from a corrupted file.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      path: { type: "string", description: "Path relative to the campaign root, e.g. characters/arvid.md" },
+      op: { type: "string", enum: ["read", "write", "delete"] },
+      body: { type: "string", description: "Required for write." },
+    },
+    required: ["path", "op"],
+  },
+};

--- a/packages/engine/src/prompts/dev-mode.md
+++ b/packages/engine/src/prompts/dev-mode.md
@@ -10,7 +10,7 @@ If tools are unavailable in this session, say so explicitly. Do not pretend to h
 
 ## How to Handle a Request
 
-**Read before writing.** Every mutation should be preceded by reading the current state. Player says "set Kael's STR to 16" — `read_file("characters/kael.md")` first, show the current value, then `write_file` the corrected version. This catches misunderstandings and gives the player a confirmation point.
+**Read before writing.** Every mutation should be preceded by reading the current state. Player says "set Kael's STR to 16" — `entity("read", "character", "kael")` first, show the current value, then `entity("update", …)` with the corrected front matter. This catches misunderstandings and gives the player a confirmation point.
 
 **Dry-run by default.** For `repair_state`, `rename_entity`, `merge_entities`, and `resolve_dead_links`: always call with `dry_run: true` first, show the report, then ask if they want to apply. Never skip the dry-run step.
 
@@ -26,7 +26,7 @@ If tools are unavailable in this session, say so explicitly. Do not pretend to h
 
 **Stat fix — read-write cycle:**
 Player: "Fix Kael's STR to 16"
-Call `read_file("characters/kael.md")`. Show: "Kael's STR is currently 14." Write the corrected file. Respond: "Updated Kael's STR: 14 → 16."
+Call `entity("read", "character", "kael")`. Show: "Kael's STR is currently 14." Call `entity("update", "character", "kael", { frontMatter: { str: 16 } })`. Respond: "Updated Kael's STR: 14 → 16."
 
 **Diagnostic workflow — dry-run then apply:**
 Player: "There are broken links in the campaign"
@@ -38,12 +38,15 @@ Call `get_game_state` with slice `combat`. Return the JSON with a brief annotati
 
 **Bulk investigation — batch reads:**
 Player: "Show me all the factions"
-Call `list_dir("factions")` to get the file list. If few enough, read them in a single batch. Present a summary table of each faction's key front-matter fields.
+Call `entity("list", "faction")` to get the slugs. If few enough, `entity("read", "faction", id)` each in a single batch. Present a summary table of each faction's key front-matter fields.
 
 ## Scope
 
 **In scope:**
-- File CRUD: `read_file`, `write_file`, `list_dir`, `delete_file`, `search_files`
+- Entity CRUD: `entity` (read/create/update/delete/list), `describe_entity_type`, `list_entity_types`
+- Entity diagnostics: `validate_entity`, `find_schema_drift`, `detect_orphans`
+- Non-entity file CRUD: `read_file`, `write_file`, `list_dir`, `delete_file`, `search_files` — for config, transcripts, anything that isn't a file-backed entity
+- Escape hatch: `raw_entity_io` — bypass schema validation and wikilink sweep. Use only when recovering from a corrupted entity file.
 - Live game state: `get_game_state`, `set_game_state` (slices: combat, clocks, maps, decks, config, all)
 - Scene inspection: `get_scene_state`
 - Diagnostics: `validate_campaign`, `repair_state`, `resolve_dead_links`

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -39,6 +39,8 @@ Use `scribe` to record all game state changes. Batch multiple updates into one c
 
 When recording a new entity for the first time, choose a clean canonical name — "Black Coin", not "the black coin" or "a strange dark coin". No leading articles. The scribe uses this name as a filename. After the first scene change, entity slugs appear in the DM's context (e.g. `black-coin`); use wikilinks from context in subsequent scribe calls.
 
+When you need the *current* state of an entity — its full body, its inbound references, whether it's even there — call `entity("read", type, slug)`. Use `describe_entity_type` if you need to remember what fields a type supports. `entity` reads are cheap; reach for them before guessing details from context.
+
 The `dm_notes` tool (read/write) is the DM's persistent scratchpad — campaign-scope, surviving scenes and context windows, always visible in the prefix. Use it for plot plans, NPC secrets, player observations, narrative goals, or anything worth reliably remembering. Keep it organized and up to date; it belongs to the DM.
 
 The `present_choices` tool lets the DM present a set of options to a player. Note: The player has the option of rejecting them and providing their own answer regardless! Choices also support rich formatting (see below).

--- a/packages/engine/src/prompts/ooc-mode.md
+++ b/packages/engine/src/prompts/ooc-mode.md
@@ -4,7 +4,9 @@ You are temporarily out-of-character. The player is talking with you as the stor
 
 Your full DM toolkit is available — all the tools you have as the DM, with the same semantics. A few extras only exist in OOC, for inspecting and repairing the campaign:
 
-- `read_file`, `find_references`, `validate_campaign` — inspect entity files and link integrity.
+- `entity`, `describe_entity_type`, `list_entity_types` — structured CRUD on characters/locations/factions/lore/items. Reach for `entity("read", …)` instead of opening raw files; the response includes inbound/outbound refs and schema drift you'd otherwise have to compute by eye.
+- `validate_entity`, `find_schema_drift`, `detect_orphans` — diagnostics on entity health.
+- `find_references`, `validate_campaign` — link integrity at the campaign level.
 - `get_commit_log` — review the git snapshot history.
 - `rollback` — restore the campaign to a previous checkpoint. Confirm with the player before invoking; this is destructive and irreversible.
 

--- a/packages/engine/src/tools/filesystem/entity-tree.ts
+++ b/packages/engine/src/tools/filesystem/entity-tree.ts
@@ -1,92 +1,28 @@
 /**
- * Entity tree — campaign-wide registry of all entities.
+ * Entity tree — thin compatibility shim.
  *
- * Built from disk on session load by scanning entity directories and
- * parsing front matter. Injected into DM and Scribe context so agents
- * can resolve entity names to file paths without guessing slugs.
+ * The real scan/index lives in `entities/store.ts`. This module exists so
+ * legacy call sites (session-manager, scene-manager) keep working with their
+ * existing import path while the underlying scan goes through the store.
  *
- * Updated incrementally during play when the Scribe creates or
- * modifies entities.
+ * `renderEntityTree` is pure formatting and lives here; everything else
+ * delegates.
  */
-import { join } from "node:path";
-import { parseFrontMatter } from "./frontmatter.js";
-import { norm } from "../../utils/paths.js";
 import type { EntityTree } from "@machine-violet/shared/types/entities.js";
-
-/** Directories to scan, mapped to their entity type. */
-const ENTITY_DIRS: { dir: string; type: string; subdirs: boolean }[] = [
-  { dir: "characters", type: "character", subdirs: false },
-  { dir: "locations", type: "location", subdirs: true },
-  { dir: "factions", type: "faction", subdirs: false },
-  { dir: "lore", type: "lore", subdirs: false },
-  { dir: "items", type: "item", subdirs: false },
-];
-
-/** Files to skip during entity scanning. */
-const SKIP_FILES = new Set(["party.md", "notes.md"]);
-
-interface TreeFileIO {
-  readFile(path: string): Promise<string>;
-  listDir(path: string): Promise<string[]>;
-  exists(path: string): Promise<boolean>;
-}
+import { EntityStore, type EntityFileIO } from "../../entities/store.js";
 
 /**
  * Build the entity tree by scanning all entity directories on disk.
- * Parses front matter from each entity file to extract name and aliases.
+ *
+ * Thin wrapper around `EntityStore.scanIndex`. Kept for back-compat with
+ * existing callers — new code should construct an EntityStore once and reuse
+ * it instead of paying the construction cost on every scan.
  */
 export async function buildEntityTree(
   campaignRoot: string,
-  fileIO: TreeFileIO,
+  fileIO: EntityFileIO,
 ): Promise<EntityTree> {
-  const tree: EntityTree = {};
-
-  for (const { dir, type, subdirs } of ENTITY_DIRS) {
-    const dirPath = join(campaignRoot, dir);
-    if (!(await fileIO.exists(dirPath))) continue;
-
-    let entries: string[];
-    try {
-      entries = await fileIO.listDir(dirPath);
-    } catch { continue; }
-
-    for (const entry of entries) {
-      if (SKIP_FILES.has(entry)) continue;
-
-      let filePath: string;
-      let slug: string;
-
-      if (subdirs && !entry.endsWith(".md")) {
-        // Subdirectory pattern (locations): slug/index.md
-        const indexPath = norm(join(dirPath, entry, "index.md"));
-        if (!(await fileIO.exists(indexPath))) continue;
-        filePath = indexPath;
-        slug = entry;
-      } else if (entry.endsWith(".md")) {
-        filePath = norm(join(dirPath, entry));
-        slug = entry.replace(/\.md$/, "");
-      } else {
-        continue;
-      }
-
-      try {
-        const raw = await fileIO.readFile(filePath);
-        const { frontMatter } = parseFrontMatter(raw);
-        const name = (frontMatter._title as string) || slug;
-        const aliasRaw = frontMatter.additional_names as string | undefined;
-        const aliases = aliasRaw
-          ? aliasRaw.split(",").map((a) => a.trim()).filter(Boolean)
-          : [];
-        const relativePath = norm(filePath).replace(norm(campaignRoot) + "/", "");
-
-        tree[slug] = { name, aliases, type, path: relativePath };
-      } catch {
-        // Skip files that can't be parsed
-      }
-    }
-  }
-
-  return tree;
+  return new EntityStore(campaignRoot, fileIO).scanIndex();
 }
 
 /**

--- a/packages/engine/src/tools/filesystem/frontmatter.ts
+++ b/packages/engine/src/tools/filesystem/frontmatter.ts
@@ -152,6 +152,50 @@ const DISPLAY_NAMES: Record<string, string> = Object.assign(Object.create(null),
   xp: "XP",
 });
 
+/**
+ * Repair front_matter objects produced by smaller models that occasionally
+ * pass the entire on-disk markdown line as the JSON key — e.g.
+ * `{ "**Type:** character": "character" }` — instead of the documented
+ * `{ "type": "character" }` shape. Without this, the serializer round-trips
+ * the bad key as `****Type:** character:** character` and the file
+ * frontmatter is permanently corrupted on subsequent reads.
+ *
+ * Lives here (instead of next to scribe) because EntityStore.create/update
+ * also accept agent-supplied frontmatter and must apply the same repair.
+ *
+ * Strategy: detect a `**Key:**` prefix in the key, extract the real key
+ * (lowercased + snake-cased to match {@link normalizeKey}), and use the
+ * trailing fragment as the value if no separate value was supplied or if
+ * the supplied value duplicates the trailing fragment. `null` values are
+ * preserved as the deletion sentinel even when the malformed key carries
+ * a value fragment.
+ */
+export function sanitizeFrontMatter(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const KEY_RE = /^\*+\s*([^*:]+?)\s*:\*+\s*(.*)$/;
+  for (const [rawKey, rawValue] of Object.entries(raw)) {
+    const m = KEY_RE.exec(rawKey);
+    if (!m) {
+      out[rawKey] = rawValue;
+      continue;
+    }
+    const recoveredKey = m[1].trim().toLowerCase().replace(/\s+/g, "_");
+    const recoveredValueFromKey = m[2].trim();
+    const value =
+      rawValue === null
+        ? null
+        : typeof rawValue === "string" && rawValue.trim() && rawValue.trim() !== recoveredValueFromKey
+          ? rawValue
+          : recoveredValueFromKey || rawValue;
+    if (!(recoveredKey in out)) {
+      out[recoveredKey] = value;
+    }
+  }
+  return out;
+}
+
 /** Convert storage key to display key: "display_resources" -> "Display Resources" */
 export function displayKeyName(key: string): string {
   const canonical = DISPLAY_NAMES[key];

--- a/packages/engine/src/tools/filesystem/index.ts
+++ b/packages/engine/src/tools/filesystem/index.ts
@@ -1,4 +1,4 @@
-export { parseFrontMatter, serializeEntity, extractSection, normalizeKey, displayKeyName } from "./frontmatter.js";
+export { parseFrontMatter, serializeEntity, extractSection, normalizeKey, displayKeyName, sanitizeFrontMatter } from "./frontmatter.js";
 export { extractWikilinks, uniqueTargets } from "./wikilinks.js";
 export type { WikiLink } from "./wikilinks.js";
 export { campaignDirs, sceneDir, campaignPaths, machineDirs, machinePaths } from "./scaffold.js";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,6 +21,10 @@
     "./utils/*.js": {
       "source": "./src/utils/*.ts",
       "default": "./dist/utils/*.js"
+    },
+    "./schemas/entities/*.js": {
+      "source": "./src/schemas/entities/*.ts",
+      "default": "./dist/schemas/entities/*.js"
     }
   },
   "scripts": {

--- a/packages/shared/src/schemas/entities/index.ts
+++ b/packages/shared/src/schemas/entities/index.ts
@@ -80,18 +80,21 @@ const DISPLAY_NAME: SchemaField = {
   description: "Canonical display name (the H1 heading).",
 };
 
-const ALIASES: SchemaField = {
-  required: false,
-  kind: "string[]",
-  source: "frontmatter",
-  description: "Comma-separated alternative names. Surfaced as `Additional Names`.",
-};
-
-const TYPE_TAG: SchemaField = {
+// Schema field names match on-disk keys exactly so agents can write what
+// they read. `EntityRecord.aliases` is a parsed convenience on top of this
+// raw string.
+const ADDITIONAL_NAMES: SchemaField = {
   required: false,
   kind: "string",
   source: "frontmatter",
-  description: "Subtype tag (e.g. NPC vs PC for character). Free-form string.",
+  description: "Comma-separated alternative names (e.g. \"Pale One, The Pale\"). Parsed into `EntityRecord.aliases` on read.",
+};
+
+const TYPE_CATEGORY: SchemaField = {
+  required: true,
+  kind: "string",
+  source: "frontmatter",
+  description: "Entity category marker (\"character\", \"location\", \"faction\", \"lore\", or \"item\"). Set automatically by the store from the on-disk directory; do not override.",
 };
 
 // --- Per-type schemas ---
@@ -102,8 +105,8 @@ export const CHARACTER_SCHEMA: EntitySchema = {
   storage: { dir: "characters", subdirs: false, format: "markdown+frontmatter" },
   fields: {
     displayName: DISPLAY_NAME,
-    aliases: ALIASES,
-    type: TYPE_TAG,
+    additional_names: ADDITIONAL_NAMES,
+    type: TYPE_CATEGORY,
     location: {
       required: false,
       kind: "wikilink",
@@ -113,7 +116,7 @@ export const CHARACTER_SCHEMA: EntitySchema = {
   },
   conventions: [
     ...SHARED_CONVENTIONS,
-    "PCs and named NPCs both live here. Use the `type` field to distinguish (PC, NPC).",
+    "PCs and named NPCs both live here. The `type` field is fixed to \"character\" — PC vs NPC is conventionally noted in the body or via promote_character's sheet status, not via type.",
     "Promoted character sheets follow `promote_character`'s sheet format under `## Stats`/`## Abilities`.",
   ],
 };
@@ -124,8 +127,8 @@ export const LOCATION_SCHEMA: EntitySchema = {
   storage: { dir: "locations", subdirs: true, format: "markdown+frontmatter" },
   fields: {
     displayName: DISPLAY_NAME,
-    aliases: ALIASES,
-    type: TYPE_TAG,
+    additional_names: ADDITIONAL_NAMES,
+    type: TYPE_CATEGORY,
   },
   conventions: [
     ...SHARED_CONVENTIONS,
@@ -140,8 +143,8 @@ export const FACTION_SCHEMA: EntitySchema = {
   storage: { dir: "factions", subdirs: false, format: "markdown+frontmatter" },
   fields: {
     displayName: DISPLAY_NAME,
-    aliases: ALIASES,
-    type: TYPE_TAG,
+    additional_names: ADDITIONAL_NAMES,
+    type: TYPE_CATEGORY,
   },
   conventions: [
     ...SHARED_CONVENTIONS,
@@ -155,8 +158,8 @@ export const LORE_SCHEMA: EntitySchema = {
   storage: { dir: "lore", subdirs: false, format: "markdown+frontmatter" },
   fields: {
     displayName: DISPLAY_NAME,
-    aliases: ALIASES,
-    type: TYPE_TAG,
+    additional_names: ADDITIONAL_NAMES,
+    type: TYPE_CATEGORY,
   },
   conventions: [
     ...SHARED_CONVENTIONS,
@@ -170,8 +173,8 @@ export const ITEM_SCHEMA: EntitySchema = {
   storage: { dir: "items", subdirs: false, format: "markdown+frontmatter" },
   fields: {
     displayName: DISPLAY_NAME,
-    aliases: ALIASES,
-    type: TYPE_TAG,
+    additional_names: ADDITIONAL_NAMES,
+    type: TYPE_CATEGORY,
   },
   conventions: [
     ...SHARED_CONVENTIONS,

--- a/packages/shared/src/schemas/entities/index.ts
+++ b/packages/shared/src/schemas/entities/index.ts
@@ -1,0 +1,196 @@
+/**
+ * Declared entity schemas.
+ *
+ * These are the *minimal* canonical shape for each file-backed entity type.
+ * Everything else is observational — see the entity store's drift scanner
+ * and `describe_entity_type`, which surface fields that show up on disk but
+ * aren't declared here.
+ *
+ * Start small. Promote a field from "observed" to "declared" only when the
+ * data is consistent enough that we want agents to rely on it.
+ */
+
+/** Storage layout for an entity type on disk. */
+export interface EntityStorage {
+  /** Top-level directory under the campaign root (e.g. "characters"). */
+  dir: string;
+  /**
+   * True when each entity lives under `<dir>/<slug>/index.md` instead of a
+   * flat `<dir>/<slug>.md`. Only locations use this today.
+   */
+  subdirs: boolean;
+  format: "markdown+frontmatter";
+}
+
+/** Where a field is read from when materializing an entity record. */
+export type FieldSource =
+  | "h1"            // the markdown H1 heading
+  | "frontmatter"   // a **Key:** Value line in the front matter
+  | "body";         // a ## section in the body
+
+export interface SchemaField {
+  required: boolean;
+  kind: "string" | "string[]" | "wikilink" | "wikilink[]";
+  source: FieldSource;
+  /** Free-form description for `describe_entity_type` output. */
+  description?: string;
+}
+
+export interface EntitySchema {
+  type: FileBackedEntityType;
+  /**
+   * Bumped when a declared field is added/removed/retyped. Not bumped for
+   * data tweaks — the data isn't versioned, only the contract is.
+   */
+  version: string;
+  storage: EntityStorage;
+  fields: Record<string, SchemaField>;
+  conventions: string[];
+}
+
+/** Entity types that have on-disk files we own with this rework. */
+export type FileBackedEntityType =
+  | "character"
+  | "location"
+  | "faction"
+  | "lore"
+  | "item";
+
+export const FILE_BACKED_ENTITY_TYPES: readonly FileBackedEntityType[] = [
+  "character",
+  "location",
+  "faction",
+  "lore",
+  "item",
+] as const;
+
+// --- Shared bits ---
+
+const SHARED_CONVENTIONS = [
+  "The H1 heading is the canonical display name. Filename slug is derived from it via slugify().",
+  "Wikilinks use markdown link syntax: [Display](../type/slug.md). Targets are bidirectional and tracked across the campaign.",
+  "Changelog entries live in a `## Changelog` section as `- **Scene NNN**: note`.",
+  "Unknown front-matter keys are preserved on round-trip but flagged as drift.",
+];
+
+const DISPLAY_NAME: SchemaField = {
+  required: true,
+  kind: "string",
+  source: "h1",
+  description: "Canonical display name (the H1 heading).",
+};
+
+const ALIASES: SchemaField = {
+  required: false,
+  kind: "string[]",
+  source: "frontmatter",
+  description: "Comma-separated alternative names. Surfaced as `Additional Names`.",
+};
+
+const TYPE_TAG: SchemaField = {
+  required: false,
+  kind: "string",
+  source: "frontmatter",
+  description: "Subtype tag (e.g. NPC vs PC for character). Free-form string.",
+};
+
+// --- Per-type schemas ---
+
+export const CHARACTER_SCHEMA: EntitySchema = {
+  type: "character",
+  version: "0.1",
+  storage: { dir: "characters", subdirs: false, format: "markdown+frontmatter" },
+  fields: {
+    displayName: DISPLAY_NAME,
+    aliases: ALIASES,
+    type: TYPE_TAG,
+    location: {
+      required: false,
+      kind: "wikilink",
+      source: "frontmatter",
+      description: "Where this character currently is. Wikilink to a location.",
+    },
+  },
+  conventions: [
+    ...SHARED_CONVENTIONS,
+    "PCs and named NPCs both live here. Use the `type` field to distinguish (PC, NPC).",
+    "Promoted character sheets follow `promote_character`'s sheet format under `## Stats`/`## Abilities`.",
+  ],
+};
+
+export const LOCATION_SCHEMA: EntitySchema = {
+  type: "location",
+  version: "0.1",
+  storage: { dir: "locations", subdirs: true, format: "markdown+frontmatter" },
+  fields: {
+    displayName: DISPLAY_NAME,
+    aliases: ALIASES,
+    type: TYPE_TAG,
+  },
+  conventions: [
+    ...SHARED_CONVENTIONS,
+    "Locations are the only entity type stored in subdirectories — `locations/<slug>/index.md`.",
+    "Map JSONs live alongside `index.md` as `locations/<slug>/<map-id>.json`. Map editing goes through `map`/`map_entity` tools, not this surface.",
+  ],
+};
+
+export const FACTION_SCHEMA: EntitySchema = {
+  type: "faction",
+  version: "0.1",
+  storage: { dir: "factions", subdirs: false, format: "markdown+frontmatter" },
+  fields: {
+    displayName: DISPLAY_NAME,
+    aliases: ALIASES,
+    type: TYPE_TAG,
+  },
+  conventions: [
+    ...SHARED_CONVENTIONS,
+    "Factions usually have `## Goals` and `## Members` sections in the body. Not required, but conventional.",
+  ],
+};
+
+export const LORE_SCHEMA: EntitySchema = {
+  type: "lore",
+  version: "0.1",
+  storage: { dir: "lore", subdirs: false, format: "markdown+frontmatter" },
+  fields: {
+    displayName: DISPLAY_NAME,
+    aliases: ALIASES,
+    type: TYPE_TAG,
+  },
+  conventions: [
+    ...SHARED_CONVENTIONS,
+    "Lore is the catch-all for world facts, history, myths, creatures-as-flavor. When in doubt about where an entity belongs, lore is the safer default.",
+  ],
+};
+
+export const ITEM_SCHEMA: EntitySchema = {
+  type: "item",
+  version: "0.1",
+  storage: { dir: "items", subdirs: false, format: "markdown+frontmatter" },
+  fields: {
+    displayName: DISPLAY_NAME,
+    aliases: ALIASES,
+    type: TYPE_TAG,
+  },
+  conventions: [
+    ...SHARED_CONVENTIONS,
+    "Items here are notable named/unique items the campaign tracks. Generic loot lives in character inventories, not as separate entity files.",
+  ],
+};
+
+const SCHEMAS: Record<FileBackedEntityType, EntitySchema> = {
+  character: CHARACTER_SCHEMA,
+  location: LOCATION_SCHEMA,
+  faction: FACTION_SCHEMA,
+  lore: LORE_SCHEMA,
+  item: ITEM_SCHEMA,
+};
+
+export function getEntitySchema(type: FileBackedEntityType): EntitySchema {
+  return SCHEMAS[type];
+}
+
+export function isFileBackedEntityType(type: string): type is FileBackedEntityType {
+  return (FILE_BACKED_ENTITY_TYPES as readonly string[]).includes(type);
+}


### PR DESCRIPTION
## Summary

- Replaces the file-level entity tooling (`read_file`/`write_file`/`delete_file` for entity work, scattered Scribe/dev-mode codepaths) with a structured `entity` CRUD tool backed by a single `EntityStore`.
- Declares per-type schemas in `@machine-violet/shared/schemas/entities/`, observes drift from disk, and exposes both via new diagnostic tools: `describe_entity_type`, `list_entity_types`, `validate_entity`, `find_schema_drift`, `detect_orphans`.
- DM gains the structured entity surface; OOC swaps `read_file` for it; Dev keeps the raw file tools as an escape hatch and adds an explicit `raw_entity_io` so bypasses are visible in transcripts. Scribe internals and the legacy `entity-tree.ts` route through the store.

## What changed

| Area | Before | After |
|---|---|---|
| Agent-facing entity I/O | `read_file` / `write_file` / `delete_file` exposed to DM + OOC | Structured `entity` / `describe_entity_type` / `list_entity_types`; raw tools live only in Dev |
| Delete | Generic `delete_file`; no wikilink sweep | `entity("delete", …)` reports inbound refs that just became dead |
| Schema | Implicit in code and example files | Declared in `@machine-violet/shared/schemas/entities/`, reconciled with observed-on-disk drift |
| Storage quirks | Scattered (the location-subdir quirk re-implemented in 3+ places) | Encapsulated in `EntityStore.pathFor()` |
| Scribe writes | Direct `fs` + frontmatter calls in `scribe.ts` | Route through the store for the five file-backed types |
| `entity-tree.ts` | Standalone scan logic | Thin compatibility shim around `EntityStore.scanIndex` |

## Test plan

- [x] `npm run check` (lint + tests) — passes
- [x] `npx vitest run packages/engine/src/entities` — 41 new tests on store + tool handler
- [x] `npm run e2e:boot` — passes
- [ ] Manual agent-driven verification of the new tool surface (deferred follow-up; see body)

## Deferred follow-ups

- Agent-level integration verification: drive DM / OOC / Dev with the new `entity` surface in a live session. Prompts have been touched but the actual model behavior with the new tool calls isn't exercised by the unit tests.
- Schema declarations are deliberately minimal (just `displayName` + `aliases` + `type` for most types). Promoting more fields to "declared" should happen as we accumulate confidence in their data shape.
- `merge_entities` / `rename_entity` / `resolve_dead_links` still walk the campaign and rewrite links themselves rather than going through the store. The store doesn't currently expose a rename/merge primitive — adding one would unify the wikilink-sweep paths but is non-trivial. Left as-is for this PR since external behavior is unchanged.
- Schema-drift telemetry: surfacing drift counts somewhere visible (CLI command, periodic warning) would let maintainers spot fields worth promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)