### PR TITLE
Cascade configDir upward so worktrees inherit parent repo config

### DIFF
--- a/packages/client-ink/src/utils/paths.ts
+++ b/packages/client-ink/src/utils/paths.ts
@@ -52,7 +52,10 @@ export function assetDir(category: "prompts" | "themes" | "systems"): string {
 }
 
 /**
- * Resolve the directory for user config files (.env, connections.json).
+ * Resolve the directory for user config artifacts — anything the client
+ * persists between runs that isn't campaign data. Today that includes
+ * `client-settings.json` plus the engine-side files the launcher reads from
+ * the same dir (`.env`, `connections.json`, `machine-settings.json`, etc.).
  *
  * Compiled: platform-conventional config dir (e.g. %APPDATA%\MachineViolet).
  * Dev: walk up from cwd looking for an ancestor containing `connections.json`
@@ -68,9 +71,14 @@ export function configDir(): string {
   return _configDir;
 }
 
+// Bounded so a stray cwd outside any project doesn't walk all the way to /.
+// 12 comfortably covers nested worktrees in this repo's `.claude/worktrees/<name>` layout
+// with headroom; matches the cap used by the test harness's launcher-cwd resolver.
+const MAX_PARENT_TRAVERSALS = 12;
+
 function findConfigDirUpward(start: string): string {
   let dir = resolve(start);
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < MAX_PARENT_TRAVERSALS; i++) {
     if (existsSync(join(dir, "connections.json"))) return dir;
     const parent = dirname(dir);
     if (parent === dir) break;

--- a/packages/client-ink/src/utils/paths.ts
+++ b/packages/client-ink/src/utils/paths.ts
@@ -1,4 +1,5 @@
-import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { defaultConfigDir } from "./platform.js";
 
 /** Normalize a path to use forward slashes (cross-platform). */
@@ -51,17 +52,31 @@ export function assetDir(category: "prompts" | "themes" | "systems"): string {
 }
 
 /**
- * Resolve the directory for user config files (.env, api-keys.json, config.json).
+ * Resolve the directory for user config files (.env, connections.json).
  *
  * Compiled: platform-conventional config dir (e.g. %APPDATA%\MachineViolet).
- * Dev: process.cwd() (repo root, where .env already lives).
+ * Dev: walk up from cwd looking for an ancestor containing `connections.json`
+ * so a worktree picks up the parent repo's saved config. Falls back to cwd
+ * (first-time setup writes there; move the file up once if you want it
+ * shared across worktrees).
  */
 let _configDir: string | undefined;
 
 export function configDir(): string {
   if (_configDir) return _configDir;
-  _configDir = isCompiled() ? defaultConfigDir() : process.cwd();
+  _configDir = isCompiled() ? defaultConfigDir() : findConfigDirUpward(process.cwd());
   return _configDir;
+}
+
+function findConfigDirUpward(start: string): string {
+  let dir = resolve(start);
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, "connections.json"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return start;
 }
 
 /** Reset the configDir cache (for tests). */

--- a/packages/engine/src/utils/paths.ts
+++ b/packages/engine/src/utils/paths.ts
@@ -62,7 +62,10 @@ export function assetDir(category: "prompts" | "themes" | "systems" | "worlds" |
 }
 
 /**
- * Resolve the directory for user config files (.env, connections.json).
+ * Resolve the directory for user config artifacts — anything the engine
+ * persists between runs that isn't campaign data. Today that includes
+ * `.env`, `connections.json`, `machine-settings.json`, `discord-settings.json`,
+ * ChatGPT OAuth token storage, and (via client-ink) `client-settings.json`.
  *
  * Compiled: platform-conventional config dir (e.g. %APPDATA%\MachineViolet).
  * Dev: walk up from cwd looking for an ancestor containing `connections.json`
@@ -78,9 +81,14 @@ export function configDir(): string {
   return _configDir;
 }
 
+// Bounded so a stray cwd outside any project doesn't walk all the way to /.
+// 12 comfortably covers nested worktrees in this repo's `.claude/worktrees/<name>` layout
+// with headroom; matches the cap used by the test harness's launcher-cwd resolver.
+const MAX_PARENT_TRAVERSALS = 12;
+
 function findConfigDirUpward(start: string): string {
   let dir = resolve(start);
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < MAX_PARENT_TRAVERSALS; i++) {
     if (existsSync(join(dir, "connections.json"))) return dir;
     const parent = dirname(dir);
     if (parent === dir) break;

--- a/packages/engine/src/utils/paths.ts
+++ b/packages/engine/src/utils/paths.ts
@@ -1,4 +1,5 @@
-import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { defaultConfigDir } from "../tools/filesystem/platform.js";
 
 /** Normalize a path to use forward slashes (cross-platform). */
@@ -61,17 +62,31 @@ export function assetDir(category: "prompts" | "themes" | "systems" | "worlds" |
 }
 
 /**
- * Resolve the directory for user config files (.env, api-keys.json, config.json).
+ * Resolve the directory for user config files (.env, connections.json).
  *
  * Compiled: platform-conventional config dir (e.g. %APPDATA%\MachineViolet).
- * Dev: process.cwd() (repo root, where .env already lives).
+ * Dev: walk up from cwd looking for an ancestor containing `connections.json`
+ * so a worktree picks up the parent repo's saved config. Falls back to cwd
+ * (first-time setup writes there; move the file up once if you want it
+ * shared across worktrees).
  */
 let _configDir: string | undefined;
 
 export function configDir(): string {
   if (_configDir) return _configDir;
-  _configDir = isCompiled() ? defaultConfigDir() : process.cwd();
+  _configDir = isCompiled() ? defaultConfigDir() : findConfigDirUpward(process.cwd());
   return _configDir;
+}
+
+function findConfigDirUpward(start: string): string {
+  let dir = resolve(start);
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, "connections.json"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return start;
 }
 
 /** Reset the configDir cache (for tests). */


### PR DESCRIPTION
## Summary
- In dev mode, `configDir()` returned `process.cwd()` — launching from a worktree read/wrote `connections.json` in the worktree itself instead of the main repo, so spawning a fresh worktree lost API keys, model selections, and provider config until you copied the file over.
- `configDir()` now walks up from cwd looking for the nearest ancestor containing `connections.json` (capped at 12 levels), falling back to cwd when nothing is found so first-time setup still works.
- Compiled-binary behavior is unchanged — that path already used the platform app-data dir (`%APPDATA%\MachineViolet` on Windows, etc).

The test harness already did this same walk at launcher-spawn time to pick the child's cwd ([harness.ts:504](packages/test-harness/src/harness.ts:504)); pushing the cascade into `configDir()` itself means anything that calls it gets the behavior, not just harness-spawned processes.

Touches both copies of the helper:
- [packages/engine/src/utils/paths.ts:71](packages/engine/src/utils/paths.ts:71)
- [packages/client-ink/src/utils/paths.ts:61](packages/client-ink/src/utils/paths.ts:61)

## Test plan
- [x] \`npm run check\` (lint + 2658 tests) green
- [x] \`npx vitest run --changed\` green
- [ ] Manual: launch \`npm run dev\` from a worktree, verify it reads the main repo's \`connections.json\` (API keys / model selection match what the main checkout sees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)