### PR TITLE
Refresh README around multi-provider support + installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,23 @@ Machine Violet is an agentic AI storytelling/roleplay engine that runs in your t
 ## What it does
 
 - **Build your story.** Interactively build a narrative with a friendly game setup agent, and then explore it with the help of a powerful AI storyteller.
-- **Create a compendium.** Characters, locations, objectives, factions, and lore are compiled into a library for you and keep the story alive.
-- **Rich support for game mechanics.** Full support for dice, decks, RPG rules, and more as agentic tools. 
+- **Create a compendium.** Characters, locations, objectives, factions, and lore are compiled into a wiki-linked library that keeps the story alive.
+- **Rich support for game mechanics.** Full support for dice, decks, maps, clocks, RPG rules, and more as agentic tools.
+- **Dozens of starter seeds.** Pick a prompt and go — from low-stakes slice-of-life to amnesia thrillers to old-magic-versus-engineered-magic — or build from scratch.
+
+## Bring your own AI
+
+Machine Violet works with whichever AI provider you already pay for:
+
+- **ChatGPT Plus / Pro / Business / Enterprise** — sign in with your existing subscription. No API credits required. Uses OpenAI's official Codex app-server under the hood for OAuth, token refresh, and rate-limit reporting.
+- **Anthropic API** — Claude Opus / Sonnet / Haiku via [console.anthropic.com](https://console.anthropic.com/).
+- **OpenAI API** — GPT-5.5 and friends via an OpenAI API key.
+- **OpenRouter** — one key, many models.
+- **Custom endpoints** — any OpenAI-compatible base URL (self-hosted, Azure, etc.).
+
+Add a connection from the main menu on first launch. Mix providers across tiers if you want — e.g., a premium model for the storyteller and a cheaper one for mechanical subagents.
 
 ## Install
-
-You'll need an [Anthropic API key](https://console.anthropic.com/) — add it from the main menu on first launch.
 
 **Windows**:
 Download the [**nightly release**](https://github.com/octopollux/machine-violet/releases/tag/nightly) and unzip, then run **MachineViolet.exe**.
@@ -38,17 +49,12 @@ Then run `machine-violet` in your terminal.
 
 ```bash
 npm install
-npm run dev                    # launch (needs ANTHROPIC_API_KEY in .env)
+npm run dev                    # launch (needs an API key in .env, or a ChatGPT login)
 npm run check                  # lint + tests
 npm run dist                   # build standalone binary
 ```
 
 See [CLAUDE.md](CLAUDE.md) for architecture, conventions, and contribution guidelines. Full documentation lives in [docs/](docs/index.md).
-
-## AI Models
-Machine Violet is based on the Claude API, and requires an **Anthropic API key**.
-
-The main storyteller runs on Claude Opus; mechanical subagents run on Sonnet and Haiku.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,19 +31,29 @@ Add a connection from the main menu on first launch. Mix providers across tiers 
 
 ## Install
 
-**Windows**:
-Download the [**nightly release**](https://github.com/octopollux/machine-violet/releases/tag/nightly) and unzip, then run **MachineViolet.exe**.
+### Windows
 
-**Homebrew** (macOS / Linux):
+**Installer (recommended)** — Download [**`MachineViolet-nightly-Setup.exe`**](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Setup.exe) and run it. Adds a Start Menu shortcut and updates itself in the background. Code-signed.
+
+**Portable** — Download [**`MachineViolet-nightly-Portable.zip`**](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Portable.zip), unzip anywhere, run `MachineViolet.exe`.
+
+> Use Windows Terminal (Preview 1.25+) for the best experience — `cmd.exe` and PowerShell ISE are not supported. The portable zip bundles a copy of Windows Terminal for convenience.
+
+### macOS (Apple Silicon) / Linux (x64)
+
+**Homebrew** (easiest):
 ```bash
 brew install octopollux/mv-tap/machine-violet
 ```
 
-**macOS / Linux** (manual):
+**Install script** — adds `machine-violet` to `~/.local/bin`:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/octopollux/machine-violet/main/scripts/install.sh | bash
 ```
-Then run `machine-violet` in your terminal. 
+
+**Tarball** — grab `machine-violet-nightly-darwin-arm64.tar.gz` or `machine-violet-nightly-linux-x64.tar.gz` from the [latest release](https://github.com/octopollux/machine-violet/releases/tag/nightly), extract, and run `./MachineViolet`.
+
+Then run `machine-violet` in your terminal.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Machine Violet is an agentic AI storytelling/roleplay engine that runs in your t
 
 Machine Violet works with whichever AI provider you already pay for:
 
-- **ChatGPT Plus / Pro / Business / Enterprise** — sign in with your existing subscription. No API credits required. Uses OpenAI's official Codex app-server under the hood for OAuth, token refresh, and rate-limit reporting.
+- **ChatGPT Plus / Pro / Business / Enterprise** — sign in with your existing subscription. No API credits required. Uses OpenAI's official Codex app-server for backend API calls and live rate-limit reporting.
 - **Anthropic API** — Claude Opus / Sonnet / Haiku via [console.anthropic.com](https://console.anthropic.com/).
 - **OpenAI API** — GPT-5.5 and friends via an OpenAI API key.
 - **OpenRouter** — one key, many models.
@@ -37,7 +37,7 @@ Add a connection from the main menu on first launch. Mix providers across tiers 
 
 **Portable** — Download [**`MachineViolet-nightly-Portable.zip`**](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Portable.zip), unzip anywhere, run `MachineViolet.exe`.
 
-> Use Windows Terminal (Preview 1.25+) for the best experience — `cmd.exe` and PowerShell ISE are not supported. The portable zip bundles a copy of Windows Terminal for convenience.
+> Use Windows Terminal (Preview 1.25+) for the best experience. PowerShell ISE is not supported; if launched from bare `cmd.exe` or by double-click, Machine Violet auto-relaunches in Windows Terminal when one is available. The portable zip bundles a copy of Windows Terminal.
 
 ### macOS (Apple Silicon) / Linux (x64)
 
@@ -45,15 +45,15 @@ Add a connection from the main menu on first launch. Mix providers across tiers 
 ```bash
 brew install octopollux/mv-tap/machine-violet
 ```
+Then run `machine-violet` in your terminal.
 
-**Install script** — adds `machine-violet` to `~/.local/bin`:
+**Install script** — downloads the tarball and symlinks `machine-violet` into `~/.local/bin`:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/octopollux/machine-violet/main/scripts/install.sh | bash
 ```
-
-**Tarball** — grab `machine-violet-nightly-darwin-arm64.tar.gz` or `machine-violet-nightly-linux-x64.tar.gz` from the [latest release](https://github.com/octopollux/machine-violet/releases/tag/nightly), extract, and run `./MachineViolet`.
-
 Then run `machine-violet` in your terminal.
+
+**Tarball (manual)** — grab `machine-violet-nightly-darwin-arm64.tar.gz` or `machine-violet-nightly-linux-x64.tar.gz` from the [latest release](https://github.com/octopollux/machine-violet/releases/tag/nightly), extract, and run `./MachineViolet` from the extracted directory.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Add a **Bring your own AI** section that leads with ChatGPT Plus / Pro / Business / Enterprise login (no API credits needed) and also lists Anthropic, OpenAI API, OpenRouter, and custom OpenAI-compatible endpoints. Removes the stale "requires Anthropic API key" framing.
- Restructure **Install** by OS instead of by install method, so each section runs easy → installer-less:
  - Windows: name `MachineViolet-nightly-Setup.exe` as the recommended download (Velopack, code-signed, in-app updates) and keep the portable zip for nerds.
  - macOS (Apple Silicon) / Linux (x64): Homebrew, install script, or tarball.
- Note the bundled Windows Terminal Preview in the portable zip (real, see `nightly.yml`).
- Drop the obsolete "AI Models" footer that claimed Machine Violet runs only on Claude.
- Minor: mention wiki-linked compendium, add maps + clocks to the mechanics bullet, add a starter-seeds bullet, soften the `npm run dev` env-var note.

## Test plan

- [ ] Render preview on the branch looks right: https://github.com/octopollux/machine-violet/blob/claude/sharp-bohr-808b98/README.md
- [ ] All file/asset names match what's on the latest nightly release
- [ ] All linked URLs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)