### PR TITLE
Make selected menu items pop in theme accent + bold

### DIFF
--- a/packages/client-ink/src/phases/ArchivedCampaignsPhase.tsx
+++ b/packages/client-ink/src/phases/ArchivedCampaignsPhase.tsx
@@ -56,7 +56,7 @@ export function ArchivedCampaignsPhase({
     return <TerminalTooSmall columns={cols} rows={termRows} />;
   }
 
-  const borderColor = themeColor(theme, "border");
+  const accentColor = themeColor(theme, "title") ?? themeColor(theme, "border");
   const dimColor = themeColor(theme, "separator") ?? "#666666";
 
   const menuLines: React.ReactNode[] = [];
@@ -79,13 +79,13 @@ export function ArchivedCampaignsPhase({
       const entry = archives[i];
       const isSelected = i === menuIndex;
       const marker = isSelected ? "◆" : "○";
-      const markerColor = isSelected ? borderColor : dimColor;
+      const markerColor = isSelected ? accentColor : dimColor;
       const dateStr = formatDate(entry.archivedDate);
 
       menuLines.push(
         <Text key={entry.zipPath}>
           <Text color={markerColor}>{marker}</Text>
-          <Text bold={isSelected}>{` ${entry.name}`}</Text>
+          <Text color={isSelected ? accentColor : undefined} bold={isSelected}>{` ${entry.name}`}</Text>
           <Text color={dimColor}>{`  Archived ${dateStr}`}</Text>
         </Text>,
       );

--- a/packages/client-ink/src/phases/DiscordSettingsPhase.tsx
+++ b/packages/client-ink/src/phases/DiscordSettingsPhase.tsx
@@ -45,7 +45,7 @@ export function DiscordSettingsPhase({
     return <TerminalTooSmall columns={cols} rows={termRows} />;
   }
 
-  const borderColor = themeColor(theme, "border");
+  const accentColor = themeColor(theme, "title") ?? themeColor(theme, "border");
   const dimColor = themeColor(theme, "separator") ?? "#666666";
   const sideWidth = theme.asset.components.edge_left.width;
   const topHeight = theme.asset.height;
@@ -77,11 +77,11 @@ export function DiscordSettingsPhase({
   for (let i = 0; i < OPTIONS.length; i++) {
     const isSelected = i === selectedIndex;
     const marker = isSelected ? "◆" : "○";
-    const markerColor = isSelected ? borderColor : dimColor;
+    const markerColor = isSelected ? accentColor : dimColor;
     lines.push(
       <Text key={OPTIONS[i]}>
         <Text color={markerColor}>{marker}</Text>
-        <Text>{` ${OPTIONS[i]}`}</Text>
+        <Text color={isSelected ? accentColor : undefined} bold={isSelected}>{` ${OPTIONS[i]}`}</Text>
       </Text>,
     );
   }

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -204,7 +204,7 @@ export function MainMenuPhase({
     return <TerminalTooSmall columns={cols} rows={termRows} />;
   }
 
-  const borderColor = themeColor(theme, "border");
+  const accentColor = themeColor(theme, "title") ?? themeColor(theme, "border");
   const dimColor = themeColor(theme, "separator") ?? "#666666";
 
   // Build menu lines
@@ -217,7 +217,7 @@ export function MainMenuPhase({
     const isSelected = !expandedCampaigns && i === mainMenuIndex;
     const disabled = isItemDisabled(item);
     const marker = isSelected ? "◆" : "○";
-    const markerColor = disabled ? "#555555" : isSelected ? borderColor : dimColor;
+    const markerColor = disabled ? "#555555" : isSelected ? accentColor : dimColor;
 
     const isUpdateItem = item === "Update Available";
     // API Keys appears in the main menu only when the active key is
@@ -232,12 +232,12 @@ export function MainMenuPhase({
     else if (item === "API Keys") description = apiKeyStatus ?? "";
     else if (item === "Settings") description = "";
 
-    const itemColor = emphasis ? "yellow" : disabled ? "#555555" : undefined;
+    const itemColor = emphasis ? "yellow" : isSelected && !disabled ? accentColor : disabled ? "#555555" : undefined;
     const descColor = emphasis ? "yellow" : disabled ? "#555555" : dimColor;
     menuLines.push(
       <Text key={item}>
         <Text color={emphasis ? "yellow" : markerColor}>{marker}</Text>
-        <Text color={itemColor} dimColor={disabled} bold={emphasis}>{` ${item}`}</Text>
+        <Text color={itemColor} dimColor={disabled} bold={emphasis || (isSelected && !disabled)}>{` ${item}`}</Text>
         {description ? <Text color={descColor} dimColor={disabled}>{` — ${description}`}</Text> : null}
       </Text>,
     );
@@ -261,12 +261,12 @@ export function MainMenuPhase({
         const archiveActive = cSelected && campaignColumn === COL_ARCHIVE;
         const deleteActive = cSelected && campaignColumn === COL_DELETE;
         const cMarker = nameActive ? "◆" : "○";
-        const cColor = nameActive ? borderColor : dimColor;
+        const cColor = nameActive ? accentColor : dimColor;
         menuLines.push(
           <Text key={`c-${campaigns[j].path}`}>
             <Text>{`    `}</Text>
             <Text color={cColor}>{cMarker}</Text>
-            <Text bold={nameActive}>{` ${campaigns[j].name}`}</Text>
+            <Text color={nameActive ? accentColor : undefined} bold={nameActive}>{` ${campaigns[j].name}`}</Text>
             <Text>{`  `}</Text>
             <Text color="yellow" bold={archiveActive} dimColor={!cSelected}>{archiveActive ? "[Archive]" : " Archive "}</Text>
             <Text>{` `}</Text>

--- a/packages/client-ink/src/phases/SettingsPhase.tsx
+++ b/packages/client-ink/src/phases/SettingsPhase.tsx
@@ -83,7 +83,7 @@ export function SettingsPhase({
     return <TerminalTooSmall columns={cols} rows={termRows} />;
   }
 
-  const borderColor = themeColor(theme, "border");
+  const accentColor = themeColor(theme, "title") ?? themeColor(theme, "border");
   const dimColor = themeColor(theme, "separator") ?? "#666666";
 
   const menuLines: React.ReactNode[] = [];
@@ -91,7 +91,7 @@ export function SettingsPhase({
     const item = items[i];
     const isSelected = i === menuIndex;
     const marker = isSelected ? "◆" : "○";
-    const markerColor = isSelected ? borderColor : dimColor;
+    const markerColor = isSelected ? accentColor : dimColor;
 
     const suffix = item.toggle !== undefined
       ? item.toggle ? "  ON" : "  OFF"
@@ -100,7 +100,7 @@ export function SettingsPhase({
     menuLines.push(
       <Text key={item.label}>
         <Text color={markerColor}>{marker}</Text>
-        <Text>{` ${item.label}`}</Text>
+        <Text color={isSelected ? accentColor : undefined} bold={isSelected}>{` ${item.label}`}</Text>
         {suffix && <Text color={item.toggle ? "#66cc66" : dimColor} bold={item.toggle}>{suffix}</Text>}
       </Text>,
     );

--- a/packages/client-ink/src/phases/UpdatePhase.tsx
+++ b/packages/client-ink/src/phases/UpdatePhase.tsx
@@ -47,7 +47,7 @@ export function UpdatePhase({
     return <TerminalTooSmall columns={cols} rows={termRows} />;
   }
 
-  const borderColor = themeColor(theme, "border");
+  const accentColor = themeColor(theme, "title") ?? themeColor(theme, "border");
   const dimColor = themeColor(theme, "separator") ?? "#666666";
   const sideWidth = theme.asset.components.edge_left.width;
   const topHeight = theme.asset.height;
@@ -90,11 +90,11 @@ export function UpdatePhase({
   for (let i = 0; i < OPTIONS.length; i++) {
     const isSelected = i === selectedIndex;
     const marker = isSelected ? "◆" : "○";
-    const markerColor = isSelected ? borderColor : dimColor;
+    const markerColor = isSelected ? accentColor : dimColor;
     lines.push(
       <Text key={OPTIONS[i]}>
         <Text color={markerColor}>{marker}</Text>
-        <Text>{` ${OPTIONS[i]}`}</Text>
+        <Text color={isSelected ? accentColor : undefined} bold={isSelected}>{` ${OPTIONS[i]}`}</Text>
       </Text>,
     );
   }

--- a/packages/client-ink/src/tui/modals/GameMenu.tsx
+++ b/packages/client-ink/src/tui/modals/GameMenu.tsx
@@ -101,8 +101,20 @@ export function GameMenu({
         : [headerText],
     );
     for (const item of group.items) {
-      const marker = flatIdx === menuIndex ? "◆" : "○";
-      styledLines.push([`   ${marker} ${item.label}`]);
+      const isSelected = flatIdx === menuIndex;
+      const marker = isSelected ? "◆" : "○";
+      if (isSelected && accentColor) {
+        styledLines.push([
+          "   ",
+          {
+            type: "color",
+            color: accentColor,
+            content: [{ type: "bold", content: [`${marker} ${item.label}`] }],
+          },
+        ]);
+      } else {
+        styledLines.push([`   ${marker} ${item.label}`]);
+      }
       flatIdx++;
     }
   }

--- a/packages/client-ink/src/tui/modals/GameMenu.tsx
+++ b/packages/client-ink/src/tui/modals/GameMenu.tsx
@@ -103,14 +103,11 @@ export function GameMenu({
     for (const item of group.items) {
       const isSelected = flatIdx === menuIndex;
       const marker = isSelected ? "◆" : "○";
-      if (isSelected && accentColor) {
+      if (isSelected) {
+        const bolded: FormattingNode = { type: "bold", content: [`${marker} ${item.label}`] };
         styledLines.push([
           "   ",
-          {
-            type: "color",
-            color: accentColor,
-            content: [{ type: "bold", content: [`${marker} ${item.label}`] }],
-          },
+          accentColor ? { type: "color", color: accentColor, content: [bolded] } : bolded,
         ]);
       } else {
         styledLines.push([`   ${marker} ${item.label}`]);


### PR DESCRIPTION
## Summary
- The filled-diamond selection marker used in the main menu, ESC menu, Settings, Discord Settings, Update prompt, and Archived Campaigns previously coloured itself with the theme's `border` swatch and left the label unstyled — easy to miss at a glance against the framed background.
- Switch the marker and label to the theme's `title` swatch (the same colour `GameMenu` already treats as the modal accent) and bold the label so the selected row reads at a glance.
- Existing yellow emphasis for the Update / API-Keys nudges in the main menu still wins; disabled items still render in `#555555`.

## Test plan
- [x] `npm run check` — lint + 2673 tests pass
- [ ] Manually skim each affected phase in `npm run dev` to confirm the accent colour reads well across all bundled themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)