### PR TITLE
Route session-fatal errors to a main-menu banner (#529)

### DIFF
--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -204,6 +204,40 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
     }
   }, [clientState.sessionStale, clientState.sessionEnded, phase]);
 
+  // Session-fatal-recoverable (issue #529): the active session is dead
+  // (auth expired, model not found, classifier refusal) but the player can
+  // fix it. Drop to menu with the verbatim cause in the existing red
+  // banner. Mid-game flush + checkpoint happens server-side before the
+  // error event lands, so the campaign reappears under "Resume" intact.
+  // Trigger from any phase where a session could be running (playing,
+  // starting, and the menu-with-a-just-started-setup-error case).
+  useEffect(() => {
+    if (clientState.lastError?.category !== "session-fatal-recoverable") return;
+    const message = clientState.lastError.message;
+    // Hide any modals that might be on top of the menu (saving overlay,
+    // delete confirm, recap modal). `setActiveModal(null)` was added in
+    // the same place returnToMenu uses for its own teardown.
+    setActiveModal(null);
+    setErrorMessage(message);
+    if (phase === "playing" || phase === "starting") {
+      // returnToMenu hits /endSession + waitForIdle. With session_fatal the
+      // server has already torn down — the call no-ops but the idle poll
+      // resolves quickly, so we don't need a separate cleanup path.
+      returnToMenu();
+    } else if (phase !== "menu") {
+      // Settings / connections / etc — just bounce to the menu so the
+      // player sees the banner.
+      setPhase("menu");
+    }
+    // Clear the error from clientState so a subsequent session start
+    // doesn't re-fire this effect from stale state.
+    setClientState((prev) => ({ ...prev, lastError: null }));
+    // returnToMenu intentionally omitted from deps: it's declared further
+    // down via useCallback, and listing it triggers a temporal dead zone
+    // at render time. The stale-session effect above uses the same
+    // pattern (closure captures the latest value at run time).
+  }, [clientState.lastError, phase]);
+
   // Handle setup → game transition: reset client state for new session.
   // The WebSocket stays connected — transitionToGame() broadcasts a fresh
   // state:snapshot to all connected clients after starting the new session.
@@ -238,6 +272,9 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
     setPhase("starting");
     setNarrativeLines([]);
     setClientState(initialClientState());
+    // Clear any lingering session-fatal banner (#529) — the player's
+    // remediation action is starting a new session.
+    setErrorMessage("");
 
     apiClientRef.current.startCampaign(id).then(() => {
       setPhase("playing");

--- a/packages/client-ink/src/event-handler.test.ts
+++ b/packages/client-ink/src/event-handler.test.ts
@@ -639,6 +639,8 @@ describe("event-handler", () => {
         status: 529,
         delayMs: 2000,
         attemptId: 1,
+        // Synthesized from `recoverable` when the wire event omits it.
+        category: "retryable",
       });
     });
 
@@ -655,7 +657,41 @@ describe("event-handler", () => {
         status: undefined,
         delayMs: undefined,
         attemptId: undefined,
+        // Synthesized from `recoverable: false` when the wire event omits
+        // it. Legacy callsites (pre-#529) that didn't set category land
+        // here so the new client UX still kicks in.
+        category: "session-fatal-recoverable",
       });
+    });
+
+    it("propagates the wire-level category discriminator (#529)", () => {
+      const h = makeHarness();
+      // Server-set category overrides the synthesized one. The OAuth-
+      // refresh case from issue #529 ships as recoverable:false +
+      // category:session-fatal-recoverable.
+      h.dispatch({
+        type: "error",
+        data: {
+          message: "Your access token could not be refreshed because your refresh token was already used.",
+          recoverable: false,
+          category: "session-fatal-recoverable",
+        },
+      });
+      expect(h.state.lastError?.category).toBe("session-fatal-recoverable");
+      expect(h.state.lastError?.message).toBe(
+        "Your access token could not be refreshed because your refresh token was already used.",
+      );
+    });
+
+    it("explicit category overrides the synthesized default (#529)", () => {
+      // recoverable:true with category:retryable matches; recoverable:true
+      // with category:process-fatal (hypothetical) lets the explicit one win.
+      const h = makeHarness();
+      h.dispatch({
+        type: "error",
+        data: { message: "fatal", recoverable: true, category: "process-fatal" },
+      });
+      expect(h.state.lastError?.category).toBe("process-fatal");
     });
 
     it("bumps attemptId on each successive recoverable retry", () => {

--- a/packages/client-ink/src/event-handler.ts
+++ b/packages/client-ink/src/event-handler.ts
@@ -23,6 +23,7 @@ import type {
   SessionEndedEvent,
   UsageUpdateEvent,
   ErrorEvent,
+  ErrorCategory,
   Turn,
   StateSnapshot,
   UsageStatus,
@@ -66,6 +67,10 @@ export interface ClientState {
      *  previous retry (the backoff caps at 12s, so successive attempts
      *  routinely look identical). */
     attemptId?: number;
+    /** Three-tier error category from the wire protocol. Absent on legacy
+     *  events; the dispatcher derives one from `recoverable` so downstream
+     *  consumers can always switch on `category`. */
+    category?: ErrorCategory;
   } | null;
   /** Per-character modeline text (character name → status string). */
   modelines: Record<string, string>;
@@ -521,6 +526,11 @@ function handleError(event: ErrorEvent, update: StateUpdater): void {
       attemptId: event.data.recoverable
         ? (prev.lastError?.attemptId ?? 0) + 1
         : undefined,
+      // Wire field is optional for backward compat. Synthesize a sensible
+      // category from the legacy `recoverable` flag so downstream consumers
+      // can always branch on `category` and ignore the boolean.
+      category: event.data.category
+        ?? (event.data.recoverable ? "retryable" : "session-fatal-recoverable"),
     },
   }));
 }

--- a/packages/client-ink/src/phases/MainMenuPhase.test.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "ink-testing-library";
-import { MainMenuPhase } from "./MainMenuPhase.js";
+import { MainMenuPhase, wrapByWord } from "./MainMenuPhase.js";
 import type { MainMenuPhaseProps } from "./MainMenuPhase.js";
 import { resetThemeCache, resolveTheme, BUILTIN_DEFINITIONS } from "../tui/themes/index.js";
 
@@ -65,6 +65,52 @@ describe("MainMenuPhase", () => {
     const props = defaultProps({ errorMsg: "Something went wrong" });
     const { lastFrame } = render(<MainMenuPhase {...props} />);
     expect(lastFrame()).toContain("Something went wrong");
+  });
+
+  it("wraps long error messages so the banner stays inside the frame (#529)", () => {
+    // The verbatim provider error from the session-fatal-recoverable
+    // bucket is ~90 chars and used to overflow the frame, producing
+    // mangled layout. Wrap at word boundaries; render every wrapped
+    // line in full so nothing gets clipped at the right edge.
+    const longMsg = "openai-chatgpt connection has no active ChatGPT login. "
+      + "Run 'Sign in with ChatGPT' from the Connections menu.";
+    const props = defaultProps({ errorMsg: longMsg });
+    const frame = render(<MainMenuPhase {...props} />).lastFrame() ?? "";
+    // Every word of the message must appear in the output, even though
+    // the message itself is longer than the wrap width.
+    for (const word of longMsg.split(/\s+/)) {
+      expect(frame).toContain(word);
+    }
+  });
+
+  it("places the error banner above the menu items (#529)", () => {
+    // The banner used to sit below the menu; that wasted vertical space
+    // on the first thing the player needs to see.
+    const props = defaultProps({ errorMsg: "uniqueErrorMarker" });
+    const frame = render(<MainMenuPhase {...props} />).lastFrame() ?? "";
+    const errorIdx = frame.indexOf("uniqueErrorMarker");
+    const menuIdx = frame.indexOf("New Campaign");
+    expect(errorIdx).toBeGreaterThanOrEqual(0);
+    expect(menuIdx).toBeGreaterThanOrEqual(0);
+    expect(errorIdx).toBeLessThan(menuIdx);
+  });
+
+  it("does not shift the menu when the banner toggles (#529)", () => {
+    // The whole point of the topBanner slot: out-of-band messages don't
+    // jitter the menu when they appear/disappear. Render the same menu
+    // with and without a multi-line wrapped error; the "New Campaign"
+    // line must land on the same terminal row in both frames.
+    function rowOf(frame: string, marker: string): number {
+      return frame.split("\n").findIndex((l) => l.includes(marker));
+    }
+    const longMsg = "openai-chatgpt connection has no active ChatGPT login. "
+      + "Run 'Sign in with ChatGPT' from the Connections menu.";
+    const baseline = render(<MainMenuPhase {...defaultProps()} />).lastFrame() ?? "";
+    const withBanner = render(
+      <MainMenuPhase {...defaultProps({ errorMsg: longMsg })} />,
+    ).lastFrame() ?? "";
+    expect(rowOf(baseline, "New Campaign"))
+      .toBe(rowOf(withBanner, "New Campaign"));
   });
 
   it("calls onNewCampaign when New Campaign selected", () => {
@@ -175,5 +221,38 @@ describe("MainMenuPhase", () => {
     // Update Available is the first item
     stdin.write("\r");
     expect(onUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("wrapByWord", () => {
+  it("returns short strings unchanged in a single line", () => {
+    expect(wrapByWord("hello world", 80)).toEqual(["hello world"]);
+  });
+
+  it("breaks at word boundaries when the line would exceed width", () => {
+    expect(wrapByWord("aaa bbb ccc", 7)).toEqual(["aaa bbb", "ccc"]);
+  });
+
+  it("emits an over-long single word on its own line rather than splitting it", () => {
+    // Splitting a URL / path token in the middle would hurt copy-paste more
+    // than wrapping past the edge. Pack what we can, then surrender.
+    expect(wrapByWord("short verylongtoken short", 10)).toEqual([
+      "short",
+      "verylongtoken",
+      "short",
+    ]);
+  });
+
+  it("collapses runs of whitespace", () => {
+    expect(wrapByWord("a   b\tc", 80)).toEqual(["a b c"]);
+  });
+
+  it("returns an empty array for whitespace-only input", () => {
+    expect(wrapByWord("   ", 80)).toEqual([]);
+  });
+
+  it("returns the original text in one line when width is non-positive (defensive)", () => {
+    expect(wrapByWord("hello", 0)).toEqual(["hello"]);
+    expect(wrapByWord("hello", -5)).toEqual(["hello"]);
   });
 });

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -277,18 +277,35 @@ export function MainMenuPhase({
     }
   }
 
-  // +2 for error message (marginTop=1 + text line) when present
-  const totalRows = menuLines.length + (errorMsg ? 2 : 0);
+  // Error banner pinned to the top via FullScreenFrame's `topBanner` slot
+  // so toggling it on/off doesn't shift the centered menu. We wrap by word
+  // to a fraction of the interior — caps at 80 cols to keep lines readable
+  // on very wide terminals — and pass the wrapped row count to the frame
+  // so its top-padding math knows how much room the banner consumes.
+  const sideWidth = theme.asset.components.edge_left.width;
+  const errorWrapWidth = Math.max(20, Math.min(80, cols - sideWidth * 2 - 4));
+  const errorLines = errorMsg ? wrapByWord(errorMsg, errorWrapWidth) : [];
+  const errorBanner = errorLines.length > 0 ? (
+    <Box flexDirection="column" width={errorWrapWidth}>
+      {errorLines.map((line, idx) => (
+        <Text key={idx} color="red">{line}</Text>
+      ))}
+    </Box>
+  ) : null;
 
   return (
     <>
-      <FullScreenFrame theme={theme} columns={cols} rows={termRows} title="Machine Violet" contentRows={totalRows} starfield>
+      <FullScreenFrame
+        theme={theme}
+        columns={cols}
+        rows={termRows}
+        title="Machine Violet"
+        contentRows={menuLines.length}
+        starfield
+        topBanner={errorBanner}
+        topBannerRows={errorLines.length}
+      >
         {menuLines}
-        {errorMsg && (
-          <Box marginTop={1}>
-            <Text color="red">{errorMsg}</Text>
-          </Box>
-        )}
       </FullScreenFrame>
       {deleteModal && (
         <DeleteCampaignModal
@@ -302,4 +319,39 @@ export function MainMenuPhase({
       )}
     </>
   );
+}
+
+/**
+ * Word-wrap `text` to a maximum line width.
+ *
+ * Splits on whitespace and packs greedily. Words longer than `width` are
+ * emitted on their own line — better to overflow one line than to split a
+ * URL or path token across two and confuse a user trying to copy it. The
+ * caller uses the returned line count to size the FullScreenFrame's
+ * `contentRows`, so the math has to match what gets rendered.
+ *
+ * Inlined here (rather than pulled from a util) to keep MainMenuPhase
+ * self-contained — it's the only caller, and the behavior is small
+ * enough that a dedicated module would be more friction than reuse.
+ */
+export function wrapByWord(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const words = text.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length === 0) return [];
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+      continue;
+    }
+    if (current.length + 1 + word.length <= width) {
+      current += " " + word;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
 }

--- a/packages/client-ink/src/tui/components/FullScreenFrame.test.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.test.tsx
@@ -46,4 +46,94 @@ describe("FullScreenFrame", () => {
     );
     expect(lastFrame()).toContain("Content");
   });
+
+  describe("topBanner slot (#529)", () => {
+    // The banner lives in the top-padding region — its whole point is to
+    // surface high-priority info (auth expired, fatal session error)
+    // without shifting the centered children around when it toggles.
+    function rowOfFirstMatch(frame: string, marker: string): number {
+      const lines = frame.split("\n");
+      return lines.findIndex((l) => l.includes(marker));
+    }
+
+    it("renders topBanner content above the centered children", () => {
+      const theme = makeTheme();
+      const banner = <Text>BANNER_MARKER</Text>;
+      const { lastFrame } = render(
+        <FullScreenFrame
+          theme={theme}
+          columns={80}
+          rows={24}
+          contentRows={1}
+          topBanner={banner}
+          topBannerRows={1}
+        >
+          <Text>CHILD_MARKER</Text>
+        </FullScreenFrame>,
+      );
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("BANNER_MARKER");
+      expect(frame).toContain("CHILD_MARKER");
+      expect(rowOfFirstMatch(frame, "BANNER_MARKER"))
+        .toBeLessThan(rowOfFirstMatch(frame, "CHILD_MARKER"));
+    });
+
+    it("keeps centered children at the same row whether or not the banner is present", () => {
+      // This is the whole reason the slot exists: out-of-band messages
+      // must not cause UI jitter when they appear/disappear. Render the
+      // same children at the same `contentRows` with and without a
+      // 3-row banner; the child row index must be identical.
+      const theme = makeTheme();
+      const without = render(
+        <FullScreenFrame theme={theme} columns={80} rows={24} contentRows={1}>
+          <Text>CHILD_MARKER</Text>
+        </FullScreenFrame>,
+      ).lastFrame() ?? "";
+      const withBanner = render(
+        <FullScreenFrame
+          theme={theme}
+          columns={80}
+          rows={24}
+          contentRows={1}
+          topBanner={
+            <>
+              <Text>BAN1</Text>
+              <Text>BAN2</Text>
+              <Text>BAN3</Text>
+            </>
+          }
+          topBannerRows={3}
+        >
+          <Text>CHILD_MARKER</Text>
+        </FullScreenFrame>,
+      ).lastFrame() ?? "";
+      expect(rowOfFirstMatch(without, "CHILD_MARKER"))
+        .toBe(rowOfFirstMatch(withBanner, "CHILD_MARKER"));
+    });
+
+    it("omits banner space when topBanner is null", () => {
+      // Skip the slot's reservation entirely when there's nothing to show
+      // (don't leave a phantom gap above the menu).
+      const theme = makeTheme();
+      const frame = render(
+        <FullScreenFrame
+          theme={theme}
+          columns={80}
+          rows={24}
+          contentRows={1}
+          topBanner={null}
+          topBannerRows={3}
+        >
+          <Text>CHILD_MARKER</Text>
+        </FullScreenFrame>,
+      ).lastFrame() ?? "";
+      const baseline = render(
+        <FullScreenFrame theme={theme} columns={80} rows={24} contentRows={1}>
+          <Text>CHILD_MARKER</Text>
+        </FullScreenFrame>,
+      ).lastFrame() ?? "";
+      expect(rowOfFirstMatch(frame, "CHILD_MARKER"))
+        .toBe(rowOfFirstMatch(baseline, "CHILD_MARKER"));
+    });
+  });
 });

--- a/packages/client-ink/src/tui/components/FullScreenFrame.test.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.test.tsx
@@ -111,6 +111,30 @@ describe("FullScreenFrame", () => {
         .toBe(rowOfFirstMatch(withBanner, "CHILD_MARKER"));
     });
 
+    it("renders the banner even when topBannerRows is omitted (Copilot review)", () => {
+      // The previous gating (`topBanner != null && topBannerRows > 0`)
+      // silently dropped the banner if a caller forgot the rows prop —
+      // an easy API footgun. Render whenever provided; rows is a
+      // layout-preservation hint, not a render gate.
+      const theme = makeTheme();
+      const frame = render(
+        <FullScreenFrame
+          theme={theme}
+          columns={80}
+          rows={24}
+          contentRows={1}
+          topBanner={<Text>BANNER_MARKER</Text>}
+        >
+          <Text>CHILD_MARKER</Text>
+        </FullScreenFrame>,
+      ).lastFrame() ?? "";
+      expect(frame).toContain("BANNER_MARKER");
+      // Banner is above the child (layout-preservation is the caller's
+      // responsibility when rows is omitted).
+      expect(rowOfFirstMatch(frame, "BANNER_MARKER"))
+        .toBeLessThan(rowOfFirstMatch(frame, "CHILD_MARKER"));
+    });
+
     it("omits banner space when topBanner is null", () => {
       // Skip the slot's reservation entirely when there's nothing to show
       // (don't leave a phantom gap above the menu).

--- a/packages/client-ink/src/tui/components/FullScreenFrame.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.tsx
@@ -28,11 +28,13 @@ export interface FullScreenFrameProps {
   bottomLeft?: React.ReactNode;
   /**
    * Optional content pinned to the top of the frame (just below the top
-   * border). Lives in the top-padding region: consumes `topBannerRows` rows
-   * from the top pad so the centered children's vertical position is
-   * preserved whether or not the banner is present. Caller is responsible
-   * for sizing `topBannerRows` to match the rendered content (pre-wrapped
-   * line count); under-sizing clips, over-sizing leaves blank space.
+   * border). Rendered whenever non-null; `topBannerRows` is a padding
+   * hint telling the frame how many rows to reserve from the top pad so
+   * the centered children's vertical position is preserved whether or
+   * not the banner is present. Caller is responsible for sizing
+   * `topBannerRows` to match the rendered content (pre-wrapped line
+   * count) — if omitted, the banner still renders but the centered
+   * children shift down by its height.
    *
    * Use case: out-of-band status surfaces like the session-fatal banner on
    * the main menu (#529) that need to be prominent but must not shift the
@@ -73,11 +75,14 @@ export function FullScreenFrame({
   const hasBottomLeft = bottomLeft != null && rawBottomPad >= 1;
   const bottomPad = hasBottomLeft ? rawBottomPad - 1 : rawBottomPad;
   // Pinned top banner eats `topBannerRows` rows from the top padding so the
-  // centered children's Y position is preserved. If the banner is taller
-  // than the available top pad (very small terminal), it overflows past
-  // the pad and shifts the menu down — acceptable degradation versus
+  // centered children's Y position is preserved. The banner renders any
+  // time it's provided — callers who omit `topBannerRows` (or pass 0)
+  // still see the banner, they just don't get the layout-preservation
+  // benefit (menu shifts down by the banner's height). If the banner is
+  // taller than the available top pad (very small terminal), it overflows
+  // past the pad and shifts the menu — acceptable degradation versus
   // hiding the message.
-  const hasTopBanner = topBanner != null && topBannerRows > 0;
+  const hasTopBanner = topBanner != null;
   const visibleTopPad = hasTopBanner ? Math.max(0, topPad - topBannerRows) : topPad;
 
   const sfEnabled = !!starfield;

--- a/packages/client-ink/src/tui/components/FullScreenFrame.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.tsx
@@ -26,6 +26,20 @@ export interface FullScreenFrameProps {
    * padding. Add starfield-aware rendering here when a caller needs both.
    */
   bottomLeft?: React.ReactNode;
+  /**
+   * Optional content pinned to the top of the frame (just below the top
+   * border). Lives in the top-padding region: consumes `topBannerRows` rows
+   * from the top pad so the centered children's vertical position is
+   * preserved whether or not the banner is present. Caller is responsible
+   * for sizing `topBannerRows` to match the rendered content (pre-wrapped
+   * line count); under-sizing clips, over-sizing leaves blank space.
+   *
+   * Use case: out-of-band status surfaces like the session-fatal banner on
+   * the main menu (#529) that need to be prominent but must not shift the
+   * primary menu around when they toggle in and out.
+   */
+  topBanner?: React.ReactNode;
+  topBannerRows?: number;
   children: React.ReactNode;
 }
 
@@ -42,6 +56,8 @@ export function FullScreenFrame({
   contentRows,
   starfield,
   bottomLeft,
+  topBanner,
+  topBannerRows = 0,
   children,
 }: FullScreenFrameProps) {
   const sideWidth = theme.asset.components.edge_left.width;
@@ -56,6 +72,13 @@ export function FullScreenFrame({
   // disturb the vertical centering of the main children.
   const hasBottomLeft = bottomLeft != null && rawBottomPad >= 1;
   const bottomPad = hasBottomLeft ? rawBottomPad - 1 : rawBottomPad;
+  // Pinned top banner eats `topBannerRows` rows from the top padding so the
+  // centered children's Y position is preserved. If the banner is taller
+  // than the available top pad (very small terminal), it overflows past
+  // the pad and shifts the menu down — acceptable degradation versus
+  // hiding the message.
+  const hasTopBanner = topBanner != null && topBannerRows > 0;
+  const visibleTopPad = hasTopBanner ? Math.max(0, topPad - topBannerRows) : topPad;
 
   const sfEnabled = !!starfield;
   const sfConfig: StarfieldConfig = {
@@ -78,10 +101,21 @@ export function FullScreenFrame({
       <Box flexDirection="row" height={contentHeight}>
         <ThemedSideFrame theme={theme} side="left" height={contentHeight} />
         <Box flexDirection="column" width={contentWidth} alignItems="center">
-          {topPad > 0 && (
+          {hasTopBanner && (
+            <Box
+              width={contentWidth}
+              flexDirection="column"
+              alignItems="flex-start"
+              flexShrink={0}
+            >
+              {topBanner}
+            </Box>
+          )}
+
+          {visibleTopPad > 0 && (
             sfEnabled
-              ? <StarfieldRows grid={grid} startRow={0} rowCount={topPad} />
-              : <Box height={topPad} />
+              ? <StarfieldRows grid={grid} startRow={hasTopBanner ? topBannerRows : 0} rowCount={visibleTopPad} />
+              : <Box height={visibleTopPad} />
           )}
 
           <Box flexDirection="column" alignItems="flex-start">

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -899,10 +899,84 @@ export class TurnCollector {
 export { CodexRpcError } from "./rpc.js";
 
 /**
+ * Structured classification of a failed codex turn. Decided at the codex
+ * boundary so callers route on the `kind` (a stable enum) instead of
+ * pattern-matching the human-readable `codexMessage` (which drifts with
+ * upstream wording changes). New kinds may be added; consumers using a
+ * switch should treat unknown values as `"unknown"`.
+ *
+ *  - `auth_expired` — the refresh_token was rejected, or codex reported
+ *    an OAuth/auth failure. Player needs to re-sign-in.
+ *  - `model_not_found` — codex (or its backend) couldn't find the
+ *    requested model name. Player needs to pick a different model.
+ *  - `tools_schema_mismatch` — codex rejected the tool definitions at
+ *    thread start (usually a protocol-version drift between us and codex).
+ *  - `unknown` — anything else. Treated as session-fatal by the error
+ *    router; better to surface the real codex message and let the player
+ *    decide than to claim it's recoverable when it isn't.
+ */
+export type CodexFailureKind = "auth_expired" | "model_not_found" | "tools_schema_mismatch" | "unknown";
+
+/**
+ * Classify a raw codex error message into a {@link CodexFailureKind}.
+ *
+ * Pattern matches are deliberately broad — codex (and the OpenAI backend
+ * it speaks to) phrases the same condition multiple ways, so we look for
+ * stable substrings rather than exact strings. When in doubt, return
+ * `"unknown"` and let the human-readable message speak for itself.
+ *
+ * Exported for unit tests; production callers see only the
+ * `CodexTurnFailedError.kind` field populated from this function.
+ */
+export function classifyCodexFailure(message: string): CodexFailureKind {
+  const m = message.toLowerCase();
+  // Auth: the canonical case from issue #529 is a refresh-token rejection
+  // ("Your access token could not be refreshed because your refresh token
+  // was already used. Please log out and sign in again."). Also catch the
+  // bare 401 / unauthorized / token-expired phrasings codex uses when the
+  // access_token is rejected without a recoverable path.
+  if (
+    /refresh.*token/.test(m)
+    || /access[_ ]token.*(expired|invalid|rejected)/.test(m)
+    || /unauthorized/.test(m)
+    || /\b401\b/.test(m)
+    || /log\s*out.*sign\s*in/.test(m)
+  ) {
+    return "auth_expired";
+  }
+  // Model not found: codex / OpenAI both phrase this as "model … not found"
+  // or "unknown model" or "does not exist". The 404 status sometimes leaks
+  // into the message string too.
+  if (
+    /model.*not\s*found/.test(m)
+    || /unknown\s*model/.test(m)
+    || /model.*(does\s*not\s*exist|doesn'?t\s*exist)/.test(m)
+    || /no\s*such\s*model/.test(m)
+  ) {
+    return "model_not_found";
+  }
+  // Tools schema mismatch — codex rejects the dynamic-tool definitions
+  // before turn/start completes. Recognisable by "tool" + a validation /
+  // schema verb.
+  if (
+    /tool.*schema/.test(m)
+    || /tool.*(invalid|rejected|malformed)/.test(m)
+    || /invalid.*tool/.test(m)
+  ) {
+    return "tools_schema_mismatch";
+  }
+  return "unknown";
+}
+
+/**
  * Thrown when a Codex turn returns `status: "failed"`. Carries the
  * `turn.error.message` Codex reported alongside the failure — without it
  * callers see only `status: "failed"` in the engine log and can't tell why
  * (model not found, auth expired, rate limit, tools schema mismatch, …).
+ *
+ * The `kind` field is the *stable* classification consumers should branch
+ * on. `codexMessage` is the verbatim string codex returned and is intended
+ * for user-visible surfacing only — never pattern-match it in code.
  *
  * Why throw instead of returning an empty ChatResult? A failed turn is a
  * system-level error, not a content refusal. The previous behavior mapped
@@ -913,11 +987,13 @@ export { CodexRpcError } from "./rpc.js";
  * explicitly or surface it as an error event.
  */
 export class CodexTurnFailedError extends Error {
+  public readonly kind: CodexFailureKind;
   constructor(
     public readonly codexMessage: string,
     public readonly turnId: string,
   ) {
     super(`Codex turn ${turnId} failed: ${codexMessage}`);
     this.name = "CodexTurnFailedError";
+    this.kind = classifyCodexFailure(codexMessage);
   }
 }

--- a/packages/engine/src/server/bridge.test.ts
+++ b/packages/engine/src/server/bridge.test.ts
@@ -59,3 +59,39 @@ describe("createBridge onRollback", () => {
     expect(() => cb.onRollback?.()).not.toThrow();
   });
 });
+
+describe("createBridge error categories (#529)", () => {
+  // The three-tier taxonomy is decided server-side; every WS error event
+  // the bridge emits must carry the right discriminant so the client UX
+  // (retry overlay vs main-menu banner vs hard error screen) matches.
+  it("tags onRetry events as category=retryable", () => {
+    const events: ServerEvent[] = [];
+    const cb = createBridge({ broadcast: (e) => events.push(e) });
+    cb.onRetry(429, 2000);
+    const e = events[0];
+    expect(e.type).toBe("error");
+    expect((e.data as { category?: string }).category).toBe("retryable");
+    expect((e.data as { recoverable: boolean }).recoverable).toBe(true);
+  });
+
+  it("tags onError events as category=session-fatal-recoverable", () => {
+    // Defensive default — most thrown errors hit the session-manager
+    // catch and get classified there, but anything that escapes to the
+    // bridge callback should drop the client to menu (with the verbatim
+    // message), not silently retry forever.
+    const events: ServerEvent[] = [];
+    const cb = createBridge({ broadcast: (e) => events.push(e) });
+    cb.onError(new Error("boom"));
+    const e = events[0];
+    expect((e.data as { category?: string }).category).toBe("session-fatal-recoverable");
+    expect((e.data as { recoverable: boolean }).recoverable).toBe(false);
+  });
+
+  it("tags onRefusal (content classifier) as category=session-fatal-recoverable", () => {
+    const events: ServerEvent[] = [];
+    const cb = createBridge({ broadcast: (e) => events.push(e) });
+    cb.onRefusal();
+    const e = events[0];
+    expect((e.data as { category?: string }).category).toBe("session-fatal-recoverable");
+  });
+});

--- a/packages/engine/src/server/bridge.test.ts
+++ b/packages/engine/src/server/bridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ServerEvent } from "@machine-violet/shared";
 import { createBridge } from "./bridge.js";
+import { CodexTurnFailedError } from "../providers/openai-chatgpt/provider.js";
 
 describe("createBridge onRollback", () => {
   // Issue #431: a streaming retry leaves partial deltas accumulated on the
@@ -74,14 +75,30 @@ describe("createBridge error categories (#529)", () => {
     expect((e.data as { recoverable: boolean }).recoverable).toBe(true);
   });
 
-  it("tags onError events as category=session-fatal-recoverable", () => {
-    // Defensive default — most thrown errors hit the session-manager
-    // catch and get classified there, but anything that escapes to the
-    // bridge callback should drop the client to menu (with the verbatim
-    // message), not silently retry forever.
+  it("tags plain Error events as category=retryable on the onError callback path", () => {
+    // GameEngine reports most failures via callbacks.onError without
+    // rethrowing — that path is the *primary* surface for transient /
+    // provider errors, so defaulting to retryable preserves the
+    // pre-existing retry-overlay UX for anything we don't explicitly
+    // recognise as session-fatal.
     const events: ServerEvent[] = [];
     const cb = createBridge({ broadcast: (e) => events.push(e) });
-    cb.onError(new Error("boom"));
+    cb.onError(new Error("transient blip"));
+    const e = events[0];
+    expect((e.data as { category?: string }).category).toBe("retryable");
+    expect((e.data as { recoverable: boolean }).recoverable).toBe(true);
+  });
+
+  it("still routes recognised session-fatal classes through onError to session-fatal-recoverable", () => {
+    // CodexTurnFailedError → auth_expired / model_not_found / etc. should
+    // drop to menu even when it arrives via the callback path rather than
+    // via the thrown-error catch in session-manager.
+    const events: ServerEvent[] = [];
+    const cb = createBridge({ broadcast: (e) => events.push(e) });
+    cb.onError(new CodexTurnFailedError(
+      "Your refresh token was already used. Please log out and sign in again.",
+      "t_xyz",
+    ));
     const e = events[0];
     expect((e.data as { category?: string }).category).toBe("session-fatal-recoverable");
     expect((e.data as { recoverable: boolean }).recoverable).toBe(false);

--- a/packages/engine/src/server/bridge.ts
+++ b/packages/engine/src/server/bridge.ts
@@ -124,9 +124,18 @@ export function createBridge(
 
     onError(error: Error): void {
       logEvent("engine:error", { message: error.message });
+      // Defensive: this fires when the engine surfaces an error via the
+      // callback path rather than throwing — session-manager's
+      // engine.processInput catch is the primary route for thrown errors
+      // and already classifies them. Default here to session-fatal so the
+      // client drops to menu instead of staying wedged.
       broadcast({
         type: "error",
-        data: { message: error.message, recoverable: false },
+        data: {
+          message: error.message,
+          recoverable: false,
+          category: "session-fatal-recoverable",
+        },
       });
     },
 
@@ -134,7 +143,13 @@ export function createBridge(
       logEvent("api:retry", { status, delayMs });
       broadcast({
         type: "error",
-        data: { message: `API retry (status ${status})`, recoverable: true, status, delayMs },
+        data: {
+          message: `API retry (status ${status})`,
+          recoverable: true,
+          status,
+          delayMs,
+          category: "retryable",
+        },
       });
     },
 
@@ -160,7 +175,11 @@ export function createBridge(
       logEvent("api:refusal");
       broadcast({
         type: "error",
-        data: { message: "Content classifier refused the response.", recoverable: false },
+        data: {
+          message: "Content classifier refused the response.",
+          recoverable: false,
+          category: "session-fatal-recoverable",
+        },
       });
     },
 

--- a/packages/engine/src/server/bridge.ts
+++ b/packages/engine/src/server/bridge.ts
@@ -16,6 +16,7 @@ import type {
 } from "@machine-violet/shared";
 import { logEvent } from "../context/engine-log.js";
 import { CostTracker } from "../context/cost-tracker.js";
+import { classifyServerError } from "./error-classify.js";
 /** Buffering config for narrative text. */
 const FLUSH_INTERVAL_MS = 50;
 
@@ -124,17 +125,20 @@ export function createBridge(
 
     onError(error: Error): void {
       logEvent("engine:error", { message: error.message });
-      // Defensive: this fires when the engine surfaces an error via the
-      // callback path rather than throwing — session-manager's
-      // engine.processInput catch is the primary route for thrown errors
-      // and already classifies them. Default here to session-fatal so the
-      // client drops to menu instead of staying wedged.
+      // GameEngine catches most failures and surfaces them via this
+      // callback rather than rethrowing — so the engine error path is the
+      // *primary* route for many transient/provider errors, not a
+      // defensive edge case. Default to "retryable" so a network blip or
+      // a 5xx doesn't drop the player to menu; only explicitly recognised
+      // session-fatal classes (e.g. CodexTurnFailedError → auth_expired)
+      // route to the new bucket via classifyServerError.
+      const category = classifyServerError(error, "retryable");
       broadcast({
         type: "error",
         data: {
           message: error.message,
-          recoverable: false,
-          category: "session-fatal-recoverable",
+          recoverable: category === "retryable",
+          category,
         },
       });
     },

--- a/packages/engine/src/server/error-classify.test.ts
+++ b/packages/engine/src/server/error-classify.test.ts
@@ -70,17 +70,21 @@ describe("classifyServerError", () => {
     expect(classifyServerError(err)).toBe("session-fatal-recoverable");
   });
 
-  it("uses the caller's default for unknown error classes", () => {
-    // The retry path passes "retryable" as default; everything else passes
-    // (or inherits) "session-fatal-recoverable".
+  it("defaults unknown error classes to retryable (Copilot review)", () => {
+    // Per issue #529: "Conservative default: when in doubt, leave as
+    // retryable. Better to retry once than to lose session state to a
+    // transient blip." Callers that have no retry mechanism of their own
+    // (e.g. the setup-error broadcast — setup tears down on any failure)
+    // override with "session-fatal-recoverable".
     const plain = new Error("something boring");
-    expect(classifyServerError(plain)).toBe("session-fatal-recoverable");
-    expect(classifyServerError(plain, "retryable")).toBe("retryable");
+    expect(classifyServerError(plain)).toBe("retryable");
+    expect(classifyServerError(plain, "session-fatal-recoverable"))
+      .toBe("session-fatal-recoverable");
   });
 
-  it("survives non-Error throws", () => {
-    expect(classifyServerError("a string")).toBe("session-fatal-recoverable");
-    expect(classifyServerError(null)).toBe("session-fatal-recoverable");
+  it("survives non-Error throws (default: retryable)", () => {
+    expect(classifyServerError("a string")).toBe("retryable");
+    expect(classifyServerError(null)).toBe("retryable");
   });
 });
 

--- a/packages/engine/src/server/error-classify.test.ts
+++ b/packages/engine/src/server/error-classify.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the server-side error → WS-event category router (#529).
+ *
+ * The taxonomy is enforced at the wire boundary; these tests guard the
+ * specific routing decisions the bridge and session-manager rely on.
+ * Wire-format propagation is covered in the client-ink event-handler
+ * tests; UX wiring (menu drop + banner) is covered in app.test.tsx.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { ServerEvent } from "@machine-violet/shared";
+import {
+  classifyServerError,
+  performSessionFatalTeardown,
+  userMessageFor,
+} from "./error-classify.js";
+import { CodexTurnFailedError, classifyCodexFailure } from "../providers/openai-chatgpt/provider.js";
+
+describe("classifyCodexFailure", () => {
+  it("classifies the canonical refresh-token failure (#529) as auth_expired", () => {
+    // Verbatim message from issue #529 — this is the trigger that
+    // prompted the whole feature.
+    const msg = "Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.";
+    expect(classifyCodexFailure(msg)).toBe("auth_expired");
+  });
+
+  it("classifies common 401 / unauthorized phrasings as auth_expired", () => {
+    expect(classifyCodexFailure("HTTP 401: Unauthorized")).toBe("auth_expired");
+    expect(classifyCodexFailure("Access token expired")).toBe("auth_expired");
+    expect(classifyCodexFailure("access token rejected by backend")).toBe("auth_expired");
+  });
+
+  it("classifies model-not-found phrasings as model_not_found", () => {
+    expect(classifyCodexFailure("model 'gpt-9' not found")).toBe("model_not_found");
+    expect(classifyCodexFailure("Unknown model: foo")).toBe("model_not_found");
+    expect(classifyCodexFailure("Model gpt-7 does not exist")).toBe("model_not_found");
+    expect(classifyCodexFailure("No such model: bar")).toBe("model_not_found");
+  });
+
+  it("classifies tools schema failures as tools_schema_mismatch", () => {
+    expect(classifyCodexFailure("invalid tool schema")).toBe("tools_schema_mismatch");
+    expect(classifyCodexFailure("tool definition rejected")).toBe("tools_schema_mismatch");
+  });
+
+  it("falls back to unknown for anything else", () => {
+    expect(classifyCodexFailure("some weird error")).toBe("unknown");
+    expect(classifyCodexFailure("")).toBe("unknown");
+  });
+});
+
+describe("CodexTurnFailedError.kind", () => {
+  it("populates the kind field from the codex message at construction", () => {
+    const err = new CodexTurnFailedError(
+      "Your access token could not be refreshed because your refresh token was already used.",
+      "t_abc",
+    );
+    expect(err.kind).toBe("auth_expired");
+    // The verbatim codex message stays intact for user-visible display.
+    expect(err.codexMessage).toContain("refresh token was already used");
+  });
+});
+
+describe("classifyServerError", () => {
+  it("routes every known CodexFailureKind to session-fatal-recoverable (#529)", () => {
+    // All four kinds map to the same UX bucket today. Pin them so a future
+    // PR that splits the routing doesn't silently misroute one.
+    const err = new CodexTurnFailedError(
+      "Your refresh token was already used.",
+      "t1",
+    );
+    expect(classifyServerError(err)).toBe("session-fatal-recoverable");
+  });
+
+  it("uses the caller's default for unknown error classes", () => {
+    // The retry path passes "retryable" as default; everything else passes
+    // (or inherits) "session-fatal-recoverable".
+    const plain = new Error("something boring");
+    expect(classifyServerError(plain)).toBe("session-fatal-recoverable");
+    expect(classifyServerError(plain, "retryable")).toBe("retryable");
+  });
+
+  it("survives non-Error throws", () => {
+    expect(classifyServerError("a string")).toBe("session-fatal-recoverable");
+    expect(classifyServerError(null)).toBe("session-fatal-recoverable");
+  });
+});
+
+describe("userMessageFor", () => {
+  it("surfaces the verbatim codex message, not our wrapper string", () => {
+    // CodexTurnFailedError.message bakes in the turn id, which is noise
+    // for the player. The user-visible banner must show codexMessage.
+    const err = new CodexTurnFailedError(
+      "Your access token could not be refreshed because your refresh token was already used.",
+      "01978a40-b1c2-7e3f-abcd-1234567890ab",
+    );
+    expect(userMessageFor(err)).toBe(
+      "Your access token could not be refreshed because your refresh token was already used.",
+    );
+    expect(userMessageFor(err)).not.toContain("01978a40");
+  });
+
+  it("falls back to Error.message for plain errors", () => {
+    expect(userMessageFor(new Error("boom"))).toBe("boom");
+  });
+
+  it("coerces non-Error throws to a string", () => {
+    expect(userMessageFor("a string")).toBe("a string");
+    expect(userMessageFor(42)).toBe("42");
+  });
+});
+
+describe("performSessionFatalTeardown (#529 acceptance: mid-game flush)", () => {
+  it("flushes streaming BEFORE endSession and broadcasts error AFTER", async () => {
+    // Acceptance criterion (c): mid-game session-fatal flushes state
+    // before dropping to menu so the campaign resumes cleanly.
+    //
+    // The sequence we're pinning:
+    //   1. narrative:complete on the *scoped* broadcast (flushes any
+    //      half-streamed DM deltas before endSession runs).
+    //   2. endSession resolves (which would emit session:ended in
+    //      production — mocked here).
+    //   3. error event with category=session-fatal-recoverable on the
+    //      *unscoped* broadcast (must reach the client even after the
+    //      session generation flipped during endSession).
+    const calls: { where: string; event?: ServerEvent }[] = [];
+    const scopedBroadcast = (event: ServerEvent): void => {
+      calls.push({ where: "scoped", event });
+    };
+    const unscopedBroadcast = (event: ServerEvent): void => {
+      calls.push({ where: "unscoped", event });
+    };
+    const endSession = vi.fn(async () => {
+      calls.push({ where: "endSession" });
+    });
+
+    const err = new CodexTurnFailedError(
+      "Your refresh token was already used. Please log out and sign in again.",
+      "t_xyz",
+    );
+    await performSessionFatalTeardown({
+      err,
+      scopedBroadcast,
+      unscopedBroadcast,
+      endSession,
+    });
+
+    // 1. The first call must be the flush via scopedBroadcast.
+    expect(calls[0]).toEqual({
+      where: "scoped",
+      event: { type: "narrative:complete", data: { text: "" } },
+    });
+
+    // 2. endSession must run after the flush and before the error broadcast.
+    expect(calls[1]).toEqual({ where: "endSession" });
+    expect(endSession).toHaveBeenCalledOnce();
+
+    // 3. The error broadcast must be last and carry the new category,
+    //    routed through unscopedBroadcast so it survives generation flip.
+    expect(calls[2].where).toBe("unscoped");
+    expect(calls[2].event).toEqual({
+      type: "error",
+      data: {
+        message: "Your refresh token was already used. Please log out and sign in again.",
+        recoverable: false,
+        category: "session-fatal-recoverable",
+      },
+    });
+  });
+
+  it("uses the verbatim codex message — no turn id leakage", async () => {
+    // Internal turn ids are noise for the player; the banner must show
+    // exactly what the provider said and nothing more.
+    const events: ServerEvent[] = [];
+    const err = new CodexTurnFailedError(
+      "Model 'gpt-9' not found",
+      "01978a40-b1c2-7e3f-deadbeef",
+    );
+    await performSessionFatalTeardown({
+      err,
+      scopedBroadcast: () => { /* irrelevant for this assertion */ },
+      unscopedBroadcast: (e) => events.push(e),
+      endSession: async () => { /* no-op */ },
+    });
+    const errorEvent = events.find((e) => e.type === "error");
+    const message = (errorEvent?.data as { message: string }).message;
+    expect(message).toBe("Model 'gpt-9' not found");
+    expect(message).not.toContain("01978a40");
+  });
+});
+
+describe("retry-path category back-compat (#529 acceptance: 429 still retries)", () => {
+  it("default category is preserved as retryable when the caller asks", () => {
+    // Acceptance criterion (d): a 429 still routes to the retry overlay.
+    // The retry path uses classifyServerError(err, "retryable") so plain
+    // errors without a structured `kind` stay in the retry bucket — they
+    // don't get demoted to session-fatal by the default.
+    const plain = new Error("API retry (status 429)");
+    expect(classifyServerError(plain, "retryable")).toBe("retryable");
+  });
+});
+

--- a/packages/engine/src/server/error-classify.ts
+++ b/packages/engine/src/server/error-classify.ts
@@ -1,0 +1,110 @@
+/**
+ * Server-side error → WS-event category router.
+ *
+ * The three-tier taxonomy lives in the wire protocol
+ * (`ErrorCategory` in `@machine-violet/shared`). This module decides
+ * which bucket a thrown engine/provider error belongs in, so the bridge
+ * and session-manager can broadcast it with the right discriminant and
+ * the client can pick the matching UX (retry overlay / main-menu banner
+ * / hard error screen).
+ *
+ * Routing is by error *class* and *structured field* — not by message
+ * regex. Provider errors are expected to carry a structured `kind` (see
+ * `CodexTurnFailedError.kind`); only one transitional regex shim survives
+ * for the Anthropic refresh case, and is annotated as such.
+ *
+ * Conservative default: `session-fatal-recoverable`. When in doubt, drop
+ * to menu and surface the verbatim message — better than claiming
+ * recoverability we can't deliver, and better than a process-fatal exit
+ * the player can't escape without a relaunch.
+ */
+import type { ErrorCategory, ServerEvent } from "@machine-violet/shared";
+import { CodexTurnFailedError, type CodexFailureKind } from "../providers/openai-chatgpt/provider.js";
+
+/**
+ * Decide which WS error category a thrown error belongs in.
+ *
+ * Returns one of the three values from `ErrorCategory`. Use the
+ * `defaultCategory` to override the fallback in contexts where a softer
+ * default is more appropriate (e.g. the retry path uses `"retryable"`).
+ */
+export function classifyServerError(
+  err: unknown,
+  defaultCategory: ErrorCategory = "session-fatal-recoverable",
+): ErrorCategory {
+  if (err instanceof CodexTurnFailedError) {
+    // Every codex failure we recognize today is session-fatal: the player
+    // can fix it (re-auth, change model, etc.) but the in-flight turn is
+    // dead. If a future kind turns out to be transient, special-case it
+    // here.
+    return categoryForCodexKind(err.kind);
+  }
+  return defaultCategory;
+}
+
+function categoryForCodexKind(kind: CodexFailureKind): ErrorCategory {
+  switch (kind) {
+    case "auth_expired":
+    case "model_not_found":
+    case "tools_schema_mismatch":
+    case "unknown":
+      return "session-fatal-recoverable";
+  }
+}
+
+/**
+ * Drive the mid-game session-fatal teardown sequence:
+ *
+ *   1. `narrative:complete` — flush any half-streamed DM deltas via the
+ *      *scoped* broadcast so the client's "streaming" state closes cleanly.
+ *   2. `endSession("session_fatal")` — flush + checkpoint so the campaign
+ *      resumes intact under "Resume" (no lost turns).
+ *   3. `error` (category: session-fatal-recoverable) via the *unscoped*
+ *      broadcast — sent *after* step 2 (which emits `session:ended`) so
+ *      the client has already exited playing-phase before the banner data
+ *      arrives.
+ *
+ * `scopedBroadcast` must be the per-session generation-guarded broadcast
+ * so step 1 can't leak into a subsequent session if endSession races a
+ * new session start. `unscopedBroadcast` is the manager's own
+ * `broadcast()` — step 3 must reach the client even though the session
+ * generation has changed by then.
+ *
+ * Extracted from SessionManager so the sequencing — which is the whole
+ * point of the new bucket — has a single owner and can be unit-tested
+ * without standing up a real engine + filesystem + providers.
+ */
+export async function performSessionFatalTeardown(opts: {
+  err: unknown;
+  scopedBroadcast: (event: ServerEvent) => void;
+  unscopedBroadcast: (event: ServerEvent) => void;
+  endSession: () => Promise<void>;
+}): Promise<void> {
+  const message = userMessageFor(opts.err);
+  opts.scopedBroadcast({ type: "narrative:complete", data: { text: "" } });
+  await opts.endSession();
+  opts.unscopedBroadcast({
+    type: "error",
+    data: {
+      message,
+      recoverable: false,
+      category: "session-fatal-recoverable",
+    },
+  });
+}
+
+/**
+ * Extract the user-visible message from an error in a way that prefers
+ * the upstream provider's wording.
+ *
+ * For `CodexTurnFailedError`, we surface the *codex* message — not our
+ * wrapper string ("Codex turn <id> failed: ..."), which leaks an
+ * internal turn id and adds no information for the player. For
+ * everything else, fall back to `.message` (or String coercion for
+ * non-Error throws).
+ */
+export function userMessageFor(err: unknown): string {
+  if (err instanceof CodexTurnFailedError) return err.codexMessage;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/engine/src/server/error-classify.ts
+++ b/packages/engine/src/server/error-classify.ts
@@ -24,13 +24,23 @@ import { CodexTurnFailedError, type CodexFailureKind } from "../providers/openai
 /**
  * Decide which WS error category a thrown error belongs in.
  *
- * Returns one of the three values from `ErrorCategory`. Use the
- * `defaultCategory` to override the fallback in contexts where a softer
- * default is more appropriate (e.g. the retry path uses `"retryable"`).
+ * Returns one of the three values from `ErrorCategory`. The default
+ * fallback is `"retryable"` per the issue #529 guidance — "Conservative
+ * default: when in doubt, leave as `retryable`. Better to retry once
+ * than to lose session state to a transient blip." Critically, this
+ * means `isSessionFatal()` only returns true for error classes we have
+ * *explicitly* recognized (today: `CodexTurnFailedError`); a plain
+ * `Error` from `engine.processInput` rethrows to TurnManager's retry
+ * fallback the same way it did before this change.
+ *
+ * Callsites that have no retry path of their own (e.g. the setup error
+ * broadcast — setup tears down on any failure) override the default to
+ * `"session-fatal-recoverable"` so the client drops to menu with the
+ * verbatim message instead of pretending the error is transient.
  */
 export function classifyServerError(
   err: unknown,
-  defaultCategory: ErrorCategory = "session-fatal-recoverable",
+  defaultCategory: ErrorCategory = "retryable",
 ): ErrorCategory {
   if (err instanceof CodexTurnFailedError) {
     // Every codex failure we recognize today is session-fatal: the player

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -454,12 +454,19 @@ export class SessionManager {
       // (auth, model, classifier refusal). Surfacing as `recoverable: false`
       // with the new category drops the client to the main menu with the
       // verbatim message in a red banner.
+      //
+      // Setup has no per-campaign persistence and no retry path of its
+      // own (we already tore down setupSession above), so pass
+      // "session-fatal-recoverable" as the explicit default — overriding
+      // classifyServerError's "retryable" fallback. Without this, an
+      // unknown error class would silently route to a retry UX that
+      // can't actually retry.
       this.broadcast({
         type: "error",
         data: {
           message: userMessageFor(err),
           recoverable: false,
-          category: classifyServerError(err),
+          category: classifyServerError(err, "session-fatal-recoverable"),
         },
       });
     });

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -47,6 +47,7 @@ import { createBridge } from "./bridge.js";
 import { createBaseFileIO } from "./fileio.js";
 import { SetupSession } from "./setup-session.js";
 import { generateDiscordStatus } from "../agents/subagents/discord-status.js";
+import { classifyServerError, userMessageFor, performSessionFatalTeardown } from "./error-classify.js";
 
 /** DM-narrative interval at which a fresh Discord presence string is generated. */
 const DISCORD_STATUS_INTERVAL = 8;
@@ -100,8 +101,15 @@ export type SessionStatus = "idle" | "starting" | "active" | "stopping";
  * the flush+checkpoint that would otherwise clobber rolled-back disk state
  * with stale in-memory values. Keep this a closed union so new callsites
  * can't silently bypass the rollback-safe path with a typo'd string.
+ *
+ * `session_fatal` is the mid-game "auth expired / wrong model / classifier
+ * refusal" path (issue #529). It behaves like `explicit` for persistence —
+ * flush + checkpoint so the player resumes with no lost turns — but the
+ * caller is expected to broadcast a `session-fatal-recoverable` error
+ * event around the teardown so the client drops to the main menu with the
+ * cause in a red banner.
  */
-export type EndSessionReason = "explicit" | "idle_timeout" | "rollback";
+export type EndSessionReason = "explicit" | "idle_timeout" | "rollback" | "session_fatal";
 
 export class SessionManager {
   private campaignsDir: string;
@@ -434,14 +442,25 @@ export class SessionManager {
         stack: err instanceof Error ? err.stack : undefined,
       });
 
-      // Tear down setup state so a new setup can be started
+      // Tear down setup state so a new setup can be started. Setup has no
+      // per-campaign persistence (the temp __setup__ dir is recreated on
+      // every retry), so we skip the flush/checkpoint dance that the
+      // mid-game session_fatal path needs.
       this.setupSession = null;
       this.turnManager = null;
       this.status = "idle";
 
+      // Session-fatal: setup has died for a reason the player must address
+      // (auth, model, classifier refusal). Surfacing as `recoverable: false`
+      // with the new category drops the client to the main menu with the
+      // verbatim message in a red banner.
       this.broadcast({
         type: "error",
-        data: { message: err instanceof Error ? err.message : String(err), recoverable: false },
+        data: {
+          message: userMessageFor(err),
+          recoverable: false,
+          category: classifyServerError(err),
+        },
       });
     });
   }
@@ -874,6 +893,14 @@ export class SessionManager {
             await this.endSession("rollback");
             return;
           }
+          // Session-fatal in OOC/Dev: same flush + teardown + banner path
+          // as the normal-play branch below. Mode session errors otherwise
+          // bubble to the setImmediate catch in TurnManager and mis-render
+          // as recoverable retries.
+          if (this.isSessionFatal(err)) {
+            await this.handleSessionFatal(err, scopedBroadcast);
+            return;
+          }
           throw err;
         }
         scopedBroadcast({ type: "narrative:complete", data: { text: "" } });
@@ -941,6 +968,20 @@ export class SessionManager {
             data: { text: `[${err.message}]`, kind: "system" },
           });
           await this.endSession("rollback");
+          return;
+        }
+        // Session-fatal mid-game (issue #529): auth expired, model not
+        // found, etc. Player can fix and start again, but this turn is
+        // dead and the in-flight stream needs closing before teardown so
+        // the client doesn't sit in "streaming" forever. Order matters:
+        //   1. narrative:complete flushes any half-rendered DM deltas.
+        //   2. endSession("session_fatal") triggers flush + checkpoint so
+        //      the campaign resumes cleanly (no lost prior turns).
+        //   3. broadcast the error with the new category — sent *after*
+        //      session:ended so the client has already transitioned out
+        //      of playing-phase state.
+        if (this.isSessionFatal(err)) {
+          await this.handleSessionFatal(err, scopedBroadcast);
           return;
         }
         throw err;
@@ -1431,6 +1472,36 @@ export class SessionManager {
         ? this.committedNarrative.slice()
         : undefined,
     };
+  }
+
+  /**
+   * Does this thrown error mean the in-flight session is done — but the
+   * process is fine and the player can fix something and try again?
+   *
+   * Recognises {@link CodexTurnFailedError} today; future provider error
+   * classes that should drop to menu (Anthropic 403 on forbidden model,
+   * setup-conversation refusal with empty content, etc.) should be added
+   * to {@link classifyServerError} rather than branched on here.
+   */
+  private isSessionFatal(err: unknown): boolean {
+    return classifyServerError(err) === "session-fatal-recoverable";
+  }
+
+  /**
+   * Mid-game session-fatal teardown. Delegates to
+   * {@link performSessionFatalTeardown} so the sequencing (flush →
+   * endSession → broadcast) can be unit-tested without a real engine.
+   */
+  private async handleSessionFatal(
+    err: unknown,
+    scopedBroadcast: (event: ServerEvent) => void,
+  ): Promise<void> {
+    await performSessionFatalTeardown({
+      err,
+      scopedBroadcast,
+      unscopedBroadcast: (event) => this.broadcast(event),
+      endSession: () => this.endSession("session_fatal"),
+    });
   }
 
   /** Teardown on server shutdown. */

--- a/packages/engine/src/server/setup-session.ts
+++ b/packages/engine/src/server/setup-session.ts
@@ -113,7 +113,13 @@ export class SetupSession {
     this.conversation = createSetupConversation(this.provider, this.model, knownPlayers, (status, delayMs) => {
       this.broadcast({
         type: "error",
-        data: { message: `API retry (status ${status})`, recoverable: true, status, delayMs },
+        data: {
+          message: `API retry (status ${status})`,
+          recoverable: true,
+          status,
+          delayMs,
+          category: "retryable",
+        },
       });
     }, paths.worldsDir, paths.personalitiesDir);
     this.started = true;

--- a/packages/engine/src/server/turn-manager.ts
+++ b/packages/engine/src/server/turn-manager.ts
@@ -111,11 +111,18 @@ export class TurnManager {
       // Use setImmediate to avoid blocking the HTTP response
       setImmediate(() => {
         this.commit().catch((err) => {
+          // session-manager's commit handler classifies session-fatal
+          // errors and broadcasts the proper category itself before
+          // returning cleanly. Anything that reaches this fallback catch
+          // either escaped that classification or originated in turn
+          // bookkeeping itself — treat it as recoverable so the client
+          // shows the retry overlay rather than getting stuck.
           this.broadcast({
             type: "error",
             data: {
               message: err instanceof Error ? err.message : String(err),
               recoverable: true,
+              category: "retryable",
             },
           });
         }).finally(() => {

--- a/packages/shared/src/protocol/events.ts
+++ b/packages/shared/src/protocol/events.ts
@@ -163,6 +163,29 @@ export const UsageUpdateEvent = Type.Object({
 
 // --- Error ---
 
+/**
+ * Three-tier error taxonomy. The discriminant tells the client *what UX to
+ * show*, not what caused the error — the same `category` can come from many
+ * underlying conditions. Decided server-side; never inferred from
+ * `message`. Keep this a closed union so new bucket-introducing PRs have to
+ * touch this type (and therefore the matching client handler).
+ *
+ *  - `retryable` (default for backward compat) — transient (429, network
+ *    blip). Server will retry; player just waits. Existing retry overlay.
+ *  - `session-fatal-recoverable` — this session is done (auth expired,
+ *    forbidden model, classifier refusal, etc.) but the process is fine.
+ *    Player must take action (re-auth, change model, fix config) and start
+ *    a new session. Client drops to main menu, shows the message verbatim
+ *    in a red banner.
+ *  - `process-fatal` — process can't continue. Existing error screen / hard
+ *    exit. Reserved for catastrophic conditions; rarely emitted today.
+ */
+export const ErrorCategory = Type.Union([
+  Type.Literal("retryable"),
+  Type.Literal("session-fatal-recoverable"),
+  Type.Literal("process-fatal"),
+]);
+
 export const ErrorEvent = Type.Object({
   type: Type.Literal("error"),
   data: Type.Object({
@@ -170,6 +193,9 @@ export const ErrorEvent = Type.Object({
     recoverable: Type.Boolean(),
     status: Type.Optional(Type.Number()),
     delayMs: Type.Optional(Type.Number()),
+    /** Three-tier discriminator. Optional so pre-existing callsites that
+     *  don't set it behave as before. Absent ↔ `retryable`. */
+    category: Type.Optional(ErrorCategory),
   }),
 });
 
@@ -233,6 +259,7 @@ export type SessionEndedEvent = Static<typeof SessionEndedEvent>;
 export type SessionTransitionEvent = Static<typeof SessionTransitionEvent>;
 export type DiscordPresenceEvent = Static<typeof DiscordPresenceEvent>;
 export type UsageUpdateEvent = Static<typeof UsageUpdateEvent>;
+export type ErrorCategory = Static<typeof ErrorCategory>;
 export type ErrorEvent = Static<typeof ErrorEvent>;
 export type ServerEvent = Static<typeof ServerEvent>;
 export type ClientViewportEvent = Static<typeof ClientViewportEvent>;


### PR DESCRIPTION
Closes #529.

## Summary

- **WS error taxonomy** — `ErrorEvent.category: "retryable" | "session-fatal-recoverable" | "process-fatal"` (optional; absent = `retryable` for back-compat). Decided server-side; never inferred client-side from `message`.
- **Server routing** — `CodexTurnFailedError` now carries a structured `kind` (`auth_expired`, `model_not_found`, `tools_schema_mismatch`, `unknown`) classified at the codex boundary. `classifyServerError()` and `performSessionFatalTeardown()` live in a new [error-classify.ts](packages/engine/src/server/error-classify.ts) so the sequencing (flush → endSession → broadcast) has one owner and is directly unit-testable. `EndSessionReason` gains a `"session_fatal"` variant — same flush+checkpoint behavior as `"explicit"`, so the campaign reappears under "Resume" with no lost turns.
- **Client UX** — On `category: "session-fatal-recoverable"`, the client clears the retry overlay, hides modals, drops to the menu phase, and shows the verbatim provider message in a red banner. The banner is pinned via a new `FullScreenFrame.topBanner` slot that lives in the top-padding region, so toggling it doesn't shift the centered menu. Long messages are word-wrapped to the frame's interior — caps at 80 cols on wide terminals.
- **Trigger that prompted this** — surfaced live during smoke testing: the local ChatGPT OAuth token expired mid-test, the new path lit up correctly, the client captured `category: "session-fatal-recoverable"` and dropped to the menu with the verbatim "Run 'Sign in with ChatGPT' from the Connections menu" hint.

## Test plan

- [x] `npm run check` — lint + typecheck + 2826 tests pass
- [x] Acceptance (a) category propagates through the WS event — `event-handler.test.ts`
- [x] Acceptance (b) menu-drop on session-fatal — surfaced live during smoke; verified state capture has `lastError.category === "session-fatal-recoverable"` and the rendered frame shows the main menu
- [x] Acceptance (c) mid-game flush-before-drop — `error-classify.test.ts` pins the `narrative:complete → endSession → error{category}` order, asserts the error broadcast routes through the *unscoped* broadcast so it survives the generation flip, and asserts the verbatim codex message (no turn-id leakage)
- [x] Acceptance (d) 429 still routes to retry overlay — existing `event-handler.test.ts` retry tests still pass; new `bridge.test.ts` asserts `onRetry` emits `category: "retryable"`
- [x] Banner layout — `FullScreenFrame.test.tsx` and `MainMenuPhase.test.tsx` assert the centered menu lands on the same terminal row whether or not the banner is present
- [x] Word-wrap helper — 6 unit tests covering short strings, word-boundary breaks, over-long words (don't split, preserves copy-paste), whitespace collapsing, empty input, defensive non-positive width
- [ ] Manual: trigger an actual auth-expired condition end-to-end in a worktree with a valid-then-revoked ChatGPT login

🤖 Generated with [Claude Code](https://claude.com/claude-code)