### PR TITLE
Canonicalize compendium slugs through slugify() (#521)

### DIFF
--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -542,6 +542,8 @@ Player-facing knowledge base. Updated by a Haiku subagent at scene transitions.
 
 All category arrays use the same `CompendiumEntry` structure. `related` contains slugs of related entries across any category.
 
+Every `slug` must equal `slugify(name)` (see [`packages/shared/src/utils/slug.ts`](../packages/shared/src/utils/slug.ts)) — leading articles `the`/`a`/`an` are stripped, so "The City" gets the slug `city`, not `the-city`. Slugs in `related[]` follow the same rule. The engine canonicalizes compendiums on read and after each subagent update, so older saves with article-retaining slugs migrate transparently.
+
 ### 5.3 Scene Directories
 
 Scene directories live under `campaign/scenes/` and are named `NNN-slug` where NNN is the 3-digit zero-padded scene number and slug is a kebab-case summary.

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -13,7 +13,7 @@ import { updatePrecis } from "./subagents/precis-updater.js";
 import { trackScene } from "./subagents/scene-tracker.js";
 import type { PlayerRead } from "./subagents/precis-updater.js";
 import { updateChangelogs } from "./subagents/changelog-updater.js";
-import { updateCompendium, emptyCompendium, renderCompendiumForDM } from "./subagents/compendium-updater.js";
+import { updateCompendium, emptyCompendium, renderCompendiumForDM, canonicalizeCompendium } from "./subagents/compendium-updater.js";
 import type { Compendium } from "@machine-violet/shared/types/compendium.js";
 import { advanceCalendar, checkClocks } from "../tools/clocks/index.js";
 import { validateCampaign } from "../tools/validation/index.js";
@@ -796,7 +796,9 @@ export class SceneManager {
     let current: Compendium;
     try {
       if (await this.fileIO.exists(paths.compendium)) {
-        current = JSON.parse(await this.fileIO.readFile(paths.compendium)) as Compendium;
+        current = canonicalizeCompendium(
+          JSON.parse(await this.fileIO.readFile(paths.compendium)) as Compendium,
+        );
       } else {
         current = emptyCompendium();
       }

--- a/packages/engine/src/agents/subagents/compendium-updater.test.ts
+++ b/packages/engine/src/agents/subagents/compendium-updater.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { LLMProvider, ChatResult, NormalizedUsage } from "../../providers/types.js";
 import {
+  canonicalizeCompendium,
   emptyCompendium,
   parseCompendiumOutput,
   renderCompendiumForDM,
   updateCompendium,
 } from "./compendium-updater.js";
 import { resetPromptCache } from "../../prompts/load-prompt.js";
-import type { Compendium, CompendiumEntry } from "@machine-violet/shared/types/compendium.js";
+import { slugify } from "@machine-violet/shared/utils/slug.js";
+import { COMPENDIUM_CATEGORIES, type Compendium, type CompendiumEntry } from "@machine-violet/shared/types/compendium.js";
 
 function mockUsage(): NormalizedUsage {
   return { inputTokens: 50, outputTokens: 80, cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 };
@@ -118,6 +120,34 @@ describe("parseCompendiumOutput", () => {
     expect(result).toBe(fallback);
   });
 
+  it("canonicalizes slugs from the model output (issue #521)", () => {
+    // Simulate the bug: the subagent emits article-retaining slugs.
+    const modelOutput = JSON.stringify({
+      version: 1,
+      lastUpdatedScene: 2,
+      characters: [
+        { name: "Lia", slug: "lia", summary: "Apprentice.", firstScene: 1, lastScene: 2, related: ["the-city", "the-arcade"] },
+      ],
+      places: [
+        { name: "The City", slug: "the-city", summary: "", firstScene: 1, lastScene: 2, related: [] },
+        { name: "The Arcade", slug: "the-arcade", summary: "", firstScene: 1, lastScene: 2, related: [] },
+      ],
+      items: [],
+      storyline: [],
+      lore: [],
+      objectives: [],
+    });
+
+    const result = parseCompendiumOutput(modelOutput, fallback);
+    for (const category of COMPENDIUM_CATEGORIES) {
+      for (const e of result[category]) {
+        expect(e.slug).toBe(slugify(e.name));
+      }
+    }
+    expect(result.places.map((e) => e.slug)).toEqual(["city", "arcade"]);
+    expect(result.characters[0].related).toEqual(["city", "arcade"]);
+  });
+
   it("ensures version is 1", () => {
     const json = JSON.stringify({
       version: 99,
@@ -130,6 +160,82 @@ describe("parseCompendiumOutput", () => {
     });
     const result = parseCompendiumOutput(json, fallback);
     expect(result.version).toBe(1);
+  });
+});
+
+// --- canonicalizeCompendium ---
+
+describe("canonicalizeCompendium", () => {
+  it("rewrites non-canonical slugs to match slugify(name)", () => {
+    const input: Compendium = {
+      ...emptyCompendium(),
+      places: [
+        entry({ name: "The City", slug: "the-city" }),
+        entry({ name: "The Arcade", slug: "the-arcade" }),
+      ],
+      characters: [entry({ name: "Vesper Caine", slug: "vesper-caine" })],
+    };
+
+    const out = canonicalizeCompendium(input);
+    expect(out.places[0].slug).toBe("city");
+    expect(out.places[1].slug).toBe("arcade");
+    expect(out.characters[0].slug).toBe("vesper-caine");
+  });
+
+  it("rewrites related[] through the same rule", () => {
+    const input: Compendium = {
+      ...emptyCompendium(),
+      places: [entry({ name: "The City", slug: "the-city" })],
+      characters: [
+        entry({
+          name: "Lia",
+          slug: "lia",
+          related: ["the-city", "the-arcade", "vesper-caine"],
+        }),
+      ],
+    };
+
+    const out = canonicalizeCompendium(input);
+    expect(out.characters[0].related).toEqual(["city", "arcade", "vesper-caine"]);
+  });
+
+  it("dedupes related entries that collapse to the same slug", () => {
+    const input: Compendium = {
+      ...emptyCompendium(),
+      characters: [
+        entry({
+          name: "Lia",
+          slug: "lia",
+          related: ["the-city", "city"],
+        }),
+      ],
+    };
+
+    const out = canonicalizeCompendium(input);
+    expect(out.characters[0].related).toEqual(["city"]);
+  });
+
+  it("is idempotent on already-canonical compendiums", () => {
+    const canonical: Compendium = {
+      ...emptyCompendium(),
+      places: [entry({ name: "The Undercroft", slug: "undercroft", related: ["mira"] })],
+      characters: [entry({ name: "Mira", slug: "mira" })],
+    };
+
+    const once = canonicalizeCompendium(canonical);
+    const twice = canonicalizeCompendium(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("does not mutate the input", () => {
+    const input: Compendium = {
+      ...emptyCompendium(),
+      places: [entry({ name: "The City", slug: "the-city", related: ["the-arcade"] })],
+    };
+
+    canonicalizeCompendium(input);
+    expect(input.places[0].slug).toBe("the-city");
+    expect(input.places[0].related).toEqual(["the-arcade"]);
   });
 });
 

--- a/packages/engine/src/agents/subagents/compendium-updater.test.ts
+++ b/packages/engine/src/agents/subagents/compendium-updater.test.ts
@@ -227,6 +227,28 @@ describe("canonicalizeCompendium", () => {
     expect(twice).toEqual(once);
   });
 
+  it("backfills missing category arrays (legacy compendiums)", () => {
+    // Old saves predate the `items` category. Canonicalizing them must not
+    // throw — disk-read migration paths in scene-manager and the data route
+    // both call this on raw JSON.
+    const legacy = {
+      version: 1 as const,
+      lastUpdatedScene: 1,
+      characters: [entry({ name: "The Hermit", slug: "the-hermit", related: ["the-thornwood"] })],
+      places: [entry({ name: "The Thornwood", slug: "the-thornwood" })],
+      // items intentionally absent
+      storyline: [],
+      lore: [],
+      objectives: [],
+    } as unknown as Compendium;
+
+    const out = canonicalizeCompendium(legacy);
+    expect(out.items).toEqual([]);
+    expect(out.characters[0].slug).toBe("hermit");
+    expect(out.characters[0].related).toEqual(["thornwood"]);
+    expect(out.places[0].slug).toBe("thornwood");
+  });
+
   it("does not mutate the input", () => {
     const input: Compendium = {
       ...emptyCompendium(),

--- a/packages/engine/src/agents/subagents/compendium-updater.ts
+++ b/packages/engine/src/agents/subagents/compendium-updater.ts
@@ -126,7 +126,12 @@ export function canonicalizeCompendium(compendium: Compendium): Compendium {
 
   for (const category of COMPENDIUM_CATEGORIES) {
     const entries = compendium[category];
-    if (!Array.isArray(entries)) continue;
+    // Legacy saves predate some categories (e.g. `items`) — backfill so the
+    // second pass below can iterate every category unconditionally.
+    if (!Array.isArray(entries)) {
+      result[category] = [];
+      continue;
+    }
     const rewritten: CompendiumEntry[] = [];
     for (const entry of entries) {
       const canonical = slugify(entry.name);

--- a/packages/engine/src/agents/subagents/compendium-updater.ts
+++ b/packages/engine/src/agents/subagents/compendium-updater.ts
@@ -3,7 +3,12 @@ import { oneShot } from "../subagent.js";
 import type { SubagentResult } from "../subagent.js";
 import { getMaxOutput } from "../../config/model-registry.js";
 import { loadPrompt } from "../../prompts/load-prompt.js";
-import type { Compendium, CompendiumEntry } from "@machine-violet/shared/types/compendium.js";
+import { slugify } from "@machine-violet/shared/utils/slug.js";
+import {
+  COMPENDIUM_CATEGORIES,
+  type Compendium,
+  type CompendiumEntry,
+} from "@machine-violet/shared/types/compendium.js";
 
 /**
  * Create an empty compendium with default structure.
@@ -93,10 +98,73 @@ export function parseCompendiumOutput(
 
     // Ensure version field
     parsed.version = 1;
-    return parsed;
+    return canonicalizeCompendium(parsed);
   } catch {
     return fallback;
   }
+}
+
+/**
+ * Force every entry's `slug` to match `slugify(entry.name)`, and rewrite
+ * every `related` array through the same rule. Idempotent.
+ *
+ * The compendium-updater subagent (and any older saved compendium) has been
+ * observed emitting slugs that retain leading articles — "the-city" instead
+ * of the canonical "city". That diverges from the slugify() the renderer
+ * uses to resolve wikilinks, so every `[[The City]]` link rendered red even
+ * though the entry existed. We treat slugify() as authoritative and rewrite
+ * the model's output to match, rather than introducing a second slug rule.
+ *
+ * Slugs we've actually seen change are remapped in `related`; any other
+ * slug there is still run through slugify() so a legacy reference like
+ * "the-arcade" → "arcade" lines up even if "the-arcade" never appeared as
+ * an entry slug in this compendium.
+ */
+export function canonicalizeCompendium(compendium: Compendium): Compendium {
+  const renames = new Map<string, string>();
+  const result: Compendium = { ...compendium };
+
+  for (const category of COMPENDIUM_CATEGORIES) {
+    const entries = compendium[category];
+    if (!Array.isArray(entries)) continue;
+    const rewritten: CompendiumEntry[] = [];
+    for (const entry of entries) {
+      const canonical = slugify(entry.name);
+      if (entry.slug !== canonical) renames.set(entry.slug, canonical);
+      rewritten.push({ ...entry, slug: canonical });
+    }
+    result[category] = rewritten;
+  }
+
+  for (const category of COMPENDIUM_CATEGORIES) {
+    for (const entry of result[category]) {
+      if (!Array.isArray(entry.related) || entry.related.length === 0) continue;
+      const seen = new Set<string>();
+      const next: string[] = [];
+      for (const ref of entry.related) {
+        const mapped = renames.get(ref) ?? canonicalizeSlugRef(ref);
+        if (!seen.has(mapped)) {
+          seen.add(mapped);
+          next.push(mapped);
+        }
+      }
+      entry.related = next;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Normalize a string that's already in slug form (hyphens, no spaces).
+ * slugify() only strips a leading article when followed by whitespace, so
+ * `slugify("the-arcade")` returns `"the-arcade"` unchanged — but the
+ * canonical slug for the display name "The Arcade" is `"arcade"`. This
+ * helper closes that gap for `related[]` cross-references that point to
+ * legacy slugs we don't have an entry-level rename for.
+ */
+function canonicalizeSlugRef(ref: string): string {
+  return slugify(ref).replace(/^(the|a|an)-/, "");
 }
 
 /**

--- a/packages/engine/src/prompts/compendium-updater.md
+++ b/packages/engine/src/prompts/compendium-updater.md
@@ -5,7 +5,7 @@ You receive the current compendium JSON and a player-safe scene summary. Update 
 ## Rules
 
 1. **Player knowledge only.** Include only what the player directly witnessed, was told, or could reasonably infer. Never add DM secrets, hidden mechanics, or information the player character does not have.
-2. **Identity tracking.** Before creating a new entry, check if an existing entry refers to the same entity under a different name. If a character's identity is revealed (e.g., "the stranger" turns out to be "Bob"), update the existing entry's `name` field and add the old name to `aliases`. The `slug` stays stable.
+2. **Identity tracking.** Before creating a new entry, check if an existing entry refers to the same entity under a different name. If a character's identity is revealed (e.g., "the stranger" turns out to be "Bob"), update the existing entry's `name` field and add the old name to `aliases`. The engine recomputes the slug from the new name (see slug rule below) — don't try to keep the old slug.
 3. **Update, don't duplicate.** When new information about an existing entry is revealed, update its `summary` and `lastScene`. Do not create a second entry.
 4. **Summaries are 1-3 sentences.** Dense, factual, no editorializing.
 5. **Wikilinks are required.** Any compendium entry named in a summary MUST be wrapped in `[[double brackets]]` using the display name (e.g. `[[Vesper Caine]]`, not `[[vesper-caine]]`). The TUI turns these into navigable links the player can Tab through to jump between entries — bare names break that navigation. Wikilink every entity-by-name mention, every time it appears, even if it appears in the same summary twice.

--- a/packages/engine/src/prompts/compendium-updater.md
+++ b/packages/engine/src/prompts/compendium-updater.md
@@ -27,7 +27,8 @@ A character who works with the cartographer Vesper Caine in the Arcade:
 Note that `vesper-caine` and `the-arcade` are NOT in `related` — they're already wikilinked inline. `the-city` is in `related` because it's contextually connected but not named in the prose.
 
 7. **Append-only.** Never remove entries. Objectives that are completed should have their summary updated to note completion.
-8. **Categories:**
+8. **Slugs.** Use lowercase with hyphens, **strip leading `the`/`a`/`an`** ("The City" → `city`, "An Old Map" → `old-map`). Slugs in `related` follow the same rule. The engine rewrites slugs through the canonical rule after parsing — emitting non-canonical slugs (e.g. `the-city`) just wastes tokens.
+9. **Categories:**
    - `characters` — NPCs, allies, antagonists, notable figures the player has met or heard of
    - `places` — Locations the player has visited or learned about
    - `items` — Named weapons, artifacts, quest items, and other narratively significant objects. Summaries should note current holder/location, origin or provenance if known, and any notable properties

--- a/packages/engine/src/server/routes/data.ts
+++ b/packages/engine/src/server/routes/data.ts
@@ -16,6 +16,8 @@ import {
 import { campaignPaths, machinePaths } from "../../tools/filesystem/scaffold.js";
 import { createArchiveFileIO } from "../fileio.js";
 import { collectDiagnostics } from "../diagnostics.js";
+import { canonicalizeCompendium } from "../../agents/subagents/compendium-updater.js";
+import type { Compendium } from "@machine-violet/shared/types/compendium.js";
 
 export const dataRoutes: FastifyPluginAsync = async (server: FastifyInstance) => {
 
@@ -79,7 +81,10 @@ export const dataRoutes: FastifyPluginAsync = async (server: FastifyInstance) =>
 
     try {
       const raw = await fileIO.readFile(path);
-      const data = JSON.parse(raw);
+      // Migrate on read: rewrite slugs through canonical slugify() so old
+      // saves with article-retaining slugs (e.g. "the-city") line up with
+      // the renderer's wikilink resolution.
+      const data = canonicalizeCompendium(JSON.parse(raw) as Compendium);
       return { data };
     } catch {
       // Return empty compendium if file doesn't exist


### PR DESCRIPTION
## Summary

Fixes [#521](https://github.com/octopollux/machine-violet/issues/521). The compendium-updater subagent emitted slugs that retained leading articles (`the-city`) while the renderer's wikilink resolution runs through `slugify()` (`city`). Every `[[The City]]` link in the new compendium-modal nav rendered red as broken even though the entry existed.

Takes the issue's preferred path (engine-level rewrite, not per-context slug rules):

- **New `canonicalizeCompendium()`** in `packages/engine/src/agents/subagents/compendium-updater.ts` rewrites every entry's `slug` to `slugify(entry.name)` and remaps `related[]` through an old→new map. Falls back to `slugify(ref).replace(/^(the|a|an)-/, "")` for legacy cross-refs not in the map — `slugify` only strips a leading article when followed by whitespace, so it leaves slug-form strings like `"the-arcade"` untouched, which is why the helper needs that extra step.
- **Applied inside `parseCompendiumOutput`** so fresh model output is always canonical.
- **Applied at every disk-read site** for transparent migration of existing campaigns:
  - `scene-manager.ts` `stepCompendiumUpdate` — the model now sees canonical slugs when updating, so it won't be tempted to re-emit the old form.
  - `GET /compendium` route — the client gets canonical slugs even before the next scene transition re-saves the file. This is the path that actually unblocks the wikilink nav on existing saves.

The helper is idempotent, so re-canonicalizing already-clean compendiums is a no-op.

## Why prompt + engine, not just prompt

Prompt-only is model-dependent and drifts. Engine-level is authoritative. Per the issue's recommendation, both ship: the prompt gains one line so the model doesn't waste tokens emitting slugs that will be overwritten, and a sentence is added to `format-spec.md` §5.2 making `slug === slugify(name)` an invariant.

## Test plan

- [x] `npm run check` — 2813 tests green, lint clean
- [x] New unit tests in `compendium-updater.test.ts`:
  - Round-trip from the issue's acceptance criteria — every entry in parsed output satisfies `entry.slug === slugify(entry.name)`
  - `related[]` rewrite via rename map
  - `related[]` dedup when multiple legacy slugs collapse to the same canonical slug
  - Idempotence
  - Non-mutation of input

Migration is transparent at read time. Existing saves with `the-city` slugs will start resolving wikilinks correctly the first time they're served, and the next scene transition will re-save with canonical slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)