### PR TITLE
Default Discord Rich Presence to on

### DIFF
--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -112,7 +112,7 @@ Model selection, campaign init, DM personalities, campaign seeds.
 |---|---|
 | `models.ts` | `getModel("large" \| "medium" \| "small")` — tier model selection (cached; tests need `loadModelConfig({ reset: true })`) |
 | `connections.ts` | Multi-provider connection management: load/save/add/remove connections, tier assignments. Supports Anthropic, OpenAI, OpenRouter, custom providers. Persists to `connections.json` |
-| `discord.ts` | Discord integration settings: opt-in/opt-out state persisted to `discord-settings.json` |
+| `discord.ts` | Discord integration settings: enabled/disabled state persisted to `discord-settings.json` (on by default) |
 | `model-registry.ts` | Dynamic model registry: shipped `known-models.json` merged with user `model-overrides.json`. Pricing, capabilities, context windows, tier defaults per provider |
 | `personalities.ts` | `PERSONALITIES`, `getPersonality()` — DM personality definitions |
 | `seeds.ts` | `SEEDS`, `seedsForGenre()` — campaign premise seeds by genre |

--- a/docs/state-atlas.md
+++ b/docs/state-atlas.md
@@ -610,7 +610,7 @@ In addition to campaign-scoped state, Machine Violet maintains machine-scoped co
 │                              apiKey (empty for openai-chatgpt — Codex owns its own token store at ~/.codex/auth.json),
 │                              optional baseUrl, optional chatgptAccount {id, email?, planType?}, discovered models,
 │                              source (env/manual/oauth). Tier assignments (large/medium/small → connectionId + modelId).
-├── discord-settings.json      Discord integration: enabled (true), disabled (false), or not-yet-asked (null).
+├── discord-settings.json      Discord integration: enabled (true) or disabled (false). On by default; absent file means enabled.
 └── model-overrides.json       User overrides merged on top of shipped known-models.json.
                                Per-model: pricing, capabilities, context window, tier defaults.
 ```

--- a/packages/client-ink/src/api-client.ts
+++ b/packages/client-ink/src/api-client.ts
@@ -326,7 +326,7 @@ export class ApiClient {
     return this.fetch("/manage/settings", { method: "PUT", body: settings });
   }
 
-  async getDiscordSettings(): Promise<{ enabled: boolean | null }> {
+  async getDiscordSettings(): Promise<{ enabled: boolean }> {
     return this.get("/manage/discord");
   }
 

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -108,7 +108,7 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
   const [apiKeyValid, setApiKeyValid] = useState(true);
   const [apiKeyStatus, setApiKeyStatus] = useState<string | undefined>(undefined);
   const [archivedCampaigns, setArchivedCampaigns] = useState<ArchivedCampaignEntry[]>([]);
-  const [discordEnabled, setDiscordEnabled] = useState<boolean | null>(null);
+  const [discordEnabled, setDiscordEnabled] = useState<boolean>(true);
   const [devModeEnabled, setDevModeEnabled] = useState(false);
   const [showVerbose, setShowVerbose] = useState(false);
   const settingsLoaded = useRef(false);
@@ -332,10 +332,9 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
   // Sync Discord opt-in changes into the controller (and the closure ref).
   useEffect(() => {
     const wasEnabled = discordEnabledRef.current;
-    const nowEnabled = discordEnabled === true;
-    discordEnabledRef.current = nowEnabled;
-    if (nowEnabled && !wasEnabled) discordControllerRef.current.enable();
-    else if (!nowEnabled && wasEnabled) discordControllerRef.current.disable();
+    discordEnabledRef.current = discordEnabled;
+    if (discordEnabled && !wasEnabled) discordControllerRef.current.enable();
+    else if (!discordEnabled && wasEnabled) discordControllerRef.current.disable();
   }, [discordEnabled]);
 
   // --- Management helpers ---
@@ -411,7 +410,6 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
         errorMsg={errorMessage || null}
         apiKeyValid={apiKeyValid}
         apiKeyStatus={apiKeyStatus}
-        discordSettingUnset={discordEnabled === null}
         devModeEnabled={devModeEnabled}
         onNewCampaign={() => {
           setSessionKey((k) => k + 1);
@@ -458,10 +456,6 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
         onAddContent={() => { /* not yet migrated */ }}
         onSettings={() => setPhase("settings")}
         onSettingsApiKeys={() => { refreshConnections(); setPhase("settings_apikeys"); }}
-        onDiscordSettings={() => {
-          apiClientRef.current.getDiscordSettings().then((s) => setDiscordEnabled(s.enabled)).catch(() => { /* ignore */ });
-          setPhase("discord_settings");
-        }}
         onQuit={() => process.exit(0)}
       />
     );

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -122,6 +122,12 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
     apiClientRef.current.getMachineSettings().then((s) => {
       setDevModeEnabled(s.devModeEnabled);
     }).catch(() => { /* best-effort — keep default */ });
+    // Honor a persisted opt-out on every launch path (menu and direct-launch
+    // via campaignId both depend on this firing before the controller-sync
+    // effect activates Rich Presence).
+    apiClientRef.current.getDiscordSettings().then((s) => {
+      setDiscordEnabled(s.enabled);
+    }).catch(() => { /* best-effort — keep default */ });
   }, []);
 
   // Persist client-only settings whenever they change (skip the initial load)

--- a/packages/client-ink/src/phases/DiscordSettingsPhase.test.tsx
+++ b/packages/client-ink/src/phases/DiscordSettingsPhase.test.tsx
@@ -17,7 +17,7 @@ function makeTheme() {
 function defaultProps(overrides?: Partial<DiscordSettingsPhaseProps>): DiscordSettingsPhaseProps {
   return {
     theme: makeTheme(),
-    currentSetting: null,
+    currentSetting: true,
     onSave: vi.fn(),
     onBack: vi.fn(),
     ...overrides,
@@ -67,9 +67,9 @@ describe("DiscordSettingsPhase", () => {
     });
   });
 
-  it("pre-selects Enable when currentSetting is null", () => {
+  it("pre-selects Enable when currentSetting is true", () => {
     const onSave = vi.fn();
-    const { stdin } = render(<DiscordSettingsPhase {...defaultProps({ onSave, currentSetting: null })} />);
+    const { stdin } = render(<DiscordSettingsPhase {...defaultProps({ onSave, currentSetting: true })} />);
     stdin.write("\r");
     expect(onSave).toHaveBeenCalledWith(true);
   });

--- a/packages/client-ink/src/phases/DiscordSettingsPhase.tsx
+++ b/packages/client-ink/src/phases/DiscordSettingsPhase.tsx
@@ -7,7 +7,7 @@ import { themeColor } from "../tui/themes/color-resolve.js";
 
 export interface DiscordSettingsPhaseProps {
   theme: ResolvedTheme;
-  currentSetting: boolean | null;
+  currentSetting: boolean;
   onSave: (enabled: boolean) => void;
   onBack: () => void;
 }
@@ -21,7 +21,7 @@ export function DiscordSettingsPhase({
   onBack,
 }: DiscordSettingsPhaseProps) {
   const { columns: cols, rows: termRows } = useWindowSize();
-  const [selectedIndex, setSelectedIndex] = useState(currentSetting === false ? 1 : 0);
+  const [selectedIndex, setSelectedIndex] = useState(currentSetting ? 0 : 1);
 
   useInput((_input, key) => {
     if (key.escape) {

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -50,10 +50,6 @@ export interface MainMenuPhaseProps {
   updateInfo?: UpdateInfo | null;
   /** Navigate to the update detail screen. */
   onUpdate?: () => void;
-  /** Whether the Discord Rich Presence setting has not been configured yet. */
-  discordSettingUnset?: boolean;
-  /** Navigate to Discord Rich Presence settings. */
-  onDiscordSettings?: () => void;
   /** Whether Dev Mode is enabled (gates advanced features like content ingest). */
   devModeEnabled?: boolean;
   onQuit: () => void;
@@ -80,8 +76,6 @@ export function MainMenuPhase({
   onSettingsApiKeys,
   updateInfo,
   onUpdate,
-  discordSettingUnset,
-  onDiscordSettings,
   devModeEnabled,
   onQuit,
 }: MainMenuPhaseProps) {
@@ -110,7 +104,6 @@ export function MainMenuPhase({
   if (campaigns.length > 0) mainMenuItems.push("Continue Campaign");
   if (devModeEnabled) mainMenuItems.push("Add Content");
   if (!apiKeyValid) mainMenuItems.push("API Keys");
-  if (discordSettingUnset) mainMenuItems.push("Discord");
   mainMenuItems.push("Settings");
   mainMenuItems.push("Quit");
 
@@ -195,8 +188,6 @@ export function MainMenuPhase({
         onAddContent();
       } else if (selected === "API Keys") {
         onSettingsApiKeys();
-      } else if (selected === "Discord") {
-        onDiscordSettings?.();
       } else if (selected === "Settings") {
         onSettings();
       } else if (selected === "Quit") {
@@ -239,7 +230,6 @@ export function MainMenuPhase({
     else if (item === "Continue Campaign" && campaigns.length > 0) description = `${campaigns.length} saved`;
     else if (item === "Add Content") description = "Import PDFs for game systems";
     else if (item === "API Keys") description = apiKeyStatus ?? "";
-    else if (item === "Discord") description = "Set up Rich Presence";
     else if (item === "Settings") description = "";
 
     const itemColor = emphasis ? "yellow" : disabled ? "#555555" : undefined;

--- a/packages/engine/src/config/discord.test.ts
+++ b/packages/engine/src/config/discord.test.ts
@@ -15,21 +15,21 @@ afterEach(() => {
 });
 
 describe("loadDiscordSettings", () => {
-  it("returns { enabled: null } when file is missing", () => {
+  it("defaults to enabled when file is missing", () => {
     const result = loadDiscordSettings(tempDir);
-    expect(result).toEqual({ enabled: null });
+    expect(result).toEqual({ enabled: true });
   });
 
-  it("returns { enabled: null } when file is corrupt", () => {
+  it("defaults to enabled when file is corrupt", () => {
     writeFileSync(join(tempDir, "discord-settings.json"), "not json", "utf-8");
     const result = loadDiscordSettings(tempDir);
-    expect(result).toEqual({ enabled: null });
+    expect(result).toEqual({ enabled: true });
   });
 
-  it("returns { enabled: null } when enabled field is not a boolean", () => {
+  it("defaults to enabled when enabled field is not a boolean", () => {
     writeFileSync(join(tempDir, "discord-settings.json"), JSON.stringify({ enabled: "yes" }), "utf-8");
     const result = loadDiscordSettings(tempDir);
-    expect(result).toEqual({ enabled: null });
+    expect(result).toEqual({ enabled: true });
   });
 });
 

--- a/packages/engine/src/config/discord.ts
+++ b/packages/engine/src/config/discord.ts
@@ -4,19 +4,22 @@ import { join } from "node:path";
 const STORE_FILENAME = "discord-settings.json";
 
 export interface DiscordSettings {
-  /** `true` = opted in, `false` = opted out, `null` = not yet asked. */
-  enabled: boolean | null;
+  enabled: boolean;
 }
 
-/** Load Discord settings from the config directory. Returns `{ enabled: null }` if missing or corrupt. */
+// Default to on — Rich Presence is normal for games. Users can opt out
+// from the Settings → Discord screen.
+const DEFAULT_SETTINGS: DiscordSettings = { enabled: true };
+
+/** Load Discord settings from the config directory. Returns the default (enabled) if missing or corrupt. */
 export function loadDiscordSettings(appDir: string): DiscordSettings {
   try {
     const raw = readFileSync(join(appDir, STORE_FILENAME), "utf-8");
     const parsed = JSON.parse(raw) as Partial<DiscordSettings>;
     if (typeof parsed.enabled === "boolean") return { enabled: parsed.enabled };
-    return { enabled: null };
+    return DEFAULT_SETTINGS;
   } catch {
-    return { enabled: null };
+    return DEFAULT_SETTINGS;
   }
 }
 

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -666,8 +666,8 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
       response: { 200: DiscordSettings },
     },
   }, async (request) => {
-    const { enabled } = (request.body as { enabled: boolean }) ?? {};
-    const settings = { enabled: enabled === true };
+    const { enabled } = request.body as { enabled: boolean };
+    const settings = { enabled };
     saveDiscordSettings(server.configDir, settings);
     return settings;
   });


### PR DESCRIPTION
## Summary

Discord Rich Presence is now on by default — normal for games. Users who explicitly disabled it stay disabled; new installs get presence out of the box and can still opt out from Settings → Discord.

## What changed

- **Engine config** ([discord.ts](packages/engine/src/config/discord.ts)): `DiscordSettings.enabled` is a plain `boolean` (was `boolean | null`). Missing/corrupt settings file → `{ enabled: true }`.
- **REST handler** ([management.ts](packages/engine/src/server/routes/management.ts)): drops the now-redundant `enabled === true` coercion (TypeBox already enforces boolean on the wire — the schema was already plain `Boolean`).
- **Client state** ([app.tsx](packages/client-ink/src/app.tsx)): `discordEnabled` is `boolean` defaulting to `true`; controller-sync effect simplified.
- **Main menu** ([MainMenuPhase.tsx](packages/client-ink/src/phases/MainMenuPhase.tsx)): dropped the "Discord" nudge entry and its plumbing — the nudge only existed to drive the unset → opt-in flow, which is now obsolete.
- **Settings phase** ([DiscordSettingsPhase.tsx](packages/client-ink/src/phases/DiscordSettingsPhase.tsx)): `currentSetting: boolean`. Enable pre-selects unless explicitly disabled.
- **Docs**: `state-atlas.md` and `module-map.md` updated to reflect the new default.

## Why drop the tri-state

The `null` state existed solely to drive the "first-launch ask" nudge. With on-by-default there's no ask, so the null branch was dead. Per the project's "no backwards-compat hacks" convention, removed it instead of leaving zombie types.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc -b` — clean
- [x] `npm test` — 2657/2658 passed. One unrelated Windows hook-timeout flake in `server.test.ts > returns empty campaign list` (10s `beforeEach`); reran in isolation, all 6 tests passed in 8s.
- [ ] Manual: launch app on a clean config dir, confirm Rich Presence activates during a session without any prompt; toggle off via Settings → Discord and confirm it disengages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)