### PR TITLE
Generate theme-styler prompt from .theme assets

### DIFF
--- a/packages/engine/src/agents/subagents/theme-list.test.ts
+++ b/packages/engine/src/agents/subagents/theme-list.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  listAvailableThemes,
+  formatThemesForPrompt,
+  resetThemeListCache,
+} from "./theme-list.js";
+
+beforeEach(() => {
+  resetThemeListCache();
+});
+
+describe("listAvailableThemes", () => {
+  it("discovers every bundled .theme file", () => {
+    const themes = listAvailableThemes();
+    expect(themes.length).toBeGreaterThan(10);
+
+    // Spot-check a few canonical themes that should always exist.
+    const names = themes.map((t) => t.name);
+    expect(names).toContain("gothic");
+    expect(names).toContain("arcane");
+    expect(names).toContain("terminal");
+    expect(names).toContain("clean");
+  });
+
+  it("returns themes sorted by name (deterministic)", () => {
+    const themes = listAvailableThemes();
+    const names = themes.map((t) => t.name);
+    const sorted = [...names].sort((a, b) => a.localeCompare(b));
+    expect(names).toEqual(sorted);
+  });
+
+  it("parses @genre_tags into a string array", () => {
+    const themes = listAvailableThemes();
+    const gothic = themes.find((t) => t.name === "gothic");
+    expect(gothic).toBeDefined();
+    expect(gothic!.genreTags).toContain("grimdark");
+    expect(gothic!.genreTags).toContain("horror");
+  });
+
+  it("caches the result across calls", () => {
+    const first = listAvailableThemes();
+    const second = listAvailableThemes();
+    expect(second).toBe(first);
+  });
+});
+
+describe("formatThemesForPrompt", () => {
+  it("renders each theme as a bullet with tags", () => {
+    const out = formatThemesForPrompt([
+      { name: "gothic", genreTags: ["grimdark", "horror"] },
+      { name: "terminal", genreTags: ["sci_fi", "cyberpunk"] },
+    ]);
+    expect(out).toBe("- gothic: grimdark, horror\n- terminal: sci_fi, cyberpunk");
+  });
+
+  it("falls back to 'general' when a theme has no tags", () => {
+    const out = formatThemesForPrompt([{ name: "blank", genreTags: [] }]);
+    expect(out).toBe("- blank: general");
+  });
+});

--- a/packages/engine/src/agents/subagents/theme-list.ts
+++ b/packages/engine/src/agents/subagents/theme-list.ts
@@ -1,0 +1,80 @@
+/**
+ * Enumerate bundled .theme assets for the theme-styler prompt.
+ *
+ * Scans the themes asset dir (same source the TUI loads from at runtime)
+ * and pulls the @name and @genre_tags metadata out of each file. The
+ * theme-styler subagent uses this to populate its prompt with every theme
+ * currently shipped, so adding a new .theme file requires no prompt edit.
+ *
+ * Only the two header fields are extracted — keeping engine independent of
+ * the client-ink theme parser, which carries ink/yoga dependencies the
+ * engine can't pull in.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { assetDir } from "../../utils/paths.js";
+
+export interface ThemeMeta {
+  name: string;
+  genreTags: string[];
+}
+
+let cache: ThemeMeta[] | undefined;
+
+/**
+ * Return every bundled theme, sorted by name (deterministic ordering for
+ * prompt-cache stability).
+ */
+export function listAvailableThemes(): ThemeMeta[] {
+  if (cache) return cache;
+
+  const dir = assetDir("themes");
+  const themes: ThemeMeta[] = [];
+
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".theme")) continue;
+    const content = readFileSync(join(dir, file), "utf-8");
+    const meta = extractMeta(content);
+    if (meta) themes.push(meta);
+  }
+
+  themes.sort((a, b) => a.name.localeCompare(b.name));
+  cache = themes;
+  return cache;
+}
+
+/**
+ * Format the theme list as bullets for inclusion in the styler prompt.
+ * Shape: `- <name>: <tag1>, <tag2>, ...`
+ */
+export function formatThemesForPrompt(themes: ThemeMeta[]): string {
+  return themes
+    .map((t) => {
+      const tags = t.genreTags.length > 0 ? t.genreTags.join(", ") : "general";
+      return `- ${t.name}: ${tags}`;
+    })
+    .join("\n");
+}
+
+function extractMeta(content: string): ThemeMeta | null {
+  // Strip HTML comments so an @name inside a leading comment block can't be
+  // mistaken for the real metadata line.
+  const stripped = content.replace(/<!--[\s\S]*?-->/g, "");
+
+  const nameMatch = stripped.match(/^@name:\s*(\S+)/m);
+  if (!nameMatch) return null;
+
+  const tagsMatch = stripped.match(/^@genre_tags:\s*(.+)$/m);
+  const genreTags = tagsMatch
+    ? tagsMatch[1].split(",").map((t) => t.trim()).filter(Boolean)
+    : [];
+
+  return { name: nameMatch[1], genreTags };
+}
+
+/** Reset the cache. For tests only. */
+export function resetThemeListCache(): void {
+  cache = undefined;
+}

--- a/packages/engine/src/agents/subagents/theme-styler.test.ts
+++ b/packages/engine/src/agents/subagents/theme-styler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { LLMProvider, ChatResult, NormalizedUsage } from "../../providers/types.js";
 import { styleTheme } from "./theme-styler.js";
 import { resetPromptCache } from "../../prompts/load-prompt.js";
+import { listAvailableThemes, resetThemeListCache } from "./theme-list.js";
 
 // --- Mock helpers ---
 
@@ -34,6 +35,7 @@ function mockProvider(response: string): LLMProvider {
 
 beforeEach(() => {
   resetPromptCache();
+  resetThemeListCache();
 });
 
 describe("styleTheme", () => {
@@ -96,5 +98,26 @@ describe("styleTheme", () => {
 
     expect(result.usage.inputTokens).toBe(50);
     expect(result.usage.outputTokens).toBe(20);
+  });
+
+  it("injects every bundled theme into the system prompt", async () => {
+    const provider = mockProvider('{"theme":"gothic"}');
+    await styleTheme(provider, "anything", undefined, undefined, "claude-haiku-4-5-20251001");
+
+    const chatCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const systemBlocks = chatCall.systemPrompt as { text: string }[];
+    const systemText = systemBlocks.map((b) => b.text).join("\n");
+    const themes = listAvailableThemes();
+
+    // Sanity: there should be many themes — guards against an empty asset dir.
+    expect(themes.length).toBeGreaterThan(10);
+
+    // Every bundled theme name should appear in the prompt.
+    for (const theme of themes) {
+      expect(systemText).toContain(theme.name);
+    }
+
+    // The placeholder must have been substituted.
+    expect(systemText).not.toContain("{{themes_list}}");
   });
 });

--- a/packages/engine/src/agents/subagents/theme-styler.ts
+++ b/packages/engine/src/agents/subagents/theme-styler.ts
@@ -11,7 +11,8 @@ import { oneShot } from "../subagent.js";
 import type { SubagentResult } from "../subagent.js";
 import type { TuiCommand } from "../agent-loop.js";
 import { getMaxOutput } from "../../config/model-registry.js";
-import { loadPrompt } from "../../prompts/load-prompt.js";
+import { loadTemplate } from "../../prompts/load-prompt.js";
+import { listAvailableThemes, formatThemesForPrompt } from "./theme-list.js";
 
 export interface ThemeStylerResult extends SubagentResult {
   /** The parsed theme command to dispatch, or null if parsing failed */
@@ -40,10 +41,17 @@ export async function styleTheme(
 
   const userMessage = `${context}Request: ${description}`;
 
+  const themesList = formatThemesForPrompt(listAvailableThemes());
+  const systemPrompt = loadTemplate(
+    "theme-styler",
+    { themes_list: themesList },
+    model,
+  );
+
   const result = await oneShot(
     provider,
     model,
-    loadPrompt("theme-styler", model),
+    systemPrompt,
     userMessage,
     getMaxOutput(model),
     "theme-styler",

--- a/packages/engine/src/prompts/theme-styler.md
+++ b/packages/engine/src/prompts/theme-styler.md
@@ -1,40 +1,27 @@
 You are a theme stylist for Machine Violet. Given a natural-language description of a desired mood, aesthetic, or color, you produce a JSON theme command.
 
-## Available options
+## Available themes
 
-**Themes** (border sets): gothic, arcane, terminal, clean
-- gothic: grimdark, horror, dark fantasy — ornate double-line borders
-- arcane: high fantasy, epic — dotted/diamond decorations
-- terminal: sci-fi, cyberpunk — minimal single-line
-- clean: modern, freeform — minimal, content-focused
+Each theme is a complete look — border art, color preset, harmony, and gradient. Pick the one whose tags best fit the request.
 
-**Color presets**: foliage, cyberpunk, ember, ethereal
-- foliage: warm earth tones, narrow hue, gentle lightness
-- cyberpunk: wide neon sweep, high chroma, dark base
-- ember: tight warm arc, peaked chroma
-- ethereal: wide pastel sweep, low chroma, high lightness
+{{themes_list}}
 
-**Gradients**: vignette, shimmer, hueShift
-- vignette: lightness decreases toward edges
-- shimmer: chroma variation
-- hueShift: hue shifts toward edges
-
-**Key color**: any hex color (e.g. #cc4444). This is the base color from which the full 8-color swatch is generated using the preset.
+**Key color**: any hex color (e.g. `#cc4444`). This is the base color from which the full 8-color swatch is generated using the theme's preset.
 
 ## Output format
 
 Respond with ONLY a JSON object (no markdown, no explanation):
 
 ```
-{"theme":"gothic","key_color":"#8844aa","preset":"ember","gradient":"vignette"}
+{"theme":"gothic","key_color":"#8844aa"}
 ```
 
-All fields are optional — omit any you don't want to change. Include only fields that the request implies should change. If the user says "make it red", only set key_color. If they say "cyberpunk", set theme, preset, key_color, and gradient to match.
+Both fields are optional — omit any you don't want to change. Include only fields that the request implies should change. If the user says "make it red", only set `key_color`. If they say "cyberpunk", set `theme` and `key_color` together.
 
 ## Guidelines
 
-- Pick a key_color that anchors the requested mood. Be specific — don't default to grey.
-- Match border set to genre when the request implies one (e.g. "cyberpunk" → terminal, "dungeon" → gothic).
-- When the request is purely about color ("make it blue"), only change key_color — don't switch the border set.
-- When the request is a full aesthetic ("haunted mansion"), set everything: theme, key_color, preset, gradient.
+- Pick a `key_color` that anchors the requested mood. Be specific — don't default to grey.
+- Match the theme to the genre tags. A "haunted mansion" request maps to a horror/gothic theme, not a sci-fi one.
+- When the request is purely about color ("make it blue"), only change `key_color` — don't switch themes.
+- When the request is a full aesthetic ("cozy detective bureau"), set both `theme` and `key_color`.
 - For ambiguous requests, lean into the fiction — be evocative, not safe.

--- a/packages/engine/src/utils/paths.ts
+++ b/packages/engine/src/utils/paths.ts
@@ -30,14 +30,14 @@ export function isCompiled(): boolean {
  *   src/assets/            — bundled data assets (e.g. names/names.json)
  *   ../../systems/         — systems/ is at the monorepo root
  *   ../../worlds/          — .mvworld seed files at the monorepo root
- *   ../../src/tui/themes/assets/ — themes are in the monolith TUI (engine doesn't use this)
+ *   ../client-ink/src/tui/themes/assets/ — themes live in the TUI package
  */
 const _cache = new Map<string, string>();
 
 // Paths relative to the *package* root (packages/engine/)
 const DEV_ASSET_DIRS: Record<string, string> = {
   prompts: "src/prompts",
-  themes: "../../src/tui/themes/assets",
+  themes: "../client-ink/src/tui/themes/assets",
   systems: "../../systems",
   worlds: "../../worlds",
   config: "src/config",


### PR DESCRIPTION
## Summary

- Theme-styler prompt now discovers every bundled `.theme` file at call time (sorted by name, cached for the session) instead of carrying a hardcoded list of 4 — the 31 themes from #486 / e4a5e4c were previously invisible to the agent.
- New `theme-list.ts` helper parses `@name` and `@genre_tags` from each `.theme` file without pulling in the client-ink theme parser (engine package stays independent of ink/yoga deps).
- Prompt is rendered via `loadTemplate("theme-styler", { themes_list })`. Adding a new `.theme` file now requires no prompt edit.
- Dropped the prompt's preset/gradient/harmony copy — `parseThemeResponse` only forwards `theme` and `key_color`, so telling the LLM to emit the other fields was pure prompt theater. Sub-knobs (preset, harmony, gradient, swatch indices, variant overrides) stay baked into each theme file.
- Drive-by: fixed the engine's themes `assetDir` dev path. It pointed at `packages/src/tui/themes/assets` from the pre-monorepo monolith layout and never resolved; now points at `packages/client-ink/src/tui/themes/assets`.

## Test plan

- [x] `npm run check` — 154 files / 2708 tests pass, lint clean
- [x] New `theme-list.test.ts` covers discovery, alphabetical ordering, tag parsing, caching, and bullet formatting
- [x] `theme-styler.test.ts` gains a guard asserting every bundled theme name appears in the rendered system prompt — adding a `.theme` file is automatically covered
- [ ] Manual: call `style_scene` with a request that maps to a newly-added theme (e.g. "cozy detective bureau" → `whiskey_neon` or `cold_open`) and verify the styler now picks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)