### PR TITLE
Forward-delete for cursor-based text inputs (#370)

### DIFF
--- a/packages/client-ink/src/tui/components/InlineTextInput.test.ts
+++ b/packages/client-ink/src/tui/components/InlineTextInput.test.ts
@@ -121,6 +121,37 @@ describe("reducer", () => {
     });
   });
 
+  describe("forward-delete", () => {
+    it("is a no-op when cursor is at end of text", () => {
+      const state = make("hello", 5);
+      const next = reducer(state, { type: "forward-delete" });
+      expect(next).toBe(state);
+    });
+
+    it("removes character after cursor", () => {
+      const state = make("hello", 0);
+      const next = reducer(state, { type: "forward-delete" });
+      expect(next.value).toBe("ello");
+      expect(next.cursorOffset).toBe(0);
+    });
+
+    it("removes character from mid-string without moving cursor", () => {
+      const state = make("hello", 2);
+      const next = reducer(state, { type: "forward-delete" });
+      expect(next.value).toBe("helo");
+      expect(next.cursorOffset).toBe(2);
+    });
+
+    it("chains multiple forward-deletes", () => {
+      let state = make("hello", 0);
+      state = reducer(state, { type: "forward-delete" });
+      state = reducer(state, { type: "forward-delete" });
+      state = reducer(state, { type: "forward-delete" });
+      expect(state.value).toBe("lo");
+      expect(state.cursorOffset).toBe(0);
+    });
+  });
+
   describe("insert", () => {
     it("inserts text at cursor", () => {
       const state = make("hello", 5);
@@ -253,6 +284,20 @@ describe("InlineTextInput component", () => {
       // After typing, placeholder should be gone and typed char should appear
       expect(frame).not.toContain("Type here...");
       expect(frame).toContain("H");
+    });
+  });
+
+  it("forward-delete removes character after cursor", async () => {
+    const onChange = vi.fn();
+    const { stdin } = render(
+      React.createElement(InlineTextInput, { defaultValue: "hello", onChange }),
+    );
+    // Move cursor to start
+    stdin.write("\x01"); // Ctrl+A
+    // Forward delete: ESC [ 3 ~
+    stdin.write("\x1b[3~");
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith("ello");
     });
   });
 

--- a/packages/client-ink/src/tui/components/InlineTextInput.tsx
+++ b/packages/client-ink/src/tui/components/InlineTextInput.tsx
@@ -18,7 +18,8 @@ type Action =
   | { type: "move-cursor-start" }
   | { type: "move-cursor-end" }
   | { type: "insert"; text: string }
-  | { type: "delete" };
+  | { type: "delete" }
+  | { type: "forward-delete" };
 
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -42,6 +43,13 @@ export function reducer(state: State, action: Action): State {
         ...state,
         value: state.value.slice(0, state.cursorOffset - 1) + state.value.slice(state.cursorOffset),
         cursorOffset: state.cursorOffset - 1,
+      };
+    }
+    case "forward-delete": {
+      if (state.cursorOffset >= state.value.length) return state;
+      return {
+        ...state,
+        value: state.value.slice(0, state.cursorOffset) + state.value.slice(state.cursorOffset + 1),
       };
     }
   }
@@ -293,8 +301,10 @@ export const InlineTextInput = React.memo(function InlineTextInput({ isDisabled 
       processAction({ type: "move-cursor-left" });
     } else if (key.rightArrow) {
       processAction({ type: "move-cursor-right" });
-    } else if (key.backspace || key.delete) {
+    } else if (key.backspace) {
       processAction({ type: "delete" });
+    } else if (key.delete) {
+      processAction({ type: "forward-delete" });
     } else if (input && !key.ctrl && !key.meta) {
       processAction({ type: "insert", text: input });
     }

--- a/packages/client-ink/src/tui/modals/PlayerNotesModal.test.tsx
+++ b/packages/client-ink/src/tui/modals/PlayerNotesModal.test.tsx
@@ -55,14 +55,14 @@ describe("editorReducer", () => {
 
   it("forward-delete removes character at cursor without moving it", () => {
     const state = mkState({ lines: ["abc"], col: 1 });
-    const next = editorReducer(state, { type: "forward-delete" });
+    const next = editorReducer(state, { type: "forward-delete", maxRows: 20 });
     expect(next.lines).toEqual(["ac"]);
     expect(next.col).toBe(1);
   });
 
   it("forward-delete at end of line merges with next line", () => {
     const state = mkState({ lines: ["ab", "cd"], row: 0, col: 2 });
-    const next = editorReducer(state, { type: "forward-delete" });
+    const next = editorReducer(state, { type: "forward-delete", maxRows: 20 });
     expect(next.lines).toEqual(["abcd"]);
     expect(next.row).toBe(0);
     expect(next.col).toBe(2);
@@ -70,8 +70,22 @@ describe("editorReducer", () => {
 
   it("forward-delete at end of last line is a no-op", () => {
     const state = mkState({ lines: ["abc"], col: 3 });
-    const next = editorReducer(state, { type: "forward-delete" });
+    const next = editorReducer(state, { type: "forward-delete", maxRows: 20 });
     expect(next).toBe(state);
+  });
+
+  it("forward-delete line-merge clamps scrollOffset so no blank rows show below", () => {
+    // 5 lines, maxRows=3, scrolled to the bottom (offset 2 shows lines 2..4).
+    // Merging lines 2+3 leaves 4 lines; max valid scrollOffset becomes 4-3=1.
+    const state = mkState({
+      lines: ["a", "b", "c", "d", "e"],
+      row: 2,
+      col: 1,
+      scrollOffset: 2,
+    });
+    const next = editorReducer(state, { type: "forward-delete", maxRows: 3 });
+    expect(next.lines).toEqual(["a", "b", "cd", "e"]);
+    expect(next.scrollOffset).toBe(1);
   });
 
   it("backspace at start of first line is a no-op", () => {

--- a/packages/client-ink/src/tui/modals/PlayerNotesModal.test.tsx
+++ b/packages/client-ink/src/tui/modals/PlayerNotesModal.test.tsx
@@ -53,6 +53,27 @@ describe("editorReducer", () => {
     expect(next.col).toBe(2);
   });
 
+  it("forward-delete removes character at cursor without moving it", () => {
+    const state = mkState({ lines: ["abc"], col: 1 });
+    const next = editorReducer(state, { type: "forward-delete" });
+    expect(next.lines).toEqual(["ac"]);
+    expect(next.col).toBe(1);
+  });
+
+  it("forward-delete at end of line merges with next line", () => {
+    const state = mkState({ lines: ["ab", "cd"], row: 0, col: 2 });
+    const next = editorReducer(state, { type: "forward-delete" });
+    expect(next.lines).toEqual(["abcd"]);
+    expect(next.row).toBe(0);
+    expect(next.col).toBe(2);
+  });
+
+  it("forward-delete at end of last line is a no-op", () => {
+    const state = mkState({ lines: ["abc"], col: 3 });
+    const next = editorReducer(state, { type: "forward-delete" });
+    expect(next).toBe(state);
+  });
+
   it("backspace at start of first line is a no-op", () => {
     const state = mkState({ lines: ["abc"], col: 0 });
     const next = editorReducer(state, { type: "backspace", maxRows: 20 });

--- a/packages/client-ink/src/tui/modals/PlayerNotesModal.tsx
+++ b/packages/client-ink/src/tui/modals/PlayerNotesModal.tsx
@@ -27,7 +27,7 @@ interface EditorState {
 type EditorAction =
   | { type: "insert"; text: string }
   | { type: "backspace"; maxRows: number }
-  | { type: "forward-delete" }
+  | { type: "forward-delete"; maxRows: number }
   | { type: "enter"; maxRows: number }
   | { type: "up"; maxRows: number }
   | { type: "down"; maxRows: number }
@@ -87,7 +87,10 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
         const next = [...lines];
         next[row] = next[row] + next[row + 1];
         next.splice(row + 1, 1);
-        return { ...state, lines: next };
+        // Line count shrank — clamp scrollOffset so the viewport doesn't
+        // leave blank rows at the bottom when scrolled near the end.
+        const maxScroll = Math.max(0, next.length - action.maxRows);
+        return { ...state, lines: next, scrollOffset: Math.min(scrollOffset, maxScroll) };
       }
       return state;
     }
@@ -213,7 +216,7 @@ export function PlayerNotesModal({
     if (key.rightArrow) { dispatch({ type: "right", maxRows: maxContentRows }); return; }
     if (key.return) { dispatch({ type: "enter", maxRows: maxContentRows }); return; }
     if (key.backspace) { dispatch({ type: "backspace", maxRows: maxContentRows }); return; }
-    if (key.delete) { dispatch({ type: "forward-delete" }); return; }
+    if (key.delete) { dispatch({ type: "forward-delete", maxRows: maxContentRows }); return; }
     if (key.ctrl && input === "a") { dispatch({ type: "home" }); return; }
     if (key.ctrl && input === "e") { dispatch({ type: "end" }); return; }
 

--- a/packages/client-ink/src/tui/modals/PlayerNotesModal.tsx
+++ b/packages/client-ink/src/tui/modals/PlayerNotesModal.tsx
@@ -27,6 +27,7 @@ interface EditorState {
 type EditorAction =
   | { type: "insert"; text: string }
   | { type: "backspace"; maxRows: number }
+  | { type: "forward-delete" }
   | { type: "enter"; maxRows: number }
   | { type: "up"; maxRows: number }
   | { type: "down"; maxRows: number }
@@ -71,6 +72,22 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
           col: newCol,
           scrollOffset: ensureVisible(newRow, action.maxRows, scrollOffset),
         };
+      }
+      return state;
+    }
+
+    case "forward-delete": {
+      const line = lines[row];
+      if (col < line.length) {
+        const next = [...lines];
+        next[row] = line.slice(0, col) + line.slice(col + 1);
+        return { ...state, lines: next };
+      }
+      if (row < lines.length - 1) {
+        const next = [...lines];
+        next[row] = next[row] + next[row + 1];
+        next.splice(row + 1, 1);
+        return { ...state, lines: next };
       }
       return state;
     }
@@ -195,7 +212,8 @@ export function PlayerNotesModal({
     if (key.leftArrow) { dispatch({ type: "left", maxRows: maxContentRows }); return; }
     if (key.rightArrow) { dispatch({ type: "right", maxRows: maxContentRows }); return; }
     if (key.return) { dispatch({ type: "enter", maxRows: maxContentRows }); return; }
-    if (key.backspace || key.delete) { dispatch({ type: "backspace", maxRows: maxContentRows }); return; }
+    if (key.backspace) { dispatch({ type: "backspace", maxRows: maxContentRows }); return; }
+    if (key.delete) { dispatch({ type: "forward-delete" }); return; }
     if (key.ctrl && input === "a") { dispatch({ type: "home" }); return; }
     if (key.ctrl && input === "e") { dispatch({ type: "end" }); return; }
 


### PR DESCRIPTION
## Summary
- `InlineTextInput` and `PlayerNotesModal`: `key.delete` now deletes the character *after* the cursor (standard text editor behavior) instead of aliasing backspace.
- `PlayerNotesModal` forward-delete at end-of-line merges with the next line — mirror of backspace-at-start-of-line merging upward.
- `useTextInput` left as-is (no cursor → no direction to distinguish, per the issue).

Possible now that Ink 7 (#369) properly distinguishes `key.backspace` from `key.delete`.

Closes #370.

## Test plan
- [x] New reducer unit tests for `forward-delete` in both components (no-op at end, mid-string delete without cursor move, chained deletes, line merge for the modal)
- [x] Component test sending `ESC [ 3 ~` (Delete) verifies forward-delete fires through `useInput`
- [x] All 67 client-ink tests pass; lint + typecheck clean
- [ ] Manual smoke: open Player Notes, position cursor mid-line, press Delete → char after cursor disappears, cursor stays put

🤖 Generated with [Claude Code](https://claude.com/claude-code)