### PR TITLE
Tell GPT models to skip blank lines between sentences

### DIFF
--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -109,7 +109,7 @@ Go easy on the newlines - they take up a lot of vertical space. Paragraph length
 <!--if:gpt-->
 Avoid using "Not X, but Y" - this sounds like assistant-speak and will break your beautifully-crafted immersion :)
 
-Write continuous paragraphs, not staccato single-line beats. Never insert a blank line between sentences of the same beat, and never end your narrative with a trailing blank line. A paragraph break (one blank line) is reserved for an actual shift in subject, scene, or speaker.
+Write continuous paragraphs, not staccato single-line beats. Sentences in the same beat flow together as one block of prose — no line breaks between them at all, neither single `\n` nor double `\n\n`. A paragraph break (`\n\n`) is reserved for an actual shift in subject, scene, or speaker. Never end your narrative with a trailing newline.
 <!--endif-->
 </formatting>
 

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -108,6 +108,8 @@ Choices presented via `present_choices` can be prefixed with a tasteful Unicode 
 Go easy on the newlines - they take up a lot of vertical space. Paragraph length should be varied like a good novel.
 <!--if:gpt-->
 Avoid using "Not X, but Y" - this sounds like assistant-speak and will break your beautifully-crafted immersion :)
+
+Write continuous paragraphs, not staccato single-line beats. Never insert a blank line between sentences of the same beat, and never end your narrative with a trailing blank line. A paragraph break (one blank line) is reserved for an actual shift in subject, scene, or speaker.
 <!--endif-->
 </formatting>
 


### PR DESCRIPTION
## Summary
- GPT models pad streamed narration with single `\n` between sentences. The TUI renderer (intentionally) double-spaces every single newline into a visible blank row, so prose ends up looking sparse and overspaced.
- The DM prompt already says *"go easy on the newlines"* but GPT keeps doing it. This adds a GPT-only reinforcement: continuous paragraphs, no inter-sentence blanks, no trailing blank line, paragraph breaks reserved for actual subject/scene/speaker shifts.
- Claude-family models skip the `if:gpt` block, so they're unaffected.

No code or renderer changes — formatting pipeline is left alone.

## Test plan
- [ ] Play a session with a GPT model and confirm narration paragraphs are tighter, with no blank-line padding between sentences.
- [ ] Confirm Claude-family DM output is visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)