### PR TITLE
Add prompt include directive + cascading entity override

### DIFF
--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -197,6 +197,24 @@ Tighten the rule against "not X, but Y" sentence construction.
 
 Cache reset: tests must call `resetPromptCache()` in `beforeEach`.
 
+### Includes and cascading entity override
+
+Reusable prompt fragments live in `packages/engine/src/prompts/include/` and are pulled in by directive:
+
+```markdown
+<!--include:NPCS-->
+<!--include:NPCS.Military-->
+```
+
+- The file is `include/<TagName>.md` — the directive's prefix is the file stem.
+- The directive expands inline to `<TagName>...</TagName>`. The outer tag is **always** the file stem, never the variant name — `NPCS.Military` produces `<NPCS>`, not `<Military>` or `<NPCS.Military>`. The dot picks a variant of the same logical entity.
+- Dotless includes look for a section named the same as the file stem (`<NPCS>` inside `NPCS.md`) as the conventional default. A file with no top-level XML sections is treated as one implicit default section.
+- Pipeline order: model conditionals → process includes → strip comments. Includes are HTML-comment-shaped, so they have to be expanded before comment stripping, but after conditionals (so a conditional can gate whether an include happens).
+
+When the same top-level `<TAG>` block appears across the DM's three prompt layers — main DM (`dm-identity` + `dm-directives`) → campaign seed (`campaign_detail`) → DM personality (`prompt_fragment` + `detail`) — the latest layer wins. Earlier occurrences are stripped entirely. This lets a personality template redefine the `<NPCS>` block established by the main prompt without editing the main file. Implemented by `applyLayeredOverrides` in `process-includes.ts`, invoked from `buildDMPrefix`.
+
+Inline `<TAG>...</TAG>` blocks (written literally in a prompt, no include directive) participate in the override too — they're the same kind of entity. Indented or inline-style XML like the narration formatters (`<b>`, `<color=...>`, `<center>`) is never matched because top-level requires the open tag at column 0.
+
 ## Client: commands/ — Slash Commands
 
 Player commands during gameplay. `trySlashCommand()` parses and dispatches.

--- a/packages/engine/src/agents/dm-prompt.test.ts
+++ b/packages/engine/src/agents/dm-prompt.test.ts
@@ -139,6 +139,66 @@ describe("buildHardStats", () => {
   });
 });
 
+describe("buildDMPrefix cascading entity override", () => {
+  // The three layers (main DM → campaign seed → DM personality) all contribute
+  // top-level XML blocks; when they collide on the same tag, the personality
+  // layer wins. This test plants a unique `<NPCS>` block in each of the three
+  // inline-string layers and proves only the personality's content survives in
+  // the assembled system prompt.
+  const baseConfig = (overrides: Partial<CampaignConfig>): CampaignConfig => ({
+    name: "Test",
+    system: "D&D 5e",
+    dm_personality: { name: "grim", prompt_fragment: "You are terse." },
+    players: [{ name: "Alice", character: "Aldric", type: "human" }],
+    combat: { initiative_method: "d20_dex", round_structure: "individual", surprise_rules: false },
+    context: { retention_exchanges: 5, max_conversation_tokens: 4000, tool_result_stub_after: 200 },
+    recovery: { auto_commit_interval: 300, max_commits: 100, enable_git: false },
+    choices: { campaign_default: "never", player_overrides: {} },
+    ...overrides,
+  } as CampaignConfig);
+
+  it("DM personality's <NPCS> block wins over seed and main DM", () => {
+    const config = baseConfig({
+      campaign_detail: "<NPCS>\nseed-npcs\n</NPCS>",
+      dm_personality: {
+        name: "grim",
+        prompt_fragment: "You are terse.\n<NPCS>\npersona-npcs\n</NPCS>",
+      },
+    });
+    const { system } = buildDMPrefix(config, {});
+    const all = system.map((b) => b.text).join("\n");
+
+    expect(all).toContain("persona-npcs");
+    expect(all).not.toContain("seed-npcs");
+    // The main DM file (dm-identity / dm-directives) does not currently define
+    // <NPCS>, so there's no "main-npcs" to assert against — the seed-vs-personality
+    // case is the meaningful collision and the one most likely to regress.
+  });
+
+  it("seed's <NPCS> block wins when personality doesn't define one", () => {
+    const config = baseConfig({
+      campaign_detail: "<NPCS>\nseed-npcs\n</NPCS>",
+    });
+    const { system } = buildDMPrefix(config, {});
+    const all = system.map((b) => b.text).join("\n");
+    expect(all).toContain("seed-npcs");
+  });
+
+  it("leaves uncolliding tags from each layer alone", () => {
+    const config = baseConfig({
+      campaign_detail: "<WORLD_LORE>\nseed-only\n</WORLD_LORE>",
+      dm_personality: {
+        name: "grim",
+        prompt_fragment: "You are terse.\n<VOICE>\npersona-only\n</VOICE>",
+      },
+    });
+    const { system } = buildDMPrefix(config, {});
+    const all = system.map((b) => b.text).join("\n");
+    expect(all).toContain("seed-only");
+    expect(all).toContain("persona-only");
+  });
+});
+
 describe("buildDMPrefix model conditionals", () => {
   // Regression guard for issue #483: the runtime tier-resolved model ID must
   // reach loadPrompt so `<!--if:gpt-->` blocks in dm-directives.md resolve

--- a/packages/engine/src/agents/dm-prompt.ts
+++ b/packages/engine/src/agents/dm-prompt.ts
@@ -3,6 +3,7 @@ import { buildCachedPrefix } from "../context/index.js";
 import type { PrefixSections, CachedPrefixResult } from "../context/index.js";
 import { getModel } from "../config/models.js";
 import { loadPrompt } from "../prompts/load-prompt.js";
+import { processIncludes, applyLayeredOverrides } from "../prompts/process-includes.js";
 
 /**
  * Session state needed to build the DM's prefix.
@@ -58,12 +59,44 @@ export function buildDMPrefix(
   modelId?: string,
 ): CachedPrefixResult {
   const model = modelId ?? getModel("large");
+
+  // Three prompt layers, in cascading-override priority order
+  // (lowest → highest): main DM (dm-identity + dm-directives) → campaign
+  // seed (campaign_detail) → DM personality (prompt_fragment + detail).
+  //
+  // Each layer's text may contain `<!--include:Tag.Variant-->` directives
+  // and top-level `<TAG>...</TAG>` blocks. Includes are resolved per layer
+  // (loadPrompt already does this for the file-based layers; the inline
+  // strings go through processIncludes here). Then applyLayeredOverrides
+  // walks all five slots in order — when the same tag appears in more than
+  // one slot, only the last occurrence survives, so a personality's
+  // `<NPCS>` block trumps a seed's, which in turn trumps the main DM's.
+  const dmIdentity = loadPrompt("dm-identity", model);
+  const dmDirectives = loadPrompt("dm-directives", model);
+  const campaignDetail = processIncludes(config.campaign_detail ?? "");
+  const personality = processIncludes(config.dm_personality.prompt_fragment ?? "");
+  const personalityDetail = processIncludes(config.dm_personality.detail ?? "");
+
+  const [
+    oDmIdentity,
+    oDmDirectives,
+    oCampaignDetail,
+    oPersonality,
+    oPersonalityDetail,
+  ] = applyLayeredOverrides([
+    dmIdentity,
+    dmDirectives,
+    campaignDetail,
+    personality,
+    personalityDetail,
+  ]);
+
   const sections: PrefixSections = {
-    dmIdentity: loadPrompt("dm-identity", model),
-    dmDirectives: loadPrompt("dm-directives", model),
-    personality: config.dm_personality.prompt_fragment,
-    personalityDetail: config.dm_personality.detail,
-    campaignDetail: config.campaign_detail,
+    dmIdentity: oDmIdentity,
+    dmDirectives: oDmDirectives,
+    personality: oPersonality,
+    personalityDetail: oPersonalityDetail || undefined,
+    campaignDetail: oCampaignDetail || undefined,
     ...sessionState,
   };
 

--- a/packages/engine/src/prompts/include/README.md
+++ b/packages/engine/src/prompts/include/README.md
@@ -1,0 +1,31 @@
+# Include Files
+
+Files here are reusable prompt fragments that other prompts (and inline
+prompt strings — campaign seed, DM personality) can pull in via the
+`<!--include:TagName-->` or `<!--include:TagName.Variant-->` directive.
+
+The directive is resolved by `processIncludes` in
+[../process-includes.ts](../process-includes.ts) — see that file's header
+comment for the authoritative spec. Short version:
+
+- An include lives at `include/<TagName>.md`. The directive
+  `<!--include:NPCS-->` reads `include/NPCS.md`; `<!--include:NPCS.Military-->`
+  selects the `<Military>` section from the same file.
+- The directive is replaced inline with `<TagName>…</TagName>`. The outer
+  tag is always the file stem, never the variant. So `NPCS.Military` always
+  produces `<NPCS>` — that's the *whole point* of the dot notation: pick a
+  variant of the same logical entity.
+- Dotless includes (`<!--include:NPCS-->`) look for a section named
+  `<NPCS>` inside `NPCS.md` — the conventional default. A file with no
+  top-level XML sections at all is treated as one implicit default section.
+
+## Cascading override
+
+When the same top-level XML tag appears in more than one prompt layer
+(main DM prompt → campaign seed → DM personality), the latest layer wins.
+Earlier occurrences are removed entirely. So a personality template can
+include `NPCS.HighFantasy` to replace whatever `<NPCS>` block the main DM
+prompt established, without editing the main file.
+
+This applies to inline `<NPCS>…</NPCS>` blocks too, not just blocks
+produced by `<!--include:-->`.

--- a/packages/engine/src/prompts/load-prompt.ts
+++ b/packages/engine/src/prompts/load-prompt.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { assetDir } from "../utils/paths.js";
 import { applyModelConditionals } from "./apply-model-conditionals.js";
+import { processIncludes } from "./process-includes.js";
 
 const cache = new Map<string, string>();
 
@@ -26,9 +27,12 @@ export function stripComments(text: string): string {
  * Load a prompt .md file from the prompts directory.
  * Reads synchronously on first call, caches thereafter (keyed by name + modelId).
  *
- * Pipeline: read → CRLF normalize → apply model conditionals → strip comments.
- * The conditional preprocessor runs before comment stripping because conditional
- * markers are HTML-comment-shaped (`<!--if:...-->`).
+ * Pipeline: read → CRLF normalize → apply model conditionals → process
+ * includes → strip comments. `processIncludes` sits between conditionals
+ * and comment stripping because the `<!--include:Tag.Variant-->` directive
+ * is HTML-comment-shaped — conditionals must still fire first (so they can
+ * gate whether an include happens), then includes resolve, then any
+ * remaining comments are stripped.
  *
  * @param name - Prompt filename without .md extension (e.g. "dm-identity")
  * @param modelId - Active model ID, used by `<!--if:PREFIX-->` conditionals.
@@ -43,7 +47,7 @@ export function loadPrompt(name: string, modelId?: string): string {
   const dir = assetDir("prompts");
   const filePath = join(dir, `${name}.md`);
   const raw = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n");
-  const content = stripComments(applyModelConditionals(raw, modelId));
+  const content = stripComments(processIncludes(applyModelConditionals(raw, modelId)));
   cache.set(key, content);
   return content;
 }

--- a/packages/engine/src/prompts/process-includes.test.ts
+++ b/packages/engine/src/prompts/process-includes.test.ts
@@ -43,6 +43,16 @@ describe("parseIncludeFile", () => {
     expect(file.variants.size).toBe(0);
   });
 
+  it("preserves intentional indentation in a flat file (only newlines are stripped)", () => {
+    // Regression: an earlier version used String.trim() which ate leading
+    // spaces. A markdown list, code block, or any deliberately-indented prose
+    // at the start of a flat include must survive verbatim.
+    const src = "\n\n  - first bullet\n  - second bullet\n\n";
+    const file = parseIncludeFile(src);
+    expect(file.isFlat).toBe(true);
+    expect(file.flatBody).toBe("  - first bullet\n  - second bullet");
+  });
+
   it("ignores indented (non-column-0) XML when deciding section boundaries", () => {
     // The inner <b> is inside the Military body; it must not be promoted to
     // a sibling variant, and it must not break the regex.

--- a/packages/engine/src/prompts/process-includes.test.ts
+++ b/packages/engine/src/prompts/process-includes.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseIncludeFile,
+  processIncludes,
+  applyLayeredOverrides,
+  type IncludeFile,
+} from "./process-includes.js";
+
+function fileOf(map: Record<string, string>): IncludeFile {
+  return {
+    variants: new Map(Object.entries(map)),
+    isFlat: false,
+    flatBody: "",
+  };
+}
+
+function flatFile(body: string): IncludeFile {
+  return { variants: new Map(), isFlat: true, flatBody: body };
+}
+
+describe("parseIncludeFile", () => {
+  it("extracts top-level <Variant> sections", () => {
+    const src = [
+      "<Military>",
+      "Three squads of the King's Guard.",
+      "</Military>",
+      "",
+      "<Civilian>",
+      "Merchant guild leader.",
+      "</Civilian>",
+    ].join("\n");
+    const file = parseIncludeFile(src);
+    expect(file.isFlat).toBe(false);
+    expect(file.variants.get("Military")).toBe("Three squads of the King's Guard.");
+    expect(file.variants.get("Civilian")).toBe("Merchant guild leader.");
+  });
+
+  it("returns a flat file when no top-level XML sections exist", () => {
+    const src = "Just some narrative text, no XML at all.";
+    const file = parseIncludeFile(src);
+    expect(file.isFlat).toBe(true);
+    expect(file.flatBody).toBe("Just some narrative text, no XML at all.");
+    expect(file.variants.size).toBe(0);
+  });
+
+  it("ignores indented (non-column-0) XML when deciding section boundaries", () => {
+    // The inner <b> is inside the Military body; it must not be promoted to
+    // a sibling variant, and it must not break the regex.
+    const src = [
+      "<Military>",
+      "Three <b>elite</b> squads.",
+      "</Military>",
+    ].join("\n");
+    const file = parseIncludeFile(src);
+    expect(file.variants.get("Military")).toBe("Three <b>elite</b> squads.");
+    expect(file.variants.has("b")).toBe(false);
+  });
+
+  it("normalizes CRLF to LF", () => {
+    const src = "<X>\r\nbody\r\n</X>\r\n";
+    const file = parseIncludeFile(src);
+    expect(file.variants.get("X")).toBe("body");
+  });
+});
+
+describe("processIncludes", () => {
+  it("replaces a dotted directive with <Stem>variant-body</Stem>", () => {
+    const loader = (name: string) => {
+      expect(name).toBe("NPCS");
+      return fileOf({ Military: "Three squads." });
+    };
+    const out = processIncludes("before <!--include:NPCS.Military--> after", { loader });
+    expect(out).toBe("before <NPCS>\nThree squads.\n</NPCS> after");
+  });
+
+  it("dotless directive picks the section named same as the file stem", () => {
+    const loader = () => fileOf({
+      NPCS: "Default world NPCs.",
+      Military: "Three squads.",
+    });
+    const out = processIncludes("<!--include:NPCS-->", { loader });
+    expect(out).toBe("<NPCS>\nDefault world NPCs.\n</NPCS>");
+  });
+
+  it("dotless directive on a flat file wraps the whole body", () => {
+    const loader = () => flatFile("Whole file body.");
+    const out = processIncludes("<!--include:NPCS-->", { loader });
+    expect(out).toBe("<NPCS>\nWhole file body.\n</NPCS>");
+  });
+
+  it("emits the file-stem tag, never the variant name", () => {
+    // The wrapping tag for NPCS.Military is <NPCS>, NOT <Military> or <NPCS.Military>.
+    // This is the core "include picks a variant of the same entity" promise.
+    const loader = () => fileOf({ Military: "body" });
+    const out = processIncludes("<!--include:NPCS.Military-->", { loader });
+    expect(out).toContain("<NPCS>");
+    expect(out).toContain("</NPCS>");
+    expect(out).not.toContain("<Military>");
+    expect(out).not.toContain("<NPCS.Military>");
+  });
+
+  it("errors when a dotted variant is missing", () => {
+    const loader = () => fileOf({ Military: "x", Civilian: "y" });
+    expect(() => processIncludes("<!--include:NPCS.Pirate-->", { loader }))
+      .toThrow(/Pirate.*Military, Civilian/);
+  });
+
+  it("errors when a dotless include has no matching default section", () => {
+    const loader = () => fileOf({ Military: "x", Civilian: "y" });
+    expect(() => processIncludes("<!--include:NPCS-->", { loader }))
+      .toThrow(/no default <NPCS> section/);
+  });
+
+  it("errors when a dotted variant is requested on a flat file", () => {
+    const loader = () => flatFile("body");
+    expect(() => processIncludes("<!--include:NPCS.Military-->", { loader }))
+      .toThrow(/flat file/);
+  });
+
+  it("resolves multiple directives in one pass", () => {
+    const loader = (name: string) => {
+      if (name === "A") return flatFile("a-body");
+      if (name === "B") return fileOf({ B: "b-default", Alt: "b-alt" });
+      throw new Error(`unexpected ${name}`);
+    };
+    const src = "<!--include:A-->\n<!--include:B-->\n<!--include:B.Alt-->";
+    const out = processIncludes(src, { loader });
+    expect(out).toBe(
+      "<A>\na-body\n</A>\n<B>\nb-default\n</B>\n<B>\nb-alt\n</B>",
+    );
+  });
+
+  it("passes through text with no directives", () => {
+    const loader = () => {
+      throw new Error("should not load");
+    };
+    expect(processIncludes("no directives here", { loader })).toBe("no directives here");
+  });
+});
+
+describe("applyLayeredOverrides", () => {
+  it("preserves layers when tags don't collide", () => {
+    const layers = [
+      "<A>\nfrom-1\n</A>",
+      "<B>\nfrom-2\n</B>",
+      "<C>\nfrom-3\n</C>",
+    ];
+    expect(applyLayeredOverrides(layers)).toEqual(layers);
+  });
+
+  it("removes earlier-layer occurrences when a later layer redefines the same tag", () => {
+    const [main, seed, persona] = applyLayeredOverrides([
+      "<NPCS>\nmain-version\n</NPCS>",
+      "<NPCS>\nseed-version\n</NPCS>",
+      "<NPCS>\npersona-version\n</NPCS>",
+    ]);
+    expect(main).toBe("");
+    expect(seed).toBe("");
+    expect(persona).toBe("<NPCS>\npersona-version\n</NPCS>");
+  });
+
+  it("removes only the colliding tag, leaving siblings intact", () => {
+    const [main, persona] = applyLayeredOverrides([
+      "<A>\nkeep-me\n</A>\n<B>\nlose-me\n</B>",
+      "<B>\nwinner\n</B>",
+    ]);
+    expect(main).toContain("<A>");
+    expect(main).toContain("keep-me");
+    expect(main).not.toContain("lose-me");
+    expect(persona).toBe("<B>\nwinner\n</B>");
+  });
+
+  it("within a single layer, last occurrence wins", () => {
+    const [out] = applyLayeredOverrides([
+      "<X>\nfirst\n</X>\nmiddle\n<X>\nlast\n</X>",
+    ]);
+    expect(out).toContain("last");
+    expect(out).not.toContain("first");
+  });
+
+  it("preserves position of the surviving block in its layer", () => {
+    // <A> defined only in layer 0 should stay where it was; <B> defined in
+    // layer 1 stays in layer 1's text. Layer 0's <B> gets removed.
+    const [main, persona] = applyLayeredOverrides([
+      "before-A\n<A>\nkept\n</A>\nbetween\n<B>\ndropped\n</B>\nafter",
+      "before-B\n<B>\nkept\n</B>\nafter-B",
+    ]);
+    expect(main).toMatch(/before-A\n<A>\nkept\n<\/A>\nbetween\n+after/);
+    expect(persona).toBe("before-B\n<B>\nkept\n</B>\nafter-B");
+  });
+
+  it("ignores indented XML and inline formatting tags", () => {
+    // `- <b>x</b>` is not at column 0; must be left alone.
+    const layers = [
+      "## heading\n- <b>scribe</b>: a tool\n- <color=#fff>red</color>: a color",
+      "<TOOLS>\nreplacement\n</TOOLS>",
+    ];
+    const out = applyLayeredOverrides(layers);
+    expect(out[0]).toContain("<b>scribe</b>");
+    expect(out[0]).toContain("<color=#fff>red</color>");
+    expect(out[1]).toBe("<TOOLS>\nreplacement\n</TOOLS>");
+  });
+});

--- a/packages/engine/src/prompts/process-includes.ts
+++ b/packages/engine/src/prompts/process-includes.ts
@@ -1,0 +1,179 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { assetDir } from "../utils/paths.js";
+
+/**
+ * Include preprocessor + cascading entity override.
+ *
+ * Two features live here because they share a vocabulary (top-level XML
+ * blocks as "entities") and because the entity-override step consumes the
+ * output of the include step.
+ *
+ * ── Includes ──
+ *
+ * A prompt may contain directives shaped like HTML comments:
+ *
+ *     <!--include:NPCS-->
+ *     <!--include:NPCS.Military-->
+ *
+ * Each directive is replaced inline with a `<TagName>...</TagName>` block:
+ *
+ *   - The file lives at `prompts/include/<TagName>.md` (here, `NPCS.md`).
+ *   - With a dot suffix (`NPCS.Military`), the file is parsed for top-level
+ *     `<Variant>...</Variant>` sections and the named variant's body is
+ *     inserted. The outer wrapping tag is always the file stem — `NPCS` —
+ *     never the variant name. So `NPCS.Military` produces `<NPCS>...</NPCS>`,
+ *     not `<Military>` or `<NPCS.Military>`. This is intentional: the file
+ *     holds variants of the same logical entity; the include picks one.
+ *   - Without a dot (`NPCS`), the file's section named the same as the file
+ *     stem is the default — so `include/NPCS.md` is expected to contain an
+ *     `<NPCS>` section that serves as the typical default. As a convenience,
+ *     a file with no top-level XML sections at all is treated as one
+ *     implicit default section: its whole body is wrapped in the stem tag.
+ *
+ * Must run AFTER `applyModelConditionals` (so conditionals can guard whether
+ * an include happens) and BEFORE `stripComments` (since the directive is
+ * itself an HTML-comment-shaped marker that comment stripping would erase).
+ *
+ * ── Cascading entity override ──
+ *
+ * Once includes are resolved, the prompt contains top-level XML blocks
+ * (some written inline, some produced by includes). When the same tag
+ * appears in multiple prompt LAYERS — main DM prompt, campaign seed prompt,
+ * DM personality template prompt — the latest layer wins. Earlier
+ * occurrences are removed entirely, and the latest layer's block stays in
+ * place.
+ *
+ * This lets a DM personality redefine the `<NPCS>` block (or any other
+ * entity) that the main DM prompt established, without editing the main
+ * prompt file. Resolution is done at the buildDMPrefix layer; this module
+ * just exposes the merge primitive.
+ */
+
+const VARIANT_RE = /^<([A-Za-z][\w]*)>([\s\S]*?)<\/\1>/gm;
+const DIRECTIVE_RE = /<!--include:([A-Za-z][\w]*)(?:\.([A-Za-z][\w]*))?-->/g;
+const TOP_LEVEL_BLOCK_RE = /^<([A-Za-z][\w]*)>([\s\S]*?)<\/\1>/gm;
+
+export interface IncludeFile {
+  /** Explicit named sections, keyed by tag name. */
+  variants: Map<string, string>;
+  /**
+   * True when the file had no top-level XML sections. The whole body is then
+   * treated as one implicit default section — see `flatBody`.
+   */
+  isFlat: boolean;
+  /** The whole trimmed body, populated only when `isFlat`. */
+  flatBody: string;
+}
+
+export function parseIncludeFile(content: string): IncludeFile {
+  const normalized = content.replace(/\r\n/g, "\n");
+  const variants = new Map<string, string>();
+  VARIANT_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = VARIANT_RE.exec(normalized)) !== null) {
+    const tag = m[1];
+    const body = m[2].replace(/^\n/, "").replace(/\n$/, "");
+    variants.set(tag, body);
+  }
+  if (variants.size === 0) {
+    return { variants, isFlat: true, flatBody: normalized.trim() };
+  }
+  return { variants, isFlat: false, flatBody: "" };
+}
+
+const fileCache = new Map<string, IncludeFile>();
+
+function loadIncludeFileFromDisk(name: string): IncludeFile {
+  const cached = fileCache.get(name);
+  if (cached) return cached;
+  const path = join(assetDir("prompts"), "include", `${name}.md`);
+  if (!existsSync(path)) {
+    throw new Error(`Include file not found: prompts/include/${name}.md`);
+  }
+  const raw = readFileSync(path, "utf-8");
+  const parsed = parseIncludeFile(raw);
+  fileCache.set(name, parsed);
+  return parsed;
+}
+
+export interface ProcessIncludesOptions {
+  /** Test-only override; default loads from prompts/include/. */
+  loader?: (name: string) => IncludeFile;
+}
+
+export function processIncludes(text: string, opts: ProcessIncludesOptions = {}): string {
+  const loader = opts.loader ?? loadIncludeFileFromDisk;
+  return text.replace(DIRECTIVE_RE, (_match, tag: string, variant: string | undefined) => {
+    const file = loader(tag);
+    let body: string;
+    if (variant === undefined) {
+      // Dotless form: section named same as file stem is the default. Falls
+      // back to flat-file body when the file has no sections at all.
+      const def = file.variants.get(tag);
+      if (def !== undefined) {
+        body = def;
+      } else if (file.isFlat) {
+        body = file.flatBody;
+      } else {
+        const choices = [...file.variants.keys()].join(", ") || "<none>";
+        throw new Error(
+          `Include '${tag}' has no default <${tag}> section in include/${tag}.md (available: ${choices}); use ${tag}.<Variant>.`,
+        );
+      }
+    } else {
+      if (file.isFlat) {
+        throw new Error(
+          `Include '${tag}' is a flat file (no variants); use ${tag} without '.${variant}'.`,
+        );
+      }
+      const v = file.variants.get(variant);
+      if (v === undefined) {
+        const choices = [...file.variants.keys()].join(", ") || "<none>";
+        throw new Error(
+          `Include variant '${tag}.${variant}' not found (available: ${choices}).`,
+        );
+      }
+      body = v;
+    }
+    return `<${tag}>\n${body}\n</${tag}>`;
+  });
+}
+
+/**
+ * Cascading entity override across an ordered list of layer texts.
+ *
+ * Layers are passed in priority order, lowest to highest. When the same
+ * top-level tag appears more than once (across or within layers), only the
+ * LATEST occurrence survives — earlier occurrences are stripped from their
+ * layer texts. The latest occurrence stays in its original position.
+ *
+ * "Top-level" means an open tag at column 0 with a matching close tag (via
+ * backreference). Indented or inline XML — like the `<b>`, `<color=...>`,
+ * `<center>` formatting markers used in DM narration — is never matched.
+ *
+ * Returns an array of the same length and order as the input, with each
+ * layer's text rewritten.
+ */
+export function applyLayeredOverrides(layers: string[]): string[] {
+  const lastOcc = new Map<string, { layerIdx: number; offset: number }>();
+  for (let li = 0; li < layers.length; li++) {
+    TOP_LEVEL_BLOCK_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = TOP_LEVEL_BLOCK_RE.exec(layers[li])) !== null) {
+      lastOcc.set(m[1], { layerIdx: li, offset: m.index });
+    }
+  }
+  return layers.map((layer, li) =>
+    layer.replace(TOP_LEVEL_BLOCK_RE, (match, tag: string, _body: string, offset: number) => {
+      const winner = lastOcc.get(tag);
+      if (!winner) return match;
+      return winner.layerIdx === li && winner.offset === offset ? match : "";
+    }),
+  );
+}
+
+/** Clear the include-file cache. For tests. */
+export function resetIncludeCache(): void {
+  fileCache.clear();
+}

--- a/packages/engine/src/prompts/process-includes.ts
+++ b/packages/engine/src/prompts/process-includes.ts
@@ -62,7 +62,11 @@ export interface IncludeFile {
    * treated as one implicit default section — see `flatBody`.
    */
   isFlat: boolean;
-  /** The whole trimmed body, populated only when `isFlat`. */
+  /**
+   * The whole body with only surrounding newlines trimmed (leading/trailing
+   * blank lines), populated only when `isFlat`. Indented prose at the start
+   * of a flat file is preserved verbatim.
+   */
   flatBody: string;
 }
 
@@ -77,7 +81,9 @@ export function parseIncludeFile(content: string): IncludeFile {
     variants.set(tag, body);
   }
   if (variants.size === 0) {
-    return { variants, isFlat: true, flatBody: normalized.trim() };
+    // Strip only surrounding newlines — preserve any intentional indentation
+    // at the start or end of the body.
+    return { variants, isFlat: true, flatBody: normalized.replace(/^\n+/, "").replace(/\n+$/, "") };
   }
   return { variants, isFlat: false, flatBody: "" };
 }
@@ -118,7 +124,7 @@ export function processIncludes(text: string, opts: ProcessIncludesOptions = {})
       } else {
         const choices = [...file.variants.keys()].join(", ") || "<none>";
         throw new Error(
-          `Include '${tag}' has no default <${tag}> section in include/${tag}.md (available: ${choices}); use ${tag}.<Variant>.`,
+          `Include '${tag}' has no default <${tag}> section in prompts/include/${tag}.md (available: ${choices}); use ${tag}.<Variant>.`,
         );
       }
     } else {


### PR DESCRIPTION
## Summary

- Adds an `<!--include:Tag-->` / `<!--include:Tag.Variant-->` directive that expands inline to `<Tag>...</Tag>`. The wrapping tag is **always** the file stem — so `NPCS.Military` produces `<NPCS>`, never `<Military>` or `<NPCS.Military>`. The dot picks a variant of the same logical entity. Reusable fragments live in a new `packages/engine/src/prompts/include/` directory. Dotless includes default to the section named the same as the file stem; flat files with no XML sections are treated as one implicit default.
- Adds cascading entity override across the DM's three prompt layers — main DM (`dm-identity` + `dm-directives`) → campaign seed (`campaign_detail`) → DM personality (`prompt_fragment` + `detail`). When the same top-level `<TAG>` block appears in more than one layer (inline or via include), the latest layer wins; earlier occurrences are stripped. Lets a personality redefine the `<NPCS>` block established by the main prompt without editing the main file. Inline `<TAG>...</TAG>` blocks participate too; indented formatting tags like `<b>` / `<color=...>` are never matched.
- Pipeline order: model conditionals → process includes → strip comments. Includes sit between because the directive is HTML-comment-shaped — it must expand before comment stripping, but after conditionals so a conditional can gate whether an include happens.

## Test plan

- [x] `npm run check` — 2730 tests pass, lint clean
- [x] 19 new unit tests in `process-includes.test.ts` cover include parsing, variant selection, dotless default behavior, flat-file fallback, error cases, and the layered-override merge
- [x] 3 new integration tests in `dm-prompt.test.ts` plant `<NPCS>` blocks in each layer and prove the personality wins, the seed wins when personality doesn't define one, and uncolliding tags survive
- [x] Existing prompts (`dm-identity.md`, `dm-directives.md`) have unique tag names across their structural blocks, so the override is dormant for them — no behavior change until something collides

🤖 Generated with [Claude Code](https://claude.com/claude-code)