### PR TITLE
Strip orphan close tags so leaked formatting never renders as literal text

### DIFF
--- a/packages/client-ink/src/tui/formatting.test.ts
+++ b/packages/client-ink/src/tui/formatting.test.ts
@@ -83,6 +83,21 @@ describe("parseFormatting", () => {
     expect(toPlainText(result)).toBe("<blink>flashing</blink>");
   });
 
+  it("strips orphan close tags silently (issue #454)", () => {
+    // A close tag with no matching open in scope is a leak from healing
+    // across a paragraph boundary — never literal text the user meant.
+    expect(parseFormatting("verse 4</i></center>")).toEqual(["verse 4"]);
+    expect(parseFormatting("</b>plain</b>")).toEqual(["plain"]);
+    expect(parseFormatting("a</color>b")).toEqual(["ab"]);
+  });
+
+  it("does not strip unrecognized close tags", () => {
+    // Only known tag names are stripped; arbitrary </blink> stays literal
+    // so e.g. code samples and quoted HTML still render.
+    const result = parseFormatting("text</blink>more");
+    expect(toPlainText(result)).toBe("text</blink>more");
+  });
+
   it("handles empty content between tags", () => {
     const result = parseFormatting("<b></b>");
     expect(result).toHaveLength(1);
@@ -1329,6 +1344,32 @@ describe("multi-line formatting across spacers", () => {
     expect(lastDm.nodes).toEqual(["clean"]);
   });
 
+  it("no dangling close tags after paragraph break (issue #454)", () => {
+    // Reported bug: poem with <center><i>...</i></center> spanning a blank
+    // verse-separator line. The blank line resets the healing stack, then
+    // </i></center> arrives on the last verse line with nothing to match —
+    // previously rendered as literal "</i></center>" text after the poem.
+    const result = processNarrativeLines([
+      dm("<center><i>verse 1"),
+      dm("verse 2"),
+      dm(""),
+      dm("verse 3"),
+      dm("verse 4</i></center>"),
+      dm(""),
+      dm("prose after"),
+    ], 80);
+    const dmLines = result.filter((l) => l.kind === "dm");
+    for (const line of dmLines) {
+      const plain = toPlainText(line.nodes);
+      expect(plain).not.toContain("</i>");
+      expect(plain).not.toContain("</center>");
+    }
+    // Verses 3 and 4 are unformatted (Layer-1 fix: strip, don't reflow).
+    const verse4 = dmLines.find((l) => toPlainText(l.nodes).startsWith("verse 4"));
+    expect(verse4).toBeDefined();
+    expect(toPlainText(verse4!.nodes)).toBe("verse 4");
+  });
+
   it("no dangling close tags after spacer", () => {
     // The core bug: close tag on second line should NOT appear as literal text
     const result = processNarrativeLines([
@@ -1371,10 +1412,12 @@ describe("wikilink tag", () => {
   });
 
   it("rejects malformed wikilink (no slug attribute)", () => {
-    // Unparseable open tag — `<wikilink>` without slug=. The `<` is emitted
-    // as literal text and the remainder is treated as plain text.
+    // Unparseable open tag — `<wikilink>` without slug=. The `<wikilink>`
+    // open emits as literal text (no matching close for an unparseable open).
+    // The trailing `</wikilink>` is a known close tag with no matching open
+    // in scope, so it's stripped as an orphan (issue #454 behavior).
     const result = parseFormatting("<wikilink>Foo</wikilink>");
-    expect(stripFormatting("<wikilink>Foo</wikilink>")).toBe("<wikilink>Foo</wikilink>");
+    expect(stripFormatting("<wikilink>Foo</wikilink>")).toBe("<wikilink>Foo");
     expect(result.length).toBeGreaterThan(0);
   });
 });

--- a/packages/client-ink/src/tui/formatting.ts
+++ b/packages/client-ink/src/tui/formatting.ts
@@ -6,6 +6,9 @@ import type { FormattingNode, FormattingTag, NarrativeLine, ProcessedLine } from
  * Supported tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>, <color=#hex>,
  * <wikilink slug=foo>...</wikilink> (render-only — emitted by the colorizer, not LLMs)
  * Unrecognized tags are stripped. Malformed tags render as plain text.
+ * Orphan close tags (e.g. `</i>` with no matching open in scope) are stripped
+ * silently — they're nearly always a leak from healing across paragraph
+ * boundaries, never something the user intended to display literally.
  * Tags can be nested: <b><i>bold italic</i></b>
  */
 export function parseFormatting(input: string): FormattingNode[] {
@@ -30,7 +33,16 @@ export function parseFormatting(input: string): FormattingNode[] {
     // Try to parse an opening tag
     const parsed = parseOpenTag(input, tagStart);
     if (!parsed) {
-      // Not a valid tag — treat the < as plain text
+      // Orphan close tag (e.g. `</i>` with no matching open in this scope):
+      // strip it silently. Healing leaves these behind when an open tag is
+      // reset by a paragraph boundary before its close arrives — without this,
+      // the close would render as literal `</tagname>` text (issue #454).
+      const orphanClose = input.slice(tagStart).match(KNOWN_CLOSE_TAG_RE);
+      if (orphanClose) {
+        i = tagStart + orphanClose[0].length;
+        continue;
+      }
+      // Not a recognized tag at all — treat the < as plain text
       pushText(result, "<");
       i = tagStart + 1;
       continue;
@@ -628,6 +640,8 @@ interface ParsedTag {
   target?: string;
   end: number; // index after the closing >
 }
+
+const KNOWN_CLOSE_TAG_RE = /^<\/(?:b|i|u|sub|sup|center|right|color|wikilink)>/;
 
 const SIMPLE_TAGS: Record<string, string> = {
   b: "bold",


### PR DESCRIPTION
## Summary

Fixes #454 — raw `</i></center>` no longer leaks into rendered DM output when a centered/italic block spans a paragraph break.

**Root cause.** The healer in `processNarrativeLines` resets its open-tag stack at every blank DM line (paragraph boundary). If the DM emits `<center><i>verse 1\nverse 2\n\nverse 3\nverse 4</i></center>`, the blank line wipes the stack, so when `</i></center>` arrives the healer has nothing to pop and leaves the closes in the healed text. `parseFormatting` had no concept of an orphan close, so each `<` rendered literally — exactly what the screenshots show.

**Fix.** In `parseFormatting`, when `<` doesn't parse as a known opening tag, also check whether it's a recognized close tag (`</b>`, `</i>`, `</center>`, …) and skip it silently. Unrecognized closes like `</blink>` still render as literal text, so quoted HTML and code samples are unaffected.

**Scope is deliberate.** This is Layer 1 of a two-layer fix — "in all cases, leaked formatting that we don't render should be stripped." Smarter cross-paragraph reflow (reopening the formatting across the gap so the unformatted verses also render centered/italic) is intentionally not done; the complexity isn't worth it for the reported failure mode. The lower portion of the poem stays unformatted, but the raw close-tag leak is gone.

**Surface area.** The carefully-tuned healer, alignment-block splitter, wrap/pad/quote phases — all untouched. Only the parser's handling of one previously-unhandled edge case.

## Test plan

- [x] New unit tests for orphan close stripping (3 cases) and a guard test confirming unrecognized closes (`</blink>`) still render literally.
- [x] New end-to-end test through `processNarrativeLines` reproducing the exact poem scenario from the bug report — `<center><i>` over a blank verse separator with `</i></center>` on the trailing line.
- [x] Updated one existing wikilink test that was asserting the old leak behavior for `</wikilink>`.
- [x] `npx vitest run packages/client-ink/src/tui/formatting.test.ts` — 154 tests pass.
- [x] `npm run lint` clean.
- [x] `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)