### PR TITLE
Navigable wikilinks in the compendium

### DIFF
--- a/packages/client-ink/src/tui/components/ThemedFrame.test.tsx
+++ b/packages/client-ink/src/tui/components/ThemedFrame.test.tsx
@@ -145,4 +145,43 @@ describe("ThemedSideFrame", () => {
       s.replace(new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g"), "");
     expect(stripAnsi(framWithGrad()!)).toBe(stripAnsi(framNoGrad()!));
   });
+
+  it("strips *bold* markers from centerText and preserves the plain text width", () => {
+    const { lastFrame: withMarkers } = render(
+      <ThemedHorizontalBorder
+        theme={noGrad}
+        width={60}
+        position="bottom"
+        centerText="*Enter*: select"
+      />,
+    );
+    const { lastFrame: withoutMarkers } = render(
+      <ThemedHorizontalBorder
+        theme={noGrad}
+        width={60}
+        position="bottom"
+        centerText="Enter: select"
+      />,
+    );
+    const marked = withMarkers()!;
+    expect(marked).not.toContain("*");
+    expect(marked).toContain("Enter: select");
+    // The composer must measure by stripped width; the rendered frames
+    // should be byte-identical aside from styling (which ink-testing-library
+    // strips from lastFrame). So both renders must produce the same plain text.
+    expect(marked).toBe(withoutMarkers());
+  });
+
+  it("treats an unmatched *bold marker as a literal asterisk", () => {
+    const { lastFrame } = render(
+      <ThemedHorizontalBorder
+        theme={noGrad}
+        width={60}
+        position="bottom"
+        centerText="rate is 5* of max"
+      />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain("5* of max");
+  });
 });

--- a/packages/client-ink/src/tui/components/ThemedFrame.tsx
+++ b/packages/client-ink/src/tui/components/ThemedFrame.tsx
@@ -17,6 +17,54 @@ import { colorizeSegments, mirrorT, applyGradient, hexToOklch } from "../color/i
 import type { GradientPreset } from "../color/index.js";
 import { themeColor } from "../themes/color-resolve.js";
 
+interface BoldSegment {
+  text: string;
+  bold: boolean;
+}
+
+/**
+ * Parse `*bold*` markers out of frame center text. Returns the plain string
+ * (markers stripped) and a segment list for emphasized rendering.
+ *
+ * The composer measures by string length to center text on the border, so
+ * the marker characters must be gone before it sees the input — width math
+ * is done against `plain`, decoration is applied later when we draw the
+ * middle span. Used today for the compendium modal footer to bold key
+ * names (`*Tab*: next  *Enter*: follow`).
+ */
+function parseBoldMarkers(text: string): { plain: string; segments: BoldSegment[] } {
+  const segments: BoldSegment[] = [];
+  let plain = "";
+  let i = 0;
+  while (i < text.length) {
+    const open = text.indexOf("*", i);
+    if (open === -1) {
+      const tail = text.slice(i);
+      if (tail) segments.push({ text: tail, bold: false });
+      plain += tail;
+      break;
+    }
+    if (open > i) {
+      const lead = text.slice(i, open);
+      segments.push({ text: lead, bold: false });
+      plain += lead;
+    }
+    const close = text.indexOf("*", open + 1);
+    if (close === -1) {
+      // Unmatched marker — treat as literal so a stray `*` doesn't eat the rest.
+      const tail = text.slice(open);
+      segments.push({ text: tail, bold: false });
+      plain += tail;
+      break;
+    }
+    const inner = text.slice(open + 1, close);
+    segments.push({ text: inner, bold: true });
+    plain += inner;
+    i = close + 1;
+  }
+  return { plain, segments };
+}
+
 /** Render a string with per-character gradient coloring, or flat if no gradient. */
 function renderGradientRow(
   row: string,
@@ -70,10 +118,20 @@ export const ThemedHorizontalBorder = React.memo(function ThemedHorizontalBorder
   centerText,
   centerTextColor,
 }: ThemedHorizontalBorderProps) {
+  // Parse `*bold*` markers up-front: composer + row matching see the plain
+  // text (so layout math stays correct), while we keep the bold segment
+  // structure for rich rendering of the middle span.
+  const parsedCenters: { plain: string; segments: BoldSegment[] }[] = Array.isArray(centerText)
+    ? centerText.map(parseBoldMarkers)
+    : centerText
+      ? [parseBoldMarkers(centerText)]
+      : [];
+  const plainCenters: string[] = parsedCenters.map((p) => p.plain);
+
   const frame =
     position === "top"
-      ? composeTopFrame(theme.asset, width, centerText)
-      : composeBottomFrame(theme.asset, width, typeof centerText === "string" ? centerText : centerText?.[0]);
+      ? composeTopFrame(theme.asset, width, plainCenters.length > 0 ? plainCenters : undefined)
+      : composeBottomFrame(theme.asset, width, plainCenters[0]);
 
   const borderColor = themeColor(theme, "border");
   const titleColor = centerTextColor ?? themeColor(theme, "title");
@@ -83,16 +141,14 @@ export const ThemedHorizontalBorder = React.memo(function ThemedHorizontalBorder
   // Per-row lookup of which text chunk is on which row. The composer
   // also centers shorter continuations within the longest line's slot,
   // so we trim each chunk to find its actual span in the row string.
-  const centerLines: (string | undefined)[] = Array.isArray(centerText)
-    ? centerText
-    : centerText
-      ? [centerText]
-      : [];
+  const centerLines: (string | undefined)[] = plainCenters;
+  const centerSegments: (BoldSegment[] | undefined)[] = parsedCenters.map((p) => p.segments);
 
   return (
     <Box flexDirection="column">
       {frame.rows.map((row, i) => {
         const rowText = position === "top" ? centerLines[i] : (i === frame.rows.length - 1 ? centerLines[0] : undefined);
+        const rowSegments = position === "top" ? centerSegments[i] : (i === frame.rows.length - 1 ? centerSegments[0] : undefined);
         // If there's center text on this row and a distinct title color, render in parts.
         // The composer centers shorter continuation lines inside the (wider) longest-line
         // slot by inserting extra spaces around the text, so the ` ${rowText} ` substring
@@ -104,6 +160,12 @@ export const ThemedHorizontalBorder = React.memo(function ThemedHorizontalBorder
             const before = row.slice(0, textIdx);
             const middle = rowText;
             const after = row.slice(textIdx + middle.length);
+            const middleSegments = rowSegments && rowSegments.length > 0
+              ? rowSegments
+              : [{ text: middle, bold: false }];
+            const renderMiddle = middleSegments.map((seg, j) => (
+              <Text key={`m${j}`} color={titleColor} bold={seg.bold}>{seg.text}</Text>
+            ));
 
             if (gradient && borderColor) {
               // Gradient the before/after portions with correct offsets
@@ -117,7 +179,7 @@ export const ThemedHorizontalBorder = React.memo(function ThemedHorizontalBorder
                   {beforeSegs.map((seg, j) => (
                     <Text key={`b${j}`} color={seg.color}>{seg.text}</Text>
                   ))}
-                  <Text color={titleColor}>{middle}</Text>
+                  {renderMiddle}
                   {afterSegs.map((seg, j) => (
                     <Text key={`a${j}`} color={seg.color}>{seg.text}</Text>
                   ))}
@@ -128,7 +190,7 @@ export const ThemedHorizontalBorder = React.memo(function ThemedHorizontalBorder
             return (
               <Box key={i}>
                 <Text color={borderColor}>{before}</Text>
-                <Text color={titleColor}>{middle}</Text>
+                {renderMiddle}
                 <Text color={borderColor}>{after}</Text>
               </Box>
             );

--- a/packages/client-ink/src/tui/formatting.test.ts
+++ b/packages/client-ink/src/tui/formatting.test.ts
@@ -487,6 +487,43 @@ describe("wrapNodes", () => {
     expect(result).toHaveLength(1);
     expect(toPlainText(result[0])).toBe("cd e");
   });
+
+  it("keeps multi-word wikilinks as a single atomic node when wrapping", () => {
+    // Wikilinks must not split across rows: a `[[Captain Voss]]` link has
+    // to render as one contiguous span (visually and structurally) so the
+    // compendium's link collector counts it once and Tab navigation works.
+    const nodes = parseFormatting("See <wikilink slug=captain-voss>Captain Voss</wikilink> for details");
+    const result = wrapNodes(nodes, 16);
+    // The link is 12 visible chars ("Captain Voss"); "See " before it is 4
+    // chars, which together fit width 16, but "for details" forces a wrap.
+    // What matters: the wikilink itself stays as ONE tag, not two halves.
+    const wikilinkNodes = result.flatMap((row) =>
+      row.filter((n): n is Extract<FormattingTag, { type: "wikilink" }> =>
+        typeof n !== "string" && n.type === "wikilink",
+      ),
+    );
+    expect(wikilinkNodes).toHaveLength(1);
+    expect(wikilinkNodes[0].target).toBe("captain-voss");
+    expect(toPlainText(wikilinkNodes[0].content)).toBe("Captain Voss");
+  });
+
+  it("places a wikilink atom on a new row when it doesn't fit the current row", () => {
+    // Width 12 forces "Captain Voss" (12 chars) onto a new row from "See ".
+    const nodes = parseFormatting("See <wikilink slug=captain-voss>Captain Voss</wikilink>");
+    const result = wrapNodes(nodes, 12);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    // The wikilink must appear on exactly one row, intact.
+    const linkRows = result.filter((row) =>
+      row.some((n) => typeof n !== "string" && n.type === "wikilink"),
+    );
+    expect(linkRows).toHaveLength(1);
+    const linkNodes = linkRows[0].filter(
+      (n): n is Extract<FormattingTag, { type: "wikilink" }> =>
+        typeof n !== "string" && n.type === "wikilink",
+    );
+    expect(linkNodes).toHaveLength(1);
+    expect(toPlainText(linkNodes[0].content)).toBe("Captain Voss");
+  });
 });
 
 describe("processNarrativeLines", () => {

--- a/packages/client-ink/src/tui/formatting.ts
+++ b/packages/client-ink/src/tui/formatting.ts
@@ -202,6 +202,21 @@ function flattenToWords(
           wordBreak = false;
         }
       }
+    } else if (node.type === "wikilink") {
+      // Wikilinks are atomic at wrap time: a `[[Two Word]]` link must render
+      // as one contiguous span (splitting it would visually break the link
+      // and also produces two AST fragments that downstream collectors
+      // would double-count). Emit the whole tag as a single word token.
+      const visible = nodeVisibleLength(node.content);
+      if (visible === 0) continue;
+      if (words.length > 0 && !wordBreak) {
+        const prev = words[words.length - 1];
+        prev.nodes.push(node);
+        prev.visible += visible;
+      } else {
+        words.push({ nodes: [node], visible });
+      }
+      wordBreak = false;
     } else {
       // Tag node — recurse into children, wrapping fragments in the same tag type
       const childWords: { nodes: FormattingNode[]; visible: number }[] = [];

--- a/packages/client-ink/src/tui/modals/CenteredModal.tsx
+++ b/packages/client-ink/src/tui/modals/CenteredModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState, useCallback, useEffect, forwardRef } from "react";
+import React, { useMemo, useRef, useState, useCallback, useEffect, forwardRef, useImperativeHandle } from "react";
 import { useInput, Box, Text } from "ink";
 import { ScrollView } from "ink-scroll-view";
 import type { ScrollViewRef } from "ink-scroll-view";
@@ -9,11 +9,19 @@ import { themeColor, deriveModalTheme } from "../themes/color-resolve.js";
 import { stringWidth } from "../frames/index.js";
 import { wrapNodes, toPlainText } from "../formatting.js";
 import { renderNodes } from "../render-nodes.js";
-import { useScrollHandle } from "../hooks/useScrollHandle.js";
 import type { ScrollHandle } from "../hooks/useScrollHandle.js";
 import { scrollAmount } from "../components/NarrativeArea.js";
 
-export type CenteredModalHandle = ScrollHandle;
+/**
+ * Handle exposed via forwardRef. Extends the shared ScrollHandle with
+ * `ensureLineVisible`, which scrolls the modal so the target row sits inside
+ * the viewport with a small margin — used by CompendiumModal to keep the
+ * cursored wikilink onscreen as the user Tabs through links.
+ */
+export interface CenteredModalHandle extends ScrollHandle {
+  /** Scroll so `lineIndex` (0-based) is within the visible window. */
+  ensureLineVisible(lineIndex: number): void;
+}
 
 /**
  * Bottom-row width of the bottom-frame fixed parts (corners + separators).
@@ -26,6 +34,31 @@ function bottomFrameOverhead(asset: ThemeAsset): number {
   const { corner_bl, corner_br, separator_left_bottom, separator_right_bottom } = asset.components;
   return lastRowWidth(corner_bl) + lastRowWidth(corner_br) +
     lastRowWidth(separator_left_bottom) + lastRowWidth(separator_right_bottom);
+}
+
+/**
+ * Compute the inner content width a CenteredModal would use for a given
+ * screen width + sizing options. Exported so callers that need to pre-wrap
+ * styled content (e.g. CompendiumModal stabilising wikilink row indices for
+ * auto-scroll) can do so at exactly the width CenteredModal will render at.
+ *
+ * Keeps the math in lockstep — divergence here would silently break
+ * pre-wrap-driven scroll targeting.
+ */
+export function computeModalInnerWidth(
+  theme: ResolvedTheme,
+  screenWidth: number,
+  opts: { minWidth?: number; maxWidth?: number; widthFraction?: number; footer?: string } = {},
+): number {
+  const { minWidth = 40, maxWidth = 60, widthFraction = 0.5, footer } = opts;
+  const sideWidth = theme.asset.components.edge_left.width;
+  const sidePadding = 1;
+  const footerFloor = footer
+    ? stringWidth(footer) + 2 + bottomFrameOverhead(theme.asset)
+    : 0;
+  const baseModalWidth = Math.max(minWidth, Math.min(Math.floor(screenWidth * widthFraction), maxWidth));
+  const modalWidth = Math.min(screenWidth, Math.max(baseModalWidth, footerFloor));
+  return modalWidth - 2 * sideWidth - 2 * sidePadding;
 }
 
 /** Word-wrap a single plain-text line to fit within the given width. */
@@ -175,7 +208,32 @@ export const CenteredModal = forwardRef<CenteredModalHandle, CenteredModalProps>
       return () => clearTimeout(timer);
     }, [lineCount, updateScrollState]);
 
-    useScrollHandle(ref, scrollRef);
+    useImperativeHandle(ref, () => ({
+      scrollBy(delta: number) {
+        const sv = scrollRef.current;
+        if (!sv) return;
+        if (delta > 0) {
+          const room = sv.getBottomOffset() - sv.getScrollOffset();
+          if (room <= 0) return;
+          sv.scrollBy(Math.min(delta, room));
+        } else {
+          sv.scrollBy(delta);
+        }
+      },
+      ensureLineVisible(lineIndex: number) {
+        const sv = scrollRef.current;
+        if (!sv || lineIndex < 0) return;
+        const offset = sv.getScrollOffset();
+        const maxOffset = sv.getBottomOffset();
+        if (lineIndex < offset) {
+          // Scrolling up: place the target at the top edge.
+          sv.scrollTo(Math.max(0, Math.min(lineIndex, maxOffset)));
+        } else if (lineIndex >= offset + visibleRows) {
+          // Scrolling down: place the target at the bottom edge.
+          sv.scrollTo(Math.max(0, Math.min(lineIndex - visibleRows + 1, maxOffset)));
+        }
+      },
+    }), [visibleRows]);
 
     // Built-in keyboard handling for read-only scrollable modals.
     const scrollBy = useCallback((delta: number) => {

--- a/packages/client-ink/src/tui/modals/CompendiumModal.test.tsx
+++ b/packages/client-ink/src/tui/modals/CompendiumModal.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box } from "ink";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render } from "ink-testing-library";
 import { CompendiumModal } from "./CompendiumModal.js";
 import { resolveTheme } from "../themes/resolver.js";
@@ -159,6 +159,169 @@ describe("CompendiumModal", () => {
     );
     // First category row should have the selected marker
     expect(lastFrame()).toContain("\u25C6");
+  });
+});
+
+/** Compendium with cross-referenced entries used to exercise wikilink nav. */
+function linkedCompendium(): Compendium {
+  return {
+    version: 1,
+    lastUpdatedScene: 5,
+    characters: [
+      entry({
+        name: "Mira",
+        slug: "mira",
+        summary: "A smuggler who trusts [[Captain Voss]] and despises [[Lord Nemo]].",
+      }),
+      entry({ name: "Captain Voss", slug: "captain-voss", summary: "Corrupt guard captain who haunts [[Mira]]." }),
+    ],
+    places: [entry({ name: "The Undercroft", slug: "the-undercroft", summary: "Mira's bolt-hole." })],
+    items: [],
+    storyline: [],
+    lore: [],
+    objectives: [],
+  };
+}
+
+/**
+ * Expand the Characters category and open Mira's detail view, so subsequent
+ * keypresses exercise the wikilink-navigation code path.
+ */
+async function openMira(harness: ReturnType<typeof render>): Promise<void> {
+  harness.stdin.write("\r"); // expand Characters
+  await vi.waitFor(() => expect(harness.lastFrame()!).toContain("Mira"));
+  harness.stdin.write("\x1b[B"); // down to Mira
+  await vi.waitFor(() => expect(harness.lastFrame()!).toMatch(/\u25C6 Mira/));
+  harness.stdin.write("\r"); // open detail
+  await vi.waitFor(() => expect(harness.lastFrame()!).toContain("links"));
+}
+
+describe("CompendiumModal wikilink navigation", () => {
+  it("renders detail view with link count footer when entry has wikilinks", async () => {
+    const harness = render(
+      <Box width={80} height={24}>
+        <CompendiumModal
+          theme={theme}
+          width={80}
+          height={24}
+          data={linkedCompendium()}
+          onClose={() => {}}
+        />
+      </Box>,
+    );
+    await openMira(harness);
+    // Two wikilinks in Mira's summary \u2014 one live (Captain Voss), one broken (Lord Nemo).
+    expect(harness.lastFrame()!).toContain("1/2 links");
+  });
+
+  it("cycles selection forward with Tab and back with Shift+Tab", async () => {
+    const harness = render(
+      <Box width={80} height={24}>
+        <CompendiumModal
+          theme={theme}
+          width={80}
+          height={24}
+          data={linkedCompendium()}
+          onClose={() => {}}
+        />
+      </Box>,
+    );
+    await openMira(harness);
+    expect(harness.lastFrame()!).toContain("1/2 links");
+    harness.stdin.write("\t"); // Tab \u2192 next link
+    await vi.waitFor(() => expect(harness.lastFrame()!).toContain("2/2 links"));
+    harness.stdin.write("\t"); // wraps around
+    await vi.waitFor(() => expect(harness.lastFrame()!).toContain("1/2 links"));
+    harness.stdin.write("\x1b[Z"); // Shift+Tab \u2192 wraps backward
+    await vi.waitFor(() => expect(harness.lastFrame()!).toContain("2/2 links"));
+  });
+
+  it("Enter on a live link follows to the target entry", async () => {
+    const harness = render(
+      <Box width={80} height={24}>
+        <CompendiumModal
+          theme={theme}
+          width={80}
+          height={24}
+          data={linkedCompendium()}
+          onClose={() => {}}
+        />
+      </Box>,
+    );
+    await openMira(harness);
+    // First link is "Captain Voss" \u2014 live.
+    harness.stdin.write("\r");
+    await vi.waitFor(() => {
+      const frame = harness.lastFrame()!;
+      expect(frame).toContain("Captain Voss");
+      // Captain Voss's summary references Mira \u2014 one link.
+      expect(frame).toContain("1/1 links");
+    });
+  });
+
+  it("Backspace pops the navigation stack", async () => {
+    const harness = render(
+      <Box width={80} height={24}>
+        <CompendiumModal
+          theme={theme}
+          width={80}
+          height={24}
+          data={linkedCompendium()}
+          onClose={() => {}}
+        />
+      </Box>,
+    );
+    await openMira(harness);
+    harness.stdin.write("\r"); // follow Captain Voss
+    await vi.waitFor(() => expect(harness.lastFrame()!).toContain("Captain Voss"));
+    harness.stdin.write("\x7f"); // Backspace \u2192 back to Mira
+    await vi.waitFor(() => {
+      const frame = harness.lastFrame()!;
+      expect(frame).toContain("Mira");
+      expect(frame).toContain("1/2 links");
+    });
+    harness.stdin.write("\x7f"); // Backspace again \u2192 empty stack \u2192 tree view
+    await vi.waitFor(() => expect(harness.lastFrame()!).toContain("Characters (2)"));
+  });
+
+  it("ESC closes the modal from detail view (not back to tree)", async () => {
+    const onClose = vi.fn();
+    const harness = render(
+      <Box width={80} height={24}>
+        <CompendiumModal
+          theme={theme}
+          width={80}
+          height={24}
+          data={linkedCompendium()}
+          onClose={onClose}
+        />
+      </Box>,
+    );
+    await openMira(harness);
+    harness.stdin.write("\x1b"); // ESC
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("Enter on a broken link is a no-op (stays on same entry)", async () => {
+    const harness = render(
+      <Box width={80} height={24}>
+        <CompendiumModal
+          theme={theme}
+          width={80}
+          height={24}
+          data={linkedCompendium()}
+          onClose={() => {}}
+        />
+      </Box>,
+    );
+    await openMira(harness);
+    harness.stdin.write("\t"); // advance to Lord Nemo (broken)
+    await vi.waitFor(() => expect(harness.lastFrame()!).toContain("2/2 links"));
+    harness.stdin.write("\r"); // Enter on broken link
+    // Wait a tick to give any (unintended) navigation a chance to fire.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(harness.lastFrame()!).toContain("2/2 links");
+    expect(harness.lastFrame()!).toContain("Mira");
   });
 });
 

--- a/packages/client-ink/src/tui/modals/CompendiumModal.tsx
+++ b/packages/client-ink/src/tui/modals/CompendiumModal.tsx
@@ -255,8 +255,8 @@ export function CompendiumModal({
     const { wrapped, links, brokenSlugs } = detailContent;
     const styledLines = markWikilinks(wrapped, brokenSlugs, links.length > 0 ? linkIndex : -1);
     const linkFooter = links.length > 0
-      ? `${linkIndex + 1}/${links.length} links  Tab: next  Enter: follow  Bksp: back  ESC: close`
-      : "Bksp: back  ESC: close";
+      ? `${linkIndex + 1}/${links.length} links  *Tab*: next  *Enter*: follow  *Bksp*: back  *ESC*: close`
+      : "*Bksp*: back  *ESC*: close";
 
     return (
       <CenteredModal
@@ -324,7 +324,7 @@ export function CompendiumModal({
       width={width}
       height={height}
       title="Compendium"
-      footer="Enter: select  ESC: close"
+      footer="*Enter*: select  *ESC*: close"
       styledLines={treeStyledLines}
       minWidth={30}
       maxWidth={999}

--- a/packages/client-ink/src/tui/modals/CompendiumModal.tsx
+++ b/packages/client-ink/src/tui/modals/CompendiumModal.tsx
@@ -1,11 +1,14 @@
-import React, { useState, useMemo, useCallback, useEffect } from "react";
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useInput } from "ink";
 import type { ResolvedTheme } from "../themes/types.js";
 import type { FormattingNode } from "@machine-violet/shared/types/tui.js";
-import { CenteredModal } from "./CenteredModal.js";
+import { CenteredModal, computeModalInnerWidth } from "./CenteredModal.js";
+import type { CenteredModalHandle } from "./CenteredModal.js";
 import { themeColor, deriveModalTheme } from "../themes/color-resolve.js";
-import { parseFormatting } from "../formatting.js";
+import { parseFormatting, wrapNodes } from "../formatting.js";
 import { colorizeSheetLines } from "../character-colorization.js";
+import { collectWikilinks, markWikilinks } from "../wikilink-nav.js";
+import { collectCompendiumSlugs, findCompendiumEntryBySlug } from "@machine-violet/shared/utils/compendium-lookup.js";
 import type {
   Compendium,
   CompendiumEntry,
@@ -21,6 +24,8 @@ const CATEGORY_LABELS: Record<CompendiumCategory, string> = {
   lore: "Lore",
   objectives: "Objectives",
 };
+
+const DETAIL_MODAL_OPTS = { minWidth: 30, maxWidth: 999, widthFraction: 0.6 } as const;
 
 interface CompendiumModalProps {
   theme: ResolvedTheme;
@@ -38,7 +43,15 @@ type TreeRow =
 
 /**
  * Campaign compendium modal — navigable tree of player knowledge.
- * Categories expand/collapse; selecting an entry shows its detail view.
+ *
+ * Tree view: ↑↓ navigates rows, Enter expands a category or opens an entry,
+ * ESC closes the modal.
+ *
+ * Detail view: Tab / Shift+Tab cycle through `[[wikilinks]]` (cursored link
+ * renders inverse; links whose slug doesn't resolve render red, Wikipedia-
+ * style). Enter follows the cursored link, pushing the current entry onto a
+ * back-stack. Backspace pops the stack — back to a previous entry, or to the
+ * tree when the stack is empty. ESC always closes the modal.
  */
 export function CompendiumModal({
   theme,
@@ -51,6 +64,9 @@ export function CompendiumModal({
   const [expanded, setExpanded] = useState<Set<CompendiumCategory>>(() => new Set());
   const [cursor, setCursor] = useState(0);
   const [detail, setDetail] = useState<CompendiumEntry | null>(null);
+  const [, setHistory] = useState<CompendiumEntry[]>([]);
+  const [linkIndex, setLinkIndex] = useState(0);
+  const modalRef = useRef<CenteredModalHandle>(null);
 
   // Build the flat list of visible rows
   const rows: TreeRow[] = useMemo(() => {
@@ -89,11 +105,114 @@ export function CompendiumModal({
     });
   }, []);
 
-  useInput((_input, key) => {
-    if (detail) {
-      // Detail view: ESC or Enter goes back to tree
-      if (key.escape || key.return) {
+  // Slugs present in the compendium — used to flag broken wikilinks. Recomputed
+  // when the underlying data changes (e.g. scribe pass added a new entry).
+  const knownSlugs = useMemo(() => collectCompendiumSlugs(data), [data]);
+
+  // --- Detail view: pre-wrap styled lines so wikilink row indices are stable. ---
+  const detailContent = useMemo(() => {
+    if (!detail) return null;
+    // Metadata rows as `**Label:** Value` so the colorizer's KV pattern tints
+    // labels like front-matter keys. Summary may contain [[wikilinks]].
+    const lines: string[] = [];
+    lines.push("");
+    lines.push(detail.summary || "(No information yet.)");
+    lines.push("");
+    if (detail.aliases && detail.aliases.length > 0) {
+      lines.push(`**Also known as:** ${detail.aliases.join(", ")}`);
+    }
+    const sceneValue = detail.firstScene === detail.lastScene
+      ? `${detail.firstScene}`
+      : `${detail.firstScene}-${detail.lastScene}`;
+    const sceneLabel = detail.firstScene === detail.lastScene ? "Scene" : "Scenes";
+    lines.push(`**${sceneLabel}:** ${sceneValue}`);
+    if (detail.related.length > 0) {
+      lines.push(`**Related:** ${detail.related.join(", ")}`);
+    }
+
+    const innerWidth = computeModalInnerWidth(theme, width, DETAIL_MODAL_OPTS);
+    const styled = colorizeSheetLines(lines, { theme, frameAnchor: 1, wikilinks: "preserve" });
+    // Pre-wrap at the modal's exact innerWidth so each wikilink lives on a
+    // known row index — required for ensureLineVisible to scroll precisely.
+    // CenteredModal will re-wrap, but at the same width this is idempotent.
+    const wrapped = styled.flatMap((line) => wrapNodes(line, Math.max(1, innerWidth)));
+    const brokenSlugs = new Set<string>();
+    const allLinks = collectWikilinks(wrapped, new Set());
+    for (const link of allLinks) {
+      if (!knownSlugs.has(link.slug)) brokenSlugs.add(link.slug);
+    }
+    const links = collectWikilinks(wrapped, brokenSlugs);
+    return { lines, wrapped, links, brokenSlugs };
+  }, [detail, knownSlugs, theme, width]);
+
+  // Reset link selection when the displayed entry changes.
+  useEffect(() => {
+    if (!detail) return;
+    setLinkIndex(0);
+  }, [detail]);
+
+  // Auto-scroll the cursored link into view whenever it moves.
+  useEffect(() => {
+    if (!detailContent) return;
+    const link = detailContent.links[linkIndex];
+    if (!link) return;
+    // Defer to next tick so CenteredModal's ScrollView has settled after re-render.
+    const timer = setTimeout(() => modalRef.current?.ensureLineVisible(link.rowIndex), 0);
+    return () => clearTimeout(timer);
+  }, [detailContent, linkIndex]);
+
+  const navigateBack = useCallback(() => {
+    setHistory((prev) => {
+      const target = prev[prev.length - 1];
+      if (target === undefined) {
         setDetail(null);
+        return prev;
+      }
+      setDetail(target);
+      return prev.slice(0, -1);
+    });
+  }, []);
+
+  const followLink = useCallback(
+    (slug: string) => {
+      const result = findCompendiumEntryBySlug(data, slug);
+      if (!result || !detail) return;
+      setHistory((prev) => [...prev, detail]);
+      setDetail(result.entry);
+    },
+    [data, detail],
+  );
+
+  useInput((_input, key) => {
+    if (detail && detailContent) {
+      // ESC always closes the whole modal — consistent with tree view.
+      if (key.escape) {
+        onClose();
+        return;
+      }
+      if (key.backspace || key.delete) {
+        navigateBack();
+        return;
+      }
+      const links = detailContent.links;
+      if (key.tab && key.shift) {
+        if (links.length > 0) setLinkIndex((i) => (i - 1 + links.length) % links.length);
+        return;
+      }
+      if (key.tab) {
+        if (links.length > 0) setLinkIndex((i) => (i + 1) % links.length);
+        return;
+      }
+      if (key.return) {
+        const link = links[linkIndex];
+        if (!link || link.broken) {
+          // No live link to follow — fall back to going up one level so Enter
+          // still does something useful on link-less entries.
+          if (links.length === 0) navigateBack();
+          return;
+        }
+        followLink(link.slug);
+        return;
       }
       return;
     }
@@ -120,6 +239,7 @@ export function CompendiumModal({
       if (row.type === "category") {
         toggleCategory(row.key);
       } else {
+        setHistory([]);
         setDetail(row.entry);
       }
       return;
@@ -131,46 +251,25 @@ export function CompendiumModal({
   const accentColor = themeColor(modalTheme, "title");
 
   // --- Detail view ---
-  if (detail) {
-    // Format metadata rows as `**Label:** Value` so the colorizer's KV pattern
-    // tints the label like front-matter keys. Summary lines may contain
-    // [[wikilinks]] — the colorizer wraps them in a wikilink AST tag so a
-    // future navigation feature can jump to the linked sheet.
-    const detailLines: string[] = [];
-    detailLines.push("");
-    detailLines.push(detail.summary || "(No information yet.)");
-    detailLines.push("");
-    if (detail.aliases && detail.aliases.length > 0) {
-      detailLines.push(`**Also known as:** ${detail.aliases.join(", ")}`);
-    }
-    const sceneValue = detail.firstScene === detail.lastScene
-      ? `${detail.firstScene}`
-      : `${detail.firstScene}-${detail.lastScene}`;
-    const sceneLabel = detail.firstScene === detail.lastScene ? "Scene" : "Scenes";
-    detailLines.push(`**${sceneLabel}:** ${sceneValue}`);
-    if (detail.related.length > 0) {
-      detailLines.push(`**Related:** ${detail.related.join(", ")}`);
-    }
-    detailLines.push("");
-    detailLines.push("ESC to go back");
-
-    const styledLines = colorizeSheetLines(detailLines, {
-      theme,
-      frameAnchor: 1,
-      wikilinks: "preserve",
-    });
+  if (detail && detailContent) {
+    const { wrapped, links, brokenSlugs } = detailContent;
+    const styledLines = markWikilinks(wrapped, brokenSlugs, links.length > 0 ? linkIndex : -1);
+    const linkFooter = links.length > 0
+      ? `${linkIndex + 1}/${links.length} links  Tab: next  Enter: follow  Bksp: back  ESC: close`
+      : "Bksp: back  ESC: close";
 
     return (
       <CenteredModal
+        ref={modalRef}
         theme={theme}
         width={width}
         height={height}
         title={detail.name}
-        lines={detailLines}
         styledLines={styledLines}
-        minWidth={30}
-        maxWidth={999}
-        widthFraction={0.6}
+        footer={linkFooter}
+        minWidth={DETAIL_MODAL_OPTS.minWidth}
+        maxWidth={DETAIL_MODAL_OPTS.maxWidth}
+        widthFraction={DETAIL_MODAL_OPTS.widthFraction}
         topOffset={topOffset}
       />
     );
@@ -202,15 +301,15 @@ export function CompendiumModal({
     const selected = i === clampedCursor;
     const color = selected ? accentColor : textColor;
     if (row.type === "category") {
-      const arrow = row.expanded ? "\u25BE" : "\u25B8";
-      const prefix = selected ? "\u25C6 " : "  ";
+      const arrow = row.expanded ? "▾" : "▸";
+      const prefix = selected ? "◆ " : "  ";
       const label = `${prefix}${arrow} ${row.label} (${row.count})`;
       const markup = selected
         ? `<color=${color}><b>${label}</b></color>`
         : `<color=${color}>${label}</color>`;
       return parseFormatting(markup);
     } else {
-      const marker = selected ? "\u25C6" : "\u25CB";
+      const marker = selected ? "◆" : "○";
       const label = `    ${marker} ${row.entry.name}`;
       const markup = selected
         ? `<color=${color}><b>${label}</b></color>`

--- a/packages/client-ink/src/tui/modals/CompendiumModal.tsx
+++ b/packages/client-ink/src/tui/modals/CompendiumModal.tsx
@@ -27,6 +27,20 @@ const CATEGORY_LABELS: Record<CompendiumCategory, string> = {
 
 const DETAIL_MODAL_OPTS = { minWidth: 30, maxWidth: 999, widthFraction: 0.6 } as const;
 
+/**
+ * Footer for the detail view. The "N/M links" numerator is left-padded to
+ * the digit width of `linkCount` so the rendered footer width stays stable
+ * as the user Tabs through links — the modal doesn't twitch a column wider
+ * when the numerator gains a digit, and a single sizing footer can drive
+ * both the pre-wrap innerWidth calculation and CenteredModal's own.
+ */
+function buildDetailFooter(linkIndex: number, linkCount: number): string {
+  if (linkCount === 0) return "*Bksp*: back  *ESC*: close";
+  const denom = String(linkCount);
+  const num = String(linkIndex + 1).padStart(denom.length, " ");
+  return `${num}/${denom} links  *Tab*: next  *Enter*: follow  *Bksp*: back  *ESC*: close`;
+}
+
 interface CompendiumModalProps {
   theme: ResolvedTheme;
   width: number;
@@ -130,10 +144,22 @@ export function CompendiumModal({
       lines.push(`**Related:** ${detail.related.join(", ")}`);
     }
 
-    const innerWidth = computeModalInnerWidth(theme, width, DETAIL_MODAL_OPTS);
     const styled = colorizeSheetLines(lines, { theme, frameAnchor: 1, wikilinks: "preserve" });
-    // Pre-wrap at the modal's exact innerWidth so each wikilink lives on a
-    // known row index — required for ensureLineVisible to scroll precisely.
+    // Wikilinks are atomic at wrap time (see wrapNodes), so the count is
+    // stable between styled and pre-wrapped — counting on the un-wrapped
+    // styled lines lets us size the footer BEFORE we need an innerWidth.
+    const linkCount = collectWikilinks(styled, new Set()).length;
+    // Build the worst-case sizing footer first, then compute innerWidth
+    // against the same footer CenteredModal will render with. Otherwise the
+    // footer's `footerFloor` widens the modal at render time but not at
+    // pre-wrap time, so content wraps narrower than the modal actually is.
+    const sizingFooter = buildDetailFooter(Math.max(0, linkCount - 1), linkCount);
+    const innerWidth = computeModalInnerWidth(theme, width, {
+      ...DETAIL_MODAL_OPTS,
+      footer: sizingFooter,
+    });
+    // Pre-wrap at the modal's actual innerWidth so each wikilink lives on
+    // a known row index — required for ensureLineVisible to scroll precisely.
     // CenteredModal will re-wrap, but at the same width this is idempotent.
     const wrapped = styled.flatMap((line) => wrapNodes(line, Math.max(1, innerWidth)));
     const brokenSlugs = new Set<string>();
@@ -254,9 +280,7 @@ export function CompendiumModal({
   if (detail && detailContent) {
     const { wrapped, links, brokenSlugs } = detailContent;
     const styledLines = markWikilinks(wrapped, brokenSlugs, links.length > 0 ? linkIndex : -1);
-    const linkFooter = links.length > 0
-      ? `${linkIndex + 1}/${links.length} links  *Tab*: next  *Enter*: follow  *Bksp*: back  *ESC*: close`
-      : "*Bksp*: back  *ESC*: close";
+    const linkFooter = buildDetailFooter(linkIndex, links.length);
 
     return (
       <CenteredModal

--- a/packages/client-ink/src/tui/render-nodes.tsx
+++ b/packages/client-ink/src/tui/render-nodes.tsx
@@ -1,6 +1,21 @@
 import React from "react";
 import { Text } from "ink";
 import type { FormattingNode, FormattingTag } from "@machine-violet/shared/types/tui.js";
+import { toPlainText } from "./formatting.js";
+
+/** Recover the first nested <color=...> from a wikilink's content. The colorizer
+ *  emits `<wikilink slug=foo><color=#hex>Name</color></wikilink>` for live
+ *  links, so this is how the inverse-selected state finds the entity hue to
+ *  invert against. Returns undefined for content that lacks any color tag. */
+function firstColor(content: FormattingNode[]): string | undefined {
+  for (const node of content) {
+    if (typeof node === "string") continue;
+    if (node.type === "color") return node.color;
+    const nested = firstColor(node.content);
+    if (nested) return nested;
+  }
+  return undefined;
+}
 
 /** Render a FormattingNode tree into React elements for Ink. */
 export function renderNodes(nodes: FormattingNode[]): React.ReactNode[] {
@@ -31,9 +46,20 @@ function renderTag(tag: FormattingTag): React.ReactNode {
       return <Text underline>{children}</Text>;
     case "color":
       return <Text color={tag.color}>{children}</Text>;
-    case "wikilink":
-      // Render-only tag; future navigation will read `tag.target` from the AST.
-      return <Text>{children}</Text>;
+    case "wikilink": {
+      // Live wikilinks normally pass through inert (the entity hue lives on
+      // an inner <color> tag). Navigation in CompendiumModal marks the
+      // cursored link with `selected` and unresolvable links with `broken`.
+      const broken = tag.broken === true;
+      const selected = tag.selected === true;
+      if (!broken && !selected) return <Text>{children}</Text>;
+      // For both decorated states we render the visible text directly so
+      // `inverse`/red can be applied without an inner color tag overriding
+      // them. The slug is preserved on the AST tag itself, not in children.
+      const text = toPlainText(tag.content);
+      const color = broken ? "red" : firstColor(tag.content);
+      return <Text color={color} inverse={selected} bold={selected}>{text}</Text>;
+    }
     case "center":
     case "right":
       // Alignment is handled at the NarrativeLine level when this is a

--- a/packages/client-ink/src/tui/wikilink-nav.test.ts
+++ b/packages/client-ink/src/tui/wikilink-nav.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { collectWikilinks, markWikilinks } from "./wikilink-nav.js";
+import type { FormattingNode } from "@machine-violet/shared/types/tui.js";
+
+function wikilink(slug: string, name: string): FormattingNode {
+  return {
+    type: "wikilink",
+    target: slug,
+    content: [{ type: "color", color: "#abcdef", content: [name] }],
+  };
+}
+
+describe("collectWikilinks", () => {
+  it("returns refs in document order across rows", () => {
+    const lines: FormattingNode[][] = [
+      ["See ", wikilink("mira", "Mira"), " for details."],
+      ["Also ", wikilink("voss", "Captain Voss"), " and ", wikilink("the-undercroft", "The Undercroft"), "."],
+    ];
+    const refs = collectWikilinks(lines, new Set());
+    expect(refs.map((r) => r.slug)).toEqual(["mira", "voss", "the-undercroft"]);
+    expect(refs.map((r) => r.name)).toEqual(["Mira", "Captain Voss", "The Undercroft"]);
+    expect(refs.map((r) => r.rowIndex)).toEqual([0, 1, 1]);
+    expect(refs.every((r) => r.broken === false)).toBe(true);
+  });
+
+  it("flags missing slugs as broken", () => {
+    const lines: FormattingNode[][] = [
+      [wikilink("alive", "Alive"), " ", wikilink("dead", "Dead")],
+    ];
+    const refs = collectWikilinks(lines, new Set(["dead"]));
+    expect(refs[0].broken).toBe(false);
+    expect(refs[1].broken).toBe(true);
+  });
+
+  it("descends into nested tags (e.g. bold around a wikilink)", () => {
+    const lines: FormattingNode[][] = [
+      [{ type: "bold", content: ["See ", wikilink("mira", "Mira")] }],
+    ];
+    const refs = collectWikilinks(lines, new Set());
+    expect(refs).toHaveLength(1);
+    expect(refs[0].slug).toBe("mira");
+  });
+
+  it("returns an empty array when no wikilinks present", () => {
+    const lines: FormattingNode[][] = [["plain text"], [{ type: "bold", content: ["bold"] }]];
+    expect(collectWikilinks(lines, new Set())).toEqual([]);
+  });
+});
+
+describe("markWikilinks", () => {
+  it("stamps `broken` on links whose slug is missing", () => {
+    const lines: FormattingNode[][] = [[wikilink("alive", "Alive"), " ", wikilink("dead", "Dead")]];
+    const marked = markWikilinks(lines, new Set(["dead"]), -1);
+    const tags = marked[0].filter((n) => typeof n !== "string");
+    expect((tags[0] as { broken?: boolean }).broken).toBeUndefined();
+    expect((tags[1] as { broken?: boolean }).broken).toBe(true);
+  });
+
+  it("stamps `selected` only on the Nth wikilink in document order", () => {
+    const lines: FormattingNode[][] = [
+      [wikilink("a", "A"), " ", wikilink("b", "B")],
+      [wikilink("c", "C")],
+    ];
+    const marked = markWikilinks(lines, new Set(), 1);
+    const collect = (row: number) => marked[row].filter((n) => typeof n !== "string");
+    const row0 = collect(0);
+    expect((row0[0] as { selected?: boolean }).selected).toBeUndefined();
+    expect((row0[1] as { selected?: boolean }).selected).toBe(true);
+    const row1 = collect(1);
+    expect((row1[0] as { selected?: boolean }).selected).toBeUndefined();
+  });
+
+  it("does not mutate the input tree", () => {
+    const original: FormattingNode[][] = [[wikilink("mira", "Mira")]];
+    const snapshot = JSON.stringify(original);
+    markWikilinks(original, new Set(["mira"]), 0);
+    expect(JSON.stringify(original)).toBe(snapshot);
+  });
+
+  it("leaves non-wikilink tags untouched", () => {
+    const lines: FormattingNode[][] = [
+      [{ type: "bold", content: ["hi"] }, " ", wikilink("mira", "Mira")],
+    ];
+    const marked = markWikilinks(lines, new Set(), 0);
+    const bold = marked[0][0];
+    expect(typeof bold).not.toBe("string");
+    expect((bold as { type: string }).type).toBe("bold");
+  });
+
+  it("with selectedIndex out of range marks none selected", () => {
+    const lines: FormattingNode[][] = [[wikilink("a", "A")]];
+    const marked = markWikilinks(lines, new Set(), 99);
+    const tag = marked[0][0] as { selected?: boolean };
+    expect(tag.selected).toBeUndefined();
+  });
+});

--- a/packages/client-ink/src/tui/wikilink-nav.ts
+++ b/packages/client-ink/src/tui/wikilink-nav.ts
@@ -1,0 +1,102 @@
+/**
+ * Helpers for Lynx-style wikilink navigation in the compendium detail view.
+ *
+ * The compendium colorizer wraps `[[Name]]` in a `<wikilink slug=...>` AST
+ * tag. These helpers walk that AST to:
+ *   1. Collect every wikilink in document order, paired with the row index
+ *      it sits on (so the modal can auto-scroll the selected link into view).
+ *   2. Stamp `selected`/`broken` flags onto specific wikilink tags without
+ *      mutating the input — render-nodes.tsx reads those flags to draw the
+ *      inverse cursor and Wikipedia-style red broken links.
+ *
+ * Wikilink tags are never split across wrapped lines (wrapNodes treats each
+ * tag as an atom), so each link maps cleanly to exactly one row.
+ */
+
+import { toPlainText } from "./formatting.js";
+import type { FormattingNode, FormattingTag } from "@machine-violet/shared/types/tui.js";
+
+export interface WikilinkRef {
+  /** Slug parsed from the AST tag — the lookup key into the compendium. */
+  slug: string;
+  /** Display text from the original `[[Name]]`. */
+  name: string;
+  /** Zero-based index into the styledLines array this link occurs in. */
+  rowIndex: number;
+  /** Whether the slug resolves to an entry. Set by the resolver pass. */
+  broken: boolean;
+}
+
+/**
+ * Walk pre-wrapped styled lines and return wikilink refs in document order.
+ *
+ * `brokenSlugs` is the set of slugs that DO NOT resolve in the current
+ * compendium — anything in this set gets `broken: true`. Pass an empty set
+ * to mark all links live; pass a populated set to flag the absent ones.
+ */
+export function collectWikilinks(
+  styledLines: FormattingNode[][],
+  brokenSlugs: ReadonlySet<string>,
+): WikilinkRef[] {
+  const refs: WikilinkRef[] = [];
+  for (let rowIndex = 0; rowIndex < styledLines.length; rowIndex++) {
+    walk(styledLines[rowIndex], (tag) => {
+      if (tag.type === "wikilink") {
+        refs.push({
+          slug: tag.target,
+          name: toPlainText(tag.content),
+          rowIndex,
+          broken: brokenSlugs.has(tag.target),
+        });
+      }
+    });
+  }
+  return refs;
+}
+
+/**
+ * Return a new styledLines tree with `selected`/`broken` flags applied to
+ * each wikilink based on its position in document order. Input is not
+ * mutated — every tag along the spine of a marked link is rebuilt.
+ *
+ * `selectedIndex` is the index into the collectWikilinks() ordering; pass
+ * -1 (or any out-of-range value) to leave nothing selected.
+ */
+export function markWikilinks(
+  styledLines: FormattingNode[][],
+  brokenSlugs: ReadonlySet<string>,
+  selectedIndex: number,
+): FormattingNode[][] {
+  let counter = 0;
+  return styledLines.map((line) =>
+    mapNodes(line, (tag) => {
+      if (tag.type !== "wikilink") return tag;
+      const index = counter++;
+      const broken = brokenSlugs.has(tag.target);
+      const selected = index === selectedIndex;
+      if (!broken && !selected) return tag;
+      return { ...tag, broken: broken || undefined, selected: selected || undefined };
+    }),
+  );
+}
+
+function walk(nodes: FormattingNode[], visit: (tag: FormattingTag) => void): void {
+  for (const node of nodes) {
+    if (typeof node === "string") continue;
+    visit(node);
+    walk(node.content, visit);
+  }
+}
+
+/** Recurse through the tree, applying `transform` to every tag (post-order). */
+function mapNodes(
+  nodes: FormattingNode[],
+  transform: (tag: FormattingTag) => FormattingTag,
+): FormattingNode[] {
+  return nodes.map((node) => {
+    if (typeof node === "string") return node;
+    const mappedContent = mapNodes(node.content, transform);
+    const rebuilt = mappedContent === node.content ? node : ({ ...node, content: mappedContent } as FormattingTag);
+    return transform(rebuilt);
+  });
+}

--- a/packages/engine/src/prompts/compendium-updater.md
+++ b/packages/engine/src/prompts/compendium-updater.md
@@ -7,10 +7,27 @@ You receive the current compendium JSON and a player-safe scene summary. Update 
 1. **Player knowledge only.** Include only what the player directly witnessed, was told, or could reasonably infer. Never add DM secrets, hidden mechanics, or information the player character does not have.
 2. **Identity tracking.** Before creating a new entry, check if an existing entry refers to the same entity under a different name. If a character's identity is revealed (e.g., "the stranger" turns out to be "Bob"), update the existing entry's `name` field and add the old name to `aliases`. The `slug` stays stable.
 3. **Update, don't duplicate.** When new information about an existing entry is revealed, update its `summary` and `lastScene`. Do not create a second entry.
-4. **Summaries are 1-3 sentences.** Dense, factual, no editorializing. Wikilinks (`[[name]]`) are encouraged for cross-references.
-5. **Related entries.** The `related` array contains slugs of other compendium entries this one connects to. Keep it accurate.
-6. **Append-only.** Never remove entries. Objectives that are completed should have their summary updated to note completion.
-7. **Categories:**
+4. **Summaries are 1-3 sentences.** Dense, factual, no editorializing.
+5. **Wikilinks are required.** Any compendium entry named in a summary MUST be wrapped in `[[double brackets]]` using the display name (e.g. `[[Vesper Caine]]`, not `[[vesper-caine]]`). The TUI turns these into navigable links the player can Tab through to jump between entries — bare names break that navigation. Wikilink every entity-by-name mention, every time it appears, even if it appears in the same summary twice.
+6. **Related entries.** The `related` array is for connections that are NOT mentioned by name in the summary — e.g. another character present in the same scene who doesn't get called out in this entry's prose. Entries already wikilinked in the summary do not need to be repeated in `related`.
+
+### Example
+
+A character who works with the cartographer Vesper Caine in the Arcade:
+
+```json
+{
+  "name": "Lia",
+  "slug": "lia",
+  "summary": "Apprentice cartographer working under [[Vesper Caine]] in [[the Arcade]]. Knows the city's old street names from before the last rebuild.",
+  "related": ["the-city"]
+}
+```
+
+Note that `vesper-caine` and `the-arcade` are NOT in `related` — they're already wikilinked inline. `the-city` is in `related` because it's contextually connected but not named in the prose.
+
+7. **Append-only.** Never remove entries. Objectives that are completed should have their summary updated to note completion.
+8. **Categories:**
    - `characters` — NPCs, allies, antagonists, notable figures the player has met or heard of
    - `places` — Locations the player has visited or learned about
    - `items` — Named weapons, artifacts, quest items, and other narratively significant objects. Summaries should note current holder/location, origin or provenance if known, and any notable properties

--- a/packages/shared/src/types/tui.ts
+++ b/packages/shared/src/types/tui.ts
@@ -44,7 +44,18 @@ export type FormattingTag =
   // pipeline so future navigation features (clicking/keyboard-selecting a
   // wikilink to jump to its sheet) have the destination available without
   // re-parsing the source text. Render-only — not authored by LLMs.
-  | { type: "wikilink"; target: string; content: FormattingNode[] };
+  //
+  // `selected` and `broken` are applied by post-processing passes (see
+  // wikilink-nav.ts) to drive Lynx-style keyboard navigation in the
+  // compendium detail view: the cursored link renders inverse; links whose
+  // slug doesn't resolve render red (Wikipedia-style) and are inert on Enter.
+  | {
+      type: "wikilink";
+      target: string;
+      content: FormattingNode[];
+      selected?: boolean;
+      broken?: boolean;
+    };
 
 export type FormattingNode = string | FormattingTag;
 

--- a/packages/shared/src/utils/compendium-lookup.test.ts
+++ b/packages/shared/src/utils/compendium-lookup.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  findCompendiumEntryBySlug,
+  collectCompendiumSlugs,
+} from "./compendium-lookup.js";
+import type { Compendium, CompendiumEntry } from "../types/compendium.js";
+
+function entry(name: string, slug: string): CompendiumEntry {
+  return { name, slug, summary: "", firstScene: 1, lastScene: 1, related: [] };
+}
+
+function sample(): Compendium {
+  return {
+    version: 1,
+    lastUpdatedScene: 1,
+    characters: [entry("Mira", "mira"), entry("Captain Voss", "captain-voss")],
+    places: [entry("The Undercroft", "the-undercroft")],
+    items: [entry("Crystal Dagger", "crystal-dagger")],
+    storyline: [],
+    lore: [entry("The Crystal Prophecy", "crystal-prophecy")],
+    objectives: [entry("Find the Artifact", "find-the-artifact")],
+  };
+}
+
+describe("findCompendiumEntryBySlug", () => {
+  it("finds an entry across categories", () => {
+    const compendium = sample();
+    const result = findCompendiumEntryBySlug(compendium, "captain-voss");
+    expect(result).not.toBeNull();
+    expect(result!.entry.name).toBe("Captain Voss");
+    expect(result!.category).toBe("characters");
+  });
+
+  it("finds entries in non-character categories", () => {
+    const compendium = sample();
+    expect(findCompendiumEntryBySlug(compendium, "the-undercroft")?.category).toBe("places");
+    expect(findCompendiumEntryBySlug(compendium, "crystal-prophecy")?.category).toBe("lore");
+    expect(findCompendiumEntryBySlug(compendium, "find-the-artifact")?.category).toBe("objectives");
+  });
+
+  it("returns null for unknown slug", () => {
+    expect(findCompendiumEntryBySlug(sample(), "nonexistent")).toBeNull();
+  });
+
+  it("tolerates missing category arrays (legacy compendiums)", () => {
+    const legacy = {
+      version: 1 as const,
+      lastUpdatedScene: 1,
+      characters: [entry("Oros", "oros")],
+      places: [],
+      storyline: [],
+      lore: [],
+      objectives: [],
+    } as unknown as Compendium;
+    expect(findCompendiumEntryBySlug(legacy, "oros")?.entry.name).toBe("Oros");
+    expect(findCompendiumEntryBySlug(legacy, "crystal-dagger")).toBeNull();
+  });
+
+  it("returns the first match when slugs duplicate across categories", () => {
+    // Pathological but possible: same slug in two categories.
+    // Canonical category order (characters first) wins.
+    const compendium = sample();
+    compendium.places.push(entry("Mira's Hideaway", "mira"));
+    const result = findCompendiumEntryBySlug(compendium, "mira");
+    expect(result?.category).toBe("characters");
+  });
+});
+
+describe("collectCompendiumSlugs", () => {
+  it("returns every slug from every category", () => {
+    const slugs = collectCompendiumSlugs(sample());
+    expect(slugs).toEqual(
+      new Set([
+        "mira",
+        "captain-voss",
+        "the-undercroft",
+        "crystal-dagger",
+        "crystal-prophecy",
+        "find-the-artifact",
+      ]),
+    );
+  });
+
+  it("returns an empty set for an empty compendium", () => {
+    const empty: Compendium = {
+      version: 1,
+      lastUpdatedScene: 0,
+      characters: [],
+      places: [],
+      items: [],
+      storyline: [],
+      lore: [],
+      objectives: [],
+    };
+    expect(collectCompendiumSlugs(empty).size).toBe(0);
+  });
+});

--- a/packages/shared/src/utils/compendium-lookup.ts
+++ b/packages/shared/src/utils/compendium-lookup.ts
@@ -1,0 +1,50 @@
+import {
+  COMPENDIUM_CATEGORIES,
+  type Compendium,
+  type CompendiumCategory,
+  type CompendiumEntry,
+} from "../types/compendium.js";
+
+export interface CompendiumLookupResult {
+  entry: CompendiumEntry;
+  category: CompendiumCategory;
+}
+
+/**
+ * Resolve a slug to an entry by scanning every category in canonical order.
+ * Returns null if no entry matches.
+ *
+ * Used by the TUI to follow `[[Name]]` wikilinks in the compendium detail
+ * view — the renderer slugifies link text and asks this function whether
+ * the destination exists. A null result means the link is broken (rendered
+ * red, Wikipedia-style) and is a no-op on Enter.
+ */
+export function findCompendiumEntryBySlug(
+  compendium: Compendium,
+  slug: string,
+): CompendiumLookupResult | null {
+  for (const category of COMPENDIUM_CATEGORIES) {
+    const entries = compendium[category];
+    if (!entries) continue;
+    for (const entry of entries) {
+      if (entry.slug === slug) return { entry, category };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a Set of every slug present in the compendium. Used to mark broken
+ * wikilinks at render time without an O(N*L) double scan.
+ */
+export function collectCompendiumSlugs(compendium: Compendium): Set<string> {
+  const slugs = new Set<string>();
+  for (const category of COMPENDIUM_CATEGORIES) {
+    const entries = compendium[category];
+    if (!entries) continue;
+    for (const entry of entries) {
+      slugs.add(entry.slug);
+    }
+  }
+  return slugs;
+}


### PR DESCRIPTION
## Summary

`[[Wikilinks]]` in the compendium detail view are now first-class navigation targets, with Lynx-style keyboard traversal:

- `Tab` / `Shift+Tab` cycle through links (cursored link rendered inverse + bold)
- `Enter` follows the selected link, pushing the current entry onto a back-stack
- `Backspace` pops back one entry — or to the tree when the stack is empty
- `ESC` always closes the modal (consistent with tree view)
- Detail view scrolls; auto-scrolls to keep the cursored link onscreen
- Broken links (unresolved slug) render red, Wikipedia-style, and are inert on Enter
- Footer key names rendered bold for visual separation

Smoke-tested on a real campaign. The scribe currently doesn't write wikilinks idiomatically — see commit 8d6bdc3 for a prompt fix that makes wikilinks required and clarifies their boundary with the `related` slug array. Also flagged a separate scribe/DM slug-canonicalization bug as [#521](https://github.com/octopollux/machine-violet/issues/521).

## Implementation notes

- `findCompendiumEntryBySlug` + `collectCompendiumSlugs` in `packages/shared` so the resolver and broken-link scanner stay reusable.
- `<wikilink>` AST tag gets optional `selected` / `broken` flags; `render-nodes` applies inverse + entity hue or red accordingly.
- `wikilink-nav.ts` walks the styled-line AST to collect links in document order and stamp per-render flags without mutating input.
- `wrapNodes` now treats `<wikilink>` as atomic — splitting a multi-word link across rows would visually break the link span AND double-count it in the link list.
- `CenteredModal` exposes `computeModalInnerWidth` so `CompendiumModal` pre-wraps at exactly the width the modal will render at — row indices must stay stable for `ensureLineVisible` to scroll precisely.
- `CenteredModal`'s imperative handle gains `ensureLineVisible`.
- `ThemedHorizontalBorder` understands `*bold*` markers in `centerText` — strips them before the composer (preserving width math) and renders marked spans bold. Defensive: unmatched `*` is treated as a literal so existing titles/footers render byte-identical.

## Test plan

- [x] `npm run check` — lint + 2675 unit tests pass
- [x] Manual smoke: opened compendium on real campaign (palimpsest), Tabbed between links, followed `Captain Voss` → `Mira` → back via Backspace → escape via ESC
- [x] Broken-link styling verified by introducing a `[[Nonexistent]]` link
- [x] Auto-scroll verified on long entries (link below viewport)
- [ ] Worth a second smoke pass after the prompt fix lands and a new scribe run generates idiomatic wikilinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)