### PR TITLE
Tunable DM page-size hint with per-client viewport floor

### DIFF
--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -189,7 +189,16 @@ Everything else is created during play.
   },
 
   // Display
-  "calendar_display_format": null         // Freeform format hint for calendar display.
+  "calendar_display_format": null,        // Freeform format hint for calendar display.
+
+  // DM prose-length tuning
+  "dm_turn_length_pct": 80                // Optional. Multiplier (in percent) applied to the
+                                          // narrative-row count reported to the DM in each turn's
+                                          // [length] hint. 80 = tell the DM the page is 20% shorter
+                                          // than it really is, nudging tighter prose. Overlong-response
+                                          // tracking still uses the real row count. Range 50–150 in
+                                          // 5% steps; default 80. Editable from the in-game Campaign
+                                          // Settings modal (Esc → Settings).
 }
 ```
 

--- a/docs/websocket-api.md
+++ b/docs/websocket-api.md
@@ -19,7 +19,9 @@ No authentication is required (localhost-only). Auth will be added when remote c
 
 ## Communication Direction
 
-All WebSocket messages flow **server to client**. The WebSocket channel is one-way push — clients send commands via REST endpoints (`POST /session/turn/contribute`, `POST /session/command/:name`, etc.), not over the WebSocket.
+WebSocket messages are predominantly **server to client**. Clients send gameplay commands via REST endpoints (`POST /session/turn/contribute`, `POST /session/command/:name`, etc.), not over the WebSocket.
+
+The one client→server WebSocket message is `client:viewport`, used to report the active terminal dimensions so the DM's per-turn length hint can adapt to the smallest connected client. See [Client Events](#client-events) below.
 
 ## Message Format
 
@@ -279,11 +281,31 @@ Error or retry notification.
 | `status`      | number? | HTTP-style status code, if applicable. |
 | `delayMs`     | number? | Suggested wait time before retry (ms). |
 
+## Client Events
+
+The handful of messages clients may send to the server over the WebSocket.
+
+### `client:viewport`
+
+Reports this client's current terminal dimensions. Sent on every WS `open` and whenever the terminal resizes. The server keeps a per-connection map of dims; the value passed to the DM's length-steering injection is the **floor** — the smallest `narrativeRows` across all connected clients. If the smallest client raises its value (resize larger) or disconnects, the floor recomputes upward to whichever client is now smallest.
+
+| Field            | Type   | Description |
+|------------------|--------|-------------|
+| `columns`        | number | Total terminal width in columns. |
+| `rows`           | number | Total terminal height in rows. |
+| `narrativeRows`  | number | Usable narrative-area rows after subtracting UI chrome (top frame, modelines, player pane, input line). The DM's `[length]` hint is keyed on this. |
+
+```json
+{ "type": "client:viewport", "data": { "columns": 120, "rows": 50, "narrativeRows": 32 } }
+```
+
+Unknown WebSocket messages from the client are logged and dropped.
+
 ## Canonical Source
 
 All event schemas are defined as TypeBox objects in:
 
-- `packages/shared/src/protocol/events.ts` — event types, `ChoicesData`, and `ServerEvent` union
+- `packages/shared/src/protocol/events.ts` — event types, `ChoicesData`, `ServerEvent`, and `ClientEvent` unions
 - `packages/shared/src/protocol/turn.ts` — `Turn` and `TurnContribution`
 - `packages/shared/src/protocol/state.ts` — `StateSnapshot`
 - `packages/shared/src/protocol/connection.ts` — `ConnectionIdentity`

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -111,12 +111,14 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
   const [discordEnabled, setDiscordEnabled] = useState<boolean>(true);
   const [devModeEnabled, setDevModeEnabled] = useState(false);
   const [showVerbose, setShowVerbose] = useState(false);
+  const [dmTurnLengthPctDefault, setDmTurnLengthPctDefault] = useState(80);
   const settingsLoaded = useRef(false);
 
   // Load persisted client settings on mount
   useEffect(() => {
     loadClientSettings().then((s) => {
       setShowVerbose(s.showVerbose);
+      setDmTurnLengthPctDefault(s.dmTurnLengthPctDefault);
       settingsLoaded.current = true;
     });
     apiClientRef.current.getMachineSettings().then((s) => {
@@ -133,8 +135,8 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
   // Persist client-only settings whenever they change (skip the initial load)
   useEffect(() => {
     if (!settingsLoaded.current) return;
-    saveClientSettings({ showVerbose }).catch(() => { /* best-effort */ });
-  }, [showVerbose]);
+    saveClientSettings({ showVerbose, dmTurnLengthPctDefault }).catch(() => { /* best-effort */ });
+  }, [showVerbose, dmTurnLengthPctDefault]);
   const [archiveStatus, setArchiveStatus] = useState("");
   const [deleteModal, setDeleteModal] = useState<CampaignDeleteInfo | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
@@ -266,6 +268,20 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
     api.getDiscordSettings().then((s) => setDiscordEnabled(s.enabled)).catch(() => { /* ignore */ });
   }, []);
 
+  /**
+   * Report the current terminal viewport to the server so the DM's
+   * length-steering hint can adapt to the smallest connected client.
+   *
+   * Buffered: if the WS isn't open yet (mid-reconnect, or before the
+   * very first connect), the latest dims are stashed and replayed in
+   * the next `onConnect`.
+   */
+  const lastViewportRef = useRef<{ columns: number; rows: number; narrativeRows: number } | null>(null);
+  const reportViewport = useCallback((dims: { columns: number; rows: number; narrativeRows: number }) => {
+    lastViewportRef.current = dims;
+    wsClientRef.current?.send({ type: "client:viewport", data: dims });
+  }, []);
+
   // Return to menu from playing
   const returnToMenu = useCallback(async () => {
     // Show a saving overlay on top of PlayingPhase while the server tears down
@@ -303,6 +319,14 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
         eventHandler(event);
       },
       onConnect: () => {
+        // Replay the last-known viewport so the server's per-client dims
+        // table picks it up immediately — including after a setup→game
+        // session:transition where the server-side entry was cleared on
+        // disconnect. Without the replay the DM would fall back to the
+        // baked default on the first turn of the new session.
+        if (lastViewportRef.current) {
+          wsClientRef.current?.send({ type: "client:viewport", data: lastViewportRef.current });
+        }
         if (campaignId) {
           startCampaign(campaignId);
         } else {
@@ -629,7 +653,9 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
       stdinFilterChain,
       devModeEnabled,
       showVerbose,
+      dmTurnLengthPctDefault,
       onReturnToMenu: returnToMenu,
+      reportViewport,
     }}>
       <PlayingPhase key={`${activeCampaignId}-${sessionKey}`} />
     </GameProvider>

--- a/packages/client-ink/src/config/client-settings.test.ts
+++ b/packages/client-ink/src/config/client-settings.test.ts
@@ -22,48 +22,62 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const DEFAULTS = { showVerbose: false, dmTurnLengthPctDefault: 80 };
+
 describe("loadClientSettings", () => {
   it("returns defaults when file is missing", async () => {
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
     const settings = await loadClientSettings();
-    expect(settings).toEqual({ showVerbose: false });
+    expect(settings).toEqual(DEFAULTS);
   });
 
   it("returns defaults when file is corrupt", async () => {
     mockReadFile.mockResolvedValue("not json" as never);
     const settings = await loadClientSettings();
-    expect(settings).toEqual({ showVerbose: false });
+    expect(settings).toEqual(DEFAULTS);
   });
 
   it("loads saved settings", async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({ showVerbose: true }) as never);
     const settings = await loadClientSettings();
-    expect(settings).toEqual({ showVerbose: true });
+    expect(settings).toEqual({ ...DEFAULTS, showVerbose: true });
   });
 
   it("fills in missing keys with defaults", async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({}) as never);
     const settings = await loadClientSettings();
-    expect(settings).toEqual({ showVerbose: false });
+    expect(settings).toEqual(DEFAULTS);
   });
 
   it("rejects non-boolean values and falls back to defaults", async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({ showVerbose: 1 }) as never);
     const settings = await loadClientSettings();
-    expect(settings).toEqual({ showVerbose: false });
+    expect(settings).toEqual(DEFAULTS);
   });
 
   it("ignores legacy devModeEnabled field", async () => {
     mockReadFile.mockResolvedValue(JSON.stringify({ devModeEnabled: true, showVerbose: true }) as never);
     const settings = await loadClientSettings();
-    expect(settings).toEqual({ showVerbose: true });
+    expect(settings).toEqual({ ...DEFAULTS, showVerbose: true });
     expect(settings).not.toHaveProperty("devModeEnabled");
+  });
+
+  it("loads a stored dmTurnLengthPctDefault and clamps it to the supported range", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ dmTurnLengthPctDefault: 95 }) as never);
+    const settings = await loadClientSettings();
+    expect(settings.dmTurnLengthPctDefault).toBe(95);
+  });
+
+  it("ignores out-of-range dmTurnLengthPctDefault and falls back to default", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ dmTurnLengthPctDefault: 9999 }) as never);
+    const settings = await loadClientSettings();
+    expect(settings.dmTurnLengthPctDefault).toBe(80);
   });
 });
 
 describe("saveClientSettings", () => {
   it("creates config directory and writes JSON", async () => {
-    await saveClientSettings({ showVerbose: false });
+    await saveClientSettings({ showVerbose: false, dmTurnLengthPctDefault: 80 });
     expect(mockMkdir).toHaveBeenCalledWith("/tmp/test-config", { recursive: true });
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining("client-settings.json"),

--- a/packages/client-ink/src/config/client-settings.ts
+++ b/packages/client-ink/src/config/client-settings.ts
@@ -12,10 +12,18 @@ import { configDir } from "../utils/paths.js";
 
 export interface ClientSettings {
   showVerbose: boolean;
+  /**
+   * Default DM turn length percentage applied to new campaigns. Existing
+   * campaigns keep whatever value is stored on their CampaignConfig; this
+   * is the seed for the next `New Campaign` flow. Range is enforced by
+   * clampDmTurnLengthPct.
+   */
+  dmTurnLengthPctDefault: number;
 }
 
 const DEFAULTS: ClientSettings = {
   showVerbose: false,
+  dmTurnLengthPctDefault: 80,
 };
 
 const FILENAME = "client-settings.json";
@@ -30,6 +38,14 @@ function sanitize(input: unknown): ClientSettings {
   if (input && typeof input === "object") {
     const obj = input as Record<string, unknown>;
     if (typeof obj.showVerbose === "boolean") result.showVerbose = obj.showVerbose;
+    if (typeof obj.dmTurnLengthPctDefault === "number") {
+      // Validate range here rather than importing the shared clamp helper —
+      // keeps client-settings free of cross-package imports for one number.
+      const v = obj.dmTurnLengthPctDefault;
+      if (v >= 50 && v <= 150 && Number.isFinite(v)) {
+        result.dmTurnLengthPctDefault = Math.round(v / 5) * 5;
+      }
+    }
   }
   return result;
 }

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -50,6 +50,8 @@ export function PlayingPhase() {
     showVerbose,
     retryOverlay,
     onReturnToMenu,
+    reportViewport,
+    dmTurnLengthPctDefault,
   } = useGameContext();
   const { columns: cols, rows } = useWindowSize();
 
@@ -119,6 +121,22 @@ export function PlayingPhase() {
     isAI: p.type === "ai",
   })) ?? [{ name: "Player", isAI: false }];
   const activeChar = players[activePlayerIndex]?.name ?? "Player";
+
+  // Layout math — used in render below and in the viewport-reporting
+  // effect. Computed up here so the report still fires even when the
+  // terminal is too small to render and we early-return.
+  const tier = getViewportTier({ columns: cols, rows });
+  const visibleElements = getVisibleElements(tier);
+  const hasDescriptions = (activeChoices?.descriptions?.length ?? 0) > 0;
+  const descExtraHeight = hasDescriptions ? DESCRIPTION_ROWS : 0;
+  const narRows = narrativeRows(rows, visibleElements, false, theme.asset.height, players.length, descExtraHeight);
+
+  // Report viewport dims to the server. The server tracks per-client
+  // dims and reports the floor (smallest narrativeRows across clients)
+  // to the DM's length hint.
+  useEffect(() => {
+    reportViewport({ columns: cols, rows, narrativeRows: narRows });
+  }, [cols, rows, narRows, reportViewport]);
 
   // Clear character sheet cache when active character changes
   if (activeChar !== characterSheetCacheCharRef.current) {
@@ -413,11 +431,6 @@ export function PlayingPhase() {
     return <TerminalTooSmall columns={cols} rows={rows} />;
   }
 
-  const tier = getViewportTier({ columns: cols, rows });
-  const visibleElements = getVisibleElements(tier);
-  const hasDescriptions = (activeChoices?.descriptions?.length ?? 0) > 0;
-  const descExtraHeight = hasDescriptions ? DESCRIPTION_ROWS : 0;
-  const narRows = narrativeRows(rows, visibleElements, false, theme.asset.height, players.length, descExtraHeight);
   const conversationPaneTop = visibleElements.topFrame ? theme.asset.height : 0;
 
   const keyHints: KeyHint[] = useMemo(() => [
@@ -562,6 +575,12 @@ export function PlayingPhase() {
               choices: { campaign_default: value, player_overrides: existingOverrides },
             }).catch(() => { /* ignore — user sees no toast, value just won't persist */ });
           }}
+          onDmTurnLengthPctChange={async (value: number) => {
+            await apiClient.patchSettings({
+              dm_turn_length_pct: value,
+            }).catch(() => { /* ignore — same rationale as Choices Frequency above */ });
+          }}
+          globalDmTurnLengthPctDefault={dmTurnLengthPctDefault}
         />
       )}
       {am?.kind === "saving" && (

--- a/packages/client-ink/src/tui/game-context.ts
+++ b/packages/client-ink/src/tui/game-context.ts
@@ -73,9 +73,22 @@ export interface GameContextValue {
   // Settings
   devModeEnabled?: boolean;
   showVerbose?: boolean;
+  /**
+   * Client-side global default for DM turn length percentage. Used by the
+   * Campaign Settings modal as the initial slider value when the active
+   * campaign has no per-campaign override saved yet. Falls through to 80.
+   */
+  dmTurnLengthPctDefault?: number;
 
   // Actions
   onReturnToMenu: () => void;
+  /**
+   * Report this client's current viewport dimensions to the server.
+   * Called on PlayingPhase mount and whenever the terminal resizes;
+   * the server tracks per-client dims and tells the DM about the floor
+   * (smallest narrativeRows across all connected clients).
+   */
+  reportViewport: (dims: { columns: number; rows: number; narrativeRows: number }) => void;
 }
 
 const GameContext = createContext<GameContextValue | null>(null);

--- a/packages/client-ink/src/tui/modals/CampaignSettingsModal.test.tsx
+++ b/packages/client-ink/src/tui/modals/CampaignSettingsModal.test.tsx
@@ -28,7 +28,12 @@ function minimalConfig(overrides?: Partial<CampaignConfig>): CampaignConfig {
   };
 }
 
-function renderModal(config: CampaignConfig, onFreq?: (v: ChoiceFrequency) => void) {
+function renderModal(
+  config: CampaignConfig,
+  onFreq?: (v: ChoiceFrequency) => void,
+  onPct?: (v: number) => void,
+  globalDefault?: number,
+) {
   const theme = makeTheme();
   return render(
     <Box width={80} height={30}>
@@ -39,6 +44,8 @@ function renderModal(config: CampaignConfig, onFreq?: (v: ChoiceFrequency) => vo
         config={config}
         onDismiss={() => {}}
         onChoicesFrequencyChange={onFreq}
+        onDmTurnLengthPctChange={onPct}
+        globalDmTurnLengthPctDefault={globalDefault}
       />
     </Box>,
   );
@@ -136,5 +143,94 @@ describe("CampaignSettingsModal", () => {
     stdin.write("\r");
     await new Promise((r) => setTimeout(r, 10));
     expect(onFreq).not.toHaveBeenCalled();
+  });
+
+  it("renders the DM Turn Length row with the default 80% when unset", () => {
+    const { lastFrame } = renderModal(minimalConfig());
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("DM Turn Length");
+    expect(frame).toContain("80%");
+  });
+
+  it("uses the per-campaign saved value when present", () => {
+    const { lastFrame } = renderModal(minimalConfig({ dm_turn_length_pct: 110 }));
+    expect(lastFrame() ?? "").toContain("110%");
+  });
+
+  it("uses the global client default when the campaign has no saved value", () => {
+    const { lastFrame } = renderModal(minimalConfig(), undefined, undefined, 95);
+    expect(lastFrame() ?? "").toContain("95%");
+  });
+
+  it("adjusts DM Turn Length by 5% on ← / → after ↓ to focus", async () => {
+    const onPct = vi.fn();
+    const { stdin, lastFrame } = renderModal(minimalConfig(), undefined, onPct);
+    stdin.write("[B"); // ↓ — focus length row
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("[C"); // → +5
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("85%");
+    stdin.write("[C"); // → +5
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("90%");
+    stdin.write("[D"); // ← -5
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("85%");
+    stdin.write("\r"); // Enter saves
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onPct).toHaveBeenCalledWith(85);
+  });
+
+  it("clamps DM Turn Length to the 50–150 range", async () => {
+    const { stdin, lastFrame } = renderModal(minimalConfig({ dm_turn_length_pct: 50 }));
+    stdin.write("[B"); // ↓
+    await new Promise((r) => setTimeout(r, 10));
+    // Already at min — left shouldn't go below 50
+    stdin.write("[D"); // ←
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("50%");
+    expect(lastFrame() ?? "").not.toContain("45%");
+  });
+
+  it("clamps at the upper bound 150", async () => {
+    const { stdin, lastFrame } = renderModal(minimalConfig({ dm_turn_length_pct: 150 }));
+    stdin.write("[B"); // ↓
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("[C"); // → — should not go above 150
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("150%");
+    expect(lastFrame() ?? "").not.toContain("155%");
+  });
+
+  it("up arrow returns focus to the Choices Frequency row", async () => {
+    const onFreq = vi.fn();
+    const onPct = vi.fn();
+    const { stdin } = renderModal(minimalConfig(), onFreq, onPct);
+    stdin.write("[B"); // ↓ — go to length
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("[A"); // ↑ — back to choices
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("[C"); // → — should adjust choices, not length
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onFreq).toHaveBeenCalledWith("rarely");
+    expect(onPct).not.toHaveBeenCalled();
+  });
+
+  it("saves both fields when both are dirty", async () => {
+    const onFreq = vi.fn();
+    const onPct = vi.fn();
+    const { stdin } = renderModal(minimalConfig(), onFreq, onPct);
+    stdin.write("[C"); // → freq
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("[B"); // ↓ length
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("[C"); // → length
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\r");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onFreq).toHaveBeenCalledWith("rarely");
+    expect(onPct).toHaveBeenCalledWith(85);
   });
 });

--- a/packages/client-ink/src/tui/modals/CampaignSettingsModal.tsx
+++ b/packages/client-ink/src/tui/modals/CampaignSettingsModal.tsx
@@ -2,7 +2,15 @@ import React, { useCallback, useState } from "react";
 import { useInput } from "ink";
 import type { ResolvedTheme } from "../themes/types.js";
 import type { CampaignConfig, ChoiceFrequency } from "@machine-violet/shared/types/config.js";
-import { CHOICE_FREQUENCY_LEVELS, CAMPAIGN_SCOPE_LABELS } from "@machine-violet/shared/types/config.js";
+import {
+  CHOICE_FREQUENCY_LEVELS,
+  CAMPAIGN_SCOPE_LABELS,
+  DM_TURN_LENGTH_PCT_DEFAULT,
+  DM_TURN_LENGTH_PCT_MIN,
+  DM_TURN_LENGTH_PCT_MAX,
+  DM_TURN_LENGTH_PCT_STEP,
+  clampDmTurnLengthPct,
+} from "@machine-violet/shared/types/config.js";
 import { CenteredModal } from "./CenteredModal.js";
 
 export interface CampaignSettingsModalProps {
@@ -13,6 +21,13 @@ export interface CampaignSettingsModalProps {
   onDismiss: () => void;
   /** Persists an edited Choices Frequency. Called on Enter when the value changed. */
   onChoicesFrequencyChange?: (value: ChoiceFrequency) => void | Promise<void>;
+  /** Persists an edited DM turn length (percent). Called on Enter when the value changed. */
+  onDmTurnLengthPctChange?: (value: number) => void | Promise<void>;
+  /**
+   * Client-side global default applied when the campaign has no saved value.
+   * Defaults to DM_TURN_LENGTH_PCT_DEFAULT (80).
+   */
+  globalDmTurnLengthPctDefault?: number;
 }
 
 const FREQUENCY_LABELS: Record<ChoiceFrequency, string> = {
@@ -30,9 +45,12 @@ function normalize(value: string | undefined): ChoiceFrequency {
   return "never";
 }
 
+type FocusRow = "choices" | "length";
+
 /**
  * Campaign settings shown from the in-campaign ESC menu.
- * Identity fields are read-only; Choices Frequency is editable with ← / →.
+ * Identity fields are read-only; Choices Frequency and DM Turn Length are
+ * editable. ↑ / ↓ move between rows; ← / → adjust the focused row.
  *
  * Uses CenteredModal's plain-text `lines` mode so every row is padded to
  * innerWidth and rendered opaque — the children-with-short-Text path leaves
@@ -45,58 +63,93 @@ export function CampaignSettingsModal({
   config,
   onDismiss,
   onChoicesFrequencyChange,
+  onDmTurnLengthPctChange,
+  globalDmTurnLengthPctDefault,
 }: CampaignSettingsModalProps) {
-  const initial = normalize(config.choices?.campaign_default);
-  const [freq, setFreq] = useState<ChoiceFrequency>(initial);
+  const initialFreq = normalize(config.choices?.campaign_default);
+  // Initial pct: saved per-campaign value → client global default → hard 80.
+  const initialPct = clampDmTurnLengthPct(
+    config.dm_turn_length_pct ?? globalDmTurnLengthPctDefault ?? DM_TURN_LENGTH_PCT_DEFAULT,
+  );
+  const [freq, setFreq] = useState<ChoiceFrequency>(initialFreq);
+  const [pct, setPct] = useState<number>(initialPct);
+  const [focus, setFocus] = useState<FocusRow>("choices");
   const [saving, setSaving] = useState(false);
-  const dirty = freq !== initial;
+  const dirtyFreq = freq !== initialFreq;
+  const dirtyPct = pct !== initialPct;
+  const dirty = dirtyFreq || dirtyPct;
 
   const commit = useCallback(async () => {
-    if (dirty && onChoicesFrequencyChange) {
-      setSaving(true);
-      try {
-        await onChoicesFrequencyChange(freq);
-      } finally {
-        setSaving(false);
+    if (!dirty) {
+      onDismiss();
+      return;
+    }
+    setSaving(true);
+    try {
+      const tasks: Promise<unknown>[] = [];
+      if (dirtyFreq && onChoicesFrequencyChange) {
+        tasks.push(Promise.resolve(onChoicesFrequencyChange(freq)));
       }
+      if (dirtyPct && onDmTurnLengthPctChange) {
+        tasks.push(Promise.resolve(onDmTurnLengthPctChange(pct)));
+      }
+      await Promise.all(tasks);
+    } finally {
+      setSaving(false);
     }
     onDismiss();
-  }, [dirty, freq, onChoicesFrequencyChange, onDismiss]);
+  }, [dirty, dirtyFreq, dirtyPct, freq, pct, onChoicesFrequencyChange, onDmTurnLengthPctChange, onDismiss]);
 
   useInput((_input, key) => {
     if (saving) return;
+    if (key.upArrow) { setFocus("choices"); return; }
+    if (key.downArrow) { setFocus("length"); return; }
     if (key.leftArrow) {
-      setFreq((f) => {
-        const idx = CHOICE_FREQUENCY_LEVELS.indexOf(f);
-        return CHOICE_FREQUENCY_LEVELS[Math.max(0, idx - 1)];
-      });
+      if (focus === "choices") {
+        setFreq((f) => {
+          const idx = CHOICE_FREQUENCY_LEVELS.indexOf(f);
+          return CHOICE_FREQUENCY_LEVELS[Math.max(0, idx - 1)];
+        });
+      } else {
+        setPct((p) => Math.max(DM_TURN_LENGTH_PCT_MIN, p - DM_TURN_LENGTH_PCT_STEP));
+      }
       return;
     }
     if (key.rightArrow) {
-      setFreq((f) => {
-        const idx = CHOICE_FREQUENCY_LEVELS.indexOf(f);
-        return CHOICE_FREQUENCY_LEVELS[Math.min(CHOICE_FREQUENCY_LEVELS.length - 1, idx + 1)];
-      });
+      if (focus === "choices") {
+        setFreq((f) => {
+          const idx = CHOICE_FREQUENCY_LEVELS.indexOf(f);
+          return CHOICE_FREQUENCY_LEVELS[Math.min(CHOICE_FREQUENCY_LEVELS.length - 1, idx + 1)];
+        });
+      } else {
+        setPct((p) => Math.min(DM_TURN_LENGTH_PCT_MAX, p + DM_TURN_LENGTH_PCT_STEP));
+      }
       return;
     }
     if (key.return) { void commit(); return; }
     if (key.escape) { onDismiss(); return; }
   });
 
-  // Build the slider line: ◂  Never  Rarely  [Sometimes]  Often  Always  ▸
-  // Each segment uses matching space-padding (" Sometimes " vs "[Sometimes]")
-  // so the line width doesn't shift as the user moves between selections.
-  const sliderSegments = CHOICE_FREQUENCY_LEVELS.map((level) => {
+  // Choices Frequency slider line.
+  const freqSegments = CHOICE_FREQUENCY_LEVELS.map((level) => {
     const label = FREQUENCY_LABELS[level];
     return level === freq ? `[${label}]` : ` ${label} `;
   });
-  const sliderLine = `  ◂ ${sliderSegments.join(" ")} ▸`;
+  const freqArrows = focus === "choices" ? "◂" : " ";
+  const freqArrowsR = focus === "choices" ? "▸" : " ";
+  const freqLine = `  ${freqArrows} ${freqSegments.join(" ")} ${freqArrowsR}`;
+
+  // DM Turn Length line — shown as "[ 80% ]" with arrows when focused.
+  const pctArrows = focus === "length" ? "◂" : " ";
+  const pctArrowsR = focus === "length" ? "▸" : " ";
+  const pctValue = focus === "length" ? `[${pct}%]` : ` ${pct}% `;
+  const pctLine = `  ${pctArrows} ${pctValue} ${pctArrowsR}    (range ${DM_TURN_LENGTH_PCT_MIN}–${DM_TURN_LENGTH_PCT_MAX}%, default ${DM_TURN_LENGTH_PCT_DEFAULT}%)`;
 
   const hintLine = saving
     ? "  Saving..."
     : dirty
-      ? "  Enter saves · ESC cancels"
-      : "  ← / → to adjust · Enter to close";
+      ? "  Enter saves · ESC cancels · ↑ / ↓ rows · ← / → adjust"
+      : "  ↑ / ↓ rows · ← / → adjust · Enter to close";
 
   const lines: string[] = [];
   lines.push(`  Campaign:   ${config.name}`);
@@ -109,10 +162,16 @@ export function CampaignSettingsModal({
     if (scopeLabel) lines.push(`  Scope:      ${scopeLabel}`);
   }
   lines.push("");
-  lines.push("  Choices Frequency");
+  lines.push(focus === "choices" ? "  ▶ Choices Frequency" : "    Choices Frequency");
   lines.push("    How often the DM offers you a set of suggested responses.");
   lines.push("");
-  lines.push(sliderLine);
+  lines.push(freqLine);
+  lines.push("");
+  lines.push(focus === "length" ? "  ▶ DM Turn Length" : "    DM Turn Length");
+  lines.push("    Page size the DM is told about. Lower = tighter prose;");
+  lines.push("    100% = actual size. 80% is a useful starting nudge.");
+  lines.push("");
+  lines.push(pctLine);
   lines.push("");
   lines.push(hintLine);
 

--- a/packages/client-ink/src/ws-client.ts
+++ b/packages/client-ink/src/ws-client.ts
@@ -5,7 +5,7 @@
  * Parses incoming messages as ServerEvent discriminated union.
  * Fires typed callbacks for each event kind.
  */
-import type { ServerEvent } from "@machine-violet/shared";
+import type { ClientEvent, ServerEvent } from "@machine-violet/shared";
 
 export type EventHandler = (event: ServerEvent) => void;
 export type ConnectionHandler = () => void;
@@ -68,6 +68,21 @@ export class WsClient {
   /** True if the WebSocket is currently open. */
   get connected(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * Send a client→server event. Currently used only for `client:viewport`
+   * (the rest of the client→server traffic goes over REST). Silently
+   * dropped if the socket isn't open — the caller is expected to re-send
+   * on the next `onConnect`.
+   */
+  send(event: ClientEvent): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      this.ws.send(JSON.stringify(event));
+    } catch {
+      // Drop — same rationale as the readyState check.
+    }
   }
 
   // --- Private ---

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -195,8 +195,15 @@ export class GameEngine {
     const lengthInjection = new LengthSteeringInjection();
     // Route the "no viewport reported" fallback warning through the same
     // dev-log channel so it surfaces alongside other injection traces
-    // instead of going to stderr.
-    lengthInjection.setWarnFn((msg) => params.callbacks.onDevLog?.(msg));
+    // instead of going to stderr. Only override when onDevLog is
+    // actually wired — otherwise leave the injection's default
+    // console.warn fallback in place so the warning isn't silently
+    // dropped in environments (tests, headless dev) that don't supply
+    // onDevLog.
+    if (params.callbacks.onDevLog) {
+      const onDevLog = params.callbacks.onDevLog;
+      lengthInjection.setWarnFn((msg) => onDevLog(msg));
+    }
     this.injectionRegistry.register(lengthInjection);
     this.injectionRegistry.register(new HardStatsInjection());
 

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -1,6 +1,7 @@
 import { registry as singletonRegistry } from "./tool-registry.js";
 import type { GameState } from "./game-state.js";
 import type { EntityTree } from "@machine-violet/shared/types/entities.js";
+import { DM_TURN_LENGTH_PCT_DEFAULT } from "@machine-violet/shared/types/config.js";
 import { agentLoopStreaming } from "./agent-loop.js";
 import type { AgentLoopConfig, TuiCommand, UsageStats } from "./agent-loop.js";
 import type { LLMProvider, NormalizedMessage, ContentPart, TierProvider } from "../providers/types.js";
@@ -191,7 +192,12 @@ export class GameEngine {
     this.injectionRegistry = new InjectionRegistry();
     this.injectionRegistry.register(new BehaviorInjection());
     this.injectionRegistry.register(new ScenePacingInjection());
-    this.injectionRegistry.register(new LengthSteeringInjection());
+    const lengthInjection = new LengthSteeringInjection();
+    // Route the "no viewport reported" fallback warning through the same
+    // dev-log channel so it surfaces alongside other injection traces
+    // instead of going to stderr.
+    lengthInjection.setWarnFn((msg) => params.callbacks.onDevLog?.(msg));
+    this.injectionRegistry.register(lengthInjection);
     this.injectionRegistry.register(new HardStatsInjection());
 
     // Wire dev logging to scene manager
@@ -524,6 +530,7 @@ export class GameEngine {
       scene: this.sceneManager.getScene(),
       skipTranscript: !!opts?.skipTranscript,
       terminalDims: this.terminalDims,
+      dmTurnLengthPct: this.gameState.config.dm_turn_length_pct ?? DM_TURN_LENGTH_PCT_DEFAULT,
       hardStatsText,
     };
     preambleParts.push(...this.injectionRegistry.buildAll(injCtx, this.callbacks.onDevLog));

--- a/packages/engine/src/agents/injections.test.ts
+++ b/packages/engine/src/agents/injections.test.ts
@@ -38,6 +38,7 @@ function baseCtx(overrides?: Partial<InjectionContext>): InjectionContext {
     scene: mockScene(),
     skipTranscript: false,
     terminalDims: undefined,
+    dmTurnLengthPct: 100, // tests assume identity unless they override
     ...overrides,
   };
 }
@@ -178,9 +179,26 @@ describe("ScenePacingInjection", () => {
 // ---------------------------------------------------------------------------
 
 describe("LengthSteeringInjection", () => {
-  it("returns null when terminalDims is undefined", () => {
+  it("falls back to baked dims and warns when terminalDims is undefined", () => {
     const inj = new LengthSteeringInjection();
-    expect(inj.build(baseCtx())).toBeNull();
+    const warnings: string[] = [];
+    inj.setWarnFn((msg) => warnings.push(msg));
+    const result = inj.build(baseCtx());
+    // Baked default is 80 cols × 20 narrative rows
+    expect(result).toContain("[length]");
+    expect(result).toContain("80 cols");
+    expect(result).toContain("20 visible rows");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("No client viewport reported");
+  });
+
+  it("only warns once across multiple fallback calls", () => {
+    const inj = new LengthSteeringInjection();
+    const warnings: string[] = [];
+    inj.setWarnFn((msg) => warnings.push(msg));
+    inj.build(baseCtx());
+    inj.build(baseCtx());
+    expect(warnings).toHaveLength(1);
   });
 
   it("injects terminal size on first call", () => {
@@ -189,6 +207,41 @@ describe("LengthSteeringInjection", () => {
     expect(result).toContain("[length]");
     expect(result).toContain("100 cols");
     expect(result).toContain("25 visible rows");
+  });
+
+  it("applies dmTurnLengthPct fib to reported rows only", () => {
+    const inj = new LengthSteeringInjection();
+    // 25 * 0.8 = 20
+    const result = inj.build(baseCtx({ terminalDims: dims(100, 40, 25), dmTurnLengthPct: 80 }));
+    expect(result).toContain("100 cols");
+    expect(result).toContain("20 visible rows");
+    // Real value not in the hint
+    expect(result).not.toContain("25 visible rows");
+  });
+
+  it("overlong tracking uses the real narrativeRows, not the fibbed value", () => {
+    const inj = new LengthSteeringInjection();
+    inj.build(baseCtx({ terminalDims: dims(100, 40, 25), dmTurnLengthPct: 80 }));
+    // 22 lines is over the fibbed 20 but under the real 25 — must NOT count as overlong.
+    inj.afterResponse(responseInfo({ wrappedLineCount: 22 }));
+    inj.afterResponse(responseInfo({ wrappedLineCount: 22 }));
+    const result = inj.build(baseCtx({ terminalDims: dims(100, 40, 25), dmTurnLengthPct: 80 }));
+    // No overlong reminder, no dims change — should be null.
+    expect(result).toBeNull();
+  });
+
+  it("supports pct > 100 (tells the DM the page is bigger than it is)", () => {
+    const inj = new LengthSteeringInjection();
+    // 20 * 1.5 = 30
+    const result = inj.build(baseCtx({ terminalDims: dims(100, 30, 20), dmTurnLengthPct: 150 }));
+    expect(result).toContain("30 visible rows");
+  });
+
+  it("never reports 0 rows even at very low pct/dim combinations", () => {
+    const inj = new LengthSteeringInjection();
+    // 1 * 0.5 = 0.5 → floor 0, clamped to 1
+    const result = inj.build(baseCtx({ terminalDims: dims(80, 10, 1), dmTurnLengthPct: 50 }));
+    expect(result).toContain("1 visible rows");
   });
 
   it("returns null on subsequent calls when dims unchanged and no overlong", () => {

--- a/packages/engine/src/agents/injections.ts
+++ b/packages/engine/src/agents/injections.ts
@@ -24,6 +24,13 @@ export interface InjectionContext {
   /** Terminal dimensions, or undefined if not yet reported by the TUI. */
   terminalDims: TerminalDims | undefined;
   /**
+   * Multiplier (in percent) applied to the reported narrativeRows in the
+   * length hint. 80 means the DM is told the page is 20% shorter than it
+   * actually is — a nudge toward economy. Affects display only; overlong
+   * tracking uses the real row count.
+   */
+  dmTurnLengthPct: number;
+  /**
    * Rendered hard-stats string for this turn (turn holder, combat round,
    * resource values). HardStatsInjection compares against its last-emitted
    * copy to decide whether to re-emit ahead of cadence.
@@ -103,16 +110,49 @@ export class ScenePacingInjection implements Injection {
 // LengthSteeringInjection — terminal-size awareness + overlong reminders
 // ---------------------------------------------------------------------------
 
+/**
+ * Conservative default used when no client has reported viewport dims by
+ * the first DM turn. In a real session this shouldn't happen — the player
+ * has already driven the setup agent over several turns by the time the
+ * first DM priming runs, and the client reports its viewport on WS
+ * connect. If we ever fall back to this, LengthSteeringInjection logs a
+ * warning the first time per session.
+ */
+export const FALLBACK_TERMINAL_DIMS: TerminalDims = {
+  columns: 80,
+  rows: 24,
+  narrativeRows: 20,
+};
+
 export class LengthSteeringInjection implements Injection {
   readonly name = "length";
   private lastReportedDims: TerminalDims | undefined;
   private dimsInjectedOnce = false;
   private consecutiveOverlong = 0;
+  private fallbackWarned = false;
+  private warnFn: ((msg: string) => void) | undefined;
   static readonly OVERLONG_THRESHOLD = 2;
 
+  /** Optional sink for the one-shot "no viewport reported" warning. */
+  setWarnFn(fn: (msg: string) => void): void {
+    this.warnFn = fn;
+  }
+
   build(ctx: InjectionContext): string | null {
-    const dims = ctx.terminalDims;
-    if (!dims) return null;
+    let dims = ctx.terminalDims;
+    if (!dims) {
+      // Use the baked default so the first-turn hint still fires. This
+      // should never happen in a real session — log once if it does so
+      // the issue surfaces rather than silently degrading prose quality.
+      if (!this.fallbackWarned) {
+        this.fallbackWarned = true;
+        const msg = "[length] No client viewport reported by first DM turn — using fallback dims. "
+          + "Expected the client to send client:viewport over WS during setup.";
+        if (this.warnFn) this.warnFn(msg);
+        else console.warn(msg);
+      }
+      dims = FALLBACK_TERMINAL_DIMS;
+    }
 
     const parts: string[] = [];
 
@@ -123,8 +163,14 @@ export class LengthSteeringInjection implements Injection {
       || this.lastReportedDims.narrativeRows !== dims.narrativeRows;
 
     if (!this.dimsInjectedOnce || dimsChanged) {
+      // Fib applied to the displayed row count only. The real value is
+      // kept for internal overlong tracking in afterResponse().
+      const reportedRows = Math.max(
+        1,
+        Math.floor(dims.narrativeRows * ctx.dmTurnLengthPct / 100),
+      );
       parts.push(
-        `Terminal: ${dims.columns} cols × ${dims.narrativeRows} visible rows.`,
+        `Terminal: ${dims.columns} cols × ${reportedRows} visible rows.`,
       );
       this.lastReportedDims = { ...dims };
       this.dimsInjectedOnce = true;

--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -40,6 +40,17 @@ function textResponse(text: string, usage?: NormalizedUsage): ChatResult {
   };
 }
 
+/** Empty refusal — what providers that don't throw on system failure return. */
+function refusalResponse(): ChatResult {
+  return {
+    text: "",
+    toolCalls: [],
+    usage: mockUsage(0, 0),
+    stopReason: "refusal",
+    assistantContent: [],
+  };
+}
+
 function presentChoicesResponse(text: string, prompt: string, choices: string[]): ChatResult {
   return {
     text,
@@ -166,6 +177,34 @@ describe("createSetupConversation", () => {
     await conv.start(noop);
 
     await expect(conv.resolveChoice("anything", noop)).rejects.toThrow("No pending choice to resolve");
+  });
+
+  it("throws a clear error when the provider returns an empty refusal", async () => {
+    // Mirrors the Codex `status: "failed"` case the openai-chatgpt
+    // provider now throws on directly. This is the defense-in-depth path
+    // for any other provider that returns refusal + empty content
+    // (Anthropic safety filter, OpenAI content_filter incomplete, etc).
+    // Previously this caused setup to render nothing — the player saw a
+    // hang. It must now surface as a visible error.
+    const provider = mockProvider([refusalResponse()]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    await expect(conv.start(noop)).rejects.toThrow(/refused or failed to respond/);
+  });
+
+  it("does NOT throw on refusal when the model still produced some content", async () => {
+    // A refusal that still has narrative text shouldn't be treated as a
+    // dead end — the model said something, just with a refusal stop reason.
+    const partial: ChatResult = {
+      text: "I can't help with that, but here's a different idea.",
+      toolCalls: [],
+      usage: mockUsage(),
+      stopReason: "refusal",
+      assistantContent: [{ type: "text", text: "I can't help with that, but here's a different idea." }],
+    };
+    const provider = mockProvider([partial]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    const result = await conv.start(noop);
+    expect(result.text).toContain("different idea");
   });
 
   it("finalize_setup populates finalized result", async () => {

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -565,6 +565,28 @@ export function createSetupConversation(
 
       const result = await streamWithRetry(provider, params, onDelta, onRetry);
 
+      // Defense-in-depth: a refusal-stop with no usable output is a dead
+      // end for setup. The previous behavior (silently continue with
+      // empty text) rendered nothing to the player and looked like a
+      // hang. The openai-chatgpt provider now throws CodexTurnFailedError
+      // on `status: "failed"`, but any provider that legitimately returns
+      // `stopReason: "refusal"` (Anthropic content filter, OpenAI
+      // content_filter incomplete) would also leave us with no narrative
+      // to render — surface it as an error so the session-manager catch
+      // can broadcast a user-visible message.
+      if (
+        result.stopReason === "refusal"
+        && !result.text
+        && (!result.assistantContent || result.assistantContent.length === 0)
+        && (!result.toolCalls || result.toolCalls.length === 0)
+      ) {
+        throw new Error(
+          "Setup agent refused or failed to respond. "
+          + "This usually means the configured model rejected the prompt or isn't reachable — "
+          + "check the connections menu and try again.",
+        );
+      }
+
       // openai-chatgpt path: codex ran the entire multi-round tool loop
       // inside its single stream() call. `runToolDispatch` already
       // captured pendingChoices / fired handleFinalize / etc. Skip the

--- a/packages/engine/src/providers/openai-chatgpt/log.ts
+++ b/packages/engine/src/providers/openai-chatgpt/log.ts
@@ -47,6 +47,13 @@ export const log = {
     logEvent("codex:thread:start", data),
   turnStart: (data: { threadId: string; turnId?: string; effort?: string }) =>
     logEvent("codex:turn:start", data),
-  turnComplete: (data: { threadId: string; turnId: string; durationMs: number; status: string }) =>
-    logEvent("codex:turn:complete", data),
+  turnComplete: (data: {
+    threadId: string;
+    turnId: string;
+    durationMs: number;
+    status: string;
+    /** Codex's own error message when status === "failed". Carries the only
+     *  hint about why the turn aborted (model not found, auth issue, etc). */
+    error?: string | null;
+  }) => logEvent("codex:turn:complete", data),
 };

--- a/packages/engine/src/providers/openai-chatgpt/provider.test.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TurnCollector } from "./provider.js";
+import { TurnCollector, CodexTurnFailedError } from "./provider.js";
 import type {
   AgentMessageDeltaNotification, ItemCompletedNotification,
   TurnCompletedNotification,
@@ -93,5 +93,24 @@ describe("TurnCollector", () => {
 
     expect(result.text).toBe("Non-streamed reply.");
     expect(result.assistantContent).toEqual([{ type: "text", text: "Non-streamed reply." }]);
+  });
+});
+
+describe("CodexTurnFailedError", () => {
+  it("carries the codex error message in both the field and the message", () => {
+    const err = new CodexTurnFailedError("model 'gpt-5.5' not found", "019e60e8-91ad");
+    expect(err.codexMessage).toBe("model 'gpt-5.5' not found");
+    expect(err.turnId).toBe("019e60e8-91ad");
+    expect(err.message).toContain("019e60e8-91ad");
+    expect(err.message).toContain("model 'gpt-5.5' not found");
+    expect(err.name).toBe("CodexTurnFailedError");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("falls back to a placeholder when codex provides no message", () => {
+    // The throw site uses "(no error message from codex)" if turn.error is null.
+    // This test guards against the constructor itself swallowing the input.
+    const err = new CodexTurnFailedError("(no error message from codex)", "t_abc");
+    expect(err.codexMessage).toBe("(no error message from codex)");
   });
 });

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -542,12 +542,23 @@ export class OpenAIChatGptProvider implements LLMProvider {
       const turnId = turnStart.turn.id;
 
       const completed = await completion;
+      const errorMessage = completed.turn.error?.message ?? null;
       log.turnComplete({
         threadId,
         turnId,
         durationMs: completed.turn.durationMs,
         status: completed.turn.status,
+        error: errorMessage,
       });
+
+      // A failed Codex turn is a system-level failure (model-not-found,
+      // auth, rate limit, tools schema mismatch, etc), not a content
+      // refusal. Surface the reason instead of returning empty text —
+      // callers like setup-conversation don't check stopReason and would
+      // otherwise render nothing.
+      if (completed.turn.status === "failed") {
+        throw new CodexTurnFailedError(errorMessage ?? "(no error message from codex)", turnId);
+      }
 
       return collected.toChatResult(completed);
     } finally {
@@ -886,3 +897,27 @@ export class TurnCollector {
 
 // Re-export for tests / callers that need to recover from spawn failures.
 export { CodexRpcError } from "./rpc.js";
+
+/**
+ * Thrown when a Codex turn returns `status: "failed"`. Carries the
+ * `turn.error.message` Codex reported alongside the failure — without it
+ * callers see only `status: "failed"` in the engine log and can't tell why
+ * (model not found, auth expired, rate limit, tools schema mismatch, …).
+ *
+ * Why throw instead of returning an empty ChatResult? A failed turn is a
+ * system-level error, not a content refusal. The previous behavior mapped
+ * `failed → stopReason: "refusal"` with empty text, which callers like
+ * setup-conversation (which calls `provider.chat()` directly without an
+ * agent-loop wrapper) silently treated as a no-op, rendering nothing to
+ * the player. Throwing forces callers to either handle the failure
+ * explicitly or surface it as an error event.
+ */
+export class CodexTurnFailedError extends Error {
+  constructor(
+    public readonly codexMessage: string,
+    public readonly turnId: string,
+  ) {
+    super(`Codex turn ${turnId} failed: ${codexMessage}`);
+    this.name = "CodexTurnFailedError";
+  }
+}

--- a/packages/engine/src/server/routes/data.ts
+++ b/packages/engine/src/server/routes/data.ts
@@ -172,6 +172,12 @@ export const dataRoutes: FastifyPluginAsync = async (server: FastifyInstance) =>
 
     // Apply patch to in-memory config
     const patch = (request.body as Record<string, unknown>) ?? {};
+    // Clamp dm_turn_length_pct to its supported range — defensive, since
+    // the modal already clamps but the endpoint is otherwise wide open.
+    if (typeof patch.dm_turn_length_pct === "number") {
+      const { clampDmTurnLengthPct } = await import("@machine-violet/shared/types/config.js");
+      patch.dm_turn_length_pct = clampDmTurnLengthPct(patch.dm_turn_length_pct);
+    }
     Object.assign(gs.config, patch);
 
     // Persist to disk

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -59,9 +59,16 @@ export interface ConnectedClient {
 }
 
 /**
- * Compute the viewport floor — the entry with the smallest `narrativeRows`
- * across all clients that have reported dims. Returns undefined if no
- * client has reported. Exported for unit testing.
+ * Compute the viewport floor — the most-constrained dims across all
+ * clients that have reported. Returns undefined if no client has
+ * reported. Exported for unit testing.
+ *
+ * Primary sort: smallest `narrativeRows` (drives the length hint).
+ * Tiebreak: smallest `columns`, then smallest `rows`. Without the
+ * tiebreak two clients sharing terminal height but with different
+ * widths would yield insertion-order-dependent columns, which mis-sizes
+ * GameEngine's wrappedLineCount calculation (it uses
+ * `terminalDims.columns - 4` as the wrap width).
  */
 export function computeViewportFloor(
   clients: Iterable<Pick<ConnectedClient, "dims">>,
@@ -69,8 +76,18 @@ export function computeViewportFloor(
   let floor: { columns: number; rows: number; narrativeRows: number } | undefined;
   for (const entry of clients) {
     if (!entry.dims) continue;
-    if (!floor || entry.dims.narrativeRows < floor.narrativeRows) {
+    if (!floor) {
       floor = entry.dims;
+      continue;
+    }
+    if (entry.dims.narrativeRows < floor.narrativeRows) {
+      floor = entry.dims;
+    } else if (entry.dims.narrativeRows === floor.narrativeRows) {
+      if (entry.dims.columns < floor.columns) {
+        floor = entry.dims;
+      } else if (entry.dims.columns === floor.columns && entry.dims.rows < floor.rows) {
+        floor = entry.dims;
+      }
     }
   }
   return floor;

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -54,6 +54,26 @@ const DISCORD_STATUS_INTERVAL = 8;
 export interface ConnectedClient {
   ws: WebSocket;
   identity: ConnectionIdentity;
+  /** Last-reported viewport dims, or undefined if never reported. */
+  dims?: { columns: number; rows: number; narrativeRows: number };
+}
+
+/**
+ * Compute the viewport floor — the entry with the smallest `narrativeRows`
+ * across all clients that have reported dims. Returns undefined if no
+ * client has reported. Exported for unit testing.
+ */
+export function computeViewportFloor(
+  clients: Iterable<Pick<ConnectedClient, "dims">>,
+): { columns: number; rows: number; narrativeRows: number } | undefined {
+  let floor: { columns: number; rows: number; narrativeRows: number } | undefined;
+  for (const entry of clients) {
+    if (!entry.dims) continue;
+    if (!floor || entry.dims.narrativeRows < floor.narrativeRows) {
+      floor = entry.dims;
+    }
+  }
+  return floor;
 }
 
 export type SessionStatus = "idle" | "starting" | "active" | "stopping";
@@ -150,6 +170,7 @@ export class SessionManager {
 
     ws.on("close", () => {
       this.clients.delete(ws);
+      this.recomputeViewportFloor();
       this.checkIdleTimeout();
     });
 
@@ -174,7 +195,36 @@ export class SessionManager {
 
   removeClient(ws: WebSocket): void {
     this.clients.delete(ws);
+    this.recomputeViewportFloor();
     this.checkIdleTimeout();
+  }
+
+  /**
+   * Update a connected client's reported viewport dims and push the new
+   * floor (min `narrativeRows` across all clients) to the engine.
+   *
+   * Called from the WS handler when a `client:viewport` message arrives.
+   * If the floor rises because the previously-smallest client either
+   * disconnected or reported larger dims, the DM sees the new (larger)
+   * floor on its next turn.
+   */
+  updateClientViewport(
+    ws: WebSocket,
+    dims: { columns: number; rows: number; narrativeRows: number },
+  ): void {
+    const entry = this.clients.get(ws);
+    if (!entry) return;
+    entry.dims = dims;
+    this.recomputeViewportFloor();
+  }
+
+  /** Recompute the floor across all connected clients and push to engine. */
+  private recomputeViewportFloor(): void {
+    if (!this.engine) return;
+    const floor = computeViewportFloor(this.clients.values());
+    if (floor) {
+      this.engine.setTerminalDims(floor);
+    }
   }
 
   // --- Broadcasting ---
@@ -737,6 +787,12 @@ export class SessionManager {
     this.gameState = gs;
     this.campaignId = campaignId;
     this.status = "active";
+
+    // Seed the engine with the current viewport floor, if any client has
+    // already reported dims (typically during setup which precedes
+    // transitionToGame). If none have, LengthSteeringInjection will fall
+    // back to its baked default and log a warning on the first turn.
+    this.recomputeViewportFloor();
 
     // Persist cumulative token usage to disk on every API call. The persister
     // queues writes asynchronously, so the per-call overhead is just a JSON

--- a/packages/engine/src/server/viewport-floor.test.ts
+++ b/packages/engine/src/server/viewport-floor.test.ts
@@ -58,4 +58,23 @@ describe("computeViewportFloor", () => {
     // a disconnects — simulate by passing only b
     expect(computeViewportFloor([b])?.narrativeRows).toBe(25);
   });
+
+  it("picks the narrower columns on a narrativeRows tie", () => {
+    // Same narrativeRows but different widths — without tiebreak, the
+    // chosen `columns` would be insertion-order-dependent, which
+    // mis-sizes GameEngine.wrappedLineCount.
+    const wide = client({ columns: 200, rows: 50, narrativeRows: 30 });
+    const narrow = client({ columns: 80, rows: 50, narrativeRows: 30 });
+    expect(computeViewportFloor([wide, narrow])?.columns).toBe(80);
+    expect(computeViewportFloor([narrow, wide])?.columns).toBe(80);
+  });
+
+  it("picks the smaller rows on a (narrativeRows, columns) tie", () => {
+    // Same narrativeRows AND same columns but different total rows —
+    // tertiary tiebreak so the result is fully deterministic.
+    const tall = client({ columns: 80, rows: 60, narrativeRows: 30 });
+    const short = client({ columns: 80, rows: 40, narrativeRows: 30 });
+    expect(computeViewportFloor([tall, short])?.rows).toBe(40);
+    expect(computeViewportFloor([short, tall])?.rows).toBe(40);
+  });
 });

--- a/packages/engine/src/server/viewport-floor.test.ts
+++ b/packages/engine/src/server/viewport-floor.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { computeViewportFloor } from "./session-manager.js";
+
+interface Dims {
+  columns: number;
+  rows: number;
+  narrativeRows: number;
+}
+
+function client(dims: Dims | undefined): { dims?: Dims } {
+  return dims ? { dims } : {};
+}
+
+describe("computeViewportFloor", () => {
+  it("returns undefined when no clients have reported", () => {
+    expect(computeViewportFloor([])).toBeUndefined();
+    expect(computeViewportFloor([client(undefined)])).toBeUndefined();
+  });
+
+  it("returns the only reported entry when exactly one client has dims", () => {
+    const floor = computeViewportFloor([client({ columns: 100, rows: 40, narrativeRows: 25 })]);
+    expect(floor).toEqual({ columns: 100, rows: 40, narrativeRows: 25 });
+  });
+
+  it("picks the entry with the smallest narrativeRows", () => {
+    const floor = computeViewportFloor([
+      client({ columns: 120, rows: 50, narrativeRows: 35 }),
+      client({ columns: 80, rows: 24, narrativeRows: 15 }),
+      client({ columns: 100, rows: 40, narrativeRows: 25 }),
+    ]);
+    expect(floor?.narrativeRows).toBe(15);
+    expect(floor?.columns).toBe(80);
+  });
+
+  it("ignores clients that have not reported", () => {
+    const floor = computeViewportFloor([
+      client(undefined),
+      client({ columns: 100, rows: 40, narrativeRows: 25 }),
+      client(undefined),
+    ]);
+    expect(floor?.narrativeRows).toBe(25);
+  });
+
+  it("rises when the previously-smallest client raises its value (re-min)", () => {
+    // Simulates a resize: the smallest client A reports a larger value;
+    // floor should re-min to whoever is now smallest.
+    const a: { dims?: Dims } = { dims: { columns: 80, rows: 24, narrativeRows: 15 } };
+    const b: { dims?: Dims } = { dims: { columns: 100, rows: 40, narrativeRows: 25 } };
+    expect(computeViewportFloor([a, b])?.narrativeRows).toBe(15);
+    a.dims = { columns: 120, rows: 50, narrativeRows: 30 };
+    expect(computeViewportFloor([a, b])?.narrativeRows).toBe(25);
+  });
+
+  it("uses the next-smallest value when the smallest client disconnects", () => {
+    const a = client({ columns: 80, rows: 24, narrativeRows: 15 });
+    const b = client({ columns: 100, rows: 40, narrativeRows: 25 });
+    expect(computeViewportFloor([a, b])?.narrativeRows).toBe(15);
+    // a disconnects — simulate by passing only b
+    expect(computeViewportFloor([b])?.narrativeRows).toBe(25);
+  });
+});

--- a/packages/engine/src/server/ws-viewport.test.ts
+++ b/packages/engine/src/server/ws-viewport.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeClientViewport } from "./ws.js";
+
+describe("sanitizeClientViewport", () => {
+  const VALID = { columns: 120, rows: 50, narrativeRows: 32 };
+
+  it("accepts a well-formed payload", () => {
+    expect(sanitizeClientViewport(VALID)).toEqual(VALID);
+  });
+
+  it("rejects non-object inputs", () => {
+    expect(sanitizeClientViewport(null)).toBeNull();
+    expect(sanitizeClientViewport(undefined)).toBeNull();
+    expect(sanitizeClientViewport("hello")).toBeNull();
+    expect(sanitizeClientViewport(42)).toBeNull();
+  });
+
+  it("rejects missing fields", () => {
+    expect(sanitizeClientViewport({ columns: 80, rows: 24 })).toBeNull();
+    expect(sanitizeClientViewport({ columns: 80, narrativeRows: 20 })).toBeNull();
+    expect(sanitizeClientViewport({ rows: 24, narrativeRows: 20 })).toBeNull();
+  });
+
+  it("rejects non-numeric fields", () => {
+    expect(sanitizeClientViewport({ ...VALID, columns: "120" })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, rows: null })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, narrativeRows: [] })).toBeNull();
+  });
+
+  it("rejects non-finite numbers", () => {
+    expect(sanitizeClientViewport({ ...VALID, columns: Number.POSITIVE_INFINITY })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, rows: Number.NaN })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, narrativeRows: Number.NEGATIVE_INFINITY })).toBeNull();
+  });
+
+  it("rejects floats — terminal dims are integer-only", () => {
+    expect(sanitizeClientViewport({ ...VALID, columns: 120.5 })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, rows: 50.1 })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, narrativeRows: 32.9 })).toBeNull();
+  });
+
+  it("rejects zero and negative values", () => {
+    expect(sanitizeClientViewport({ ...VALID, columns: 0 })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, rows: -10 })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, narrativeRows: 0 })).toBeNull();
+  });
+
+  it("rejects values above the 10k ceiling", () => {
+    expect(sanitizeClientViewport({ ...VALID, columns: 100_000 })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, rows: 50_000 })).toBeNull();
+    expect(sanitizeClientViewport({ ...VALID, narrativeRows: 20_000 })).toBeNull();
+  });
+
+  it("rejects narrativeRows greater than rows", () => {
+    // narrativeRows is supposed to be a subset of the full terminal
+    // height; a client claiming more narrative rows than total rows is
+    // confused (or malicious).
+    expect(sanitizeClientViewport({ columns: 80, rows: 24, narrativeRows: 30 })).toBeNull();
+  });
+
+  it("accepts narrativeRows equal to rows (no chrome)", () => {
+    expect(sanitizeClientViewport({ columns: 80, rows: 24, narrativeRows: 24 })).toEqual({
+      columns: 80,
+      rows: 24,
+      narrativeRows: 24,
+    });
+  });
+});

--- a/packages/engine/src/server/ws.ts
+++ b/packages/engine/src/server/ws.ts
@@ -38,10 +38,40 @@ export const wsHandler: FastifyPluginAsync = async (server: FastifyInstance) => 
       );
     });
 
-    // Clients send commands via REST, not WebSocket.
-    // This handler is intentionally empty — the WS is server→client only.
+    // Most client→server traffic goes over REST. The one exception is
+    // `client:viewport`, which the client emits on connect and on resize
+    // so the DM's length-steering hint can adapt to the smallest connected
+    // terminal. Unknown messages are logged and dropped.
     socket.on("message", (data: Buffer) => {
-      // Log unexpected messages but don't process them
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(String(data));
+      } catch {
+        server.log.warn({ data: String(data) }, "Unparseable WebSocket message from client");
+        return;
+      }
+      if (
+        parsed
+        && typeof parsed === "object"
+        && (parsed as { type?: unknown }).type === "client:viewport"
+      ) {
+        const d = (parsed as { data?: unknown }).data;
+        if (
+          d
+          && typeof d === "object"
+          && typeof (d as { columns?: unknown }).columns === "number"
+          && typeof (d as { rows?: unknown }).rows === "number"
+          && typeof (d as { narrativeRows?: unknown }).narrativeRows === "number"
+        ) {
+          const v = d as { columns: number; rows: number; narrativeRows: number };
+          sm.updateClientViewport(socket, {
+            columns: v.columns,
+            rows: v.rows,
+            narrativeRows: v.narrativeRows,
+          });
+          return;
+        }
+      }
       server.log.warn({ data: String(data) }, "Unexpected WebSocket message from client");
     });
   });

--- a/packages/engine/src/server/ws.ts
+++ b/packages/engine/src/server/ws.ts
@@ -10,6 +10,41 @@
 import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 import type { ConnectionIdentity } from "@machine-violet/shared";
 
+/**
+ * Sane terminal-size ceiling for inbound viewport reports. A real
+ * terminal won't be wider than a few hundred columns even on the
+ * widest monitor — anything larger is either a buggy client or
+ * deliberately malformed. Rejecting > MAX_DIM avoids surprises in
+ * downstream code that uses these as buffer/budget sizes.
+ */
+const MAX_DIM = 10_000;
+
+/**
+ * Validate a `client:viewport` payload. Returns the normalized dims
+ * when every field is a finite positive integer ≤ MAX_DIM and
+ * narrativeRows ≤ rows; returns null on any rejection.
+ *
+ * Hand-rolled rather than TypeBox-compiled because the WS handler
+ * already takes the message via untyped JSON.parse and we'd rather not
+ * pull TypeBox runtime checking into this path for one event.
+ *
+ * Exported for unit testing — not part of the public API surface.
+ */
+export function sanitizeClientViewport(
+  d: unknown,
+): { columns: number; rows: number; narrativeRows: number } | null {
+  if (!d || typeof d !== "object") return null;
+  const obj = d as Record<string, unknown>;
+  const columns = obj.columns;
+  const rows = obj.rows;
+  const narrativeRows = obj.narrativeRows;
+  if (typeof columns !== "number" || !Number.isInteger(columns) || columns <= 0 || columns > MAX_DIM) return null;
+  if (typeof rows !== "number" || !Number.isInteger(rows) || rows <= 0 || rows > MAX_DIM) return null;
+  if (typeof narrativeRows !== "number" || !Number.isInteger(narrativeRows) || narrativeRows <= 0 || narrativeRows > MAX_DIM) return null;
+  if (narrativeRows > rows) return null;
+  return { columns, rows, narrativeRows };
+}
+
 export const wsHandler: FastifyPluginAsync = async (server: FastifyInstance) => {
   server.get("/ws", { websocket: true }, (socket, request) => {
     // Parse connection identity from query params
@@ -41,7 +76,7 @@ export const wsHandler: FastifyPluginAsync = async (server: FastifyInstance) => 
     // Most client→server traffic goes over REST. The one exception is
     // `client:viewport`, which the client emits on connect and on resize
     // so the DM's length-steering hint can adapt to the smallest connected
-    // terminal. Unknown messages are logged and dropped.
+    // terminal. Unknown or malformed messages are logged and dropped.
     socket.on("message", (data: Buffer) => {
       let parsed: unknown;
       try {
@@ -56,21 +91,13 @@ export const wsHandler: FastifyPluginAsync = async (server: FastifyInstance) => 
         && (parsed as { type?: unknown }).type === "client:viewport"
       ) {
         const d = (parsed as { data?: unknown }).data;
-        if (
-          d
-          && typeof d === "object"
-          && typeof (d as { columns?: unknown }).columns === "number"
-          && typeof (d as { rows?: unknown }).rows === "number"
-          && typeof (d as { narrativeRows?: unknown }).narrativeRows === "number"
-        ) {
-          const v = d as { columns: number; rows: number; narrativeRows: number };
-          sm.updateClientViewport(socket, {
-            columns: v.columns,
-            rows: v.rows,
-            narrativeRows: v.narrativeRows,
-          });
+        const viewport = sanitizeClientViewport(d);
+        if (viewport) {
+          sm.updateClientViewport(socket, viewport);
           return;
         }
+        server.log.warn({ data }, "Rejecting client:viewport with invalid dims");
+        return;
       }
       server.log.warn({ data: String(data) }, "Unexpected WebSocket message from client");
     });

--- a/packages/shared/src/protocol/events.ts
+++ b/packages/shared/src/protocol/events.ts
@@ -173,6 +173,29 @@ export const ErrorEvent = Type.Object({
   }),
 });
 
+// --- Client → server events ---
+
+/**
+ * Client viewport dimensions. Sent on WS connect and on resize.
+ * The server tracks dims per WS connection and reports the *floor*
+ * (smallest narrativeRows across all connected clients) to the DM's
+ * length-steering injection. A user-tunable percentage is applied to
+ * the floor before it reaches the DM (see CampaignConfig.dm_turn_length_pct).
+ */
+export const ClientViewportEvent = Type.Object({
+  type: Type.Literal("client:viewport"),
+  data: Type.Object({
+    columns: Type.Number(),
+    rows: Type.Number(),
+    /** Usable narrative-area rows (after subtracting UI chrome). */
+    narrativeRows: Type.Number(),
+  }),
+});
+
+export const ClientEvent = Type.Union([
+  ClientViewportEvent,
+]);
+
 // --- Union of all server events ---
 
 export const ServerEvent = Type.Union([
@@ -212,3 +235,5 @@ export type DiscordPresenceEvent = Static<typeof DiscordPresenceEvent>;
 export type UsageUpdateEvent = Static<typeof UsageUpdateEvent>;
 export type ErrorEvent = Static<typeof ErrorEvent>;
 export type ServerEvent = Static<typeof ServerEvent>;
+export type ClientViewportEvent = Static<typeof ClientViewportEvent>;
+export type ClientEvent = Static<typeof ClientEvent>;

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -110,4 +110,23 @@ export interface CampaignConfig {
   recovery: RecoveryConfig;
   choices: ChoicesConfig;
   calendar_display_format?: string;
+  /**
+   * Multiplier (in percent) applied to the narrative row count reported to
+   * the DM in the per-turn `[length]` hint. Default 80 — the DM sees a
+   * smaller page than the terminal actually has, which nudges it toward
+   * tighter prose. Overlong-response tracking still uses the real row count.
+   * Range 50–150 in 5% steps.
+   */
+  dm_turn_length_pct?: number;
+}
+
+export const DM_TURN_LENGTH_PCT_DEFAULT = 80;
+export const DM_TURN_LENGTH_PCT_MIN = 50;
+export const DM_TURN_LENGTH_PCT_MAX = 150;
+export const DM_TURN_LENGTH_PCT_STEP = 5;
+
+/** Clamp a candidate pct to the supported range, rounded to the step. */
+export function clampDmTurnLengthPct(value: number): number {
+  const stepped = Math.round(value / DM_TURN_LENGTH_PCT_STEP) * DM_TURN_LENGTH_PCT_STEP;
+  return Math.max(DM_TURN_LENGTH_PCT_MIN, Math.min(DM_TURN_LENGTH_PCT_MAX, stepped));
 }


### PR DESCRIPTION
## Summary

- Wire the client→server viewport that was lost in the client-server split, then add a per-campaign `dm_turn_length_pct` (default 80) so the row count reported to the DM's `[length]` hint can be dialed below the real value to nudge tighter prose. The DM is told the page is 20% shorter than it actually is; overlong-response tracking continues to use the real row count.
- Multi-client safe: server keeps a per-WS map of viewport dims and pushes the **floor** (smallest `narrativeRows` across all clients) to the engine on every update/disconnect. An SSH user on 80×24 isn't penalized by a collaborator on a 200-column tiling window.
- Bonus from smoke-testing: codex turn failures (`status: "failed"`) used to silently return an empty `ChatResult` — setup-conversation rendered nothing. The provider now captures `turn.error.message`, logs it, and throws `CodexTurnFailedError`. Setup-conversation gets a defense-in-depth check for refusal-with-no-content. The same error-handling plumbing that catches setup failures broadcasts the message to the player.

## What changed

**Wire-through (the gap):**
- New `client:viewport` WS event — first client→server WS message (prior client traffic was REST-only).
- `SessionManager.updateClientViewport(ws, dims)` updates per-client dims; `recomputeViewportFloor()` re-mins on update/disconnect/session-start. Pure helper `computeViewportFloor()` is unit-tested.
- Baked 80×20 fallback in `LengthSteeringInjection` with a one-shot warn through the dev-log channel, so first-turn priming always emits `[length]` even if the wire is somehow broken.

**Tunable:**
- `CampaignConfig.dm_turn_length_pct` (50–150 in 5% steps, default 80) with `clampDmTurnLengthPct()` helper shared between modal + server PATCH handler.
- "DM Turn Length" row in the in-game Campaign Settings modal. ↑/↓ between rows, ←/→ adjusts. Multiple dirty fields commit in parallel.
- Global default in client-settings (`dmTurnLengthPctDefault`) seeds the modal for campaigns with no per-campaign override.

**Codex error surfacing:**
- `provider.ts` captures `completed.turn.error?.message`, logs on `codex:turn:complete`, throws `CodexTurnFailedError` on `status: "failed"`.
- `setup-conversation.ts` guards against refusal-with-empty-everything from any provider.
- Both throw paths feed existing error-broadcast handling (`session-manager.ts:425` + `turn-manager.ts:113`).

## Follow-up

- #529 — Surface session-fatal-but-recoverable errors with a "main menu + red banner" UX. Came out of this PR's smoke-testing when the codex OAuth refresh-token expired mid-setup and we realized we had no UX for "this session is dead but the app isn't."

## Test plan

- [x] `npm run check` — lint + tests pass across all three packages
- [x] `npx tsc -b` — typecheck clean
- [x] `npm run e2e -- golden-path` — full new-campaign → first-turn → player-response cycle passes in 295s on Anthropic
- [x] New unit tests: viewport-floor helper, `LengthSteeringInjection` pct fib + fallback + warn, `CampaignSettingsModal` multi-row navigation + clamping, `CodexTurnFailedError` shape, setup-conversation refusal guard
- [ ] Manual: open Campaign Settings on an existing campaign, verify "DM Turn Length" reads back the saved value or falls through to global default → 80
- [ ] Manual: start fresh campaign, check `.debug/context/dm.json` immediately after turn 1 — the `<context>` block should contain `[length] Terminal: NN cols × MM visible rows.` where MM ≈ narrativeRows × 0.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)