### PR TITLE
Add /smoketest skill as the canonical handle for the e2e harness

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,8 @@
       "Read(.claude/**)",
       "Read(scripts/**)",
       "Bash(npx tsx scripts/dump-state.ts:*)",
+      "Bash(npm run e2e:*)",
+      "Bash(npm run e2e -- :*)",
       "Edit(src/**)",
       "Edit(design-docs/**)",
       "Write(src/**)",

--- a/.claude/skills/smoketest/SKILL.md
+++ b/.claude/skills/smoketest/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: smoketest
+description: Run the Machine Violet end-to-end smoke test against the local repo. Default scenario is `golden-path` — the full new-campaign → live DM turn cycle, ~5-7 minutes, real LLM API calls. Pass `boot-and-quit` for the cheap precondition (no API key, ~10s). USE THIS SKILL whenever validating cross-cutting changes — anything touching UI flow, session lifecycle, the setup agent, the DM loop, save/load, or any code path that spans server + client + WebSocket — and whenever the user says "smoke test", "/smoketest", "run the harness", "validate end-to-end", "golden path", "run e2e", "did I break it", "is it still working". Type checks and unit tests do not prove the flow works end-to-end; the harness does.
+---
+
+# Smoketest
+
+Runs `packages/test-harness` against the full launcher stack (engine server + Ink TUI client + agent sidecar). The harness drives the TUI like a human player and asserts state-driven success.
+
+## Pick the scenario
+
+If `$ARGUMENTS` is non-empty, use it as the scenario id. Otherwise default to `golden-path`.
+
+Available scenarios live in `packages/test-harness/src/scenarios/`. Today:
+
+- `golden-path` — full live cycle. ~5-7 min. Real LLM calls. The baseline every cross-cutting change should clear.
+- `boot-and-quit` — confirms the launcher boots and the main menu renders. ~10s. No API key needed. The precondition for everything else.
+
+## How to invoke
+
+Use the `Bash` tool with `run_in_background: true`:
+
+```
+npm run e2e -- <scenario>
+```
+
+Then continue with whatever else needs doing in the same turn — write a commit message, draft a follow-up doc edit, sketch the next change. The harness auto-invokes you with a `<task-notification>` when the process exits.
+
+**Do NOT delegate this to a subagent.** Subagent `Bash` has a 10-minute hard cap that orphans the run mid-poll on a worst-case golden-path. Main-thread background does not share that cap. (`boot-and-quit` is short enough that delegating it is fine, but there's no real reason to — the main-thread pattern works for both.)
+
+**Do NOT tail the output file in subsequent turns.** Wait for the notification. Polling adds nothing and burns context.
+
+## Reading the result
+
+The notification arrives with the output file path. The harness writes exactly one terminal line as its last output:
+
+- `✔ OK <scenario> (<n>s)` — pass. Report one line with the wall-clock time. Nothing else.
+- `✘ FAIL <scenario> (<n>s)` — fail, followed by a structured dump (error, stack, last 50 lines of launcher output, `/state`, `/screen`). Paste the dump verbatim. Do not summarize, do not propose fixes inline, do not interpret the DM's narrative — let the human or next agent read it and decide.
+
+## Running lint and tests at the same time
+
+When you're finishing a cross-cutting change, kick off `npm run check` (lint + tests, ~80s) in parallel — but as a `general-purpose` subagent, not in the main thread. Both validations cover different ground: lint/tests catch code-level breakage in seconds; smoketest catches behavioral breakage over minutes. Launch both in the same turn so they run concurrently while you keep working.
+
+## Reference
+
+See [docs/e2e-harness.md](../../../docs/e2e-harness.md) for the scenario catalogue, harness primitives (`Harness.launch`, `waitFor*` family, `sendKey`/`submitText`), the engine-state pitfalls section (why certain naive predicates time out), and how to author a new scenario.

--- a/.claude/skills/smoketest/SKILL.md
+++ b/.claude/skills/smoketest/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: smoketest
 description: Run the Machine Violet end-to-end smoke test against the local repo. Default scenario is `golden-path` — the full new-campaign → live DM turn cycle, ~5-7 minutes, real LLM API calls. Pass `boot-and-quit` for the cheap precondition (no API key, ~10s). USE THIS SKILL whenever validating cross-cutting changes — anything touching UI flow, session lifecycle, the setup agent, the DM loop, save/load, or any code path that spans server + client + WebSocket — and whenever the user says "smoke test", "/smoketest", "run the harness", "validate end-to-end", "golden path", "run e2e", "did I break it", "is it still working". Type checks and unit tests do not prove the flow works end-to-end; the harness does.
+allowed-tools: Bash(npm run e2e:*), Bash(npm run e2e -- :*), Read
 ---
 
 # Smoketest
@@ -9,7 +10,7 @@ Runs `packages/test-harness` against the full launcher stack (engine server + In
 
 ## Pick the scenario
 
-If `$ARGUMENTS` is non-empty, use it as the scenario id. Otherwise default to `golden-path`.
+If `$ARGUMENTS` is non-empty, use it verbatim as the scenario id. Otherwise default to `golden-path`.
 
 Available scenarios live in `packages/test-harness/src/scenarios/`. Today:
 
@@ -18,10 +19,14 @@ Available scenarios live in `packages/test-harness/src/scenarios/`. Today:
 
 ## How to invoke
 
-Use the `Bash` tool with `run_in_background: true`:
+Use the `Bash` tool with `run_in_background: true`. The command is exactly one of:
 
-```
-npm run e2e -- <scenario>
+```bash
+# When $ARGUMENTS is empty (the default):
+npm run e2e:golden-path
+
+# When $ARGUMENTS is non-empty (substitute the scenario id):
+npm run e2e -- $ARGUMENTS
 ```
 
 Then continue with whatever else needs doing in the same turn — write a commit message, draft a follow-up doc edit, sketch the next change. The harness auto-invokes you with a `<task-notification>` when the process exits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,10 @@ Live API key in `.env` with limited credit. Default dev override uses Sonnet for
 
 Before reporting any cross-cutting change as done — anything touching UI flow, session lifecycle, the setup agent, the DM loop, save/load, or any code path that spans server + client + WebSocket — **run a harness scenario**. Type checks and unit tests do not prove the flow works end-to-end.
 
+The canonical handle is the **`/smoketest` skill** (`.claude/skills/smoketest/`). Users invoke it as `/smoketest` (or `/smoketest boot-and-quit`); agents invoke it via the Skill tool when validating cross-cutting work. The skill defaults to `golden-path` and follows the parallelization pattern below.
+
+Underneath, the skill calls these npm scripts directly:
+
 ```bash
 npm run e2e:boot           # 10s, no API key — precondition for everything else
 npm run e2e:golden-path    # 5-10 min, real LLM calls — the baseline smoke test

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -56,6 +56,16 @@ scenario" below.
 
 ## Running
 
+The canonical handle is the **`/smoketest` skill** (`.claude/skills/smoketest/`):
+
+```
+/smoketest                  # golden-path (default)
+/smoketest boot-and-quit    # the cheap precondition
+/smoketest <scenario-id>    # any scenario from packages/test-harness/src/scenarios/
+```
+
+Agents invoke the same skill via the Skill tool when validating cross-cutting work. Under the hood, it calls these npm scripts — which you can also run directly:
+
 ```bash
 # Quick precondition — no API key needed:
 npm run e2e:boot

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -87,11 +87,16 @@ This project maintains a closed loop between code and documentation. When you ch
 2. Register it in `ALL_SCENARIOS` in `packages/test-harness/bin/run.ts`
 3. Append a row to the scenarios table in [e2e-harness.md](e2e-harness.md)
 4. If you change the golden path's contract (what it proves, what it walks through), update the "The golden path" section in both [e2e-harness.md](e2e-harness.md) and the "Validating changes end-to-end" section in [CLAUDE.md](../CLAUDE.md)
+5. If the new scenario is a candidate default (rare), update the `/smoketest` skill description in `.claude/skills/smoketest/SKILL.md`. Most scenarios don't need a skill edit — they're reachable via `/smoketest <id>` without any changes.
 
 ### Changing harness primitives (wait helpers, input methods, state shape)
 
 1. Update the method on `Harness` / re-export from `packages/test-harness/src/index.ts`
 2. Update the "State-driven waiting" table in [e2e-harness.md](e2e-harness.md)
+
+### Changing what `/smoketest` does
+
+The skill at `.claude/skills/smoketest/SKILL.md` is the single source of truth for how agents and users invoke the harness. If you change which scenario it defaults to, the argument convention, or the "do/don't delegate to a subagent" guidance, edit that file. The skill's description field is what triggers it for agents — keep it specific about the trigger phrases ("smoke test", "validate end-to-end", "did I break it", etc.) so it fires when it should.
 
 ### Adding a `codex:*` event
 


### PR DESCRIPTION
## Summary

Gives agents and users a single shared way to invoke the smoke test landed in #507. Users type `/smoketest` (optionally with a scenario id); agents invoke the same skill via the Skill tool when finishing cross-cutting work. Both paths land on `npm run e2e -- <scenario>` with `golden-path` as the default.

The skill body encodes the validation pattern from CLAUDE.md so behavior stays consistent across invocations:

- Run via `Bash run_in_background:true` in the main thread — **not** a subagent (the subagent's 10-min Bash cap orphans long polls and silently abandons the run).
- Don't tail the output file in subsequent turns; wait for the task notification.
- On completion: `PASS in <n>s` as one line, or paste the structured failure dump verbatim.

## Files

- `.claude/skills/smoketest/SKILL.md` — the new skill. Description is intentionally "pushy" with the trigger phrases that should fire it (`smoke test`, `validate end-to-end`, `did I break it`, etc.).
- `CLAUDE.md` — "Validating changes end-to-end" now points at `/smoketest` first, with the npm scripts retained as the underlying interface.
- `docs/e2e-harness.md` — "Running" section leads with the skill.
- `docs/maintenance.md` — short note on when adding a scenario requires a skill edit (rare).

## Test plan

- [ ] Type `/smoketest` in Claude Code from a checkout of this branch — the skill triggers and the golden path kicks off in the background.
- [ ] Type `/smoketest boot-and-quit` — runs the cheap precondition (~10s, no API key).
- [ ] Verify the skill description fires for natural-language phrasing like "run the smoke test" or "validate end-to-end" (agents should pick it up via the Skill tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)