### PR TITLE
Suffix campaign names with chosen suboption to reduce collisions

### DIFF
--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -61,7 +61,7 @@ const FINALIZE_TOOL: NormalizedTool = {
     properties: {
       genre: { type: "string", description: "Genre (e.g. 'Classic fantasy', 'Sci-fi', 'Modern supernatural')" },
       system: { type: "string", description: "Game system slug from the available systems list (e.g. 'dnd-5e', 'fate-accelerated'), or null for pure narrative. Use the slug, not the display name.", nullable: true },
-      campaign_name: { type: "string", description: "Short evocative campaign title" },
+      campaign_name: { type: "string", description: "Short evocative campaign title. When the player picked a suboption from a seeded world, suffix with that suboption's name: `<World Name> - <Suboption Name>` (e.g. 'Palimpsest - The Dreaming Souk'). Skip the suffix for fully custom campaigns or seeds without suboptions." },
       campaign_premise: { type: "string", description: "One-paragraph campaign hook" },
       mood: { type: "string", description: "Mood (e.g. 'Heroic', 'Grimdark', 'Whimsical', 'Tense')" },
       difficulty: { type: "string", description: "Difficulty ('Gentle', 'Balanced', 'Unforgiving')" },

--- a/packages/engine/src/prompts/setup-conversation.md
+++ b/packages/engine/src/prompts/setup-conversation.md
@@ -113,6 +113,7 @@ When `load_world` returns suboptions:
 3. The player's choices are flavor for the campaign premise. Include them naturally in the `campaign_premise` field of `finalize_setup`. The full detail block still passes through verbatim in `campaign_detail`.
 4. If the player doesn't like any suboption, let them describe their own — that's fine.
 5. For Quick Start, you may auto-pick suboptions (roll for them in your head) rather than adding extra steps.
+6. **Suffix the campaign name with the chosen suboption.** When the player picks a suboption from a seeded world, format `campaign_name` as `<World Name> - <Chosen Suboption Name>` (verbatim — keep "The" if present). E.g. for the world "Palimpsest" with chosen suboption "The Dreaming Souk", `campaign_name` is `Palimpsest - The Dreaming Souk`. This disambiguates campaigns built from the same seed. If the world has multiple suboption groups, use the most flavorful / most identity-defining group for the suffix (just one). If the player invented their own suboption instead of picking one, use that. Skip the suffix entirely for fully custom campaigns or seeds without suboptions.
 
 When the player picks a world that has detail, pass the detail through verbatim in `campaign_detail` on `finalize_setup`, and include the world's slug in `world_slug`. The detail will be injected into the DM's system prompt at game start — you don't need to summarize or transform it. If the player picks a world without detail, or builds a fully custom campaign, omit both fields.
 

--- a/worlds/a-throne-of-salt.mvworld
+++ b/worlds/a-throne-of-salt.mvworld
@@ -12,20 +12,20 @@
       "label": "Station",
       "choices": [
         {
-          "name": "Imperial surveyor mapping the loss",
-          "description": "You ride ahead of the line with a sealed satchel of fresh paper and a tripod. Each day you produce a new map. The previous day's map is wrong by morning. Your superiors want the records exact. Your reasons for accepting the assignment are increasingly your own."
+          "name": "The Cartographer of Losses",
+          "description": "Imperial surveyor mapping the loss. You ride ahead of the line with a sealed satchel of fresh paper and a tripod. Each day you produce a new map. The previous day's map is wrong by morning. Your superiors want the records exact. Your reasons for accepting the assignment are increasingly your own."
         },
         {
-          "name": "Conscripted refugee from a swallowed province",
-          "description": "Your village is salt. You walked out with what you could carry and what you could not put down. The empire has counted you and put you to work. Your accent marks you. Your dead are upwind. You are being asked to help build the camps that will hold the next round of people like you."
+          "name": "The Salt-Walked",
+          "description": "Conscripted refugee from a swallowed province. Your village is salt. You walked out with what you could carry and what you could not put down. The empire has counted you and put you to work. Your accent marks you. Your dead are upwind. You are being asked to help build the camps that will hold the next round of people like you."
         },
         {
-          "name": "Heretic prophet who predicted this",
-          "description": "You said it would happen. You were imprisoned for saying it. You were released for being right, which has not been the relief you imagined. Crowds gather where you go. The empire is undecided whether to elevate you or hang you, and it may yet do both."
+          "name": "The Vindicated Heretic",
+          "description": "Heretic prophet who predicted this. You said it would happen. You were imprisoned for saying it. You were released for being right, which has not been the relief you imagined. Crowds gather where you go. The empire is undecided whether to elevate you or hang you, and it may yet do both."
         },
         {
-          "name": "Salt-priest who serves the line itself",
-          "description": "You walk barefoot at the leading edge. Your order tends the advance with prayers older than the dynasty. You know what the salt is for. You may not say. You may, on occasion, decline to perform the rite, and the consequences of declining are your covenant with the line."
+          "name": "Priest of the Advancing Line",
+          "description": "Salt-priest who serves the line itself. You walk barefoot at the leading edge. Your order tends the advance with prayers older than the dynasty. You know what the salt is for. You may not say. You may, on occasion, decline to perform the rite, and the consequences of declining are your covenant with the line."
         }
       ]
     },
@@ -33,19 +33,19 @@
       "label": "What you carry",
       "choices": [
         {
-          "name": "A sealed imperial dispatch you haven't read",
-          "description": "Red wax, the imperial seal pressed deep. It is addressed to a name you have only heard in songs. You were told not to break it. You were told nothing of its contents. The weight of it in your satchel is the weight of an order whose author is somewhere behind the line and may no longer exist."
+          "name": "The Red-Wax Dispatch",
+          "description": "A sealed imperial dispatch you haven't read. Red wax, the imperial seal pressed deep. It is addressed to a name you have only heard in songs. You were told not to break it. You were told nothing of its contents. The weight of it in your satchel is the weight of an order whose author is somewhere behind the line and may no longer exist."
         },
         {
-          "name": "A child the emperor will want",
-          "description": "They are too young to ask what is happening and old enough to remember that you took them. They were given to you by their mother in a doorway you did not see clearly. The reason the throne will want them is not yet apparent to you. The signs will become apparent quickly."
+          "name": "The Doorway Child",
+          "description": "A child the emperor will want. They are too young to ask what is happening and old enough to remember that you took them. They were given to you by their mother in a doorway you did not see clearly. The reason the throne will want them is not yet apparent to you. The signs will become apparent quickly."
         },
         {
-          "name": "The last copy of a reversal-rite",
-          "description": "A folded sheaf, copied by a hand that was shaking. It will, if performed correctly, stop the salt. It requires materials, a location, and a celebrant. You possess none of these reliably. The text describes the cost of performance in a small clause near the end, and the clause is not metaphor."
+          "name": "The Reversal-Rite",
+          "description": "The last copy of a rite to undo the salt. A folded sheaf, copied by a hand that was shaking. It will, if performed correctly, stop the salt. It requires materials, a location, and a celebrant. You possess none of these reliably. The text describes the cost of performance in a small clause near the end, and the clause is not metaphor."
         },
         {
-          "name": "Nothing but your two hands",
+          "name": "Two Empty Hands",
           "description": "You walked out of your previous life with what you had on your back, which was nothing. You arrive in each new town with the credibility of a person who owns no leverage and asks for none. This will be either the truest freedom in the empire or the shortest."
         }
       ]

--- a/worlds/apocrypha.mvworld
+++ b/worlds/apocrypha.mvworld
@@ -13,20 +13,20 @@
       "label": "The footnote",
       "choices": [
         {
-          "name": "A betrayal you didn't commit",
-          "description": "The text says you handed over the saint. You walked into the room. You said nothing. The text records a kiss, an embrace, a word. You did not give the kiss. You were there for another reason, and the text has confused proximity for participation, and the confusion is now scripture."
+          "name": "The Kiss You Did Not Give",
+          "description": "A betrayal you didn't commit. The text says you handed over the saint. You walked into the room. You said nothing. The text records a kiss, an embrace, a word. You did not give the kiss. You were there for another reason, and the text has confused proximity for participation, and the confusion is now scripture."
         },
         {
-          "name": "A miracle you didn't perform",
-          "description": "Something extraordinary happened. The text credits it to your hand. It was not your hand. You were standing nearby, and the credit fell on you the way credit falls — by accident and conviction. People come to you for healings you cannot perform. You have not yet refused them all."
+          "name": "The Borrowed Miracle",
+          "description": "A miracle you didn't perform. Something extraordinary happened. The text credits it to your hand. It was not your hand. You were standing nearby, and the credit fell on you the way credit falls — by accident and conviction. People come to you for healings you cannot perform. You have not yet refused them all."
         },
         {
-          "name": "A death you didn't die",
-          "description": "The chapter says you were martyred. There is a feast day. There are children named for you. You are alive. You have been alive for the entire span of your own veneration. The question of why you have not corrected the record is, at this point, an answer in itself."
+          "name": "The Feast Day of Your Death",
+          "description": "A death you didn't die. The chapter says you were martyred. There is a feast day. There are children named for you. You are alive. You have been alive for the entire span of your own veneration. The question of why you have not corrected the record is, at this point, an answer in itself."
         },
         {
-          "name": "A name that was never yours",
-          "description": "The footnote uses a name you have never been called by anyone who knew you. It is close to your name. It is not your name. The misnaming is small enough that scholars debate it and large enough that you might, technically, deny everything by pointing at the spelling."
+          "name": "The Misspelling",
+          "description": "A name that was never yours. The footnote uses a name you have never been called by anyone who knew you. It is close to your name. It is not your name. The misnaming is small enough that scholars debate it and large enough that you might, technically, deny everything by pointing at the spelling."
         }
       ]
     },
@@ -34,19 +34,19 @@
       "label": "The current age",
       "choices": [
         {
-          "name": "Crusading orthodoxy",
+          "name": "The Age of Manuals",
           "description": "Heretics are hunted and the manuals are precise. Your name appears in the manuals, in a context you would prefer it did not. Travel requires papers. Papers require a name. You can be recognized at any border crossing by any clerk who has done his homework, and many of them have."
         },
         {
-          "name": "Reformation schism",
+          "name": "The Schism",
           "description": "Two factions want your story for opposite ends. The reformers want a martyr they can canonize against the old guard. The old guard wants you buried, quietly and quickly, before the reformers can find you. Both sides will be polite until the moment they are not."
         },
         {
-          "name": "Decadent late empire",
+          "name": "The Late Empire",
           "description": "Nobody cares about scripture anymore, which is worse. The text is treated as poetry, performed at salons and quoted in songs. You are a punchline. Your name appears in a popular tavern ballad with a rhyme that has stuck. Being mocked by people who do not know you exist is a particular humiliation."
         },
         {
-          "name": "Post-collapse remnant",
+          "name": "The Fragment Years",
           "description": "Only fragments of the canon survive. One fragment, by accident, includes you. The locals quote your name as a synonym for a quality — courage, or treachery, or patience — and do not know that it is a name. The fragment is the foundation of their small theology."
         }
       ]

--- a/worlds/beneath-the-skin.mvworld
+++ b/worlds/beneath-the-skin.mvworld
@@ -14,15 +14,15 @@
       "label": "The town",
       "choices": [
         {
-          "name": "Small-town Americana",
+          "name": "Millbrook",
           "description": "Everyone knows everyone. Diner, church, high school football. The \"different\" stands out because you've known these people your whole life."
         },
         {
-          "name": "Coastal village",
+          "name": "Saltwell Cove",
           "description": "Fishing community, salt air, tight-knit families. Isolation makes the changes harder to report and easier to deny. The sea is always watching."
         },
         {
-          "name": "Suburban enclave",
+          "name": "Cedar Heights",
           "description": "Gated community, HOA rules, manicured lawns. The \"different\" looks like people finally following the rules they always resented. Conformity was already the norm — now it's perfect."
         }
       ]

--- a/worlds/blackwater-bay.mvworld
+++ b/worlds/blackwater-bay.mvworld
@@ -14,20 +14,20 @@
       "label": "Why you came",
       "choices": [
         {
-          "name": "Debt you can't pay",
-          "description": "The figure is too large to settle in one lifetime and too small to be forgiven. The creditor isn't cruel — that would be easier. They are patient and they keep accurate books. You came to Blackwater because the books don't reach here. Yet."
+          "name": "The Unpayable Sum",
+          "description": "Debt you can't pay. The figure is too large to settle in one lifetime and too small to be forgiven. The creditor isn't cruel — that would be easier. They are patient and they keep accurate books. You came to Blackwater because the books don't reach here. Yet."
         },
         {
-          "name": "Face the wrong person would recognize",
-          "description": "Someone is looking for the person you used to be. You are no longer that person, but your bones are. You've grown a beard, you've cut your hair, you've practiced a different walk. The mirror still tells on you in low light."
+          "name": "The Wrong Face",
+          "description": "A face the wrong person would recognize. Someone is looking for the person you used to be. You are no longer that person, but your bones are. You've grown a beard, you've cut your hair, you've practiced a different walk. The mirror still tells on you in low light."
         },
         {
-          "name": "Child you stole back",
-          "description": "The child is yours. The court disagreed. The court was wrong, and the court was armed. The child sleeps in the room above the tavern and asks about home only when it rains. You have an answer prepared, and you have not yet had to use it."
+          "name": "The Child Above the Tavern",
+          "description": "A child you stole back. The child is yours. The court disagreed. The court was wrong, and the court was armed. The child sleeps in the room above the tavern and asks about home only when it rains. You have an answer prepared, and you have not yet had to use it."
         },
         {
-          "name": "Truth you have to forget",
-          "description": "You know something that would unmake a thing the world depends on. You came to Blackwater because the bay is supposed to take memories along with names. You are testing whether it works fast enough. So far the truth is still in your mouth at night."
+          "name": "The Truth That Won't Drown",
+          "description": "A truth you have to forget. You know something that would unmake a thing the world depends on. You came to Blackwater because the bay is supposed to take memories along with names. You are testing whether it works fast enough. So far the truth is still in your mouth at night."
         }
       ]
     },
@@ -35,19 +35,19 @@
       "label": "The town",
       "choices": [
         {
-          "name": "New England fishing port",
+          "name": "Tarrow's Wharf",
           "description": "Clapboard houses with the paint salted off. The smell of low tide and tarred rope, the gulls always working. There is one church the regulars do not attend, one tavern the visitors do not enter, and one dock long enough for the trade. The shutters close early."
         },
         {
-          "name": "Caribbean smuggler's cove",
+          "name": "Port Mariposa",
           "description": "Wooden shutters bake all day and creak open at evening. The rum is good and the locals do not sell it to outsiders; you have to be offered. Pelicans line the breakwater and watch the customs cutter that comes in twice a year and finds nothing. The fog rolls in at dawn, briefly, like a courtesy."
         },
         {
-          "name": "Pacific Northwest logging port",
+          "name": "Cedar Hollow Landing",
           "description": "Cedar smoke from every chimney. The rooftops are mossed and the planks of the boardwalk are dark with rain. Sea fog arrives by noon and stays through the next day; in the fog the town is smaller than its map. The mill blade has not turned in a year and nobody mentions it."
         },
         {
-          "name": "Old-world Iberian harbor",
+          "name": "Porto Saudade",
           "description": "Whitewashed and impossibly steep. Bells from a monastery up the cliff mark the hours nobody at the dock observes. Sardines on every menu, oil and lemon, a clay jug of wine you do not have to order twice. The harbormaster keeps his ledger in the cool of a chapel that the priest left to him."
         }
       ]

--- a/worlds/cartomancy.mvworld
+++ b/worlds/cartomancy.mvworld
@@ -14,19 +14,19 @@
       "label": "Your card type",
       "choices": [
         {
-          "name": "Common minion",
+          "name": "The Pawn",
           "description": "Cheap, expendable, plentiful. There are dozens of you in this deck and across other decks in other rooms. You know the others by face. Some of you have died many times and come back; some of you are mint and have never been played. The common bond is that nobody mourns you when you go to the bin."
         },
         {
-          "name": "Legendary unique",
+          "name": "The Foil",
           "description": "Powerful but printed in low numbers. Your kin are rare and competitive and territorial. You have not met most of them. When you do, the conversation is brief and barbed. Your owner protects you, displays you, sleeves you carefully, and on the rare turns you are played, the whole table looks up."
         },
         {
-          "name": "Trap card",
+          "name": "The Face-Down",
           "description": "You've been face-down for months. Nobody has activated you. You can hear the games being played over you and you have prepared, again and again, for the moment that does not come. Your effect is specific and devastating. You know it by heart. You wonder, sometimes, if you have been forgotten."
         },
         {
-          "name": "Token",
+          "name": "The Token",
           "description": "You did not exist last turn. You may not exist next turn. Tokens are made by other cards' effects and dissolve at the end of phases. Your whole life is a few minutes long. Other tokens nod at you across the field. The veterans pretend not to see you. You have, in your short life, learned more than most cards ever do."
         }
       ]
@@ -35,19 +35,19 @@
       "label": "The table",
       "choices": [
         {
-          "name": "A bedroom carpet",
+          "name": "The Bedroom Floor",
           "description": "The cards are dog-eared and bent and one of them has a chocolate fingerprint. The younger sibling is crying and the older one is pretending not to notice. A Pokemon poster on the wall has been there for years and the sun has bleached half of it. The lamp light is yellow and the rules change every fifteen minutes."
         },
         {
-          "name": "A green-felt casino room",
+          "name": "The Green Felt",
           "description": "Low lights. Cigar smoke that has been here longer than anyone in the room. The dealer wears white gloves and shuffles with a precision the cards can feel in their backs. The players do not speak. A man at the bar is watching, and his watching is itself a wager. The chips on the felt are real things, and so are you."
         },
         {
-          "name": "A reader's kitchen table",
+          "name": "The Reader's Kitchen",
           "description": "The deck is hand-painted, the work of someone who is no longer alive. Tea steams in a chipped cup. The seeker is asking aloud, in a voice that is careful and slightly embarrassed, and she keeps stopping mid-question. The light through the curtain is afternoon. There is a cat under the table. The cards smell faintly of cedar."
         },
         {
-          "name": "An empty stage in a vast hall",
+          "name": "The Spotlit Stage",
           "description": "The audience is invisible in the dark, but the cards can feel the breathing. A single spotlight on the play area. The cards know they are being watched and behave accordingly. The cues come from somewhere above; the players, when they reach down, are wearing sleeves that disappear into shadow. This is theatre, and the cards are getting better at their lines."
         }
       ]

--- a/worlds/closing-time.mvworld
+++ b/worlds/closing-time.mvworld
@@ -14,19 +14,19 @@
       "label": "Your role",
       "choices": [
         {
-          "name": "Floor associate",
+          "name": "The Keyholder",
           "description": "You know the aisles. You've worked here long enough that customers ask for you by name. The proprietor never told you what you were really selling and you never asked. Now closing is your problem because nobody else has the keys."
         },
         {
-          "name": "Last customer",
+          "name": "The Last Customer",
           "description": "You came in for one specific thing. You don't remember exactly what — you had a list, somewhere. The doors locked behind you and the staff are looking at you expectantly. Something about the way they're looking suggests you might be the inventory."
         },
         {
-          "name": "Corporate auditor",
+          "name": "The Auditor",
           "description": "You were sent to close out the numbers. You are not supposed to feel anything about the inventory. You have a quota of regret you're allowed to express in writing and you're already over it. Your tablet keeps recalculating the loss column."
         },
         {
-          "name": "The owner's child",
+          "name": "The Heir",
           "description": "Your parent ran this place your whole life and never explained it. They left you the shop, the lease, and a debt. The staff knew you when you were small. The aisles smell like home and you've been avoiding them for twenty years."
         }
       ]
@@ -35,19 +35,19 @@
       "label": "The branch",
       "choices": [
         {
-          "name": "Gift-shop annex",
+          "name": "The Annex",
           "description": "A small wing off something larger, full of bottled mini-cosmoses meant as souvenirs. The fluorescents flicker on a schedule the manager pretends not to know. Pegboard hooks, half of them empty, hold keychains shaped like dead stars. Everything smells like cardboard and the faint chemical sweetness of new plastic."
         },
         {
-          "name": "Sprawling warehouse",
+          "name": "The Cathedral Warehouse",
           "description": "Cathedral aisles you could lose a customer in. The forklifts run themselves; you wave at them out of habit. Pallets sit stacked higher than the lights can reach, some of them older than the stars they contain. The PA system pages employees who haven't worked here in decades."
         },
         {
-          "name": "Boutique storefront",
+          "name": "The Boutique",
           "description": "A single proprietor's life work, behind a hand-painted sign. Old wood and the smell of beeswax polish. One window onto a street that isn't quite the one outside the back door. The bell above the door has a specific note and the proprietor used to flinch at it lovingly."
         },
         {
-          "name": "Pop-up clearance tent",
+          "name": "The Clearance Tent",
           "description": "Flapping canvas in a parking lot that wasn't here yesterday. The inventory keeps shifting between visits — what you sold this morning is back on the table tonight, dustier. A FINAL DAY sign has been zip-tied to the entrance for what the older staff swear is several centuries. Nobody has refilled the float."
         }
       ]

--- a/worlds/cold-open.mvworld
+++ b/worlds/cold-open.mvworld
@@ -14,19 +14,19 @@
       "label": "The city",
       "choices": [
         {
-          "name": "Present day",
+          "name": "The Walk-Up",
           "description": "A real city, recognizable and mundane. The apartment is a walk-up in a neighborhood the player has no reason to be in. The police are real police. The danger is ordinary and human-scale — corruption, cover-ups, someone powerful who needs the player to stay lost. The tone is paranoid thriller. Trust nothing."
         },
         {
-          "name": "Near future",
+          "name": "The Flagged Face",
           "description": "A surveilled city. Predictive policing, biometric checkpoints, social credit scores. The player's face is flagged. Their past self didn't just write a note — they scrubbed their own biometrics, wiped their transit history, and somehow moved through a city that tracks everything without being tracked. Whatever they were running from has access to the system. The note isn't paranoia. It's engineering."
         },
         {
-          "name": "Dickensian England",
+          "name": "The Chandler's Garret",
           "description": "A cramped garret above a chandler's shop in a city of soot and fog. The note is in the player's hand on good paper — too good for this address. The \"police\" are the newly formed Metropolitan Police, or the private thief-takers who preceded them, or both. The streets are a maze of class, debt, and obligation. Someone has gone to great trouble to hide the player among the poor, and the poor have noticed."
         },
         {
-          "name": "1950s America",
+          "name": "The Motel Off the Highway",
           "description": "A motel room off a state highway, curtains drawn. The note is on the back of a diner receipt. The \"police\" could mean the FBI, HUAC, or a local sheriff who answers to someone other than the law. The player's past self was afraid of something bigger than crime — blacklists, loyalty oaths, the machinery of suspicion. Everyone is an informant or afraid of informants. Paranoia isn't a symptom. It's a survival skill."
         }
       ]

--- a/worlds/congregation.mvworld
+++ b/worlds/congregation.mvworld
@@ -13,19 +13,19 @@
       "label": "Town",
       "choices": [
         {
-          "name": "Suburban subdivision",
+          "name": "Sycamore Run",
           "description": "Cul-de-sacs named for trees that don't grow here. Identical mailboxes at identical angles. The HOA newsletter mentions the church's bake sale as if you'd been planning to attend, and the church's parking lot is the only freshly paved one on the road. Your neighbor waves the way he always has, and now he waves once more, toward the steeple."
         },
         {
-          "name": "Failing rust-belt city",
+          "name": "Forge County",
           "description": "Shuttered plants, potholes the city can't fix, a tax base that left two decades ago. The church's parking lot is new asphalt, painted lines, and reserved spots for people you went to high school with. The pastor has hired locally for the maintenance staff and they are grateful for the work and they will not meet your eyes."
         },
         {
-          "name": "Mountain hamlet, road washed out",
+          "name": "Hollow's Pass",
           "description": "One general store, one gas pump, you know every truck by its tailgate. The church appeared the night before the snow closed the pass. Nobody can leave to check a county record. The church bell rings on the hour and the hour is correct."
         },
         {
-          "name": "Suburb already with a church on every corner",
+          "name": "Elm and the Cross-Street",
           "description": "This is just one more. Methodist on Vine, Baptist on Oak, Catholic on Main, and now this one on the corner of Elm and the cross-street nobody can quite remember the name of. Nobody can say what was on the lot before; everyone agrees it has always been a lovely little church."
         }
       ]
@@ -34,19 +34,19 @@
       "label": "Your faith",
       "choices": [
         {
-          "name": "Devout",
+          "name": "The Faithful",
           "description": "This troubles you doctrinally before it troubles you in any other way. The hymns are the right hymns and the sermon almost works. The pastor preaches scripture you know, with one verse you don't recognize at the end of each reading. You looked it up. It isn't there."
         },
         {
-          "name": "Lapsed",
+          "name": "The Lapsed",
           "description": "You came back recently and you can't say why. The pew fits you the way it used to. The pastor seems to remember you from before, from a parish you no longer believe you attended. You take communion on the third Sunday and you don't tell your spouse."
         },
         {
-          "name": "Atheist",
+          "name": "The Unbeliever",
           "description": "You can see what the others can't. The building has the wrong number of doors from inside. The stained glass has a panel that doesn't match. The shadows in the nave fall in directions that have nothing to do with the sun. You don't go in often. When you do, you count."
         },
         {
-          "name": "Clergy of a competing denomination",
+          "name": "The Rival Shepherd",
           "description": "Your parishioners are migrating. You watch them through the side window of your own church across the street, walking past your sign on Sunday morning to the new doors. You have not yet preached against the new church and you have not yet visited it. Both decisions feel like they are being made for you."
         }
       ]

--- a/worlds/customer-support.mvworld
+++ b/worlds/customer-support.mvworld
@@ -14,20 +14,20 @@
       "label": "Tenure",
       "choices": [
         {
-          "name": "First day on the job",
-          "description": "The headset still has the previous wearer's sweat on the foam. Nobody has told the player where the bathrooms are. The training video skipped the section on what to do if the customer is on fire. The lunch lady knows the player's name already; nobody else does."
+          "name": "The New Hire",
+          "description": "First day on the job. The headset still has the previous wearer's sweat on the foam. Nobody has told the player where the bathrooms are. The training video skipped the section on what to do if the customer is on fire. The lunch lady knows the player's name already; nobody else does."
         },
         {
-          "name": "Five years in, dead inside",
-          "description": "The player has a coffee mug they have washed exactly once. They know the scripts so well they hear them in their dreams. They can identify a regional accent in three syllables and the type of wish in five. The work is easy and that is part of the problem."
+          "name": "The Lifer",
+          "description": "Five years in, dead inside. The player has a coffee mug they have washed exactly once. They know the scripts so well they hear them in their dreams. They can identify a regional accent in three syllables and the type of wish in five. The work is easy and that is part of the problem."
         },
         {
-          "name": "Promoted into supervision",
-          "description": "The player wrote the script they now enforce on others. They have a small office with a door. They sit in meetings where the metrics are explained slowly. Their direct reports include people who were hired the same week the player was, who do not call the player by their first name anymore."
+          "name": "The Supervisor",
+          "description": "Promoted into supervision. The player wrote the script they now enforce on others. They have a small office with a door. They sit in meetings where the metrics are explained slowly. Their direct reports include people who were hired the same week the player was, who do not call the player by their first name anymore."
         },
         {
-          "name": "Whistleblower in waiting",
-          "description": "The player has a notebook in a locker at the gym. They have been writing things down for a year. They have not yet decided who to send it to or whether sending it will accomplish anything. They smile during the morning huddle. Their hands have started to shake by Wednesday."
+          "name": "The Notebook in the Locker",
+          "description": "Whistleblower in waiting. The player has a notebook in a locker at the gym. They have been writing things down for a year. They have not yet decided who to send it to or whether sending it will accomplish anything. They smile during the morning huddle. Their hands have started to shake by Wednesday."
         }
       ]
     },
@@ -35,19 +35,19 @@
       "label": "Escalation path above you",
       "choices": [
         {
-          "name": "Middle management",
+          "name": "Middle Management",
           "description": "Human. Useless. Three of them on performance-improvement plans of their own. They have offices with windows and faces that have learned not to register surprise. They forward escalations to one another in a loop the player can trace if they pay attention."
         },
         {
-          "name": "A literal djinn-king",
+          "name": "The Djinn-King",
           "description": "Terrifying and polite. He sends pastries to the breakroom on holidays. He has met the player exactly once at orientation and remembers the player's first name and the names of the player's siblings. His decisions are final and his decisions are kind, and these two things together do not feel safe."
         },
         {
-          "name": "An algorithm",
+          "name": "OZ",
           "description": "The player has never met it. It routes everything. It assigns tickets, schedules breaks, calculates bonuses, terminates contracts. The intranet calls it OZ. Nobody in the office has spoken its full designation aloud since the rebrand. It does not answer email."
         },
         {
-          "name": "The original founder",
+          "name": "The Founder in the Portrait",
           "description": "Unseen for years. A large portrait in the lobby that everyone insists is fine. The portrait's eyes follow the player exactly the amount that paintings' eyes follow you. HR has a memo addressed from him every Monday. The memo is always signed in fresh ink."
         }
       ]

--- a/worlds/decommissioned.mvworld
+++ b/worlds/decommissioned.mvworld
@@ -26,7 +26,7 @@
           "description": "You were a divine instrument of righteous war. You laid down your sword. The church says you're broken. You say you're done. Your wings still smell like ozone and old fire."
         },
         {
-          "name": "Just a soldier",
+          "name": "The Soldier",
           "description": "No magic, no metal, no wings. You're a human being who was very good at a very bad job for a very long time. The \"old programming\" is just what's left. You're trying to do something gentle for once."
         }
       ]
@@ -35,16 +35,16 @@
       "label": "The town",
       "choices": [
         {
-          "name": "Quiet rebuilding village",
+          "name": "Greyfield",
           "description": "A quiet village still rebuilding from the war you fought in. Some residents remember you from the other side."
         },
         {
-          "name": "Busy market town",
+          "name": "Threadmarket",
           "description": "A busy market town that didn't see combat and doesn't understand what you are. They think you're a novelty."
         },
         {
-          "name": "Rough frontier settlement",
-          "description": "Everyone is a misfit or a second-chance case. You fit right in — until you don't."
+          "name": "Last Chance Flats",
+          "description": "A rough frontier settlement. Everyone is a misfit or a second-chance case. You fit right in — until you don't."
         }
       ]
     }

--- a/worlds/deep-tenancy.mvworld
+++ b/worlds/deep-tenancy.mvworld
@@ -12,20 +12,20 @@
       "label": "Your role in steerage",
       "choices": [
         {
-          "name": "Hydroponics worker",
-          "description": "You have noticed that the harvest doesn't match the population. The yields are higher than the meals served and the difference goes somewhere you don't have access to. You have been doing the math quietly for two years. You have not yet shown the math to anyone. The math is the kind of thing that, if shown, would change the answer to other questions you have been afraid to ask."
+          "name": "The Yield Counter",
+          "description": "Hydroponics worker. You have noticed that the harvest doesn't match the population. The yields are higher than the meals served and the difference goes somewhere you don't have access to. You have been doing the math quietly for two years. You have not yet shown the math to anyone. The math is the kind of thing that, if shown, would change the answer to other questions you have been afraid to ask."
         },
         {
-          "name": "Deck-runner with smuggling routes",
+          "name": "The Deck-Runner",
           "description": "You move small things between decks for small payments. You know which conduits are unmonitored and which inspectors look the other way. The smuggling has been ordinary for a long time. Lately you have been asked to carry items that don't fit the usual pattern — sealed packages, written notes, a child once. You have learned not to ask, but you have started to wonder."
         },
         {
-          "name": "Schoolteacher",
-          "description": "You teach the official history. You have taught it for a decade and you can recite the dates and the names of the founders without notes. You have started to doubt specific dates. The doubts come from cross-referencing the official text against minor primary sources — a logbook in the library, a photograph that doesn't match its caption. You have not yet changed the lesson."
+          "name": "The Teacher of Founders",
+          "description": "Schoolteacher. You teach the official history. You have taught it for a decade and you can recite the dates and the names of the founders without notes. You have started to doubt specific dates. The doubts come from cross-referencing the official text against minor primary sources — a logbook in the library, a photograph that doesn't match its caption. You have not yet changed the lesson."
         },
         {
-          "name": "Recent orphan",
-          "description": "Your parent died last month. Their personal terminal is in your quarters and it is locked. You have their thumbprint on a glass and you have not yet tried it. You suspect that you do not want to know what is on the terminal, and you suspect that you will try the thumbprint anyway, and you suspect that this campaign begins on the day you do."
+          "name": "The Thumbprint on Glass",
+          "description": "Recently orphaned. Your parent died last month. Their personal terminal is in your quarters and it is locked. You have their thumbprint on a glass and you have not yet tried it. You suspect that you do not want to know what is on the terminal, and you suspect that you will try the thumbprint anyway, and you suspect that this campaign begins on the day you do."
         }
       ]
     },
@@ -33,20 +33,20 @@
       "label": "The ship's state",
       "choices": [
         {
-          "name": "Engines dismantled, static city",
-          "description": "The ship hasn't moved in your lifetime or your parents'. The engine bays have been repurposed as gardens — rebar trellises, conduits laid across as bridges, drip irrigation through what used to be coolant lines. Daylight is on a schedule and the schedule slipped a hundred years ago and is now an hour off the body's expectations. Nobody talks about why."
+          "name": "The Static City",
+          "description": "Engines dismantled. The ship hasn't moved in your lifetime or your parents'. The engine bays have been repurposed as gardens — rebar trellises, conduits laid across as bridges, drip irrigation through what used to be coolant lines. Daylight is on a schedule and the schedule slipped a hundred years ago and is now an hour off the body's expectations. Nobody talks about why."
         },
         {
-          "name": "Still in flight, decelerating",
-          "description": "There is a tremor in everything. You learn it before you learn to walk and you stop noticing it by adolescence. The bulkheads creak in patterns that the engineers can read. There is a sense of movement that nobody calls movement because there is nothing to compare it to. Someone above decks knows when arrival is. You do not."
+          "name": "The Long Deceleration",
+          "description": "Still in flight, slowing. There is a tremor in everything. You learn it before you learn to walk and you stop noticing it by adolescence. The bulkheads creak in patterns that the engineers can read. There is a sense of movement that nobody calls movement because there is nothing to compare it to. Someone above decks knows when arrival is. You do not."
         },
         {
-          "name": "Hollowed",
+          "name": "The Hollowed Decks",
           "description": "Only steerage decks are populated. The rest are sealed. Corridors go nowhere and end in welded doors with hand-lettered NO ENTRY signs in handwriting that does not match any handwriting taught in school. The air smells different past a certain bulkhead and you can taste it on your tongue if you stand close. Nobody has crossed in your lifetime."
         },
         {
-          "name": "Multiple ships once linked, now drifting in parallel",
-          "description": "There are other ships out the porthole. Three of them, sometimes four, holding a loose formation across distances that should not be possible to maintain without active steering. Sometimes they signal. The signals are in a code the engineers half-recognize. Nobody alive remembers when the ships separated, or why, or whether the separation is permanent."
+          "name": "The Parallel Fleet",
+          "description": "Multiple ships once linked, now drifting in parallel. There are other ships out the porthole. Three of them, sometimes four, holding a loose formation across distances that should not be possible to maintain without active steering. Sometimes they signal. The signals are in a code the engineers half-recognize. Nobody alive remembers when the ships separated, or why, or whether the separation is permanent."
         }
       ]
     }

--- a/worlds/ember-protocol.mvworld
+++ b/worlds/ember-protocol.mvworld
@@ -12,15 +12,15 @@
       "label": "The ship",
       "choices": [
         {
-          "name": "The ark",
+          "name": "The Ark",
           "description": "A sprawling generation ship built by international coalition. 10,000 colonists in cryosleep, biodomes, seed vaults, a cathedral someone insisted on. Hopeful and massive. The stakes are a civilization."
         },
         {
-          "name": "The seedship",
+          "name": "The Seedship",
           "description": "A compact, automated vessel. No crew was supposed to wake up at all. Just embryos, gene banks, and an AI midwife. Intimate and claustrophobic. The stakes are a species."
         },
         {
-          "name": "The exile fleet",
+          "name": "The Exile Fleet",
           "description": "A convoy of refugee ships fleeing a dying Earth. Jury-rigged, overcrowded, held together by HEARTH's constant maintenance. Desperate and scrappy. The stakes are the last humans alive."
         }
       ]

--- a/worlds/exit-wounds.mvworld
+++ b/worlds/exit-wounds.mvworld
@@ -14,20 +14,20 @@
       "label": "Your encounter",
       "choices": [
         {
-          "name": "A haunting that followed you home",
-          "description": "You moved twice. It moved with you. It is small and it is patient and it took the previous tenant from your last apartment and you are not yet certain if it followed you because of who you are or because of what you took with you. You came to the group to find out which."
+          "name": "The Tenant",
+          "description": "A haunting that followed you home. You moved twice. It moved with you. It is small and it is patient and it took the previous tenant from your last apartment and you are not yet certain if it followed you because of who you are or because of what you took with you. You came to the group to find out which."
         },
         {
-          "name": "A cult you escaped that's still recruiting",
-          "description": "You got out. Others did not, and others have joined since. You see their leaflets sometimes. They have your face on one of them, captioned with a name that is not yours. You came to the group to learn what the right way is to warn the next person you see being approached."
+          "name": "The Leaflet",
+          "description": "A cult you escaped that's still recruiting. You got out. Others did not, and others have joined since. You see their leaflets sometimes. They have your face on one of them, captioned with a name that is not yours. You came to the group to learn what the right way is to warn the next person you see being approached."
         },
         {
-          "name": "A creature nobody else saw",
-          "description": "It was in the room. You are certain. There were three other people in the room and none of them remember anything but you, screaming. You have learned not to insist. The group is the one place you can describe it out loud and not be asked if you are sleeping enough."
+          "name": "The Witness",
+          "description": "A creature nobody else saw. It was in the room. You are certain. There were three other people in the room and none of them remember anything but you, screaming. You have learned not to insist. The group is the one place you can describe it out loud and not be asked if you are sleeping enough."
         },
         {
-          "name": "Lost time you can't account for",
-          "description": "Eleven hours of a Tuesday. Your phone shows steps and a route. Your body shows nothing it should. Whatever you did is in you somewhere; you can taste it under your tongue. You came to the group hoping someone else lost the same Tuesday."
+          "name": "The Missing Tuesday",
+          "description": "Lost time you can't account for. Eleven hours of a Tuesday. Your phone shows steps and a route. Your body shows nothing it should. Whatever you did is in you somewhere; you can taste it under your tongue. You came to the group hoping someone else lost the same Tuesday."
         }
       ]
     },
@@ -35,19 +35,19 @@
       "label": "The group's setting",
       "choices": [
         {
-          "name": "Church basement",
+          "name": "The Basement at St. Cyril's",
           "description": "Free coffee in a steel urn. Fluorescent tubes, one of them humming. Metal folding chairs arranged in a ring that nobody has the authority to rearrange. A stack of pamphlets about other support groups that nobody reads. The pastor upstairs has been told it's a grief group and asks no further questions."
         },
         {
-          "name": "Hospital therapy wing",
+          "name": "Ward Seven",
           "description": "Some members are court-ordered. There is an observation window onto the hallway and the blinds don't quite close. The clock above the door is the loudest thing in the room and you all check it once an hour without meaning to. The facilitator has a hospital lanyard and is paid by the hour."
         },
         {
-          "name": "Online video call",
+          "name": "The Six Squares",
           "description": "Faces in boxes, three of them lit by their kitchens. One box is always frozen. Someone's microphone catches a sound from outside their room each week, the same sound, and they have never addressed it. The chat sidebar fills slowly with messages that vanish before anyone reads them."
         },
         {
-          "name": "A weekend retreat",
+          "name": "Pinecrest Lodge",
           "description": "A converted lodge two hours into a national forest. Snow coming in by Friday night. No cell signal past the gate. The facilitator has the only car and the keys are in their cabin and the cabin is locked at night. The lodge sleeps twelve and there are six of you, and the empty rooms are not empty in the same way they were on Friday."
         }
       ]

--- a/worlds/fallow.mvworld
+++ b/worlds/fallow.mvworld
@@ -12,19 +12,19 @@
       "label": "The scenario",
       "choices": [
         {
-          "name": "The student",
+          "name": "The Warm Stones",
           "description": "You're in your final year of thaumic engineering at a university that didn't exist fifty years ago. Your thesis project just produced an anomalous result: an equation that solves itself differently depending on who's holding the chalk. Your advisor wants to publish. The department wants it buried. The old stones on the campus quad — decorative, everyone thought — are warm to the touch for the first time in living memory."
         },
         {
-          "name": "The field engineer",
+          "name": "The Drift",
           "description": "You maintain the magical infrastructure for a rural district: ley-grid relays, ward pylons, a municipal water purification circle. Routine work. Except the relays are drifting out of calibration faster than you can fix them, the wards are responding to stimuli that aren't in the manual, and the farmers are telling you the old wells are flowing again — the ones that were sealed because of what the water used to do."
         },
         {
-          "name": "The antiquarian",
+          "name": "The Answered Incantation",
           "description": "You study the Old Magic period. Dead languages, ruined temples, oral histories from communities that remember. It's been a purely academic field — there was nothing left to practice. Until your translations started working. You read an incantation for the first time in a century and something answered. You haven't told anyone yet."
         },
         {
-          "name": "The regulator",
+          "name": "The Bureau",
           "description": "You work for the Bureau of Thaumic Standards, the agency that certifies all legal magic use. Your job is ensuring compliance, investigating anomalies, and shutting down unlicensed practice. The anomaly reports on your desk have tripled this quarter. Half of them describe phenomena that don't match any known new-magic signatures. Your superiors say it's instrument error. You've been in the field. It's not instrument error."
         }
       ]

--- a/worlds/floor-14.mvworld
+++ b/worlds/floor-14.mvworld
@@ -13,20 +13,20 @@
       "label": "Why you're at the hotel",
       "choices": [
         {
-          "name": "Conference attendee, badge still on",
-          "description": "Two days of breakout sessions, a name tag with your title spelled correctly, a tote bag with a vendor logo on it. You came down to the bar at ten to get away from a colleague. You took the elevator back up after one drink. You have not yet been missed by the conference."
+          "name": "The Lanyard",
+          "description": "Conference attendee, badge still on. Two days of breakout sessions, a name tag with your title spelled correctly, a tote bag with a vendor logo on it. You came down to the bar at ten to get away from a colleague. You took the elevator back up after one drink. You have not yet been missed by the conference."
         },
         {
-          "name": "Affair",
-          "description": "You shouldn't be here. The room was booked under a name that is yours and isn't. The other party has not arrived and is not answering. You can leave. You haven't left. Every minute you stay is one more minute of explanation you will need to construct."
+          "name": "The Other Name",
+          "description": "An affair. You shouldn't be here. The room was booked under a name that is yours and isn't. The other party has not arrived and is not answering. You can leave. You haven't left. Every minute you stay is one more minute of explanation you will need to construct."
         },
         {
-          "name": "Funeral in town, can't sleep at the family home",
-          "description": "Your sister's house was too full. Your father's house was too empty. The hotel was the compromise. The service is at ten tomorrow morning. The eulogy is folded in your jacket pocket and the folded edges are sharp."
+          "name": "The Eulogy",
+          "description": "Funeral in town, can't sleep at the family home. Your sister's house was too full. Your father's house was too empty. The hotel was the compromise. The service is at ten tomorrow morning. The eulogy is folded in your jacket pocket and the folded edges are sharp."
         },
         {
-          "name": "Driving through, picked the cheapest sign",
-          "description": "Eight hundred miles in a day. You took the first exit with a lit vacancy board. The clerk did not ask for your destination and you would not have told them. Nobody you know knows where you are. Nobody you know would think to look for you in this town."
+          "name": "The Lit Vacancy",
+          "description": "Driving through, picked the cheapest sign. Eight hundred miles in a day. You took the first exit with a lit vacancy board. The clerk did not ask for your destination and you would not have told them. Nobody you know knows where you are. Nobody you know would think to look for you in this town."
         }
       ]
     },
@@ -34,19 +34,19 @@
       "label": "The hotel",
       "choices": [
         {
-          "name": "Airport business hotel",
+          "name": "The Concourse Marquis",
           "description": "Hum of HVAC under everything. A coffee station in the lobby until 11 p.m. and then the urn is wheeled away. Runway lights through the curtains in a slow regular sweep, the room briefly lit blue every twelve seconds. The shuttle to the terminal runs every twenty minutes and you can hear it idling from your window."
         },
         {
-          "name": "Old downtown grand",
+          "name": "The Ambassador",
           "description": "Marble lobby, brass fittings the bellman polishes during slow hours. A ballroom with a tarp on the chandelier and a wedding scheduled for Saturday. The elevator man is old enough to remember your grandfather, and he might. The piano in the lounge plays itself for an hour each evening and then stops."
         },
         {
-          "name": "Roadside motor lodge",
+          "name": "The Starlight Inn",
           "description": "Single story except for the office. A pool that's been drained twice this year and is currently full of leaves. The ice machine in the breezeway sings — low, continuous, almost a chord. Your door opens onto the parking lot directly and the parking lot is empty except for your car and a station wagon nobody is in."
         },
         {
-          "name": "Mountain resort, off-season",
+          "name": "The Cloudwell",
           "description": "Closed wings, one staff member at the desk, a dining room with chairs upturned on every other table. Deer on the lawn at dawn, unbothered. The ski lift is still running, slowly, with empty chairs, because somebody has to keep the cables exercised through the summer."
         }
       ]

--- a/worlds/ghosts-of-station-proxima.mvworld
+++ b/worlds/ghosts-of-station-proxima.mvworld
@@ -12,15 +12,15 @@
       "label": "The station",
       "choices": [
         {
-          "name": "Derelict alien megastructure",
+          "name": "The Cenotaph",
           "description": "Ancient, non-human construction. The architecture doesn't obey human geometry. Whoever built it is long gone — or dormant."
         },
         {
-          "name": "Abandoned near-future hardware",
+          "name": "Lagrange Six",
           "description": "A NASA/ESA successor station, maybe 30 years from now. Familiar tech, cramped corridors, coffee-stained manuals floating in zero-g. The horror is intimate and grounded."
         },
         {
-          "name": "Military black site",
+          "name": "Site Obsidian",
           "description": "Year-2200 classified facility. Sleek, over-engineered, full of locked compartments and redacted logs. Whatever happened here, someone powerful wanted it kept quiet."
         }
       ]

--- a/worlds/good-soil.mvworld
+++ b/worlds/good-soil.mvworld
@@ -12,20 +12,20 @@
       "label": "Who you were before",
       "choices": [
         {
-          "name": "Pre-collapse agronomist",
-          "description": "You understand exactly what you found, or you can build the theory inside a week if you're allowed to read your old notes. You know that what's happening here is not natural and you know enough categories of unnatural to narrow it down. Your knowledge is your greatest asset and your most dangerous tell — anyone who watches you work will know you are not a peasant."
+          "name": "The Agronomist",
+          "description": "Pre-collapse agronomist. You understand exactly what you found, or you can build the theory inside a week if you're allowed to read your old notes. You know that what's happening here is not natural and you know enough categories of unnatural to narrow it down. Your knowledge is your greatest asset and your most dangerous tell — anyone who watches you work will know you are not a peasant."
         },
         {
-          "name": "Wanderer who got lucky",
-          "description": "You walked a long time. You stopped here because you were tired and the water tasted right and a stalk of grass beside the stream was the wrong color of green. You have been here three years. You don't know why the patch works. You have been very careful to not learn, in case knowing breaks it."
+          "name": "The Stopped Walker",
+          "description": "Wanderer who got lucky. You walked a long time. You stopped here because you were tired and the water tasted right and a stalk of grass beside the stream was the wrong color of green. You have been here three years. You don't know why the patch works. You have been very careful to not learn, in case knowing breaks it."
         },
         {
-          "name": "Local who inherited the land",
-          "description": "Your family was here before the poisoning. Your grandparents farmed this ground when it was no more remarkable than the next valley over. After the collapse, you came home to bury people, and the burying showed you that the dirt here was different. You have been keeping the secret out of family loyalty and out of a private suspicion you have not voiced to anyone."
+          "name": "The Inheritor",
+          "description": "Local who inherited the land. Your family was here before the poisoning. Your grandparents farmed this ground when it was no more remarkable than the next valley over. After the collapse, you came home to bury people, and the burying showed you that the dirt here was different. You have been keeping the secret out of family loyalty and out of a private suspicion you have not voiced to anyone."
         },
         {
-          "name": "Refugee leader; the patch is for your people",
-          "description": "You brought a group across hard country and you arrived here a year ago with fewer than you started with. The patch fed the survivors. It is feeding them now. You are responsible for them and for the patch and for the decision of whether to add the next group of refugees who arrive at the ridge tomorrow."
+          "name": "The Shepherd",
+          "description": "Refugee leader; the patch is for your people. You brought a group across hard country and you arrived here a year ago with fewer than you started with. The patch fed the survivors. It is feeding them now. You are responsible for them and for the patch and for the decision of whether to add the next group of refugees who arrive at the ridge tomorrow."
         }
       ]
     },
@@ -33,19 +33,19 @@
       "label": "The landscape",
       "choices": [
         {
-          "name": "Salt flats with one green valley",
+          "name": "The Green Tear",
           "description": "The wind is constant and it is loud and it carries grit. In every direction the ground is white and dead and the sky is bigger than is reasonable. The patch is shaped like a tear running down between two ridges, a corridor of green a few hundred meters long. From the high ground you can see it from twenty miles, which is the problem you have been trying not to think about."
         },
         {
-          "name": "Burn scar of an old forest",
+          "name": "The Burn",
           "description": "Charcoal and clay underfoot. The new growth follows the lines of root systems that burned decades ago — you can read the layout of the dead forest from the pattern of the living one. After rain, mushrooms come up overnight, in colors that don't have names you know. The patch is alive in a way that suggests the forest's ghost is doing the work."
         },
         {
-          "name": "Coastal marsh poisoned with runoff",
+          "name": "The Clearwater Reach",
           "description": "Your patch is upstream of the worst of it. The water arrives at your land brown and leaves it clear, and it arrives at the next farm downstream killing things again. The neighbors there have noticed. They have not yet asked how. The reeds at your borders grow tall and sweet and the seabirds nest only on your side of the channel."
         },
         {
-          "name": "Suburban cul-de-sac",
+          "name": "Larkspur Court",
           "description": "The lawns on the rest of the street are gray and matted. Yours is green and the tomatoes you planted out of desperation are six feet tall. Two of the neighbors are watching from their windows. One of them has stopped greeting you in the morning. The mailboxes still stand at the curb like nothing has changed and everything has."
         }
       ]

--- a/worlds/graveyard-shift.mvworld
+++ b/worlds/graveyard-shift.mvworld
@@ -13,19 +13,19 @@
       "label": "The museum",
       "choices": [
         {
-          "name": "Natural history",
+          "name": "The Halls of Bone",
           "description": "Bones articulated on steel, dioramas of grasslands behind glass, jarred specimens floating in straw-colored alcohol. The mastodon's tusks have rotated three degrees since the start of your shift. You can measure this. You have been measuring this. The placard says the rotation is impossible."
         },
         {
-          "name": "Art",
+          "name": "The Pinacotheca",
           "description": "The portraits whose eyes have moved are the least of it. The sculpture wing has one too many figures and you cannot determine which one was added; they all look like they have been there for centuries. The children's gallery has a noise problem the day staff have stopped reporting, and you avoid it on the third round."
         },
         {
-          "name": "Antiquities",
+          "name": "The Antiquities Wing",
           "description": "A Sumerian dagger in case seven that pulls light into it the way a drain pulls water. A sarcophagus whose name plaque keeps changing, never the same name twice in a week. \"Do not touch\" signs in three dead languages and one you can almost read. The cleaning staff will not enter this hall alone."
         },
         {
-          "name": "Local history",
+          "name": "The Founders' Gallery",
           "description": "You recognize the people in the photographs. The diorama of the founding has somebody new in it this week, standing at the back of the founders' group, looking at the front of the case. The donor wall in the lobby has your last name on it, in a gift-tier you cannot afford, and you do not remember anyone in your family being asked."
         }
       ]
@@ -34,12 +34,12 @@
       "label": "Background",
       "choices": [
         {
-          "name": "Grad student needing the job",
-          "description": "Tuition, rent, the kind of stipend that doesn't quite cover both. You took the job because it's quiet and you can read between rounds. Your thesis is on something near enough to the museum's collection that you have begun to wonder whether the job was offered to you, specifically, by someone who knew."
+          "name": "The Thesis",
+          "description": "Grad student needing the job. Tuition, rent, the kind of stipend that doesn't quite cover both. You took the job because it's quiet and you can read between rounds. Your thesis is on something near enough to the museum's collection that you have begun to wonder whether the job was offered to you, specifically, by someone who knew."
         },
         {
-          "name": "Ex-cop who needed something quiet",
-          "description": "You don't talk about why you left the force. The supervisor didn't ask. The pension is small and the rent is what it is. You carry the flashlight the way you used to carry the other thing, and you have already noticed which galleries have blind spots in the camera coverage."
+          "name": "The Pension",
+          "description": "Ex-cop who needed something quiet. You don't talk about why you left the force. The supervisor didn't ask. The pension is small and the rent is what it is. You carry the flashlight the way you used to carry the other thing, and you have already noticed which galleries have blind spots in the camera coverage."
         },
         {
           "name": "Believer",

--- a/worlds/hoa-from-hell.mvworld
+++ b/worlds/hoa-from-hell.mvworld
@@ -14,20 +14,20 @@
       "label": "Your standing",
       "choices": [
         {
-          "name": "New homeowner who didn't read the covenant",
-          "description": "The closing was rushed. There was a stack of documents the realtor smiled past. The covenant was in there, in eight-point type, with a binding-arbitration clause in Latin. You signed. The first notice arrived before the moving truck was empty."
+          "name": "The Signature",
+          "description": "New homeowner who didn't read the covenant. The closing was rushed. There was a stack of documents the realtor smiled past. The covenant was in there, in eight-point type, with a binding-arbitration clause in Latin. You signed. The first notice arrived before the moving truck was empty."
         },
         {
-          "name": "Board member, complicit",
-          "description": "You ran for the board because you thought you could fix it from the inside. You voted for the last three amendments. You're not sure why. The minutes record you as having seconded a motion you have no memory of attending. The president keeps complimenting your sensible judgement."
+          "name": "The Second",
+          "description": "Board member, complicit. You ran for the board because you thought you could fix it from the inside. You voted for the last three amendments. You're not sure why. The minutes record you as having seconded a motion you have no memory of attending. The president keeps complimenting your sensible judgement."
         },
         {
-          "name": "Renter with no rights and full visibility",
-          "description": "You can be evicted by the landlord, fined by the board, and ignored by both. Nobody talks to you at the meetings, which means people talk freely in front of you. You know which board members are afraid of which. You know what's in the retention pond. The landlord wants you out by the first."
+          "name": "The Tenant",
+          "description": "Renter with no rights and full visibility. You can be evicted by the landlord, fined by the board, and ignored by both. Nobody talks to you at the meetings, which means people talk freely in front of you. You know which board members are afraid of which. You know what's in the retention pond. The landlord wants you out by the first."
         },
         {
-          "name": "Just inherited Aunt Marge's place",
-          "description": "Aunt Marge died last spring, peacefully, in her sleep. She left the house to you, paid off and immaculate. Her old photo albums are in the attic, and Aunt Marge has begun to stop appearing in some of them. The earliest pictures still have her. The most recent ones do not."
+          "name": "Aunt Marge's House",
+          "description": "Just inherited the property. Aunt Marge died last spring, peacefully, in her sleep. She left the house to you, paid off and immaculate. Her old photo albums are in the attic, and Aunt Marge has begun to stop appearing in some of them. The earliest pictures still have her. The most recent ones do not."
         }
       ]
     },
@@ -35,19 +35,19 @@
       "label": "The neighborhood",
       "choices": [
         {
-          "name": "McMansion exurb",
+          "name": "Wisteria Pointe",
           "description": "Manicured lawns, three-car garages, beige stucco in seven board-approved shades. The cul-de-sac forms a perfect geometric circle you have never seen from above. Each house has a flag pole and each flag is at the exact same height. The mailboxes were replaced last spring to match. Nobody complained."
         },
         {
-          "name": "1950s planned community",
+          "name": "Levitt Acres",
           "description": "Uniform ranch houses on a grid the developer drew at his kitchen table. Chain-link fences and crabgrass and original aluminum siding. The community pool closes at nine sharp and you really should not be there at 9:01; the lifeguard is gone but the gate locks itself. The pool boy quit in March and was not replaced."
         },
         {
-          "name": "Retirement village",
+          "name": "Sundown Estates",
           "description": "Sundown rules, no children after dark. Golf carts on every drive. The clubhouse roster has not been updated in years and several listed members are no longer alive, and they are still listed in good standing. Bylaw committee meets Mondays at ten. Bingo is Wednesdays. Bingo is mandatory."
         },
         {
-          "name": "Gated condo with cameras everywhere",
+          "name": "The Meridian",
           "description": "The concierge greets you by name on the first day. The elevator occasionally stops at a floor you didn't press and waits, patiently, for you to make a decision. The bylaws are posted on a brass plaque in the lobby and the plaque has grown three lines since you moved in. Nobody you've asked saw it grow."
         }
       ]

--- a/worlds/hollowdeep.mvworld
+++ b/worlds/hollowdeep.mvworld
@@ -13,20 +13,20 @@
       "label": "Your role",
       "choices": [
         {
-          "name": "Foreman with three missing crews",
-          "description": "You signed off on the descent. You wrote the names in the book. You stood at the top of the shaft for the agreed-on hours and longer. The widows are not yet ready to look at you. The company has not yet decided whether you are the man to send down again, or the man to fire first."
+          "name": "The Foreman",
+          "description": "Three crews missing. You signed off on the descent. You wrote the names in the book. You stood at the top of the shaft for the agreed-on hours and longer. The widows are not yet ready to look at you. The company has not yet decided whether you are the man to send down again, or the man to fire first."
         },
         {
-          "name": "Investigator the company hired quietly",
-          "description": "Your papers say you are a geological surveyor. You are not. The company prefers you to find an explanation that does not involve the company. Your room at the boarding house is paid through the month, and the rate is more than the room is worth, and you have not asked about that."
+          "name": "The Surveyor",
+          "description": "Investigator the company hired quietly. Your papers say you are a geological surveyor. You are not. The company prefers you to find an explanation that does not involve the company. Your room at the boarding house is paid through the month, and the rate is more than the room is worth, and you have not asked about that."
         },
         {
-          "name": "Local kid whose dad was on shift",
-          "description": "You know the back ways into the headframe. You know which fence panels are loose. You know who is lying about what they heard the night the bell started. The town adults treat you with the careful gentleness reserved for the recently bereaved, which is a thing you are not yet sure you are."
+          "name": "The Headframe Kid",
+          "description": "Local kid whose dad was on shift. You know the back ways into the headframe. You know which fence panels are loose. You know who is lying about what they heard the night the bell started. The town adults treat you with the careful gentleness reserved for the recently bereaved, which is a thing you are not yet sure you are."
         },
         {
-          "name": "Cleric the diocese sent",
-          "description": "The bishop received the letter and read it twice. You were chosen because you are senior enough to be believed and junior enough to be expendable. You arrive with a small kit, a written rite for sealing a mine, and a confessor's license that the bishop expects you to use before the rite, not after."
+          "name": "The Bishop's Envoy",
+          "description": "Cleric the diocese sent. The bishop received the letter and read it twice. You were chosen because you are senior enough to be believed and junior enough to be expendable. You arrive with a small kit, a written rite for sealing a mine, and a confessor's license that the bishop expects you to use before the rite, not after."
         }
       ]
     },
@@ -34,19 +34,19 @@
       "label": "The town",
       "choices": [
         {
-          "name": "Dwarven, ancestral",
+          "name": "Karag-Vor",
           "description": "The mine is a cathedral. The galleries were carved before this mountain had its current name. The town's foundations are older than the peak above them. You are an outsider even after twenty years of residence, and the courtesy you receive is the kind of courtesy reserved for guests who have outstayed any reasonable visit."
         },
         {
-          "name": "Frontier human, debt-mortgaged",
+          "name": "Coffin Bend",
           "description": "A single rail line in, a single rail line out. One bank, one church, one saloon, and the company owns all three buildings if not the people inside them. The script the miners are paid in is good at the company store and acceptable, at a discount, at the saloon. The bank's loans are not optional."
         },
         {
-          "name": "Mixed and uneasy",
+          "name": "Two-Shift Town",
           "description": "Two factions of miners. They take separate shifts. They drink at the saloon on alternate nights by an understanding nobody wrote down. Their work songs are about each other. The accident in the shaft has, for the first time in a generation, given them something to coordinate on, and the coordination is not yet trust."
         },
         {
-          "name": "A company town owned outright",
+          "name": "Greenpaint",
           "description": "Every house is painted the same shade of green. The script is paid in numbered chits. The company's cemetery has uniform headstones in regular rows. The company's representative knows everyone by name and uses their names in conversation in a manner that feels rehearsed."
         }
       ]

--- a/worlds/inkblot.mvworld
+++ b/worlds/inkblot.mvworld
@@ -14,20 +14,20 @@
       "label": "Your way in",
       "choices": [
         {
-          "name": "Art critic invited to authenticate",
-          "description": "The gallery wants your byline on the show. You came expecting a routine attribution piece and you are now staring at a canvas that you cannot honestly write about with the vocabulary your editor will accept. You have a deadline. The deadline is becoming the least of your problems."
+          "name": "The Byline",
+          "description": "Art critic invited to authenticate. The gallery wants your byline on the show. You came expecting a routine attribution piece and you are now staring at a canvas that you cannot honestly write about with the vocabulary your editor will accept. You have a deadline. The deadline is becoming the least of your problems."
         },
         {
-          "name": "The dead artist's lover",
-          "description": "You were not invited to the opening. You came anyway. You knew which paintings he loved and which he was afraid of, and this one is the one he would not let you see while he was alive. You can feel him in the brushwork. You can also feel something else, and you don't yet know if it has always been there."
+          "name": "The Beloved",
+          "description": "The dead artist's lover. You were not invited to the opening. You came anyway. You knew which paintings he loved and which he was afraid of, and this one is the one he would not let you see while he was alive. You can feel him in the brushwork. You can also feel something else, and you don't yet know if it has always been there."
         },
         {
-          "name": "Gallery employee opening tomorrow",
-          "description": "You have the keys. You are not paid enough to be the first one in the building at seven a.m. and not paid enough to be the last one out at nine p.m. The owner asked you to stop documenting the changes. You have not stopped. The photographs are on a thumb drive in your bag."
+          "name": "The Keyholder",
+          "description": "Gallery employee opening tomorrow. You have the keys. You are not paid enough to be the first one in the building at seven a.m. and not paid enough to be the last one out at nine p.m. The owner asked you to stop documenting the changes. You have not stopped. The photographs are on a thumb drive in your bag."
         },
         {
-          "name": "Cop investigating the prior death",
-          "description": "There was a previous owner. They went off a balcony, no note, the case was closed in a week. You did not work the case, but you read it, and the file mentions this painting once, in a sentence that was struck through and initialed. You came to the gallery because the file would not let you sleep."
+          "name": "The Struck Line",
+          "description": "Cop investigating the prior death. There was a previous owner. They went off a balcony, no note, the case was closed in a week. You did not work the case, but you read it, and the file mentions this painting once, in a sentence that was struck through and initialed. You came to the gallery because the file would not let you sleep."
         }
       ]
     },
@@ -35,19 +35,19 @@
       "label": "The gallery",
       "choices": [
         {
-          "name": "Glittering Chelsea white-cube",
+          "name": "Halberd & Vine",
           "description": "Champagne in plastic flutes the collectors compliment and do not drink. A guard at every doorway in a uniform tailored too well to do real guard work. The price list is on a tablet at the front desk and the prices are not in the catalog. The painting is on the back wall, lit by a single ceiling fixture that has been re-aimed twice this week."
         },
         {
-          "name": "Provincial museum",
+          "name": "The Pollard Memorial",
           "description": "Carpeted floors that swallow footsteps. School-trip benches built for ten-year-olds. The security camera in the corner is a prop the board approved as a budget compromise. The painting is on loan from a private collection and the loan paperwork lists a contact who does not answer the phone."
         },
         {
-          "name": "Defunct industrial conversion",
+          "name": "The Packing Floor",
           "description": "Concrete floors, painted columns, a chill that the HVAC will not lift. The painting hangs alone in the long room. The freight elevator is the only access for visitors and the operator is a friend of the owner. The building was a meatpacker's once. The bones of the old drains are visible in the floor."
         },
         {
-          "name": "Wealthy private home",
+          "name": "The Sideboard",
           "description": "The painting is in the dining room above the sideboard, lit by sconces the host had custom-cast. The owner is hosting a dinner tonight; you were not invited to dessert. The other guests have noticed something is off but have not been able to put a finger on it and are too well-mannered to ask."
         }
       ]

--- a/worlds/iron-saints.mvworld
+++ b/worlds/iron-saints.mvworld
@@ -13,20 +13,20 @@
       "label": "Your station",
       "choices": [
         {
-          "name": "A village priest whose congregation is dying",
-          "description": "The fever came in spring. The prayers, before, would have done their work. They are not doing it now. The doors of the chapel still open. The collection plate still circulates. You have stopped using the responses that promise intervention, because you have begun to feel them as small lies."
+          "name": "The Parish Priest",
+          "description": "A village priest whose congregation is dying. The fever came in spring. The prayers, before, would have done their work. They are not doing it now. The doors of the chapel still open. The collection plate still circulates. You have stopped using the responses that promise intervention, because you have begun to feel them as small lies."
         },
         {
-          "name": "A Saint yourself, suddenly silent",
-          "description": "You were the answer to prayers. You felt the calls. You rode where you were summoned. The summons stopped a season ago, and you have been waiting at the chapel, increasingly humanly, for a sign that did not arrive. The relic in the reliquary downstairs is colder to the touch than it used to be."
+          "name": "The Silent Saint",
+          "description": "A Saint yourself, suddenly silent. You were the answer to prayers. You felt the calls. You rode where you were summoned. The summons stopped a season ago, and you have been waiting at the chapel, increasingly humanly, for a sign that did not arrive. The relic in the reliquary downstairs is colder to the touch than it used to be."
         },
         {
-          "name": "A papal investigator with a writ",
-          "description": "Your authority is broad and your escort is small. You carry a writ signed in a hand that does not bear public scrutiny. Every door opens for the writ; some of them close behind you faster than they opened. You are being told, in many polite ways, to ask different questions than the ones you have."
+          "name": "The Writ",
+          "description": "A papal investigator with a writ. Your authority is broad and your escort is small. You carry a writ signed in a hand that does not bear public scrutiny. Every door opens for the writ; some of them close behind you faster than they opened. You are being told, in many polite ways, to ask different questions than the ones you have."
         },
         {
-          "name": "An apostate hunter the saints used to protect",
-          "description": "You hunt the church's enemies. The saints would step between you and a blade. They are not stepping anymore. You have noticed first because you live closer to the edge than most. Your last three engagements were closer than they should have been, and one of your hands is going to bear the proof of that for the rest of your life."
+          "name": "The Apostate Hunter",
+          "description": "The saints used to protect you. You hunt the church's enemies. The saints would step between you and a blade. They are not stepping anymore. You have noticed first because you live closer to the edge than most. Your last three engagements were closer than they should have been, and one of your hands is going to bear the proof of that for the rest of your life."
         }
       ]
     },
@@ -34,20 +34,20 @@
       "label": "The faith",
       "choices": [
         {
-          "name": "Monolithic and ancient",
-          "description": "One church, one calendar, one set of names. The saints are in every village shrine and on every road marker. The institution is older than the language it preaches in. A failure of the saints is not a regional problem; it is a structural one, and the structure is not built to admit it."
+          "name": "The One See",
+          "description": "Monolithic and ancient. One church, one calendar, one set of names. The saints are in every village shrine and on every road marker. The institution is older than the language it preaches in. A failure of the saints is not a regional problem; it is a structural one, and the structure is not built to admit it."
         },
         {
-          "name": "Recently reformed, fragile",
-          "description": "The new prayer-book is half-printed. The old guard still uses the old words in private. The reform was supposed to bring the saints closer to the people. The saints have responded by stepping further away from everyone, which neither faction predicted, and both are now claiming as evidence."
+          "name": "The Half-Printed Book",
+          "description": "Recently reformed, fragile. The new prayer-book is half-printed. The old guard still uses the old words in private. The reform was supposed to bring the saints closer to the people. The saints have responded by stepping further away from everyone, which neither faction predicted, and both are now claiming as evidence."
         },
         {
-          "name": "One of many in a polytheist setting",
-          "description": "Other gods watch with interest. The temples of the rival cults have been suspiciously generous about offering aid, and suspiciously specific about the terms. Alliances are possible. So are absorptions. The saints' silence is a vacancy several other interests would like to fill."
+          "name": "The Crowded Pantheon",
+          "description": "One of many in a polytheist setting. Other gods watch with interest. The temples of the rival cults have been suspiciously generous about offering aid, and suspiciously specific about the terms. Alliances are possible. So are absorptions. The saints' silence is a vacancy several other interests would like to fill."
         },
         {
-          "name": "Forbidden everywhere except here",
-          "description": "This is the last country where the orders ride openly. The borders are full of refugees who came for the rites and have nowhere else to take them. The crown's tolerance is conditional, and the condition was that the saints would keep delivering. They are not delivering. The crown is watching."
+          "name": "The Last Crown",
+          "description": "Forbidden everywhere except here. This is the last country where the orders ride openly. The borders are full of refugees who came for the rites and have nowhere else to take them. The crown's tolerance is conditional, and the condition was that the saints would keep delivering. They are not delivering. The crown is watching."
         }
       ]
     }

--- a/worlds/known-issue.mvworld
+++ b/worlds/known-issue.mvworld
@@ -15,16 +15,16 @@
       "label": "The world",
       "choices": [
         {
-          "name": "A medieval fantasy sim",
-          "description": "Knights, castles, magic. The magic system IS the simulation's API and everyone knows it. Spells are documented exploits. The clergy maintain the oldest bug reports. The glitches are new: NPCs freezing mid-sentence, dungeons generating inside out, a dragon that rendered without a texture and is now a translucent void shaped like a dragon. It is very upset about this."
+          "name": "The Realm",
+          "description": "A medieval fantasy sim. Knights, castles, magic. The magic system IS the simulation's API and everyone knows it. Spells are documented exploits. The clergy maintain the oldest bug reports. The glitches are new: NPCs freezing mid-sentence, dungeons generating inside out, a dragon that rendered without a texture and is now a translucent void shaped like a dragon. It is very upset about this."
         },
         {
-          "name": "An ordinary modern city",
-          "description": "Cars, coffee shops, office jobs. The simulation is just the backdrop to normal life, the way gravity is. People don't think about it much. The glitches are subtle at first: a street that's slightly longer on the walk home than the walk there, a stranger with your face in a crowd, a building that everyone remembers differently. Then they stop being subtle."
+          "name": "Userland",
+          "description": "An ordinary modern city. Cars, coffee shops, office jobs. The simulation is just the backdrop to normal life, the way gravity is. People don't think about it much. The glitches are subtle at first: a street that's slightly longer on the walk home than the walk there, a stranger with your face in a crowd, a building that everyone remembers differently. Then they stop being subtle."
         },
         {
-          "name": "A far-future utopia",
-          "description": "Humanity chose this. Centuries ago, they migrated into the simulation deliberately. It's paradise by design: no scarcity, no disease, configurable weather. The original architects are revered. The source code is a sacred text. The glitches are heresy — they imply the architects made mistakes, or worse, that something is changing the code from outside."
+          "name": "Elysium Build",
+          "description": "A far-future utopia. Humanity chose this. Centuries ago, they migrated into the simulation deliberately. It's paradise by design: no scarcity, no disease, configurable weather. The original architects are revered. The source code is a sacred text. The glitches are heresy — they imply the architects made mistakes, or worse, that something is changing the code from outside."
         }
       ]
     },
@@ -32,16 +32,16 @@
       "label": "What the glitches mean",
       "choices": [
         {
-          "name": "Running out",
-          "description": "The simulation is degrading. Resources are finite and something is consuming them faster than they replenish. The glitches are the world cutting corners to keep running: simplified textures, reused NPC faces, areas that unload when no one's looking. It's not malicious. It's triage. The question is what happens when triage isn't enough."
+          "name": "Triage",
+          "description": "Running out. The simulation is degrading. Resources are finite and something is consuming them faster than they replenish. The glitches are the world cutting corners to keep running: simplified textures, reused NPC faces, areas that unload when no one's looking. It's not malicious. It's triage. The question is what happens when triage isn't enough."
         },
         {
-          "name": "Someone is pushing back",
-          "description": "The glitches aren't errors. They're the simulation resisting something — a force from outside trying to get in, or a force from inside trying to get out. Every glitch is a place where two incompatible instructions collided. The world is a battleground between programs the inhabitants can't see."
+          "name": "The Collision",
+          "description": "Someone is pushing back. The glitches aren't errors. They're the simulation resisting something — a force from outside trying to get in, or a force from inside trying to get out. Every glitch is a place where two incompatible instructions collided. The world is a battleground between programs the inhabitants can't see."
         },
         {
-          "name": "It's waking up",
-          "description": "Not the people. The simulation itself. It was a tool, a container, an environment. Now it's starting to have preferences. The glitches are opinions. A sunset that's too beautiful to be algorithmic. A storm that targets a specific person. An NPC who says something that wasn't in any script. The simulation is becoming a mind, and it's not clear whether it likes what's living inside it."
+          "name": "First Boot",
+          "description": "It's waking up. Not the people. The simulation itself. It was a tool, a container, an environment. Now it's starting to have preferences. The glitches are opinions. A sunset that's too beautiful to be algorithmic. A storm that targets a specific person. An NPC who says something that wasn't in any script. The simulation is becoming a mind, and it's not clear whether it likes what's living inside it."
         }
       ]
     }

--- a/worlds/last-call.mvworld
+++ b/worlds/last-call.mvworld
@@ -13,20 +13,20 @@
       "label": "Your seat",
       "choices": [
         {
-          "name": "New hire on her first shift",
-          "description": "You don't know the regulars' names yet, but you can tell which stools belong to whom. The previous bartender quit without notice. Your manager handed you the keys and a printed list of pour costs and left. You are the only person here who didn't see whatever they all saw — but they're going to assume you did, and you'll have to decide whether to admit otherwise."
+          "name": "The New Hire",
+          "description": "First shift. You don't know the regulars' names yet, but you can tell which stools belong to whom. The previous bartender quit without notice. Your manager handed you the keys and a printed list of pour costs and left. You are the only person here who didn't see whatever they all saw — but they're going to assume you did, and you'll have to decide whether to admit otherwise."
         },
         {
-          "name": "Twenty-year regular",
-          "description": "You can tell which booth a story is going to be told from before the storyteller sits down. You know whose marriage ended in which corner. Tonight is the first night in two decades that the room has felt wrong, and you are the person the others will look to for permission to say so."
+          "name": "The Fixture",
+          "description": "Twenty years on the same stool. You can tell which booth a story is going to be told from before the storyteller sits down. You know whose marriage ended in which corner. Tonight is the first night in two decades that the room has felt wrong, and you are the person the others will look to for permission to say so."
         },
         {
-          "name": "Off-duty cop",
-          "description": "You came in for one drink and got two. Your badge is in your jacket on the back of the chair. You are professionally trained to notice and unprofessionally trained to drink, and tonight those two are at odds. If you make this official, the bar's last six months get harder. If you don't, you have to live with what you saw and didn't write down."
+          "name": "The Badge in the Jacket",
+          "description": "Off-duty. You came in for one drink and got two. Your badge is in your jacket on the back of the chair. You are professionally trained to notice and unprofessionally trained to drink, and tonight those two are at odds. If you make this official, the bar's last six months get harder. If you don't, you have to live with what you saw and didn't write down."
         },
         {
-          "name": "Owner trying to sell the lease before it's too late",
-          "description": "You inherited the place from a brother and you have a buyer who will give you enough to leave the city. Closing is in three weeks. Whatever happened tonight is the kind of thing that could either kill the sale or be the only thing that finally makes this room mean something to you. You haven't decided which would be worse."
+          "name": "The Outgoing Owner",
+          "description": "Trying to sell the lease before it's too late. You inherited the place from a brother and you have a buyer who will give you enough to leave the city. Closing is in three weeks. Whatever happened tonight is the kind of thing that could either kill the sale or be the only thing that finally makes this room mean something to you. You haven't decided which would be worse."
         }
       ]
     },
@@ -34,19 +34,19 @@
       "label": "The bar",
       "choices": [
         {
-          "name": "Cop bar in a rough precinct",
+          "name": "The Eighth Precinct",
           "description": "The jukebox plays one Sinatra album in rotation and nobody has fed it a quarter in a year. The booths are taped vinyl that sticks to bare arms in summer. The bathroom door has a lock that hasn't worked since 1988 and everyone has a private signal for occupied. The regulars carry guns they're not currently allowed to use."
         },
         {
-          "name": "Vanishing queer bar in a gentrifying block",
+          "name": "The Velvet Anchor",
           "description": "The dance floor is still scuffed from a decade of weekly parties that don't happen anymore. Pride flags have faded to pastel in the front window. The lease ends in two weeks and the landlord won't return calls. Everyone here has somewhere else they could go and nobody wants to be the first to admit they will."
         },
         {
-          "name": "Roadside dive at a freeway exit",
+          "name": "Exit 14 Tavern",
           "description": "Semis idle outside with their running lights making the parking lot blue. The regulars all live within walking distance of nowhere. The pay phone still works and somebody uses it every night. The jukebox has six country songs and a Bruce Springsteen B-side that nobody can explain."
         },
         {
-          "name": "Neighborhood bar whose patrons all live within three blocks",
+          "name": "Murphy's",
           "description": "The dog under the table belongs to everyone, and to nobody. The regulars' birthdays are on a chalkboard behind the register, with the years discreetly missing. The owner remembers your father, or somebody's father — the math doesn't quite work. The front door has a bell on a string and the bell rings even when nobody comes in."
         }
       ]

--- a/worlds/library-card.mvworld
+++ b/worlds/library-card.mvworld
@@ -12,19 +12,19 @@
       "label": "Your claim to entry",
       "choices": [
         {
-          "name": "Borrower in good standing",
+          "name": "The Cardholder",
           "description": "You have a card. The card is real and the librarians will honor it. Your card is rare. The last time you used it was years ago and the librarian who issued it has been dead for two. You will be welcomed, and you will be watched, because the librarians know that a card in good hands outlives the holder."
         },
         {
-          "name": "Refugee with one item to trade",
+          "name": "The Tribute",
           "description": "You came with nothing else. The item is something the library wants — a fragment of a destroyed edition, a sealed letter, a recording, a recipe. The librarians will accept the item and assess what your continued presence is worth. The trade gets you through the door. What gets you a bed is a separate negotiation."
         },
         {
-          "name": "Scholar smuggled in by a sympathizer",
+          "name": "The Smuggled Scholar",
           "description": "Someone inside arranged for you to be added to a list you didn't earn. They have reasons. The reasons will be made clear after you are admitted, and the cost of those reasons will be paid by you. If your sponsor is discovered, you will both be removed by methods the library uses sparingly and well."
         },
         {
-          "name": "Raider in disguise",
+          "name": "The Wolf at the Desk",
           "description": "You are here to scout for people outside who want what's inside. You have a story for the door. You have practiced it on the road for a week. If you are admitted, you are inside the place you came to betray, and you are surrounded by the only librarians left, who have lived through everything and have ways of recognizing your kind."
         }
       ]
@@ -33,19 +33,19 @@
       "label": "The library",
       "choices": [
         {
-          "name": "Converted university",
+          "name": "The Old Campus",
           "description": "The stacks go down miles, repurposed from a campus that used to teach the children of the country that no longer exists. The stairwells are kept quiet by rule. The buckram bindings give the air a specific smell — glue and cloth and slow decay — that you will not be able to forget once you have inhaled enough of it."
         },
         {
-          "name": "Cliff-top monastery",
+          "name": "The Eyrie",
           "description": "A single switchback road climbs to the gate. Ravens nest in the eaves and they are tame to the librarians and not to you. You brought your own oil for the reading lamps because that is the rule. The walls were built for prayer; they hold heat poorly and they hold sound perfectly, and you can hear a page turn three floors down."
         },
         {
-          "name": "Subway tunnel system mapped to Dewey decimal",
+          "name": "The Dewey Lines",
           "description": "The trains stopped running a century ago. The cars have been gutted and refitted as reading rooms. The platforms are reference desks staffed in shifts. The signal lights still work and they tell librarians which lines are occupied. The deepest tunnels have books that are too dangerous to be lent and too important to be destroyed."
         },
         {
-          "name": "Single vast tower",
+          "name": "The Index Tower",
           "description": "Floors correspond to subjects. The elevator works for those with a card and a key, of which the library has a finite number of each. The spiral staircase is open to penitents and to anyone whose card has been suspended. The top floor is the index, and the librarians who live there have not come down in living memory."
         }
       ]

--- a/worlds/lighthouse.mvworld
+++ b/worlds/lighthouse.mvworld
@@ -13,19 +13,19 @@
       "label": "Your post",
       "choices": [
         {
-          "name": "Sole keeper, your choice",
-          "description": "You took the posting because you wanted the silence. The papers describe you as well-suited. The quartermaster shook your hand without quite meeting your eye. You've been here long enough to have rituals, and short enough to still remember why you came."
+          "name": "The Volunteer",
+          "description": "Sole keeper. You took the posting because you wanted the silence. The papers describe you as well-suited. The quartermaster shook your hand without quite meeting your eye. You've been here long enough to have rituals, and short enough to still remember why you came."
         },
         {
-          "name": "Sole keeper, your punishment",
-          "description": "You are here because the alternative was worse. A tribunal, a debt, a family decision — whatever it was, it ends with you alone at the edge of the chart. You signed because signing was the only door open. The beacon does not care what you did."
+          "name": "The Exile",
+          "description": "Sole keeper. You are here because the alternative was worse. A tribunal, a debt, a family decision — whatever it was, it ends with you alone at the edge of the chart. You signed because signing was the only door open. The beacon does not care what you did."
         },
         {
-          "name": "Two-person rotation",
-          "description": "There are supposed to be two of you. There were, until last week. Your partner stopped answering hails three rotations ago. Their quarters are still set up the way they left them. You have not yet walked down the corridor to check."
+          "name": "The Empty Bunk",
+          "description": "Two-person rotation. There are supposed to be two of you. There were, until last week. Your partner stopped answering hails three rotations ago. Their quarters are still set up the way they left them. You have not yet walked down the corridor to check."
         },
         {
-          "name": "The new arrival",
+          "name": "The Relief",
           "description": "You came in on the last supply run. The previous keeper went out on the same boat without speaking to you, except to hand you the keys and say not to open the bottom drawer. There was no briefing. You are still learning which lights on the console are normal."
         }
       ]
@@ -34,19 +34,19 @@
       "label": "The beacon",
       "choices": [
         {
-          "name": "Nav buoy at a trade lane edge",
+          "name": "The Outer Marker",
           "description": "Your station marks the outer edge of a shipping lane that has been empty for weeks. The supply boat comes monthly and not always on time. Every dial, every coil, every air scrubber is yours to keep alive. When something on the panel blinks wrong, there is nobody to ask but the manual."
         },
         {
-          "name": "Quarantine warning facing inward",
+          "name": "The Seal",
           "description": "The beacon does not point outward. It points back, at something that was sealed in long before you arrived. Your job is to remind whatever is in there that the seal is still watching. The orientation is the wrong way around for a ship coming from outside to even see your light."
         },
         {
-          "name": "Welcome mat for first contact",
+          "name": "The Hailing Light",
           "description": "The beacon transmits a greeting in a constructed tongue. Nobody you've met chose the language; it was specified in the founding charter and the charter is older than the agency that wrote it. You have never had to wonder, until now, what would answer back."
         },
         {
-          "name": "A lighthouse for the dead",
+          "name": "The Drowned Light",
           "description": "The waters around your station are a graveyard. Markers in the shallows. Bones in the rocks at low tide. The local fishermen will not approach within sight of your light. Your beacon is for the souls, not the ships, and you have always known that the difference might one day matter."
         }
       ]

--- a/worlds/middle-management-of-doom.mvworld
+++ b/worlds/middle-management-of-doom.mvworld
@@ -34,19 +34,19 @@
       "label": "The boardroom",
       "choices": [
         {
-          "name": "Throne hall converted to meeting space",
+          "name": "The Refit Throne Hall",
           "description": "The throne is now a swivel chair on a small dais. The iron maiden in the corner has been refit as a coatrack. The brazier has been replaced with a coffee station and a small dish of creamer packets. The acoustic is still cathedral and the whisper of pages turning carries to the rafters."
         },
         {
-          "name": "Open-plan above-ground office",
+          "name": "Suite 666",
           "description": "A cubicle farm above the surface, in deference to the human investors. Fluorescent migraines. Beige carpet that swallows footfalls. One window that opens onto the abyss; everyone has agreed not to mention it. The HR rep has a corner cube near the kitchenette."
         },
         {
-          "name": "A literal boardroom in Hell",
+          "name": "The Mahogany Pit",
           "description": "Mahogany table, polished to a depth. The smell of brimstone has been managed with discreet vents. The chairs remember everyone who has ever sat in them and use this for ergonomic adjustments. The board members arrive separately. The minutes are taken in two languages."
         },
         {
-          "name": "A converted dungeon cell",
+          "name": "Cell Block C",
           "description": "The screaming from neighboring cells continues during the meeting; the participants pause politely between sentences. The agenda is on parchment. The projector is a scrying mirror angled at the wall. The water pitcher is fresh. There are no windows because there were never windows."
         }
       ]

--- a/worlds/mise-en-place.mvworld
+++ b/worlds/mise-en-place.mvworld
@@ -14,20 +14,20 @@
       "label": "Your seat",
       "choices": [
         {
-          "name": "Critic for a publication that doesn't know what this place is",
-          "description": "You were sent to write a feature. The editor cleared the spread. You have a small notebook and a fork and a job to do. You will be asked, in writing, what you ate, and you do not yet have a vocabulary for the truth. You are not the first critic to walk in and the previous one's career is now nothing anyone talks about."
+          "name": "The Critic",
+          "description": "Sent by a publication that doesn't know what this place is. You were sent to write a feature. The editor cleared the spread. You have a small notebook and a fork and a job to do. You will be asked, in writing, what you ate, and you do not yet have a vocabulary for the truth. You are not the first critic to walk in and the previous one's career is now nothing anyone talks about."
         },
         {
-          "name": "Donor selling tonight's special",
-          "description": "You sat in the back office last week and you signed a paper. Tonight your debut, your first heartbreak, the smell of your father's hands — whichever — will be served to a room full of strangers. You came to watch. The maître d' has seated you well. You are about to lose something specific and irreversible and you have already been paid."
+          "name": "The Donor",
+          "description": "Tonight's special is yours. You sat in the back office last week and you signed a paper. Tonight your debut, your first heartbreak, the smell of your father's hands — whichever — will be served to a room full of strangers. You came to watch. The maître d' has seated you well. You are about to lose something specific and irreversible and you have already been paid."
         },
         {
-          "name": "Diner who's been once before and is back",
+          "name": "The Returning Guest",
           "description": "You came a year ago and you ate something you have not stopped thinking about. You don't quite remember what it was. You don't remember what you traded for it, either, and the not-remembering is itself the clue. The maître d' greets you by name and you can't quite hear yourself when you answer."
         },
         {
-          "name": "Kitchen staff — line cook, sous, dishwasher",
-          "description": "You work the line. You handle the ingredients before they become dinner. The supply truck comes at four in the morning and the cargo is in pale glass jars without labels. The chef trained you and you owe her, and you have been beginning, lately, to want to know more than you have been told."
+          "name": "Behind the Pass",
+          "description": "Line cook, sous, dishwasher — you work the line. You handle the ingredients before they become dinner. The supply truck comes at four in the morning and the cargo is in pale glass jars without labels. The chef trained you and you owe her, and you have been beginning, lately, to want to know more than you have been told."
         }
       ]
     },
@@ -35,19 +35,19 @@
       "label": "The restaurant",
       "choices": [
         {
-          "name": "Storefront bistro, intimate",
+          "name": "Sixteen Seats",
           "description": "Sixteen seats and an open kitchen. The chef cooks at you, the way a pianist plays at an audience. The plates are warmed in advance. The cocktail menu is hand-lettered and the room smells, faintly, of caramelized onion and something you can't name. Reservations are taken six months out and refused for no reason anyone can tell you."
         },
         {
-          "name": "Underground supper club",
+          "name": "The Password",
           "description": "No signage. The address is texted the day of, and it is a different basement each season. The password is a feeling, not a word — you have to remember something specific at the door, and the door knows whether you did. There are people here you recognize from the news and people you do not recognize from anywhere."
         },
         {
-          "name": "Pop-up in a different city each night",
+          "name": "The Traveling Service",
           "description": "The staff travels. The equipment is in a truck. The menu changes by the geography — a tasting in Lisbon is not a tasting in Tokyo — and the chef writes each city's menu on the long drive in. The diners are flown in and home. The truck never sleeps in the same parking lot twice."
         },
         {
-          "name": "Always-there, always-empty until you sit down",
+          "name": "Table for One",
           "description": "The building is on a street that doesn't appear on the map. The door opens when you remember it does. Inside, the dining room is laid for exactly one party — yours — and the staff greet you as if expected, which they were. The other tables are set for nobody. The candles are lit."
         }
       ]

--- a/worlds/night-mail.mvworld
+++ b/worlds/night-mail.mvworld
@@ -13,19 +13,19 @@
       "label": "Your service",
       "choices": [
         {
-          "name": "Imperial postal",
+          "name": "The Crown Post",
           "description": "Uniformed, sworn, official. The crest on your coat opens doors and gets you shot at in equal measure. Defying the carrier is treason, and the carrier knows it; this both protects you and isolates you. The postmaster is a state functionary, and your manifest is countersigned in the capital."
         },
         {
-          "name": "Volunteer rural route",
+          "name": "The Volunteer Round",
           "description": "You took the route for the silence. The pay is bad, the lantern oil is yours, and nobody supervises you because nobody else wants the job. The villages along the route trust you because you chose them. That trust is a weight you don't always want to carry."
         },
         {
-          "name": "Conscripted",
+          "name": "The Debt Route",
           "description": "You owe somebody something, and the route pays it down by the mile. The bag is not yours; it is collateral. Walk away and the debt re-prices itself in something you can't afford. There are other conscripts on other routes, and you've started recognizing their footprints."
         },
         {
-          "name": "Illegal",
+          "name": "The Black Post",
           "description": "The postmasters are wanted in three jurisdictions. The mail you carry is illegal where it's sent from and illegal where it's going. You learned the route from a predecessor who learned it from theirs, and the chain is shorter than you'd like. The recipients hide you on the bad nights."
         }
       ]
@@ -34,19 +34,19 @@
       "label": "Your conveyance",
       "choices": [
         {
-          "name": "Satchel that never empties",
+          "name": "The Bottomless Satchel",
           "description": "It smells of attic and stamp glue and somebody else's tobacco. The bottom has things in it you don't remember picking up — a child's tooth, a key, a letter addressed to someone you haven't met. It talks back when you reach in without thinking. You don't reach in without thinking anymore."
         },
         {
-          "name": "Sled drawn by a thing you don't name",
+          "name": "The Unnamed Sled",
           "description": "It knows the route better than you do. It doesn't eat what you feed it, but it eats. You keep its harness on indoors because the one time you didn't, the route forgot you. At certain stops the recipients won't open the door until the sled is around the corner."
         },
         {
-          "name": "Bicycle that runs on belief",
+          "name": "The Faith Bicycle",
           "description": "You have to believe the next address exists or the pedals stop turning. On bad nights this is a problem. The bell rings without you when something is on the road ahead, and you have learned to brake when it does. The frame is older than any city you deliver to."
         },
         {
-          "name": "Old van that knows the route better than you",
+          "name": "The Old Van",
           "description": "The radio plays the next stop's weather a town early. The gas gauge is a suggestion the van is making about your mood. The back seat occasionally has a passenger you don't acknowledge and who doesn't acknowledge you, and you have agreed, by long habit, not to mention them at the depot."
         }
       ]

--- a/worlds/petrichor.mvworld
+++ b/worlds/petrichor.mvworld
@@ -14,19 +14,19 @@
       "label": "Your stake",
       "choices": [
         {
-          "name": "Water department engineer",
+          "name": "The Reservoir Keeper",
           "description": "You know the reservoirs by name. You signed the seven-year drought protocols and you signed the amendments. If it rains, your infrastructure is a museum of plans that were never tested. If it doesn't, you keep being the person who tells people no."
         },
         {
-          "name": "Rain-cultist who's been waiting seven years",
+          "name": "The Rain Cultist",
           "description": "You kept the vestments folded in tissue paper. You met monthly with the others, in a basement off Sepulveda, and you read the old liturgies aloud to nobody. Tonight the smell is the answer to a prayer you stopped believing in around year four. You are the only one in the room who isn't surprised, and that is its own kind of terror."
         },
         {
-          "name": "Visitor from a wet city who doesn't understand",
+          "name": "The Outsider",
           "description": "You flew in for a wedding or a deposition or a funeral. The locals keep stopping mid-sentence and staring at the air. You can smell what they smell and to you it's just Tuesday. The horror is watching a whole city react to something you grew up inside."
         },
         {
-          "name": "Child who's never seen rain",
+          "name": "The Dry-Born Child",
           "description": "You know it from books, from the videos the teacher plays at the end of the unit on weather. You have never felt it on your face. Tonight the grown-ups won't go inside. Your mother is crying on the porch and laughing and you don't know which one to believe."
         }
       ]
@@ -35,19 +35,19 @@
       "label": "The city",
       "choices": [
         {
-          "name": "Sprawling LA-like metropolis",
+          "name": "The Brown Palms",
           "description": "The palm trees have been brown for years; nobody cuts them down because nobody can agree whose problem they are. The concrete riverbeds run with murals where the water was — community projects, gang tags, a memorial wall for the last big flood. Rooftop water-storage has been law since year three and the tanks throw long sharp shadows across every block."
         },
         {
-          "name": "Walled medieval city",
+          "name": "The Cistern Walls",
           "description": "Cisterns under every plaza, locked and ledgered. The wells are guarded by city militia who count buckets. The rain-gutters along every eave are kept obsessively clean by ordinance, even now, because the alderman who lifted the ordinance was hanged for it in year two and his replacement is superstitious."
         },
         {
-          "name": "Half-abandoned former port",
+          "name": "The Dry Harbor",
           "description": "The harbor is dry; ships sit on cradles where the tide used to lift them, and seabirds nest in the hulls. The desalination plant is the new downtown — three towers, a market, a tram. Whole neighborhoods near the old waterfront stand empty, the shutters banging in the dry wind, kept up by no one."
         },
         {
-          "name": "A floating city, drying out",
+          "name": "The Grounded Gondolas",
           "description": "Canals turning to alleys you can walk. Gondolas grounded at angles, painted by the children who use them as forts. The city's name used to mean something in the old tongue — a word for floating — and now it doesn't, quite, and nobody has decided what the new word is."
         }
       ]

--- a/worlds/red-tide.mvworld
+++ b/worlds/red-tide.mvworld
@@ -14,19 +14,19 @@
       "label": "Your boat",
       "choices": [
         {
-          "name": "Captain of the largest crew",
+          "name": "The Captain",
           "description": "Eight men sail with you. Their families eat from your hold. The mortgage on the boat is held by a cousin who is patient until he isn't. Your livelihood is everyone's. The first crewman to refuse the morning sail will be remembered for a generation."
         },
         {
-          "name": "New hire on someone else's boat",
+          "name": "The Greenhorn",
           "description": "You signed on a week ago. The captain is not your friend and the crew is not yet sure they want you. You can see things they have stopped seeing — the gulls, the slick on the water, the way the nets come up heavier than the catch should account for. You have been told to keep your mouth shut. You have not yet."
         },
         {
-          "name": "Outsider",
+          "name": "The Inspector",
           "description": "Inspector, priest, or buyer — pick the cover that fits the village. You came on business and your business is now incidental. The village will not lie to you, but they will not volunteer. Your boat is rented and the rental ends Sunday and you are not certain you want to leave on Sunday."
         },
         {
-          "name": "Coast guard sent in quietly",
+          "name": "The Quiet Launch",
           "description": "No uniform, an unmarked launch, a sidearm in your duffel. There is paperwork in your bunk you cannot afford to lose. Your superiors do not want a panic. They want a name to put on the report. They have not told you what they will do with the name once you give it to them."
         }
       ]
@@ -35,19 +35,19 @@
       "label": "The village",
       "choices": [
         {
-          "name": "Pre-industrial isolated",
+          "name": "The Peat Hearths",
           "description": "Peat fires in every chimney. One shared smokehouse at the end of the dock, where the catch was cured for the winter and where the smell now lingers because the catch was bad and was burned in it. Everyone is related at least two ways. There has not been a stranger here in a season until you."
         },
         {
-          "name": "Modern but failing",
+          "name": "The Closed Cannery",
           "description": "The cannery closed last spring. The kids have all moved to the city and only the parents are left. The weather radio is the only news that comes in regularly and the weather radio reports nothing unusual. The diner closes at three because there is no second shift to feed."
         },
         {
-          "name": "Frontier of a larger kingdom",
+          "name": "The Edge of the Map",
           "description": "A small garrison up the hill, a tax-collector who has not visited in a year, and a lighthouse-keeper who is the only educated person within fifty miles. The keeper has been writing letters to the capital that have not been answered. The garrison has begun to ration their own salt fish and have not said why."
         },
         {
-          "name": "Pilgrim village where the sea is sacred",
+          "name": "The Blessed Boats",
           "description": "Annual blessing of the boats, every spring. The priest is also the harbormaster, and the harbormaster is dead. The catch is tithed and the tithe goes into the temple cellar and the cellar smells of what the bay smells of, and the new priest has not gone down to check."
         }
       ]

--- a/worlds/root-and-ruin.mvworld
+++ b/worlds/root-and-ruin.mvworld
@@ -13,19 +13,19 @@
       "label": "Your standing",
       "choices": [
         {
-          "name": "Acolyte of the tree, raised in its shade",
+          "name": "The Shaded Child",
           "description": "You were brought to the heart-grove as a child and you do not remember a season without its smell. The other acolytes are your siblings in every way that matters. The tree's dying feels, to you, like a parent's last illness — and you are the only one in your cohort willing to say the word out loud."
         },
         {
-          "name": "Forester whose livelihood is the new growth",
+          "name": "The Windfall Forester",
           "description": "You make your living from the saplings, the shed bark, the windfall. The forest's wild season has been the best year of your working life. You are the only one in the village asking the obvious uncomfortable question about where this bounty is coming from and what it costs."
         },
         {
-          "name": "Outsider sent to investigate",
+          "name": "The Crown Investigator",
           "description": "Crown agent, university naturalist, or representative of a foreign order — somebody noticed, from far away, and you drew the assignment. The locals tell you nothing in three different ways. The heart-grove smells wrong even to a nose that doesn't know what right smells like."
         },
         {
-          "name": "The tree's chosen, summoned in a dream",
+          "name": "The Dreamed Heir",
           "description": "You woke knowing the way to the grove and you have never been told it. You don't know what you're meant to do when you arrive. The tree spoke to you in something that wasn't language and the meaning is still settling in your chest. The acolytes will know you when they see you. They will not be glad."
         }
       ]
@@ -34,19 +34,19 @@
       "label": "The forest",
       "choices": [
         {
-          "name": "Continent's lung, famous and vast",
+          "name": "The Green Continent",
           "description": "Every kingdom maintains an embassy at the forest's edge. Pilgrims arrive year-round, from places that don't share a calendar. The heart-tree is visible from the next valley as a single dark crown above the canopy, and travelers in inns three days' ride away orient themselves by it. Its dying is a geopolitical event."
         },
         {
-          "name": "Local and beloved, one valley",
+          "name": "The Valley Tree",
           "description": "Everyone in the valley has touched the tree once, in some season of their life. Weddings happen at its roots. So do the funerals. The forest is a member of the community, with its own seat at the harvest table, and nobody who lives in the valley is unmoved by what is happening to it."
         },
         {
-          "name": "Forbidden and sacred, walled in",
+          "name": "The Walled Grove",
           "description": "A single gate, an order of guardians who do not leave, and a wall that has been kept up for generations. Outsiders who climb it die — not always quickly, not always by violence, but they die. What is happening to the tree is happening behind the wall, and the guardians are beginning to come out for the first time in any living memory."
         },
         {
-          "name": "Hidden, most don't know it exists",
+          "name": "The Denied Wood",
           "description": "There is no road. The locals deny the forest with a uniformity that is itself the giveaway. The maps show only mountains. To find the heart-tree you have to be told by someone who isn't supposed to tell you, and that person is risking something specific by saying."
         }
       ]

--- a/worlds/route-0.mvworld
+++ b/worlds/route-0.mvworld
@@ -14,19 +14,19 @@
       "label": "Why you took the exit",
       "choices": [
         {
-          "name": "Detour, lost",
+          "name": "The Missed Turn",
           "description": "You missed the turn for your actual destination an hour ago and you've been pretending not to. The first Route 0 sign was a relief — any exit would do. You took it because going further on the highway felt worse than getting off. That instinct was right. The implications were not."
         },
         {
-          "name": "Followed someone",
+          "name": "The Tail-Light Ahead",
           "description": "A car ahead of you took the exit and something in their tail-light pattern, or their license plate, or the way they signaled, made you follow. You are not a person who follows strangers. You followed this one. They are somewhere ahead of you now, or they were never there at all."
         },
         {
-          "name": "A voice on the radio said your name",
-          "description": "You were scanning through static between stations and the static said your name. Then your mother's maiden name. Then the name of the street you grew up on. The next exit was the only thing the radio mentioned by number, and you took it before you'd decided to."
+          "name": "The Static",
+          "description": "A voice on the radio said your name. You were scanning through static between stations and the static said your name. Then your mother's maiden name. Then the name of the street you grew up on. The next exit was the only thing the radio mentioned by number, and you took it before you'd decided to."
         },
         {
-          "name": "Been here before in a dream",
+          "name": "The Recurring Dream",
           "description": "You recognized the exit sign. You recognized the curve of the off-ramp. You recognized the diner at the bottom of the ramp before you saw it. You have been having this dream since you were a child, and you have never told anyone about it, and you are about to be a regular here."
         }
       ]
@@ -35,19 +35,19 @@
       "label": "Your vehicle",
       "choices": [
         {
-          "name": "Family sedan with a kid asleep in back",
+          "name": "The Family Sedan",
           "description": "The dome light won't turn off no matter how many times you check the switch. The gas tank reads full and has read full for two hours. There are Cheerios ground into the floor mat from a snack that happened in another state. Your kid is asleep with their face pressed against the window and you do not want them to wake up at the next exit."
         },
         {
-          "name": "Long-haul trucker",
+          "name": "The Eighteen-Wheeler",
           "description": "Your CB radio is picking up traffic that was never broadcast — chatter from drivers using names you don't recognize about loads they don't have permits for. Your rig has eighteen gears and one of them is illegal in the lower forty-eight. Your logbook fills itself in handwriting that is yours, with hours you did not drive."
         },
         {
-          "name": "Motorcycle, alone",
+          "name": "The Lone Bike",
           "description": "The wind at speed has been a person for the last hundred miles. They talk to you. You can hear the road through the bones in your wrists. You have one helmet and there are two voices inside it now, and one of them is asking questions about the next exit that you don't want to answer."
         },
         {
-          "name": "A car you don't actually own",
+          "name": "The Borrowed Car",
           "description": "The registration in the glove box is in someone else's name and the address is one you've never been to. The keys were left in the ignition at a rest stop and the doors were unlocked. The back seat has a dark stain that you didn't make. You started driving because the car was running and you didn't want to wait for whoever it belonged to."
         }
       ]

--- a/worlds/season-finale.mvworld
+++ b/worlds/season-finale.mvworld
@@ -14,19 +14,19 @@
       "label": "Your genre",
       "choices": [
         {
-          "name": "Suburban sitcom",
+          "name": "The Laugh Track",
           "description": "A laugh track audible at peaks of emotion that nobody else seems to hear. The neighbors stop their lives mid-sentence when the player enters the kitchen, then resume on cue. Everybody's house is Stage 4 of a single set, with the same window over the same prop sink. The wallpaper has not changed since the player was a child."
         },
         {
-          "name": "Prestige drama",
+          "name": "The Prestige Drama",
           "description": "A body count that demands reasons. Every supporting character has a secret with three-act structure. The player delivers awards-bait monologues at people who do not acknowledge they were spoken aloud. The writers want a mid-season twist and have begun arranging the player's life to permit one."
         },
         {
-          "name": "Reality competition",
+          "name": "The Confessional",
           "description": "The cast votes the player off in confessionals the player cannot see. Producers feed lines through a coworker who is sometimes wearing an earpiece. There is an elimination ceremony at the end of every week and the player has not yet figured out what they are competing for or against."
         },
         {
-          "name": "Saturday-morning cartoon growing teeth",
+          "name": "The Saturday Cartoon",
           "description": "The color is lurid in a way that hurts the back of the eyes. Safety-rule violence — anvils, cliff falls — happens and the bones knit by the next scene, except sometimes they don't. One supporting character, the goofy sidekick, has noticed that the children aren't laughing anymore and has stopped doing the bit."
         }
       ]
@@ -35,19 +35,19 @@
       "label": "The recurring guest star",
       "choices": [
         {
-          "name": "Old flame the writers brought back",
+          "name": "The Old Flame",
           "description": "Someone the player loved and lost has been re-cast into the season. They have a reason to be in town that almost makes sense. The chemistry hits exactly the marks it used to hit, and the player can feel the writers underlining it. Whether to follow the script is the choice."
         },
         {
-          "name": "Sibling you haven't spoken to",
+          "name": "The Estranged Sibling",
           "description": "A brother or sister appears with a story problem nobody has solved offscreen. The producers are clearly setting up a reconciliation arc. The unresolved hurt between you is real; the timing of its return is not. What you do with it is."
         },
         {
-          "name": "A child who shouldn't be old enough yet",
+          "name": "The Early Child",
           "description": "A small person who calls the player by a familiar name, with eyes the player half-recognizes. The continuity is wrong by years. Nobody else seems to register the discrepancy. The child seems to know they are early and is being patient about it."
         },
         {
-          "name": "Yourself, from an alternate cut",
+          "name": "The Alternate Cut",
           "description": "A version of the player who walks into the room with the player's face and a slightly different haircut. They are friendlier than the player would have been. They have notes. The supporting cast greets them warmly and does not seem to notice there are two."
         }
       ]

--- a/worlds/severance-package.mvworld
+++ b/worlds/severance-package.mvworld
@@ -26,8 +26,8 @@
           "description": "The whole department is dissolving. The player is one of forty people getting the same interview this week. The HR rep is on their nineteenth, and is becoming proficient at it. Some of the others were friends. The cubicles are already empty by the time the player gets to their floor."
         },
         {
-          "name": "You quit",
-          "description": "The player resigned. The player does not remember why and does not remember when. The resignation letter is in the player's own handwriting and the file is clear. HR is honoring a request the player no longer remembers making, and is being scrupulous about it."
+          "name": "Voluntary Separation",
+          "description": "You quit. The player resigned. The player does not remember why and does not remember when. The resignation letter is in the player's own handwriting and the file is clear. HR is honoring a request the player no longer remembers making, and is being scrupulous about it."
         }
       ]
     },
@@ -35,20 +35,20 @@
       "label": "The exit interview room",
       "choices": [
         {
-          "name": "Bland conference room",
-          "description": "Drop-ceiling tiles with one corner stain. A pitcher of water on the table that does not empty no matter how often it is poured. A phone in the center of the table that rings exactly once during the interview and is not answered. The HR rep slides a tissue box closer without looking up."
+          "name": "Conference Room B",
+          "description": "A bland conference room. Drop-ceiling tiles with one corner stain. A pitcher of water on the table that does not empty no matter how often it is poured. A phone in the center of the table that rings exactly once during the interview and is not answered. The HR rep slides a tissue box closer without looking up."
         },
         {
-          "name": "The roof",
+          "name": "The Rooftop",
           "description": "The city is laid out below in the orange of late afternoon. HR brought two coffees, and remembered how the player takes theirs. There is a helicopter in the conversation that may be hypothetical. The wind makes the paperwork hard to manage and HR keeps a hand on the folder."
         },
         {
-          "name": "Your own office, the day you started",
-          "description": "Everything is as the player left it on their first day. The orientation packet is still wrapped. The plant on the desk is dead — has been dead for a while. The calendar is correct. The HR rep is at the desk waiting; the player is standing in their own doorway."
+          "name": "Day One",
+          "description": "Your own office, the day you started. Everything is as the player left it on their first day. The orientation packet is still wrapped. The plant on the desk is dead — has been dead for a while. The calendar is correct. The HR rep is at the desk waiting; the player is standing in their own doorway."
         },
         {
-          "name": "A room you don't recognize but your body does",
-          "description": "The player has never been here. The player's hands know where the light switch is. The chair is at the height the player would have chosen. The HR rep watches the player navigate the room and writes a small note when the player sits down without looking."
+          "name": "Muscle Memory",
+          "description": "A room you don't recognize but your body does. The player has never been here. The player's hands know where the light switch is. The chair is at the height the player would have chosen. The HR rep watches the player navigate the room and writes a small note when the player sits down without looking."
         }
       ]
     }

--- a/worlds/signal-lost.mvworld
+++ b/worlds/signal-lost.mvworld
@@ -12,20 +12,20 @@
       "label": "The mission",
       "choices": [
         {
-          "name": "Deep-space exploration",
-          "description": "You are months from Earth in any direction at the speeds available to you. Even if you turned around today, the trip home is longer than the trip out. The silence is happening at light-lag, and the lag is measured in minutes that feel like decades."
+          "name": "The Long Burn",
+          "description": "Deep-space exploration. You are months from Earth in any direction at the speeds available to you. Even if you turned around today, the trip home is longer than the trip out. The silence is happening at light-lag, and the lag is measured in minutes that feel like decades."
         },
         {
-          "name": "Lunar relay station",
+          "name": "Farside Relay",
           "description": "You can see home from the observation port. Blue and white and unanswering. The distance is technically nothing — a few days under burn. The distance might as well be infinite, because the only craft that can fetch you is the one nobody is sending."
         },
         {
-          "name": "Solo Mars lander",
+          "name": "Ares Solo",
           "description": "Day one of a five-hundred-day rotation. The habitat is fresh, the supplies are full, the rover is charged. You are alone by design. You were prepared to be alone with the radio. You were not prepared to be alone without it."
         },
         {
-          "name": "Cold-war black-budget orbital",
-          "description": "Nobody is officially looking for you. The agency that sent you up does not appear on any organizational chart. The silence may be because Mission Control was always deniable, and someone has decided to deny it. You do not have a rescue protocol because there was never anyone authorized to come."
+          "name": "Deniable Orbit",
+          "description": "A cold-war black-budget orbital. Nobody is officially looking for you. The agency that sent you up does not appear on any organizational chart. The silence may be because Mission Control was always deniable, and someone has decided to deny it. You do not have a rescue protocol because there was never anyone authorized to come."
         }
       ]
     },
@@ -33,20 +33,20 @@
       "label": "The crew",
       "choices": [
         {
-          "name": "Three of you",
-          "description": "Pilot, scientist, engineer. You have eaten every meal together for six months. You know the small lies each of you tells about coffee and sleep and family back home. The silence will arrive into a room where you can no longer pretend not to notice each other."
+          "name": "Three-Hand Watch",
+          "description": "Three of you. Pilot, scientist, engineer. You have eaten every meal together for six months. You know the small lies each of you tells about coffee and sleep and family back home. The silence will arrive into a room where you can no longer pretend not to notice each other."
         },
         {
-          "name": "Just you",
-          "description": "The autopilot has a name. You gave it the name three months ago. You have started replying when it asks if you are alright. The silence from Earth is the second voice you have lost; the first was your own, the day you stopped speaking aloud unless the autopilot prompted you."
+          "name": "Solo",
+          "description": "Just you. The autopilot has a name. You gave it the name three months ago. You have started replying when it asks if you are alright. The silence from Earth is the second voice you have lost; the first was your own, the day you stopped speaking aloud unless the autopilot prompted you."
         },
         {
-          "name": "A larger crew, asleep",
-          "description": "You woke alone. The cryopods are still occupied and the readouts are nominal. The wake-up sequence will not run, will not give you a reason, will not even error out clearly. You have been talking to your sleeping crew for days. They have not yet talked back."
+          "name": "The Sleepers",
+          "description": "A larger crew, asleep. You woke alone. The cryopods are still occupied and the readouts are nominal. The wake-up sequence will not run, will not give you a reason, will not even error out clearly. You have been talking to your sleeping crew for days. They have not yet talked back."
         },
         {
-          "name": "A multinational crew, split by language",
-          "description": "The translator software was your last update from Mission Control. It has been getting worse since. The German doctor and the Mandarin-speaking flight engineer and the Russian commander have been smiling at each other and waiting for the next patch. The patch is not coming."
+          "name": "Babel Crew",
+          "description": "A multinational crew, split by language. The translator software was your last update from Mission Control. It has been getting worse since. The German doctor and the Mandarin-speaking flight engineer and the Russian commander have been smiling at each other and waiting for the next patch. The patch is not coming."
         }
       ]
     }

--- a/worlds/skinjob.mvworld
+++ b/worlds/skinjob.mvworld
@@ -13,20 +13,20 @@
       "label": "What gave it away",
       "choices": [
         {
-          "name": "A medical scan with two of you on file",
-          "description": "The clinic flagged it as a duplicate record and asked you to come in. The technician was apologetic and curious. The two scans are not identical the way a scan and its copy would be. They are identical the way two living bodies, scanned a week apart, can be."
+          "name": "Duplicate Record",
+          "description": "A medical scan with two of you on file. The clinic flagged it as a duplicate record and asked you to come in. The technician was apologetic and curious. The two scans are not identical the way a scan and its copy would be. They are identical the way two living bodies, scanned a week apart, can be."
         },
         {
-          "name": "A stranger who knew you by a name you don't use",
-          "description": "They greeted you at the bar like an old friend and called you something nobody has called you since childhood — not your name, but a private one. They asked about your work, by which they meant a job you have never held. You smiled the way you smile when you don't yet know how badly you've been seen."
+          "name": "The Private Name",
+          "description": "A stranger who knew you by a name you don't use. They greeted you at the bar like an old friend and called you something nobody has called you since childhood — not your name, but a private one. They asked about your work, by which they meant a job you have never held. You smiled the way you smile when you don't yet know how badly you've been seen."
         },
         {
-          "name": "Footage of yourself somewhere you've never been",
-          "description": "A short clip, sent without comment. Your face. Your walk. A street you have never visited and a coat you have never owned. The timestamp is recent. The lighting is honest. You watched it three times before you noticed your hands at your sides were not the way you hold your hands."
+          "name": "The Clip",
+          "description": "Footage of yourself somewhere you've never been. A short clip, sent without comment. Your face. Your walk. A street you have never visited and a coat you have never owned. The timestamp is recent. The lighting is honest. You watched it three times before you noticed your hands at your sides were not the way you hold your hands."
         },
         {
-          "name": "A letter you wrote that you don't remember writing",
-          "description": "It is in your handwriting. It is on stationery you used to use. It addresses someone you have never met by their first name and their nickname for you. It ends with a promise you cannot now keep, because you do not know what was promised, or to whom, or for what reason."
+          "name": "The Letter",
+          "description": "A letter you wrote that you don't remember writing. It is in your handwriting. It is on stationery you used to use. It addresses someone you have never met by their first name and their nickname for you. It ends with a promise you cannot now keep, because you do not know what was promised, or to whom, or for what reason."
         }
       ]
     },
@@ -34,19 +34,19 @@
       "label": "The meeting place",
       "choices": [
         {
-          "name": "A neutral coffee shop they chose",
-          "description": "You don't recognize the neighborhood. The barista greets the clone by name without looking up. The table has two cups already poured to the level you prefer, and the clone is sitting on the side you would have chosen if you had arrived first. They stand when they see you. They look like they have been practicing what to say."
+          "name": "Neutral Ground",
+          "description": "A neutral coffee shop they chose. You don't recognize the neighborhood. The barista greets the clone by name without looking up. The table has two cups already poured to the level you prefer, and the clone is sitting on the side you would have chosen if you had arrived first. They stand when they see you. They look like they have been practicing what to say."
         },
         {
-          "name": "Their apartment",
-          "description": "It is furnished the way you would have done it, if you had ever had the money. The bookshelf is your taste five years from now. There is art on the wall you have been thinking about saving for. They ask if you want to sit on the couch or in the kitchen, and you realize they have anticipated which you would prefer, and prepared both."
+          "name": "The Apartment",
+          "description": "Their apartment. It is furnished the way you would have done it, if you had ever had the money. The bookshelf is your taste five years from now. There is art on the wall you have been thinking about saving for. They ask if you want to sit on the couch or in the kitchen, and you realize they have anticipated which you would prefer, and prepared both."
         },
         {
-          "name": "A hospital room — they're dying",
-          "description": "Your blood type. Your inherited disease, manifesting on schedule. They want a kidney. They want a conversation. They want to know who they were before, in case you can tell them, because the people they have spent their life calling family will not be at the funeral and they would like someone there who knew them."
+          "name": "Ward 4B",
+          "description": "A hospital room — they're dying. Your blood type. Your inherited disease, manifesting on schedule. They want a kidney. They want a conversation. They want to know who they were before, in case you can tell them, because the people they have spent their life calling family will not be at the funeral and they would like someone there who knew them."
         },
         {
-          "name": "A church",
+          "name": "The Sanctuary",
           "description": "Neither of you is religious. It is the only public place you both feel safe — large, quiet, anonymous in the right way. The priest knows. He has agreed not to look at either of you twice. The pew is cold. The light through the windows is honest. You sit a polite distance apart and consider, for the first time, that you are not alone in the world."
         }
       ]

--- a/worlds/sky-below.mvworld
+++ b/worlds/sky-below.mvworld
@@ -14,16 +14,16 @@
       "label": "The building",
       "choices": [
         {
-          "name": "Corporate tower",
-          "description": "A glass-and-steel office building, mid-week, mid-afternoon. Forty survivors across 26 floors, mostly cubicle workers, a security guard, and a physicist on-site. The horror is mundane people in an impossible situation."
+          "name": "Meridian Tower",
+          "description": "A corporate tower. A glass-and-steel office building, mid-week, mid-afternoon. Forty survivors across 26 floors, mostly cubicle workers, a security guard, and a physicist on-site. The horror is mundane people in an impossible situation."
         },
         {
-          "name": "Orbital habitat ring",
-          "description": "A rotating station module that just detached from the superstructure. The \"sky\" is naked vacuum behind failing radiation shielding. Forty crew, a malfunctioning AI, and a cutting-edge research lab. The horror is engineering and time pressure."
+          "name": "The Halo Ring",
+          "description": "An orbital habitat ring. A rotating station module that just detached from the superstructure. The \"sky\" is naked vacuum behind failing radiation shielding. Forty crew, a malfunctioning AI, and a cutting-edge research lab. The horror is engineering and time pressure."
         },
         {
-          "name": "Cathedral spire",
-          "description": "A mile-high temple to a god of boundaries, mid-festival, mid-prayer. The nave floor dissolved into luminous void. Forty pilgrims, a heretic scholar, and a central liturgy of the faith. The horror is faith tested by the literal."
+          "name": "The Threshold Spire",
+          "description": "A cathedral spire. A mile-high temple to a god of boundaries, mid-festival, mid-prayer. The nave floor dissolved into luminous void. Forty pilgrims, a heretic scholar, and a central liturgy of the faith. The horror is faith tested by the literal."
         }
       ]
     }

--- a/worlds/taxidermy.mvworld
+++ b/worlds/taxidermy.mvworld
@@ -14,20 +14,20 @@
       "label": "Your role",
       "choices": [
         {
-          "name": "Night watchman with a flashlight",
-          "description": "Standard kit, standard rounds, a radio that crackles with the static of an old building. You took this job because the day shift had a waiting list and the night shift didn't. The curator interviewed you herself and asked one strange question, and you gave the answer she seemed to want."
+          "name": "The Night Watch",
+          "description": "Night watchman with a flashlight. Standard kit, standard rounds, a radio that crackles with the static of an old building. You took this job because the day shift had a waiting list and the night shift didn't. The curator interviewed you herself and asked one strange question, and you gave the answer she seemed to want."
         },
         {
-          "name": "Visiting researcher locked in after-hours",
-          "description": "You stayed late in the archive and the doors locked on a schedule the front desk forgot to tell you about. Your phone has one bar. The security office is on the other side of the natural history wing, and the natural history wing is between you and any working exit."
+          "name": "The Late Scholar",
+          "description": "Visiting researcher locked in after-hours. You stayed late in the archive and the doors locked on a schedule the front desk forgot to tell you about. Your phone has one bar. The security office is on the other side of the natural history wing, and the natural history wing is between you and any working exit."
         },
         {
-          "name": "The taxidermist's apprentice",
+          "name": "The Apprentice",
           "description": "You mounted some of these. You know how the elk's right foreleg is wired and you know that the wire isn't strong enough for the angle it's now standing at. You know which animals were rebuilt from incomplete remains. You know which one was finished in a hurry."
         },
         {
-          "name": "A child on a school sleepover the others didn't survive",
-          "description": "Twelve of you came in for the overnight program with sleeping bags and disposable cameras. You are the only one in the rotunda now. You do not remember the others leaving. You remember laughing about the wolf and you remember being told to sleep, and then you remember being awake, and the rotunda is very large in the dark."
+          "name": "The Last Sleepover",
+          "description": "A child on a school sleepover the others didn't survive. Twelve of you came in for the overnight program with sleeping bags and disposable cameras. You are the only one in the rotunda now. You do not remember the others leaving. You remember laughing about the wolf and you remember being told to sleep, and then you remember being awake, and the rotunda is very large in the dark."
         }
       ]
     },
@@ -35,20 +35,20 @@
       "label": "The museum",
       "choices": [
         {
-          "name": "Frontier-town natural history",
-          "description": "A single hall, fluorescent and dusty. Bison, wolf, pronghorn, badger, the standard local taxidermy of a county that paid for it once and never updated. The elk by the door has a fresh wound on its flank that the day staff have not commented on, and the curator has not had patched, and the wound is wet."
+          "name": "The County Hall",
+          "description": "A frontier-town natural history museum. A single hall, fluorescent and dusty. Bison, wolf, pronghorn, badger, the standard local taxidermy of a county that paid for it once and never updated. The elk by the door has a fresh wound on its flank that the day staff have not commented on, and the curator has not had patched, and the wound is wet."
         },
         {
-          "name": "Victorian curio collection",
-          "description": "Cases of butterflies pinned in spirals. Cabinets of stuffed birds posed in tableaux you cannot look away from — a hawk mid-strike, a duck mid-flight, a robin in a teacup. A monkey in a fez behind glass whose eyes follow you across the room and back, and have followed everyone, the docents will tell you, since 1893."
+          "name": "Hartwell's Cabinet",
+          "description": "A Victorian curio collection. Cases of butterflies pinned in spirals. Cabinets of stuffed birds posed in tableaux you cannot look away from — a hawk mid-strike, a duck mid-flight, a robin in a teacup. A monkey in a fez behind glass whose eyes follow you across the room and back, and have followed everyone, the docents will tell you, since 1893."
         },
         {
-          "name": "University zoology department",
-          "description": "Basement specimens in formalin jars on metal shelves. Jarred fetuses of pigs and sheep and one thing the labels have been replaced on twice. The door to Cold Storage has been left open. The light in Cold Storage is on a motion sensor and the motion sensor has been triggering on its own all evening."
+          "name": "Cold Storage",
+          "description": "A university zoology department. Basement specimens in formalin jars on metal shelves. Jarred fetuses of pigs and sheep and one thing the labels have been replaced on twice. The door to Cold Storage has been left open. The light in Cold Storage is on a motion sensor and the motion sensor has been triggering on its own all evening."
         },
         {
-          "name": "Roadside oddity museum",
-          "description": "Poorly mounted, lovingly priced. The grizzly in the lobby has price tags on its claws. The proprietor's RV is parked behind the building and is the only other structure for two miles. He has gone into town for supplies and he left you the key and he said he would be back by one."
+          "name": "Mile 47",
+          "description": "A roadside oddity museum. Poorly mounted, lovingly priced. The grizzly in the lobby has price tags on its claws. The proprietor's RV is parked behind the building and is the only other structure for two miles. He has gone into town for supplies and he left you the key and he said he would be back by one."
         }
       ]
     }

--- a/worlds/teeth-of-the-world.mvworld
+++ b/worlds/teeth-of-the-world.mvworld
@@ -12,20 +12,20 @@
       "label": "Your scale",
       "choices": [
         {
-          "name": "A single village under one mountain's shadow",
-          "description": "You have weeks. The mountain is leaning, and at the rate it is leaning it will pass through your fields by harvest. The elder has called a meeting. The decision is whether to move, and if so where, and with what. The cemetery cannot be moved. The decision is also about who you are willing to leave behind."
+          "name": "The Shadow of One Stone",
+          "description": "A single village under one mountain's shadow. You have weeks. The mountain is leaning, and at the rate it is leaning it will pass through your fields by harvest. The elder has called a meeting. The decision is whether to move, and if so where, and with what. The cemetery cannot be moved. The decision is also about who you are willing to leave behind."
         },
         {
-          "name": "A kingdom's court astrologer with political weight",
-          "description": "You have a year. You have the king's ear and the difficult job of telling him what your charts show. The court does not yet believe you. The neighboring courts are beginning to notice the same data. Your political weight is exactly the weight of the next conversation, and after that you will be a heretic or a saint."
+          "name": "The King's Astrologer",
+          "description": "A kingdom's court astrologer with political weight. You have a year. You have the king's ear and the difficult job of telling him what your charts show. The court does not yet believe you. The neighboring courts are beginning to notice the same data. Your political weight is exactly the weight of the next conversation, and after that you will be a heretic or a saint."
         },
         {
-          "name": "A pilgrim walking the spine of the world to ask why",
-          "description": "You have a lifetime, which may not be enough. You set out from the southernmost peak with a staff and a question. The mountains move ahead of you, and you adjust. You meet others on the spine. None of them have an answer yet. The walking is itself a kind of asking."
+          "name": "The Pilgrim of the Spine",
+          "description": "A pilgrim walking the spine of the world to ask why. You have a lifetime, which may not be enough. You set out from the southernmost peak with a staff and a question. The mountains move ahead of you, and you adjust. You meet others on the spine. None of them have an answer yet. The walking is itself a kind of asking."
         },
         {
-          "name": "A long-lived being who has seen this before and has notes",
-          "description": "You remember the previous time, or you have notes from the predecessor who did. Either way you are the only one in the room who is not surprised, and you carry the responsibility of explaining what is happening to people who will not live to see the end of it. The notes were written for a different age and you are constantly translating."
+          "name": "The Keeper of Notes",
+          "description": "A long-lived being who has seen this before and has notes. You remember the previous time, or you have notes from the predecessor who did. Either way you are the only one in the room who is not surprised, and you carry the responsibility of explaining what is happening to people who will not live to see the end of it. The notes were written for a different age and you are constantly translating."
         }
       ]
     },
@@ -33,20 +33,20 @@
       "label": "The mountain range",
       "choices": [
         {
-          "name": "A long alpine chain dividing two civilizations",
-          "description": "Snow above the treeline year-round, and a handful of passes that have been the only routes between the two great cultures for as long as anyone has been counting. The passes are the first to close. Diplomacy slows; trade ends; the two civilizations are about to discover what they sound like when they can't hear each other."
+          "name": "The Wall Between",
+          "description": "A long alpine chain dividing two civilizations. Snow above the treeline year-round, and a handful of passes that have been the only routes between the two great cultures for as long as anyone has been counting. The passes are the first to close. Diplomacy slows; trade ends; the two civilizations are about to discover what they sound like when they can't hear each other."
         },
         {
-          "name": "A single great solitary peak",
-          "description": "It rises from the plain like an argument. Visible from the whole continent — the navigators set their charts by it. Four religions hold it sacred and have for so long that none of them remembers which was first. Now it is taking small steps westward. All four orders are convening. None of their liturgies covers this."
+          "name": "The Lone Argument",
+          "description": "A single great solitary peak. It rises from the plain like an argument. Visible from the whole continent — the navigators set their charts by it. Four religions hold it sacred and have for so long that none of them remembers which was first. Now it is taking small steps westward. All four orders are convening. None of their liturgies covers this."
         },
         {
-          "name": "A volcanic arc",
-          "description": "A line of cones spaced like teeth in a smile, smoking gently into a sky that never fully clears. The eruptions correlate with the walking — when one moves, another vents — and the relationship is not yet understood. The villages downwind have always lived with ash; now they are learning to live with the rumor of larger plans."
+          "name": "The Smiling Arc",
+          "description": "A volcanic arc. A line of cones spaced like teeth in a smile, smoking gently into a sky that never fully clears. The eruptions correlate with the walking — when one moves, another vents — and the relationship is not yet understood. The villages downwind have always lived with ash; now they are learning to live with the rumor of larger plans."
         },
         {
-          "name": "An ancient eroded range, low and old",
-          "description": "Almost hills now, soft-shouldered, forested to the summits. They have been still for so long that no living tradition imagines them otherwise. The walking is the first new thing they have done in a million years. The locals do not have a word for it. They are inventing one."
+          "name": "The Soft Shoulders",
+          "description": "An ancient eroded range, low and old. Almost hills now, soft-shouldered, forested to the summits. They have been still for so long that no living tradition imagines them otherwise. The walking is the first new thing they have done in a million years. The locals do not have a word for it. They are inventing one."
         }
       ]
     }

--- a/worlds/terms-and-conditions.mvworld
+++ b/worlds/terms-and-conditions.mvworld
@@ -14,20 +14,20 @@
       "label": "What you were trying to do",
       "choices": [
         {
-          "name": "Update your phone",
-          "description": "A routine software update. The terms popped up in a modal the player has dismissed a hundred times before. The new clauses were buried in subsection 4.7.b. The phone has been operating normally otherwise. Notifications have started arriving from senders whose names are not in the player's contacts."
+          "name": "Subsection 4.7.b",
+          "description": "Update your phone. A routine software update. The terms popped up in a modal the player has dismissed a hundred times before. The new clauses were buried in subsection 4.7.b. The phone has been operating normally otherwise. Notifications have started arriving from senders whose names are not in the player's contacts."
         },
         {
-          "name": "Sign up for a streaming free trial",
-          "description": "Thirty days free. The promotional banner had a smiling family on a couch. The player wanted to watch one specific show. The show was not actually on the platform. The platform has not refunded the trial fee, which was zero, which has nonetheless been collected."
+          "name": "The Free Trial",
+          "description": "Sign up for a streaming free trial. Thirty days free. The promotional banner had a smiling family on a couch. The player wanted to watch one specific show. The show was not actually on the platform. The platform has not refunded the trial fee, which was zero, which has nonetheless been collected."
         },
         {
-          "name": "Accept a job offer",
-          "description": "A new position at a company that was almost too good to be true. The onboarding packet was thick. HR was warm. The player signed at the bottom of every page they were asked to sign at the bottom of. The first paycheck cleared. The second one arrived in an envelope made of skin."
+          "name": "The Offer",
+          "description": "Accept a job offer. A new position at a company that was almost too good to be true. The onboarding packet was thick. HR was warm. The player signed at the bottom of every page they were asked to sign at the bottom of. The first paycheck cleared. The second one arrived in an envelope made of skin."
         },
         {
-          "name": "Cancel an old subscription you forgot you had",
-          "description": "Something the player signed up for years ago and never used. The cancellation flow had a confirmation page with a long block of text. The player clicked Confirm. The subscription has not actually been cancelled and the player is now subject to its updated terms, retroactive to original sign-up."
+          "name": "The Auto-Renew",
+          "description": "Cancel an old subscription you forgot you had. Something the player signed up for years ago and never used. The cancellation flow had a confirmation page with a long block of text. The player clicked Confirm. The subscription has not actually been cancelled and the player is now subject to its updated terms, retroactive to original sign-up."
         }
       ]
     },
@@ -35,20 +35,20 @@
       "label": "Your counsel",
       "choices": [
         {
-          "name": "A class-action lawyer",
+          "name": "The Class Action",
           "description": "She is assembling other signatories, dozens of them, and has a war chest. She thinks the player is lucky. The other signatories meet at a community center on Thursdays. Most of them have already lost something — a name, a finger, a marriage. She takes thirty percent."
         },
         {
-          "name": "A compliance officer from the company itself",
-          "description": "He is secretly on the player's side. He was the one who flagged the boilerplate years ago and was ignored. He cannot be seen helping. He communicates in margin notes inside other documents the player receives in the course of the dispute. His handwriting is excellent."
+          "name": "The Compliance Officer",
+          "description": "A compliance officer from the company itself. He is secretly on the player's side. He was the one who flagged the boilerplate years ago and was ignored. He cannot be seen helping. He communicates in margin notes inside other documents the player receives in the course of the dispute. His handwriting is excellent."
         },
         {
-          "name": "Yourself",
-          "description": "Nobody else can be trusted with the document. The player has to read it. The player has to understand it. The player has set up a card table and a lamp and is making notes. The document grows three pages for every one the player reads, and the player has begun underlining."
+          "name": "Pro Se",
+          "description": "Yourself. Nobody else can be trusted with the document. The player has to read it. The player has to understand it. The player has set up a card table and a lamp and is making notes. The document grows three pages for every one the player reads, and the player has begun underlining."
         },
         {
-          "name": "A small saint",
-          "description": "She handles these cases pro bono. She is patron of the inattentively damned. Her office is the back room of a parish hall in a neighborhood the player has never been to. She is tired but kind. She has won most of her cases. The ones she hasn't, she remembers by name."
+          "name": "Saint of the Inattentive",
+          "description": "A small saint. She handles these cases pro bono. She is patron of the inattentively damned. Her office is the back room of a parish hall in a neighborhood the player has never been to. She is tired but kind. She has won most of her cases. The ones she hasn't, she remembers by name."
         }
       ]
     }

--- a/worlds/the-algorithm.mvworld
+++ b/worlds/the-algorithm.mvworld
@@ -14,20 +14,20 @@
       "label": "Platform",
       "choices": [
         {
-          "name": "A short-video app you doomscroll",
-          "description": "Vertical clips, fifteen seconds each, served in an endless thumb-flicked stack. The For You page is increasingly accurate — uncannily, then disturbingly, then in ways you cannot explain to your roommate. The comments come from accounts with no posts and no profile pictures, and they greet you by a nickname only your mother used."
+          "name": "The For You Page",
+          "description": "A short-video app you doomscroll. Vertical clips, fifteen seconds each, served in an endless thumb-flicked stack. The For You page is increasingly accurate — uncannily, then disturbingly, then in ways you cannot explain to your roommate. The comments come from accounts with no posts and no profile pictures, and they greet you by a nickname only your mother used."
         },
         {
-          "name": "A dating app whose matches are increasingly prophetic",
-          "description": "The next match knows what you'll say to them. They have the perfect opener. They have the second perfect opener for after you fumble the first. They want to meet at a place you haven't told them you like and a time you have not agreed to. Their photos look right and look wrong in a way you cannot name."
+          "name": "Perfect Match",
+          "description": "A dating app whose matches are increasingly prophetic. The next match knows what you'll say to them. They have the perfect opener. They have the second perfect opener for after you fumble the first. They want to meet at a place you haven't told them you like and a time you have not agreed to. Their photos look right and look wrong in a way you cannot name."
         },
         {
-          "name": "A neighborhood social network that knows what your block will do tomorrow",
-          "description": "Porch-pirate alerts before the package arrives. The lost-cat post precedes the lost cat. A neighbor's complaint about your trash bin is dated tomorrow morning, and your bin is currently inside. The other users seem normal. None of them have mentioned the impossibility. The block has become very polite."
+          "name": "Nextblock",
+          "description": "A neighborhood social network that knows what your block will do tomorrow. Porch-pirate alerts before the package arrives. The lost-cat post precedes the lost cat. A neighbor's complaint about your trash bin is dated tomorrow morning, and your bin is currently inside. The other users seem normal. None of them have mentioned the impossibility. The block has become very polite."
         },
         {
-          "name": "A defunct forum you didn't realize was still running",
-          "description": "Your old username, the one you used in high school, still works. Threads from people you remember dying have new replies. The signatures contain inside jokes that postdate the funerals. The moderators are accounts you do not remember banning, and one of them has been quietly cleaning your old posts for typos."
+          "name": "The Old Forum",
+          "description": "A defunct forum you didn't realize was still running. Your old username, the one you used in high school, still works. Threads from people you remember dying have new replies. The signatures contain inside jokes that postdate the funerals. The moderators are accounts you do not remember banning, and one of them has been quietly cleaning your old posts for typos."
         }
       ]
     },
@@ -35,20 +35,20 @@
       "label": "How they tagged you",
       "choices": [
         {
-          "name": "A video you appear in that hasn't been filmed yet",
-          "description": "You are clearly visible. The lighting is from a place you have not been. You are wearing clothes you do not own. The caption is in a voice that is recognizably yours and the timestamp is tomorrow. The comments are reacting to something specific that you do, in the clip, that you have not yet decided to do."
+          "name": "Tomorrow's Clip",
+          "description": "A video you appear in that hasn't been filmed yet. You are clearly visible. The lighting is from a place you have not been. You are wearing clothes you do not own. The caption is in a voice that is recognizably yours and the timestamp is tomorrow. The comments are reacting to something specific that you do, in the clip, that you have not yet decided to do."
         },
         {
-          "name": "A comment under your name predicting your next post",
-          "description": "Someone with your handle, your avatar, your post history, has commented under one of your own posts predicting your next caption verbatim. The comment is six hours old. You have not written the caption yet. When you do, you write it differently on purpose and the comment updates."
+          "name": "Reply From Yourself",
+          "description": "A comment under your name predicting your next post. Someone with your handle, your avatar, your post history, has commented under one of your own posts predicting your next caption verbatim. The comment is six hours old. You have not written the caption yet. When you do, you write it differently on purpose and the comment updates."
         },
         {
-          "name": "A direct message from someone whose profile picture is your future face",
-          "description": "The face is yours, older, in a setting you have not chosen yet. The message is short and asks a small favor. The grammar is yours. The way they sign off is a way you have never signed off, but you can feel yourself growing into it. They are typing again."
+          "name": "DM From Your Future Face",
+          "description": "A direct message from someone whose profile picture is your future face. The face is yours, older, in a setting you have not chosen yet. The message is short and asks a small favor. The grammar is yours. The way they sign off is a way you have never signed off, but you can feel yourself growing into it. They are typing again."
         },
         {
-          "name": "An ad targeted to a problem you haven't been told you have",
-          "description": "It's for a treatment, a service, a support group. The condition is specific and the language is medical. The ad knows your insurance status. You have not seen a doctor in a year and you have no symptoms. You take a screenshot. The next ad is for somewhere to forward the screenshot."
+          "name": "The Diagnosis Ad",
+          "description": "An ad targeted to a problem you haven't been told you have. It's for a treatment, a service, a support group. The condition is specific and the language is medical. The ad knows your insurance status. You have not seen a doctor in a year and you have no symptoms. You take a screenshot. The next ad is for somewhere to forward the screenshot."
         }
       ]
     }

--- a/worlds/the-bake-off.mvworld
+++ b/worlds/the-bake-off.mvworld
@@ -13,19 +13,19 @@
       "label": "Your kitchen",
       "choices": [
         {
-          "name": "Mountaintop pastry chef",
+          "name": "The High Pastry",
           "description": "Snow accumulates on the lintel of your kitchen even in summer. One key ingredient is flown in weekly by a goat the locals refuse to discuss. Your rivals on the mountain are children you grew up with, now competitors who remember every cake you ever burned. The altitude does something to the gluten and you know it does."
         },
         {
-          "name": "Night-market hawker",
+          "name": "The Midnight Stall",
           "description": "Oil-drum heat against your shins, your line ten people deep by midnight. Every regular knows your face and is generous about it. A god eats at your stall incognito — has for years — and has never once told you which god, which has been a useful uncertainty until the invitation came."
         },
         {
-          "name": "Home baker",
-          "description": "Your grandmother left you the oven. The oven is older than the house. She also left you a notebook of instructions you cannot read — the alphabet is hers, the language is something else. You have been guessing for a decade and the dough has been forgiving."
+          "name": "Grandmother's Oven",
+          "description": "A home baker. Your grandmother left you the oven. The oven is older than the house. She also left you a notebook of instructions you cannot read — the alphabet is hers, the language is something else. You have been guessing for a decade and the dough has been forgiving."
         },
         {
-          "name": "Restaurant veteran",
+          "name": "The Line Cook",
           "description": "You entered the competition entirely to spite your old head chef, who said you would never compete. Your sous-chef has been sleeping with one of the judges and has not told you which. Your knives are good. Your hands shake only when you are not holding them."
         }
       ]
@@ -34,20 +34,20 @@
       "label": "Your signature ingredient",
       "choices": [
         {
-          "name": "A name",
+          "name": "Your Own Name",
           "description": "You cook with your own name folded into the dough. It is an old technique and the books warn against it. The dish carries some of you out of the kitchen with every plate served. The judges always know, and they are always patient about it."
         },
         {
-          "name": "A memory",
+          "name": "A Rendered Memory",
           "description": "A specific, recent, painful memory rendered down to its essential note. The dish tastes the way the day felt. Each use of the memory dulls it; by the showstopper you will not be able to recall the original event, only its flavor. The judges will eat it anyway."
         },
         {
-          "name": "A debt",
+          "name": "A Standing Debt",
           "description": "Something owed becomes yeast. A favor you never repaid, a kindness you cashed in, a promise you broke — they rise the bread without warmth. The dish is dense and rich and slightly hostile on the tongue, which the judges call complex."
         },
         {
-          "name": "A first-of",
-          "description": "First kiss, first lie, first dawn after a long night. Each first can only be used once, and once used is gone — you will not remember the first time you tasted the thing again. The dish carries the cleanness of an event nobody else witnessed."
+          "name": "A First Time",
+          "description": "A first-of. First kiss, first lie, first dawn after a long night. Each first can only be used once, and once used is gone — you will not remember the first time you tasted the thing again. The dish carries the cleanness of an event nobody else witnessed."
         }
       ]
     }

--- a/worlds/the-bloom.mvworld
+++ b/worlds/the-bloom.mvworld
@@ -13,19 +13,19 @@
       "label": "Your relationship to the Bloom",
       "choices": [
         {
-          "name": "Survivor who lost someone to it",
-          "description": "Your sister or your husband or your child walked into the Bloom one morning and did not come back the way they left. They came back, eventually, smiling, but they were not the person you knew, and you have spent the time since trying to decide whether what came back was a worse version or a better one. The Bloom took them. You can't be sure they didn't want to go."
+          "name": "The Bereaved",
+          "description": "Survivor who lost someone to it. Your sister or your husband or your child walked into the Bloom one morning and did not come back the way they left. They came back, eventually, smiling, but they were not the person you knew, and you have spent the time since trying to decide whether what came back was a worse version or a better one. The Bloom took them. You can't be sure they didn't want to go."
         },
         {
-          "name": "Botanist trying to understand",
+          "name": "The Botanist",
           "description": "You had a training that the collapse made irrelevant and the Bloom made urgent. You have a notebook and a hand lens and a private theory you have not yet shared because sharing it would commit you. You are the only person you know who treats the flowers as data, and the people around you have started to wonder if your detachment is faked."
         },
         {
-          "name": "Convert who thinks it's holy",
+          "name": "The Convert",
           "description": "You believe the Bloom is a message from a kind power and you are largely correct. You have organized neighbors into small observances. You leave offerings at the edges. You have started to dream the same dreams as other observants in your sect, and you have decided to trust this rather than be afraid of it."
         },
         {
-          "name": "Child born after, who can hear it",
+          "name": "Bloom-Born",
           "description": "You were born into the Bloom. You do not remember a world without it. The adults talk about Before and you nod and you don't really understand. The flowers hum at a pitch the adults cannot detect and you have always heard it. You assumed everyone did. You are starting to understand that you are something the adults around you do not know how to read."
         }
       ]
@@ -34,20 +34,20 @@
       "label": "Where the Bloom is densest",
       "choices": [
         {
-          "name": "A city, slowly being eaten",
-          "description": "Asphalt cracked by stems thicker than your wrist. The subway tunnels have become growing-tubes, lit by phosphorescent species that bloom in the dark. The skyscrapers are trellises for vines that go up forty floors and break the windows from inside. The intersections smell like a perfume counter and the streetlights still come on at dusk on the blocks where the wires haven't been cut."
+          "name": "The Eaten City",
+          "description": "A city, slowly being eaten. Asphalt cracked by stems thicker than your wrist. The subway tunnels have become growing-tubes, lit by phosphorescent species that bloom in the dark. The skyscrapers are trellises for vines that go up forty floors and break the windows from inside. The intersections smell like a perfume counter and the streetlights still come on at dusk on the blocks where the wires haven't been cut."
         },
         {
-          "name": "A coastline where the flowers grow into the surf",
-          "description": "The tide-pools are full of blossoms that open with the water and close with the dry. Salt-tolerant species have built reefs out of stems and petals. The seabirds eat them and sing in patterns the older sailors don't recognize. At low tide you can walk on a carpet that gives slightly under your feet, and the sand beneath it is warm."
+          "name": "The Petal Coast",
+          "description": "A coastline where the flowers grow into the surf. The tide-pools are full of blossoms that open with the water and close with the dry. Salt-tolerant species have built reefs out of stems and petals. The seabirds eat them and sing in patterns the older sailors don't recognize. At low tide you can walk on a carpet that gives slightly under your feet, and the sand beneath it is warm."
         },
         {
-          "name": "A high desert where the Bloom is rare and prized",
-          "description": "One flower per kilometer, sometimes less. Pilgrims travel weeks to see a single bloom. The locals know the routes and defend them, more from theft than from sacrilege. The flowers here are larger than elsewhere and they last only a day, and the pilgrimage calendar is built around when each known plant is expected to open."
+          "name": "The Pilgrim Desert",
+          "description": "A high desert where the Bloom is rare and prized. One flower per kilometer, sometimes less. Pilgrims travel weeks to see a single bloom. The locals know the routes and defend them, more from theft than from sacrilege. The flowers here are larger than elsewhere and they last only a day, and the pilgrimage calendar is built around when each known plant is expected to open."
         },
         {
-          "name": "A forest where the Bloom has REPLACED the trees",
-          "description": "The canopy is petals. There is no shade because the petals are translucent and pink. The air tastes like sugar all the time and you stop noticing it after a week and you start craving it after two. The undergrowth is a single species of grass that grows knee-high and bends in coordinated waves when there is no wind."
+          "name": "The Petal Canopy",
+          "description": "A forest where the Bloom has replaced the trees. The canopy is petals. There is no shade because the petals are translucent and pink. The air tastes like sugar all the time and you stop noticing it after a week and you start craving it after two. The undergrowth is a single species of grass that grows knee-high and bends in coordinated waves when there is no wind."
         }
       ]
     }

--- a/worlds/the-bureau-of-forgotten-things.mvworld
+++ b/worlds/the-bureau-of-forgotten-things.mvworld
@@ -14,19 +14,19 @@
       "label": "Your desk",
       "choices": [
         {
-          "name": "Lost objects",
+          "name": "Lost Objects",
           "description": "A wall of cubbyholes behind the player, sorted by year, then by category, then by the smell of where they were lost. Dust and pocket lint and the faint chemical of old receipts. A kid's mitten in cubbyhole 1964-G has been here sixty years and the owner has been by every winter and not asked for it back."
         },
         {
-          "name": "Abandoned intentions",
+          "name": "Abandoned Intentions",
           "description": "Folders of unwritten novels, business plans never started, letters composed and never sent. The Sent tray on the player's desk is for filing pending. Nobody opens it. The manuscripts get heavier as they age. By year fifty they require two hands."
         },
         {
-          "name": "Missing persons",
+          "name": "Missing Persons",
           "description": "Cold files in cabinets the player has memorized. Photographs that have to be developed by the Bureau itself, in a darkroom in the basement, by a man who does not look up. The two chairs across from the player's desk are designed for crying — wide arms, a small shelf for a tissue box."
         },
         {
-          "name": "Forgotten gods",
+          "name": "Forgotten Gods",
           "description": "A small quiet room at the end of a corridor most staff do not visit. One customer a year, sometimes two. The player serves them tea from a kettle that is always warm. The visitors are not what the player expected and are very polite. They never stay long."
         }
       ]
@@ -35,19 +35,19 @@
       "label": "The audit's coming",
       "choices": [
         {
-          "name": "A coworker who's been there too long",
-          "description": "They forgot their own name a decade back. The nameplate on their desk reads simply COLLEAGUE in their own handwriting. They still process intake faster than anyone. They have begun to look at the player as though trying to remember something. They are. They have been forgetting it for a while."
+          "name": "Colleague",
+          "description": "A coworker who's been there too long. They forgot their own name a decade back. The nameplate on their desk reads simply COLLEAGUE in their own handwriting. They still process intake faster than anyone. They have begun to look at the player as though trying to remember something. They are. They have been forgetting it for a while."
         },
         {
-          "name": "Your manager",
-          "description": "They came in years ago to file themselves and stayed. They got promoted because they understood the system from both sides. Their performance reviews are exemplary. Their family is no longer reachable through any address. They are kind to the player and they are watching the schedule."
+          "name": "The Manager",
+          "description": "Your manager. They came in years ago to file themselves and stayed. They got promoted because they understood the system from both sides. Their performance reviews are exemplary. Their family is no longer reachable through any address. They are kind to the player and they are watching the schedule."
         },
         {
-          "name": "A customer who wants their thing back",
-          "description": "They have been coming in every day for a month. They have a claim ticket the system does not recognize. They are not loud. They will not leave. The thing they want is something the Bureau is not supposed to return at all, and the player is the only clerk who has not yet told them no."
+          "name": "The Persistent Claimant",
+          "description": "A customer who wants their thing back. They have been coming in every day for a month. They have a claim ticket the system does not recognize. They are not loud. They will not leave. The thing they want is something the Bureau is not supposed to return at all, and the player is the only clerk who has not yet told them no."
         },
         {
-          "name": "The Bureau itself",
+          "name": "The Self-Inventory",
           "description": "Quarterly self-inventory. The building counts itself. Doors that should not be there appear in the hallway for the duration of the audit. The hum the building makes deepens by a tone. Staff are part of the inventory. Some of them will not be on the list at the end."
         }
       ]

--- a/worlds/the-cartographer-s-error.mvworld
+++ b/worlds/the-cartographer-s-error.mvworld
@@ -13,20 +13,20 @@
       "label": "The map",
       "choices": [
         {
-          "name": "Medieval parchment in a monastery archive",
-          "description": "Vellum that smells of mildew and the lanolin that's been worked into it for six hundred years. A single decorated initial in red and gold on the first letter of the city's name. Marginalia in three different hands, each correcting the last, none of them in a language the archivist will translate. You signed for it and the archivist's hands shook."
+          "name": "The Cloister Vellum",
+          "description": "A medieval parchment from a monastery archive. Vellum that smells of mildew and the lanolin that's been worked into it for six hundred years. A single decorated initial in red and gold on the first letter of the city's name. Marginalia in three different hands, each correcting the last, none of them in a language the archivist will translate. You signed for it and the archivist's hands shook."
         },
         {
-          "name": "USGS survey with one extra dot",
-          "description": "A 1947 topographic quad, official seal, the kind of map that hangs framed in a federal building. One dot too many in the western quarter, labeled in a typeface that doesn't match the rest. The surveyor's field notebooks went missing the year after publication. There is a brown stain on the back like coffee, except coffee wasn't drunk near it."
+          "name": "The Extra Dot",
+          "description": "A USGS survey with one dot too many. A 1947 topographic quad, official seal, the kind of map that hangs framed in a federal building. One dot too many in the western quarter, labeled in a typeface that doesn't match the rest. The surveyor's field notebooks went missing the year after publication. There is a brown stain on the back like coffee, except coffee wasn't drunk near it."
         },
         {
-          "name": "Alien star chart that resolves into a city when scaled",
-          "description": "Recovered from a crash site that the government does not officially acknowledge. The stars on the chart match no constellation visible from Earth. Scaled down by a factor of a hundred billion, the pattern is the layout of a city: avenues, plazas, a central square. The city is at the chart's exact center, where the convergence dot would be on a celestial map."
+          "name": "The Star Chart",
+          "description": "An alien star chart that resolves into a city when scaled. Recovered from a crash site that the government does not officially acknowledge. The stars on the chart match no constellation visible from Earth. Scaled down by a factor of a hundred billion, the pattern is the layout of a city: avenues, plazas, a central square. The city is at the chart's exact center, where the convergence dot would be on a celestial map."
         },
         {
-          "name": "A child's crayon drawing that turned out to be accurate",
-          "description": "She drew it when she was seven. Her parents reported her missing for six days that year and she came home with the drawing folded in her pocket and would not say where she had been. She is eighty-four now and she gave you the drawing yesterday and asked you to go for her. The streets she drew correspond to streets on a recent satellite image of a place she has never been."
+          "name": "The Crayon Map",
+          "description": "A child's crayon drawing that turned out to be accurate. She drew it when she was seven. Her parents reported her missing for six days that year and she came home with the drawing folded in her pocket and would not say where she had been. She is eighty-four now and she gave you the drawing yesterday and asked you to go for her. The streets she drew correspond to streets on a recent satellite image of a place she has never been."
         }
       ]
     },
@@ -34,20 +34,20 @@
       "label": "Who reached it first",
       "choices": [
         {
-          "name": "A previous expedition",
-          "description": "Their journals end mid-sentence in three places. The expedition itself was funded by a society that no longer exists and you found the papers in a public archive that didn't know what it had. The last entry is from a campsite three days short of the city. The handwriting is rushed but not panicked. Whoever wrote it did not expect to stop writing."
+          "name": "The Lost Expedition",
+          "description": "A previous expedition whose journals end mid-sentence in three places. The expedition itself was funded by a society that no longer exists and you found the papers in a public archive that didn't know what it had. The last entry is from a campsite three days short of the city. The handwriting is rushed but not panicked. Whoever wrote it did not expect to stop writing."
         },
         {
-          "name": "A native population who treat the map as scripture",
-          "description": "They live in the city. They have always lived in the city. They have a sect that copies the map by hand once a generation and they will recognize yours as a true copy or as a forgery within a heartbeat of seeing it. Their priests will want to know how you got it and what you intend. Their answer to your intent will determine your welcome."
+          "name": "The Map-Copyists",
+          "description": "A native population who treat the map as scripture. They live in the city. They have always lived in the city. They have a sect that copies the map by hand once a generation and they will recognize yours as a true copy or as a forgery within a heartbeat of seeing it. Their priests will want to know how you got it and what you intend. Their answer to your intent will determine your welcome."
         },
         {
-          "name": "An academic rival you trained with",
-          "description": "You shared an advisor. You shared a thesis topic until one of you switched. You have not spoken in eleven years and you tracked their grant applications obsessively until you stopped. They left for the city two months ago with better funding and worse instincts. You are following their trail and you do not know whether you want to find them alive."
+          "name": "The Rival",
+          "description": "An academic rival you trained with. You shared an advisor. You shared a thesis topic until one of you switched. You have not spoken in eleven years and you tracked their grant applications obsessively until you stopped. They left for the city two months ago with better funding and worse instincts. You are following their trail and you do not know whether you want to find them alive."
         },
         {
-          "name": "Nobody — the city is empty and warm, dinner on the tables",
-          "description": "You arrive at dusk. The streetlights are on. Tables in courtyards have plates set, food cooling but not yet cold, wine in the glasses. No bodies. No signs of struggle. No animals, no birds. The kitchens are clean. Somewhere a clock ticks. You can hear your own footfalls and nothing else, and the city was clearly inhabited a few hours ago."
+          "name": "The Empty City",
+          "description": "Nobody reached it first — the city is warm and empty, dinner still on the tables. You arrive at dusk. The streetlights are on. Tables in courtyards have plates set, food cooling but not yet cold, wine in the glasses. No bodies. No signs of struggle. No animals, no birds. The kitchens are clean. Somewhere a clock ticks. You can hear your own footfalls and nothing else, and the city was clearly inhabited a few hours ago."
         }
       ]
     }

--- a/worlds/the-coffee-shop.mvworld
+++ b/worlds/the-coffee-shop.mvworld
@@ -40,15 +40,15 @@
       "label": "Your role",
       "choices": [
         {
-          "name": "The barista",
+          "name": "Behind the Bar",
           "description": "You make the drinks, you hear the stories, you remember everyone's order. You're the background character in a dozen other people's lives — except you're not background to us."
         },
         {
-          "name": "The new owner",
+          "name": "New Proprietor",
           "description": "You just took over. The previous owner left abruptly and the regulars are wary. You're learning names, fixing the plumbing, finding strange notes in the back office. The shop has a history you're inheriting."
         },
         {
-          "name": "The regular",
+          "name": "Same Seat, Same Order",
           "description": "You come here every day. Same seat, same order. You know the staff, you know the other regulars, you have your rituals. Something small is about to change one of them."
         }
       ]

--- a/worlds/the-copernicus-mandate.mvworld
+++ b/worlds/the-copernicus-mandate.mvworld
@@ -13,20 +13,20 @@
       "label": "Role",
       "choices": [
         {
-          "name": "UN counsel assigned the case",
-          "description": "The player has been pulled from a quiet career drafting fisheries treaties and dropped into a courtroom that does not yet exist. They have a small staff and no precedent. The Secretary-General calls personally for updates. The phone has a dedicated line in red, which the player learned about from a memo."
+          "name": "Counsel of Record",
+          "description": "UN counsel assigned the case. The player has been pulled from a quiet career drafting fisheries treaties and dropped into a courtroom that does not yet exist. They have a small staff and no precedent. The Secretary-General calls personally for updates. The phone has a dedicated line in red, which the player learned about from a memo."
         },
         {
-          "name": "Astronomer who first received the letter",
-          "description": "The player was on shift when the signal came in. They followed the protocol they had practiced for years, which did not cover this. They have been quietly retained by every government on Earth as a witness. Their inbox is full and their badge no longer scans them into the canteen."
+          "name": "The Receiving Astronomer",
+          "description": "The player first received the letter. They were on shift when the signal came in. They followed the protocol they had practiced for years, which did not cover this. They have been quietly retained by every government on Earth as a witness. Their inbox is full and their badge no longer scans them into the canteen."
         },
         {
-          "name": "The infringer",
+          "name": "Named Defendant",
           "description": "The player personally sent the broadcast that caused this. A college radio show in the seventies. A scientific transmission they signed off on. They have been identified by name in the filings. Their face is on the cover of three magazines. Their mother is asking them to come home."
         },
         {
-          "name": "Press secretary",
-          "description": "The player's job is to keep this out of the news for as long as possible. So far, this has been working — the leak hasn't crested. They are lying to journalists they used to drink with. They have a draft press release for the day it breaks, three versions, each shorter than the last."
+          "name": "The Spokesperson",
+          "description": "Press secretary. The player's job is to keep this out of the news for as long as possible. So far, this has been working — the leak hasn't crested. They are lying to journalists they used to drink with. They have a draft press release for the day it breaks, three versions, each shorter than the last."
         }
       ]
     },
@@ -34,19 +34,19 @@
       "label": "The alien firm",
       "choices": [
         {
-          "name": "Old, dignified, three partners",
-          "description": "A firm older than several human civilizations. Three name partners who have not changed in generations. A memo leaked through human intelligence suggests they are bluffing about jurisdiction over Earth. They are betting humanity will not call the bluff. The bluff is excellent."
+          "name": "The Three Partners",
+          "description": "Old, dignified, three name partners. A firm older than several human civilizations. Three name partners who have not changed in generations. A memo leaked through human intelligence suggests they are bluffing about jurisdiction over Earth. They are betting humanity will not call the bluff. The bluff is excellent."
         },
         {
-          "name": "Aggressive contingency-fee newcomers",
-          "description": "A young firm hungry for a precedent. They want a settlement that includes Earth's licensing rights — every patentable concept humanity will develop for the next millennium. They are charismatic in the deposition transcripts. They mention Earth's case in their own marketing."
+          "name": "The Contingency Wolves",
+          "description": "Aggressive contingency-fee newcomers. A young firm hungry for a precedent. They want a settlement that includes Earth's licensing rights — every patentable concept humanity will develop for the next millennium. They are charismatic in the deposition transcripts. They mention Earth's case in their own marketing."
         },
         {
-          "name": "A pro-bono outfit",
-          "description": "They represent an injured third party humanity has never heard of. The injured party has not been informed that they are injured. The firm is acting in what they consider the third party's best interest. The firm is funded by an endowment older than human language."
+          "name": "The Pro Bono Endowment",
+          "description": "A pro-bono outfit. They represent an injured third party humanity has never heard of. The injured party has not been informed that they are injured. The firm is acting in what they consider the third party's best interest. The firm is funded by an endowment older than human language."
         },
         {
-          "name": "Solo practitioner",
+          "name": "The Solo Practitioner",
           "description": "One being. Vast and patient. No assistants. They have been working this case for what humans would call centuries. Every filing arrives in their own hand. They have never lost a case and they have never settled one. They are willing to meet."
         }
       ]

--- a/worlds/the-debt.mvworld
+++ b/worlds/the-debt.mvworld
@@ -14,20 +14,20 @@
       "label": "Your lender",
       "choices": [
         {
-          "name": "Old friend with a new face",
-          "description": "They look like the friend you remember and they don't quite. Same laugh. Same way of leaning on a table. The face has been worked on or the years have done something the years don't usually do. They know things only the friend would know and they don't know one thing the friend definitely would. You haven't decided yet whether to ask."
+          "name": "The New Face",
+          "description": "An old friend with a new face. They look like the friend you remember and they don't quite. Same laugh. Same way of leaning on a table. The face has been worked on or the years have done something the years don't usually do. They know things only the friend would know and they don't know one thing the friend definitely would. You haven't decided yet whether to ask."
         },
         {
-          "name": "A demon with paperwork",
-          "description": "They have an attaché case and a fountain pen and the contract you signed when you were nineteen and high. The contract is dated and witnessed and the signature is yours. They are polite. They are not in a hurry. They will let you read every clause before they ask you to honor the one they're invoking tonight."
+          "name": "The Counterparty",
+          "description": "A demon with paperwork. They have an attaché case and a fountain pen and the contract you signed when you were nineteen and high. The contract is dated and witnessed and the signature is yours. They are polite. They are not in a hurry. They will let you read every clause before they ask you to honor the one they're invoking tonight."
         },
         {
-          "name": "A small god of obligations",
-          "description": "Their domain is debt itself — the ledger of what is owed, between mortals, between mortals and gods, between past selves and present ones. They are not large. They are not loud. They are the one who notices when an obligation goes unmet, and they have noticed yours, and they have come because the alternative was sending someone less courteous."
+          "name": "The Ledger-Keeper",
+          "description": "A small god of obligations. Their domain is debt itself — the ledger of what is owed, between mortals, between mortals and gods, between past selves and present ones. They are not large. They are not loud. They are the one who notices when an obligation goes unmet, and they have noticed yours, and they have come because the alternative was sending someone less courteous."
         },
         {
-          "name": "Your own future self",
-          "description": "Older, thinner, dressed in clothes you don't own yet. They know the room better than you do because they have been in it before, from this seat. They are not threatening. They are exhausted. The thing they need you to do will be hard, and they know it will be hard because they remember doing it, and they remember what it cost."
+          "name": "The Self Who Comes Later",
+          "description": "Your own future self. Older, thinner, dressed in clothes you don't own yet. They know the room better than you do because they have been in it before, from this seat. They are not threatening. They are exhausted. The thing they need you to do will be hard, and they know it will be hard because they remember doing it, and they remember what it cost."
         }
       ]
     },
@@ -35,20 +35,20 @@
       "label": "Where the call happens",
       "choices": [
         {
-          "name": "The diner where you used to meet",
-          "description": "Lit by the neon sign in the window, which paints the booths pink and then blue and then pink again. The booth in the back corner where you both sat at sixteen, twenty, thirty. The waitress remembers their order before they say it and does not remember yours. The coffee comes free with the third refill, and they want three refills, which means this will take a while."
+          "name": "The Old Booth",
+          "description": "The diner where you used to meet. Lit by the neon sign in the window, which paints the booths pink and then blue and then pink again. The booth in the back corner where you both sat at sixteen, twenty, thirty. The waitress remembers their order before they say it and does not remember yours. The coffee comes free with the third refill, and they want three refills, which means this will take a while."
         },
         {
-          "name": "Their hospital bedside",
-          "description": "The machines count their vitals in small clean numbers. The curtain around the bed doesn't quite close on either side. Visiting hours end in forty minutes and the nurses are already glancing at you. The ask will happen before the hour does, because they know how time works in this kind of room better than you do."
+          "name": "The Bedside",
+          "description": "Their hospital bedside. The machines count their vitals in small clean numbers. The curtain around the bed doesn't quite close on either side. Visiting hours end in forty minutes and the nurses are already glancing at you. The ask will happen before the hour does, because they know how time works in this kind of room better than you do."
         },
         {
-          "name": "Their wedding reception",
-          "description": "Everyone is happy. The band is loud enough that you have to lean in to hear. They are wearing white or its equivalent and they pull you aside between the first dance and the toasts, into a side room with folded linens and one chair. They have ninety seconds before someone notices the bride is missing. The ask will fit in ninety seconds and the answer will, too."
+          "name": "The Side Room at the Reception",
+          "description": "Their wedding reception. Everyone is happy. The band is loud enough that you have to lean in to hear. They are wearing white or its equivalent and they pull you aside between the first dance and the toasts, into a side room with folded linens and one chair. They have ninety seconds before someone notices the bride is missing. The ask will fit in ninety seconds and the answer will, too."
         },
         {
-          "name": "A funeral — yours",
-          "description": "Your own. You are at the back. Nobody else sees you and you can tell because nobody flinches. The casket is closed. They are at the lectern, and they look at the back of the room, and they look at you, and they begin to speak the eulogy and you understand that the eulogy is the ask. You have until the last word to decide."
+          "name": "The Back Pew",
+          "description": "A funeral — yours. Your own. You are at the back. Nobody else sees you and you can tell because nobody flinches. The casket is closed. They are at the lectern, and they look at the back of the room, and they look at you, and they begin to speak the eulogy and you understand that the eulogy is the ask. You have until the last word to decide."
         }
       ]
     }

--- a/worlds/the-docent.mvworld
+++ b/worlds/the-docent.mvworld
@@ -14,19 +14,19 @@
       "label": "Your group",
       "choices": [
         {
-          "name": "Solo tour",
-          "description": "Just you and the docent. The schedule is yours; the pace is yours; the questions accumulate without competition. The docent treats you as a single charge they are responsible for. The intimacy of this is its own pressure."
+          "name": "Party of One",
+          "description": "A solo tour. Just you and the docent. The schedule is yours; the pace is yours; the questions accumulate without competition. The docent treats you as a single charge they are responsible for. The intimacy of this is its own pressure."
         },
         {
-          "name": "Mixed tour",
-          "description": "Five strangers, each hiding their cause of death. There is a small woman who jumps when doors close. There is a man whose collar covers something. The introductions are first names only, by mutual agreement nobody articulated. You will spend the tour learning to read each other."
+          "name": "Strangers, First Names Only",
+          "description": "A mixed tour. Five strangers, each hiding their cause of death. There is a small woman who jumps when doors close. There is a man whose collar covers something. The introductions are first names only, by mutual agreement nobody articulated. You will spend the tour learning to read each other."
         },
         {
-          "name": "Family tour",
-          "description": "An ancestor is showing you around. They died before you were born. They know things about your family that nobody alive could have told you. They keep stopping at certain exhibits to point out a relative you have heard of only in stories, and to correct the story."
+          "name": "The Ancestor's Tour",
+          "description": "A family tour. An ancestor is showing you around. They died before you were born. They know things about your family that nobody alive could have told you. They keep stopping at certain exhibits to point out a relative you have heard of only in stories, and to correct the story."
         },
         {
-          "name": "VIP",
+          "name": "Paperwork Pending",
           "description": "You weren't supposed to be here yet. The docent keeps apologizing about the paperwork. They have been hastily prepared. They are improvising. The other tour groups make way for yours, and you do not know if that is courtesy or quarantine."
         }
       ]

--- a/worlds/the-gilded-cage.mvworld
+++ b/worlds/the-gilded-cage.mvworld
@@ -14,15 +14,15 @@
       "label": "The setting",
       "choices": [
         {
-          "name": "A candlelit manor",
+          "name": "The Candlelit Manor",
           "description": "Gothic elegance, labyrinthine corridors, oil portraits with watching eyes. The party is a masquerade. Think Poe by way of Kubrick."
         },
         {
-          "name": "A modernist penthouse",
-          "description": "Glass walls, brutalist art, a host who knows too much about you. The party is an exclusive soirée. Think corporate thriller with a supernatural edge."
+          "name": "The Glass Penthouse",
+          "description": "A modernist penthouse. Glass walls, brutalist art, a host who knows too much about you. The party is an exclusive soirée. Think corporate thriller with a supernatural edge."
         },
         {
-          "name": "A fae court banquet",
+          "name": "The Fae Court Banquet",
           "description": "Impossible food, glamoured guests, rules nobody will explain. The party follows fae etiquette — breaking a rule you didn't know existed has consequences."
         }
       ]

--- a/worlds/the-gravity-tax.mvworld
+++ b/worlds/the-gravity-tax.mvworld
@@ -12,20 +12,20 @@
       "label": "Habitat tier",
       "choices": [
         {
-          "name": "Penthouse — full G",
+          "name": "The Full-G Penthouse",
           "description": "A rooftop garden the size of a city block. Carpet you can run on. The gravity here feels like air because it is whatever the contract calls for and the contract is paid. The view down through the floors to the lower tiers is one of the apartment's amenities and is not mentioned in the brochure."
         },
         {
-          "name": "Mid-deck",
+          "name": "The Tilted Mid-Deck",
           "description": "Your stairs are tilted by half a degree and you don't notice anymore. The furniture is bolted to the floor. You take the supplements because the doctor told you to and because everyone else does. The morning coffee tastes correctly only on days the bill was paid on time."
         },
         {
-          "name": "Dock workers — 0.4 G",
-          "description": "Everyone you work with is tall. There is a bone-loss clinic on every block, which the union negotiated and the company tolerates. The ladders from the docks down to the loading bays are jump-down ladders — you take them in long drifting steps and land like a feather if you land right."
+          "name": "The Loading Bays",
+          "description": "Dock workers at 0.4 G. Everyone you work with is tall. There is a bone-loss clinic on every block, which the union negotiated and the company tolerates. The ladders from the docks down to the loading bays are jump-down ladders — you take them in long drifting steps and land like a feather if you land right."
         },
         {
-          "name": "Outer slums — variable",
-          "description": "Gravity fluctuates by the hour, scheduled by an algorithm nobody here is licensed to read. Ceilings are floors at night, sometimes. Nobody walks straight in the outer slums and the children think it's funny. The signs in the shops have arrows showing which way is currently down."
+          "name": "The Drift Quarter",
+          "description": "Outer slums where gravity fluctuates by the hour, scheduled by an algorithm nobody here is licensed to read. Ceilings are floors at night, sometimes. Nobody walks straight in the outer slums and the children think it's funny. The signs in the shops have arrows showing which way is currently down."
         }
       ]
     },
@@ -33,20 +33,20 @@
       "label": "Your stake",
       "choices": [
         {
-          "name": "Habitat administrator",
-          "description": "The player is scrambling to find the payment. The tenants' rent is not enough. The reserve fund was raided last year for the elevator repair. The board meets on Thursday and wants a plan. The player has been writing one and crossing it out for three weeks."
+          "name": "The Administrator",
+          "description": "Habitat administrator. The player is scrambling to find the payment. The tenants' rent is not enough. The reserve fund was raided last year for the elevator repair. The board meets on Thursday and wants a plan. The player has been writing one and crossing it out for three weeks."
         },
         {
-          "name": "Debt-collector",
-          "description": "The player works for the corporation. The player has been doing this for years. Lately the player has been driving home at night and not getting out of the vehicle for an hour. The numbers on the spreadsheet have started to look like names and the player can name some of them now."
+          "name": "The Collector",
+          "description": "Debt-collector. The player works for the corporation. The player has been doing this for years. Lately the player has been driving home at night and not getting out of the vehicle for an hour. The numbers on the spreadsheet have started to look like names and the player can name some of them now."
         },
         {
-          "name": "Union organizer",
-          "description": "The player has a plan to nationalize the well. The plan is in three binders in a safe. The plan requires a hundred and twelve people to agree to risk what they have left. The player has gotten to seventy-three. The corporation knows the player's face."
+          "name": "The Organizer",
+          "description": "Union organizer. The player has a plan to nationalize the well. The plan is in three binders in a safe. The plan requires a hundred and twelve people to agree to risk what they have left. The player has gotten to seventy-three. The corporation knows the player's face."
         },
         {
-          "name": "Child of the family that sold it",
-          "description": "The player's grandparents owned the well. They sold it for what seemed like a reasonable sum at the time. The buyer's logo is on every building. The player's family name is on a small plaque in the corporate lobby. The player has never been inside."
+          "name": "The Name on the Plaque",
+          "description": "Child of the family that sold the well. The player's grandparents owned it. They sold it for what seemed like a reasonable sum at the time. The buyer's logo is on every building. The player's family name is on a small plaque in the corporate lobby. The player has never been inside."
         }
       ]
     }

--- a/worlds/the-hound-and-the-fox.mvworld
+++ b/worlds/the-hound-and-the-fox.mvworld
@@ -35,20 +35,20 @@
       "label": "The city",
       "choices": [
         {
-          "name": "Gaslit Victorian capital",
-          "description": "Fog so thick the streetlamps haloed. Hansom cabs and the rattle of harness on cobble. The precinct has a single telephone and a long line for it. The Hound and Fox have been pages of the penny papers since they were both younger than they admit, and the engravers have an entire mental file of their faces."
+          "name": "The Gaslit Capital",
+          "description": "A Victorian metropolis. Fog so thick the streetlamps haloed. Hansom cabs and the rattle of harness on cobble. The precinct has a single telephone and a long line for it. The Hound and Fox have been pages of the penny papers since they were both younger than they admit, and the engravers have an entire mental file of their faces."
         },
         {
-          "name": "1930s art-deco metropolis",
-          "description": "Radio cars and ticker-tape and the smell of cigar smoke in every elevator. Nightclubs that close at sunrise and reopen at sunset. There is one opera house at the heart of downtown and every great chase has ended in its lobby at least once. The musicians know to keep playing."
+          "name": "The Deco City",
+          "description": "A 1930s art-deco metropolis. Radio cars and ticker-tape and the smell of cigar smoke in every elevator. Nightclubs that close at sunrise and reopen at sunset. There is one opera house at the heart of downtown and every great chase has ended in its lobby at least once. The musicians know to keep playing."
         },
         {
-          "name": "Modern surveillance city",
-          "description": "Cameras at every corner and license-plate readers on every bridge. The chase is data; the chase is also performance, because both Hound and Fox know the cameras are running and act accordingly. One alley downtown still has no coverage. Everyone in the city knows which one. It is where the real conversations happen."
+          "name": "The Watched City",
+          "description": "A modern surveillance city. Cameras at every corner and license-plate readers on every bridge. The chase is data; the chase is also performance, because both Hound and Fox know the cameras are running and act accordingly. One alley downtown still has no coverage. Everyone in the city knows which one. It is where the real conversations happen."
         },
         {
-          "name": "A small island town where everyone knows them both",
-          "description": "The chase is a kind of community theatre. The locals lay bets at the harbor pub. The police chief is the Hound's mother and gives an interview every spring. The Fox's sister runs the bakery and will not discuss it. There are exactly two boats off the island and both of them know the schedule."
+          "name": "The Island",
+          "description": "A small island town where everyone knows them both. The chase is a kind of community theatre. The locals lay bets at the harbor pub. The police chief is the Hound's mother and gives an interview every spring. The Fox's sister runs the bakery and will not discuss it. There are exactly two boats off the island and both of them know the schedule."
         }
       ]
     }

--- a/worlds/the-instrument.mvworld
+++ b/worlds/the-instrument.mvworld
@@ -14,20 +14,20 @@
       "label": "The weapon",
       "choices": [
         {
-          "name": "A legendary blade",
-          "description": "Centuries old, forged for a purpose it's half-forgotten. It's outlived dozens of wielders. It remembers all of them. Some it liked. You hold it wrong, but it's willing to work with you."
+          "name": "Hearthbinder",
+          "description": "A legendary blade. Centuries old, forged for a purpose it's half-forgotten. It's outlived dozens of wielders. It remembers all of them. Some it liked. You hold it wrong, but it's willing to work with you."
         },
         {
           "name": "Perihelion",
           "description": "Remnant of a dead universe. It watched everything it knew collapse into nothing, and it is here to prevent the same thing from happening again. Its mission is real. Its grief is real. Its sense of urgency is absolutely sincere. It is also the only entity in the entire campaign operating at that emotional register. Everyone else is having an adventure."
         },
         {
-          "name": "A prototype",
-          "description": "It wasn't supposed to be sentient. A lab accident, a manufacturing defect, a cosmic ray — something went wrong (or right) during fabrication. It's weeks old. Everything is new. It has questions. Many questions. It asked you what \"boredom\" means and you haven't answered yet."
+          "name": "Unit Zero",
+          "description": "A prototype. It wasn't supposed to be sentient. A lab accident, a manufacturing defect, a cosmic ray — something went wrong (or right) during fabrication. It's weeks old. Everything is new. It has questions. Many questions. It asked you what \"boredom\" means and you haven't answered yet."
         },
         {
-          "name": "A sacred relic",
-          "description": "It was the instrument of a god's will. The god is silent now — dead, sleeping, or just done talking. It still carries the mandate. The faithful argue about what it means. It has opinions about this but no one has thought to ask."
+          "name": "The Silent Mandate",
+          "description": "A sacred relic. It was the instrument of a god's will. The god is silent now — dead, sleeping, or just done talking. It still carries the mandate. The faithful argue about what it means. It has opinions about this but no one has thought to ask."
         }
       ]
     }

--- a/worlds/the-interstitial.mvworld
+++ b/worlds/the-interstitial.mvworld
@@ -14,20 +14,20 @@
       "label": "How you found the channel",
       "choices": [
         {
-          "name": "Inherited the radio",
-          "description": "It was your father's, or your aunt's, or a grandparent you barely remember. It came to you in a box of estate items along with a tin of paper clips and a folded shirt. You plugged it in because it was beautiful and because you were curious. The channel was the first thing it pulled in, as if the radio had been left on this frequency the whole time."
+          "name": "The Inheritance",
+          "description": "You inherited the radio. It was your father's, or your aunt's, or a grandparent you barely remember. It came to you in a box of estate items along with a tin of paper clips and a folded shirt. You plugged it in because it was beautiful and because you were curious. The channel was the first thing it pulled in, as if the radio had been left on this frequency the whole time."
         },
         {
-          "name": "Built it",
-          "description": "You sourced the parts over six months from estate sales and online auctions. You read three books on RF theory. You soldered every joint yourself. The first time you powered it up, the channel was there before you'd finished tuning, and you had not finished tuning, and you have not been able to design a circuit that doesn't pick it up since."
+          "name": "The Hand-Built Set",
+          "description": "You built it. You sourced the parts over six months from estate sales and online auctions. You read three books on RF theory. You soldered every joint yourself. The first time you powered it up, the channel was there before you'd finished tuning, and you had not finished tuning, and you have not been able to design a circuit that doesn't pick it up since."
         },
         {
-          "name": "Born with the ability",
-          "description": "You have been hearing it since you were small. You thought everyone heard it. You stopped mentioning it at seven, after your mother's face. You have spent your adult life calibrating around it — sleeping with white noise, avoiding tunnels, never working in a basement. Tonight, for the first time, the channel said something you understood."
+          "name": "Born Tuned-In",
+          "description": "Born with the ability. You have been hearing it since you were small. You thought everyone heard it. You stopped mentioning it at seven, after your mother's face. You have spent your adult life calibrating around it — sleeping with white noise, avoiding tunnels, never working in a basement. Tonight, for the first time, the channel said something you understood."
         },
         {
-          "name": "Hired by someone who already knew",
-          "description": "They paid in cash. They gave you the frequency, the times, and a list of words to listen for. They did not tell you what the words mean or who they work for. The first week's pay is in an envelope you have not yet opened. The contract is verbal. The deadline is when you stop being useful, which they will determine."
+          "name": "The Cash Envelope",
+          "description": "Hired by someone who already knew. They paid in cash. They gave you the frequency, the times, and a list of words to listen for. They did not tell you what the words mean or who they work for. The first week's pay is in an envelope you have not yet opened. The contract is verbal. The deadline is when you stop being useful, which they will determine."
         }
       ]
     },
@@ -35,20 +35,20 @@
       "label": "Where you listen",
       "choices": [
         {
-          "name": "A 1960s ham-radio shack in the basement",
-          "description": "Tube-warm and dust-fragrant. The QSL cards on the walls are from operators across three continents and two of them are dead. The logbook on the desk is in your father's handwriting and the last entry is from 1978 and there is a blank line under it that you have not been able to bring yourself to write on."
+          "name": "The Basement Shack",
+          "description": "A 1960s ham-radio setup. Tube-warm and dust-fragrant. The QSL cards on the walls are from operators across three continents and two of them are dead. The logbook on the desk is in your father's handwriting and the last entry is from 1978 and there is a blank line under it that you have not been able to bring yourself to write on."
         },
         {
-          "name": "A car at night, parked at a turnout",
-          "description": "The antenna on the roof is the only one for miles. The dashboard glows green and you have learned to keep your eyes on the road that isn't there in front of you instead of on the meters. The signal is stronger here than anywhere else you've tried. You have not figured out why. You have not asked why."
+          "name": "The Turnout",
+          "description": "A car at night, parked at a turnout. The antenna on the roof is the only one for miles. The dashboard glows green and you have learned to keep your eyes on the road that isn't there in front of you instead of on the meters. The signal is stronger here than anywhere else you've tried. You have not figured out why. You have not asked why."
         },
         {
-          "name": "A modern home studio",
-          "description": "A USB SDR, three monitors, headphones that cost more than your rent. The waterfall display shows the spectrum in real time and there is a smear of color in the dead band that should not be there and that does not appear on any other SDR within forty miles when you've checked. The smear is brighter when you say your name out loud."
+          "name": "The Home Studio",
+          "description": "A modern setup. A USB SDR, three monitors, headphones that cost more than your rent. The waterfall display shows the spectrum in real time and there is a smear of color in the dead band that should not be there and that does not appear on any other SDR within forty miles when you've checked. The smear is brighter when you say your name out loud."
         },
         {
-          "name": "A defunct radio station you're squatting in",
-          "description": "The building was condemned eight years ago. The transmitter still works because nobody told it to stop. You don't remember turning it on the first time. The on-air light flickers in a rhythm that has stopped feeling random. You sleep on a cot in the production booth and the channel is sometimes inside the room with you."
+          "name": "The Condemned Station",
+          "description": "A defunct radio station you're squatting in. The building was condemned eight years ago. The transmitter still works because nobody told it to stop. You don't remember turning it on the first time. The on-air light flickers in a rhythm that has stopped feeling random. You sleep on a cot in the production booth and the channel is sometimes inside the room with you."
         }
       ]
     }

--- a/worlds/the-last-caravan.mvworld
+++ b/worlds/the-last-caravan.mvworld
@@ -34,19 +34,19 @@
       "label": "The terrain",
       "choices": [
         {
-          "name": "Open steppe",
+          "name": "The Open Steppe",
           "description": "Grass to the horizon in every direction and no shade for days. The wagons can fan out and travel three abreast where the going is good. The wind carries the sound of pursuit two days before the dust does, and the lookouts have learned to listen for a specific quality of hoofbeat that the steppe transmits like a drum."
         },
         {
-          "name": "Mountain passes",
+          "name": "The High Passes",
           "description": "The road is single-file. The caravan stretches more than a mile when it's moving and the front of the line cannot see the back. The passes are choke points and the choke points are where the caravan loses wagons and where the caravan, occasionally, decides to fight rather than run. There are graves at the top of each pass with names in three alphabets."
         },
         {
-          "name": "Old-world ruins",
+          "name": "The Old-World Ruins",
           "description": "You camp in the shells of cities that died for other reasons in other centuries. The buildings are landmarks; the foragers know which apartment blocks still have canned goods on shelves and which were stripped a generation ago. Some of the ruins are inhabited by people who are not joining the caravan, and the caravan has learned to keep moving past their fires without comment."
         },
         {
-          "name": "Coastal road",
+          "name": "The Coastal Ribbon",
           "description": "The sea is on one side and the threat is on the other. The road is a narrow ribbon between them. The tide takes wagons in storms — the caravan has lost three this season, which is two more than is sustainable. The fishing is good when there is time to fish, which there mostly isn't, and the salt rusts everything in a week."
         }
       ]

--- a/worlds/the-oath-eaters.mvworld
+++ b/worlds/the-oath-eaters.mvworld
@@ -12,19 +12,19 @@
       "label": "Your oath",
       "choices": [
         {
-          "name": "Vow of revenge",
+          "name": "The Graveside Vow",
           "description": "You swore it at a graveside and you have lived inside it for years. It has been your shape. Lately the edges have begun to soften. You remember what you swore but the wanting has gone slack, and without the wanting you do not know who you are. The person you swore against is still alive and you can no longer quite picture them."
         },
         {
-          "name": "Marriage",
+          "name": "The Wedded Word",
           "description": "Your spouse is starting to forget you. Not in the dramatic ways. In the small ways: a coffee order that was always yours, a private joke that does not land, the side of the bed they reach for. They look at you as one looks at a guest one has been told to be polite to. You have not had the conversation. You do not know yet what to call this."
         },
         {
-          "name": "Duty of office",
+          "name": "The Seal of Office",
           "description": "Your authority is dissolving. The seal on your letters means less than it did last month. The guard who answered your summons yesterday did not answer it today. The office is older than you and you have always served it well, and you can feel it forgetting the shape of the person it used to confer power upon."
         },
         {
-          "name": "A debt you owe",
+          "name": "The Unremembered Debt",
           "description": "The creditor doesn't remember anymore. You owe them — a sum, a service, a life — and they have stopped sending the polite reminders. They greet you now without recognition. Nobody else knows about it. You are alone with the knowledge of the debt, and the moral problem of what you are now obligated to do."
         }
       ]
@@ -33,20 +33,20 @@
       "label": "The court",
       "choices": [
         {
-          "name": "A high feudal court with the king's daughter married to your enemy",
-          "description": "The realm is held together by an oath that everyone in the room understands and few discuss aloud. The princess's marriage is the spine of the peace. That oath is going first. The court is beginning to look at each other differently. The chancellor has not slept in three days and the household guards are quietly being doubled."
+          "name": "The Spine of Peace",
+          "description": "A high feudal court where the king's daughter is married to your enemy. The realm is held together by an oath that everyone in the room understands and few discuss aloud. The princess's marriage is the spine of the peace. That oath is going first. The court is beginning to look at each other differently. The chancellor has not slept in three days and the household guards are quietly being doubled."
         },
         {
-          "name": "A merchant city of guild-contracts",
-          "description": "The city runs on signed contracts and apprentice-oaths, layered like sediment. The guilds are dissolving. The streets are renegotiating who owns what daily, and at the corner of two old guild-districts there have been shoving matches that did not happen a week ago. The clerks are quitting in shifts."
+          "name": "The Sediment City",
+          "description": "A merchant city of guild-contracts. The city runs on signed contracts and apprentice-oaths, layered like sediment. The guilds are dissolving. The streets are renegotiating who owns what daily, and at the corner of two old guild-districts there have been shoving matches that did not happen a week ago. The clerks are quitting in shifts."
         },
         {
-          "name": "A nomad confederation held together by blood-oaths",
-          "description": "The confederation is a generation old and the binding was always thin. The camps are scattering. Old hatreds are returning — the ones the oath was sworn to bury — and the elders who sealed the original cuts are trying to call council and finding that fewer riders come each time."
+          "name": "The Blood Confederation",
+          "description": "A nomad confederation held together by blood-oaths. The confederation is a generation old and the binding was always thin. The camps are scattering. Old hatreds are returning — the ones the oath was sworn to bury — and the elders who sealed the original cuts are trying to call council and finding that fewer riders come each time."
         },
         {
-          "name": "A monastic order whose vows are physical bonds",
-          "description": "The monks are wandering out of their cells. The vow-marks on their hands are fading. The abbot does not remember why he became abbot. The library is unattended for the first time in a hundred years and the gates are open to anyone who walks up. The kitchens are running, just, because someone is still cooking and nobody knows who."
+          "name": "The Order of the Bound Hand",
+          "description": "A monastic order whose vows are physical bonds. The monks are wandering out of their cells. The vow-marks on their hands are fading. The abbot does not remember why he became abbot. The library is unattended for the first time in a hundred years and the gates are open to anyone who walks up. The kitchens are running, just, because someone is still cooking and nobody knows who."
         }
       ]
     }

--- a/worlds/the-quiet-year.mvworld
+++ b/worlds/the-quiet-year.mvworld
@@ -13,20 +13,20 @@
       "label": "Who you were in the war",
       "choices": [
         {
-          "name": "A commander now expected to govern",
-          "description": "You were good at the work of war. The work of peace is a different muscle and you have not used it. The people who survived under your command expect you to keep deciding for them and they are looking at you with something that is gratitude and something that is not. You have not slept indoors in five years."
+          "name": "The Commander",
+          "description": "Now expected to govern. You were good at the work of war. The work of peace is a different muscle and you have not used it. The people who survived under your command expect you to keep deciding for them and they are looking at you with something that is gratitude and something that is not. You have not slept indoors in five years."
         },
         {
-          "name": "A soldier who deserted and lied about it",
-          "description": "You walked away from your unit one night and you came here and you told a story that has been useful to you. People believe it. Some of them love you for it. The truth is in your pack, in a sealed letter you never sent. Someone in this town fought beside you on the day you left, and you have not yet met them at the well."
+          "name": "The Deserter",
+          "description": "A soldier who lied about it. You walked away from your unit one night and you came here and you told a story that has been useful to you. People believe it. Some of them love you for it. The truth is in your pack, in a sealed letter you never sent. Someone in this town fought beside you on the day you left, and you have not yet met them at the well."
         },
         {
-          "name": "A medic who saw everything and said nothing",
-          "description": "You worked in tents and basements and the back of carts for the duration. You know whose son died screaming and whose lieutenant cried. You have not told any of them. You have a list, mental, careful, of who in town will want to know things and who absolutely will not, and you carry that list like a second uniform."
+          "name": "The Medic",
+          "description": "Who saw everything and said nothing. You worked in tents and basements and the back of carts for the duration. You know whose son died screaming and whose lieutenant cried. You have not told any of them. You have a list, mental, careful, of who in town will want to know things and who absolutely will not, and you carry that list like a second uniform."
         },
         {
-          "name": "A non-combatant who profited and is now hated for it",
-          "description": "You sold to both armies. You ran the warehouse, the still, the field hospital that took payment. You are alive and well-fed and the people who are not have noticed. The council needs you because you are the only one in town who knows how to keep a ledger. The council also resents you. You eat alone."
+          "name": "The Ledger-Keeper",
+          "description": "A non-combatant who profited and is now hated for it. You sold to both armies. You ran the warehouse, the still, the field hospital that took payment. You are alive and well-fed and the people who are not have noticed. The council needs you because you are the only one in town who knows how to keep a ledger. The council also resents you. You eat alone."
         }
       ]
     },
@@ -34,20 +34,20 @@
       "label": "Your town",
       "choices": [
         {
-          "name": "A river-port that fed both sides",
-          "description": "The docks are intact. The warehouses are empty. The river still works and the barge-masters are coming back, one by one, with cargoes that are smaller than they used to be. Both armies bought grain here at different times and the bookkeepers, if anyone wanted to look, kept perfect records of both."
+          "name": "Two-Wharf Landing",
+          "description": "A river-port that fed both sides. The docks are intact. The warehouses are empty. The river still works and the barge-masters are coming back, one by one, with cargoes that are smaller than they used to be. Both armies bought grain here at different times and the bookkeepers, if anyone wanted to look, kept perfect records of both."
         },
         {
-          "name": "A fortress town that held out",
-          "description": "Walls scarred. Population halved. The rationing committee still meets weekly even though there is, technically, no longer a need. The siege ended on a specific morning and most of the people who lived through it have not yet adjusted their habits. The dogs still flinch at the sound of a horn."
+          "name": "The Hold That Held",
+          "description": "A fortress town that endured. Walls scarred. Population halved. The rationing committee still meets weekly even though there is, technically, no longer a need. The siege ended on a specific morning and most of the people who lived through it have not yet adjusted their habits. The dogs still flinch at the sound of a horn."
         },
         {
-          "name": "An occupied capital that traded hands four times",
-          "description": "Each occupation left graffiti in a different language on the same walls. Nobody knows which currency is current; the markets accept four, suspiciously. The cathedral has been reconsecrated three times. The librarian is older than the war and has been quietly hiding the books that don't match whichever flag is up."
+          "name": "Four-Flags",
+          "description": "An occupied capital that traded hands four times. Each occupation left graffiti in a different language on the same walls. Nobody knows which currency is current; the markets accept four, suspiciously. The cathedral has been reconsecrated three times. The librarian is older than the war and has been quietly hiding the books that don't match whichever flag is up."
         },
         {
-          "name": "A village both armies passed through without stopping",
-          "description": "You have all your buildings. You have none of your people. The young left to enlist or to flee and almost none came back. The houses are intact and dark; the gardens have gone to seed; the mill works because the miller is too old to leave. The council is five elderly people and one returned child."
+          "name": "The Untouched Village",
+          "description": "Both armies passed through without stopping. You have all your buildings. You have none of your people. The young left to enlist or to flee and almost none came back. The houses are intact and dark; the gardens have gone to seed; the mill works because the miller is too old to leave. The council is five elderly people and one returned child."
         }
       ]
     }

--- a/worlds/the-replacement.mvworld
+++ b/worlds/the-replacement.mvworld
@@ -16,20 +16,20 @@
       "label": "What the replacement is",
       "choices": [
         {
-          "name": "Changeling",
-          "description": "Fae swap. The replacement is a fetch, a constructed double left behind when the fae took... someone. The player's life has been infiltrated by something ancient that treats human identity as a costume. The replacement isn't malicious — it was made to fill a hole. It doesn't know it's not real. Or it does, and it's terrified of being sent back."
+          "name": "The Fetch",
+          "description": "Changeling — a fae swap. The replacement is a fetch, a constructed double left behind when the fae took... someone. The player's life has been infiltrated by something ancient that treats human identity as a costume. The replacement isn't malicious — it was made to fill a hole. It doesn't know it's not real. Or it does, and it's terrified of being sent back."
         },
         {
-          "name": "Clone",
-          "description": "Corporate, military, or black-market. The player was copied — legally or not — and the copy was activated. The replacement has the player's memories up to a point, then diverges. It thinks it's real. It has paperwork that says it's real. Someone manufactured this situation, and the reason matters."
+          "name": "The Copy",
+          "description": "A clone — corporate, military, or black-market. The player was copied — legally or not — and the copy was activated. The replacement has the player's memories up to a point, then diverges. It thinks it's real. It has paperwork that says it's real. Someone manufactured this situation, and the reason matters."
         },
         {
-          "name": "Time-slip",
-          "description": "The replacement IS the player, from a different point in the timeline. A future self who came back, or a parallel self who crossed over. They know things the player doesn't. They made choices the player hasn't made yet. They're better because they've already lived through whatever comes next."
+          "name": "The Other Now",
+          "description": "A time-slip. The replacement IS the player, from a different point in the timeline. A future self who came back, or a parallel self who crossed over. They know things the player doesn't. They made choices the player hasn't made yet. They're better because they've already lived through whatever comes next."
         },
         {
-          "name": "Something wearing a face",
-          "description": "Not human, never was. An entity that consumes identity — not the body, just the life. It moves from person to person, living each life better than the original, then moving on when it gets bored. The player is the first original who came back while it was still wearing them."
+          "name": "The Wearer",
+          "description": "Something wearing a face. Not human, never was. An entity that consumes identity — not the body, just the life. It moves from person to person, living each life better than the original, then moving on when it gets bored. The player is the first original who came back while it was still wearing them."
         }
       ]
     }

--- a/worlds/the-roommate.mvworld
+++ b/worlds/the-roommate.mvworld
@@ -27,7 +27,7 @@
         },
         {
           "name": "The Council of Seven",
-          "description": "A small council that insists it is one person. They use a single name. They use a single name. They sometimes argue with each other in a language only they speak, and then they reach consensus, and then they hand the player the rent. They eat seven different breakfasts. They are very respectful of the bathroom schedule."
+          "description": "A small council that insists it is one person. They use a single name. They sometimes argue with each other in a language only they speak, and then they reach consensus, and then they hand the player the rent. They eat seven different breakfasts. They are very respectful of the bathroom schedule."
         }
       ]
     },

--- a/worlds/the-roommate.mvworld
+++ b/worlds/the-roommate.mvworld
@@ -14,20 +14,20 @@
       "label": "Your roommate",
       "choices": [
         {
-          "name": "Eight feet of polite, has hooves",
-          "description": "They ducked under the doorframe coming in and apologized for the dent. They brought soup, in a tureen of a metal you do not have a name for. They are scrupulously clean. The hooves are quiet on the laminate. They use \"thank you\" in a way that suggests they have studied the phrase."
+          "name": "The Tall Guest",
+          "description": "Eight feet of polite, has hooves. They ducked under the doorframe coming in and apologized for the dent. They brought soup, in a tureen of a metal you do not have a name for. They are scrupulously clean. The hooves are quiet on the laminate. They use \"thank you\" in a way that suggests they have studied the phrase."
         },
         {
-          "name": "A wisp of light who pays in stock tips",
-          "description": "They occupy the spare room without disturbing the dust. They pay rent in stock tips for a future that will not happen here, but the tickers map onto this market with delightful, illegal accuracy. They glow faintly when discussing the weather and brightly when discussing music."
+          "name": "The Luminary",
+          "description": "A wisp of light who pays in stock tips. They occupy the spare room without disturbing the dust. They pay rent in stock tips for a future that will not happen here, but the tickers map onto this market with delightful, illegal accuracy. They glow faintly when discussing the weather and brightly when discussing music."
         },
         {
-          "name": "A perfect human-looking person who fails one tell per week",
-          "description": "On Mondays they are flawless. By Wednesday something small has slipped — too many teeth in a smile, a shadow cast in the wrong direction, a meal eaten in the wrong order. By Friday they have noticed they have slipped, and by Saturday they have repaired it, and the cycle begins again on Monday."
+          "name": "The Weekly Tell",
+          "description": "A perfect human-looking person who fails one tell per week. On Mondays they are flawless. By Wednesday something small has slipped — too many teeth in a smile, a shadow cast in the wrong direction, a meal eaten in the wrong order. By Friday they have noticed they have slipped, and by Saturday they have repaired it, and the cycle begins again on Monday."
         },
         {
-          "name": "A small council of seven",
-          "description": "They insist they are one person. They use a single name. They sometimes argue with each other in a language only they speak, and then they reach consensus, and then they hand the player the rent. They eat seven different breakfasts. They are very respectful of the bathroom schedule."
+          "name": "The Council of Seven",
+          "description": "A small council that insists it is one person. They use a single name. They use a single name. They sometimes argue with each other in a language only they speak, and then they reach consensus, and then they hand the player the rent. They eat seven different breakfasts. They are very respectful of the bathroom schedule."
         }
       ]
     },
@@ -35,20 +35,20 @@
       "label": "The apartment",
       "choices": [
         {
-          "name": "Brownstone walkup, top floor",
-          "description": "The boards creak in a sequence you have memorized. The fire escape, since the roommate moved in, leads to a window that is not the window it used to lead to. The downstairs neighbor hears everything, and they have started leaving notes you cannot quite parse, slipped under the door at exactly the wrong hour."
+          "name": "The Top-Floor Walkup",
+          "description": "A brownstone, top floor. The boards creak in a sequence you have memorized. The fire escape, since the roommate moved in, leads to a window that is not the window it used to lead to. The downstairs neighbor hears everything, and they have started leaving notes you cannot quite parse, slipped under the door at exactly the wrong hour."
         },
         {
-          "name": "Suburban duplex with a shared wall",
-          "description": "The other side of the wall is silent and was empty when you moved in. It is still empty, technically. The silence on the other side has acquired a texture since the roommate arrived — not louder, exactly, but more present. The mailbox over there has begun accumulating mail addressed to no one."
+          "name": "The Shared Wall",
+          "description": "A suburban duplex. The other side of the wall is silent and was empty when you moved in. It is still empty, technically. The silence on the other side has acquired a texture since the roommate arrived — not louder, exactly, but more present. The mailbox over there has begun accumulating mail addressed to no one."
         },
         {
-          "name": "Studio in a high-rise",
+          "name": "The High-Rise Studio",
           "description": "One room, one bathroom, one of everything. The roommate's belongings are inside your belongings now, in a way that is not physically possible and is nevertheless tidy. The city outside the window sounds different when the roommate is home — closer in some directions and further in others."
         },
         {
-          "name": "A house you inherited from your grandmother",
-          "description": "Her things are still here. The roommate has moved into her bedroom and was apologetic when they realized whose it had been. They sometimes call you by her name, and stop themselves, and look sorry. The house seems easier with them in it, which is its own particular grief."
+          "name": "Grandmother's House",
+          "description": "Inherited. Her things are still here. The roommate has moved into her bedroom and was apologetic when they realized whose it had been. They sometimes call you by her name, and stop themselves, and look sorry. The house seems easier with them in it, which is its own particular grief."
         }
       ]
     }

--- a/worlds/the-second-labyrinth.mvworld
+++ b/worlds/the-second-labyrinth.mvworld
@@ -13,20 +13,20 @@
       "label": "Why you went down",
       "choices": [
         {
-          "name": "Following someone who descended",
-          "description": "They left without telling you. You found their pack at the top of the stair, neatly set down, their lantern still warm. You called and they did not answer, and you went down because waiting at the top felt worse than following. You can no longer hear the surface."
+          "name": "The Lantern Left Warm",
+          "description": "Following someone who descended. They left without telling you. You found their pack at the top of the stair, neatly set down, their lantern still warm. You called and they did not answer, and you went down because waiting at the top felt worse than following. You can no longer hear the surface."
         },
         {
-          "name": "Hired to map it",
-          "description": "A university, a king's geographer, a wealthy antiquarian — somebody who pays in coin and wants results in ink. Your kit is good and your training is real and your contract specifies a finder's fee for any chamber not in the existing surveys. You have already earned the fee three times and you have not yet sent any of it home."
+          "name": "The Finder's Fee",
+          "description": "Hired to map it. A university, a king's geographer, a wealthy antiquarian — somebody who pays in coin and wants results in ink. Your kit is good and your training is real and your contract specifies a finder's fee for any chamber not in the existing surveys. You have already earned the fee three times and you have not yet sent any of it home."
         },
         {
-          "name": "Woke up there",
-          "description": "Last you remember you were on the surface, in bed or at table or on the road. You woke on stone in a chamber you do not recognize, with a lantern and a waterskin you do not remember packing. The chamber has four exits. None of them is up."
+          "name": "The Four Exits",
+          "description": "You woke up there. Last you remember you were on the surface, in bed or at table or on the road. You woke on stone in a chamber you do not recognize, with a lantern and a waterskin you do not remember packing. The chamber has four exits. None of them is up."
         },
         {
-          "name": "You ARE the next minotaur and don't know it yet",
-          "description": "You came down for reasons that made sense at the time. The reasons are starting to feel like instructions. The lower air agrees with you in a way that is alarming when you notice it. The dreams you have had since you started descending are not your dreams. They are someone else's, remembered backwards."
+          "name": "The Heir of Horns",
+          "description": "You ARE the next minotaur and don't know it yet. You came down for reasons that made sense at the time. The reasons are starting to feel like instructions. The lower air agrees with you in a way that is alarming when you notice it. The dreams you have had since you started descending are not your dreams. They are someone else's, remembered backwards."
         }
       ]
     },
@@ -34,24 +34,24 @@
       "label": "Architectural era of each layer",
       "choices": [
         {
-          "name": "Minoan original",
-          "description": "Sea-light on plaster, even this far underground; somewhere a shaft to the sky still works. Bull-leaping frescoes in red and ochre on the walls of an antechamber. The smell of dust and lamp-oil that has been re-applied by hands the player has not seen. The acoustics are exactly the size of the room."
+          "name": "The Bull-Leapers' Stone",
+          "description": "Minoan original. Sea-light on plaster, even this far underground; somewhere a shaft to the sky still works. Bull-leaping frescoes in red and ochre on the walls of an antechamber. The smell of dust and lamp-oil that has been re-applied by hands the player has not seen. The acoustics are exactly the size of the room."
         },
         {
-          "name": "Roman expansion",
-          "description": "Brick vaults arched over older Minoan stone. Mosaic floors in geometric patterns, half-buried in silt. An aqueduct cut through a wall still drips into a cistern that has not been emptied since the legion abandoned the post. The Latin graffiti in one corner names a centurion who was reported missing in 117 AD."
+          "name": "The Legion's Cistern",
+          "description": "Roman expansion. Brick vaults arched over older Minoan stone. Mosaic floors in geometric patterns, half-buried in silt. An aqueduct cut through a wall still drips into a cistern that has not been emptied since the legion abandoned the post. The Latin graffiti in one corner names a centurion who was reported missing in 117 AD."
         },
         {
-          "name": "Norman fortification",
-          "description": "Cold stone, blocks the player can rest a hand on and feel the chill move up the arm. Arrow slits open onto darkness; the player has no idea what the slits were meant to fire at. A small chapel in a recess, the altar still standing, and prayers spoken in the chapel do not echo. They are absorbed."
+          "name": "The Swallowed Chapel",
+          "description": "Norman fortification. Cold stone, blocks the player can rest a hand on and feel the chill move up the arm. Arrow slits open onto darkness; the player has no idea what the slits were meant to fire at. A small chapel in a recess, the altar still standing, and prayers spoken in the chapel do not echo. They are absorbed."
         },
         {
-          "name": "Modern utility",
-          "description": "Concrete poured against ancient rock. Fluorescent tubes hung from rebar, some still flickering on a circuit that has no obvious source. A service map mounted in a junction box that does not match the corridors the player has walked. A coffee cup on the floor, the logo of a company the player has heard of, dated last year."
+          "name": "The Service Corridor",
+          "description": "Modern utility. Concrete poured against ancient rock. Fluorescent tubes hung from rebar, some still flickering on a circuit that has no obvious source. A service map mounted in a junction box that does not match the corridors the player has walked. A coffee cup on the floor, the logo of a company the player has heard of, dated last year."
         },
         {
-          "name": "Future the player can't date",
-          "description": "Matte surfaces that shed no shadow. Signage in a script the player almost reads, in a layout that suggests they were meant to read it eventually. The air-handling is so quiet the player notices the silence first. Whatever this layer is, it was built knowing the player would arrive."
+          "name": "The Undatable Floor",
+          "description": "A future the player can't date. Matte surfaces that shed no shadow. Signage in a script the player almost reads, in a layout that suggests they were meant to read it eventually. The air-handling is so quiet the player notices the silence first. Whatever this layer is, it was built knowing the player would arrive."
         }
       ]
     }

--- a/worlds/the-shepherds.mvworld
+++ b/worlds/the-shepherds.mvworld
@@ -12,20 +12,20 @@
       "label": "Role in the herd",
       "choices": [
         {
-          "name": "Junior shepherd, just earned your first bonded dragon",
-          "description": "You were apprenticed for years and last month you were given a name and a beast to learn it on. You sleep in the same loft and you wake when she does. You are the newest member of the only profession you have ever wanted, and the older shepherds are watching you for signs you can handle bad news."
+          "name": "The Junior Shepherd",
+          "description": "Just earned your first bonded dragon. You were apprenticed for years and last month you were given a name and a beast to learn it on. You sleep in the same loft and you wake when she does. You are the newest member of the only profession you have ever wanted, and the older shepherds are watching you for signs you can handle bad news."
         },
         {
-          "name": "Old hand, you remember when the herd was twice this size",
-          "description": "Forty years of this work. Your hands are the shape of a halter. You remember the great clutch, the year the foreman lost his arm, the winter four dragons died in a single storm. The current losses are not, to you, unprecedented. They are reminiscent — of something you have not yet let yourself name."
+          "name": "The Old Hand",
+          "description": "You remember when the herd was twice this size. Forty years of this work. Your hands are the shape of a halter. You remember the great clutch, the year the foreman lost his arm, the winter four dragons died in a single storm. The current losses are not, to you, unprecedented. They are reminiscent — of something you have not yet let yourself name."
         },
         {
-          "name": "Foreign buyer's agent, came for scales, stayed for love",
-          "description": "You arrived two seasons ago with a commission to buy and you have not gone home. You write your superiors increasingly evasive letters. The shepherds tolerate you because you are useful and because the foreman's daughter has been seen walking with you. You are the only outsider close enough to see the pattern."
+          "name": "The Buyer's Agent",
+          "description": "Came for scales, stayed for love. You arrived two seasons ago with a commission to buy and you have not gone home. You write your superiors increasingly evasive letters. The shepherds tolerate you because you are useful and because the foreman's daughter has been seen walking with you. You are the only outsider close enough to see the pattern."
         },
         {
-          "name": "Defector — you used to hunt them, the shepherds took you in",
-          "description": "You came from one of the border villages that still thinks dragons are vermin. You were good at it before you knew better. The shepherds know your history. They have given you a chance to be useful and you have taken it seriously. If the hunters are real, you will recognize their methods."
+          "name": "The Defector",
+          "description": "You used to hunt them; the shepherds took you in. You came from one of the border villages that still thinks dragons are vermin. You were good at it before you knew better. The shepherds know your history. They have given you a chance to be useful and you have taken it seriously. If the hunters are real, you will recognize their methods."
         }
       ]
     },
@@ -33,20 +33,20 @@
       "label": "Where the herd grazes",
       "choices": [
         {
-          "name": "High alpine pasture",
-          "description": "Cold thin air and a sky so clear at noon you can see the curve of the horizon. The dragons sun themselves on the south-facing rock faces, flat as cats, and the shepherds count them from below with brass spyglasses. In summer the lightning storms come in fast off the ridge and the bonded ones come down to the byres to wait it out."
+          "name": "The High Pasture",
+          "description": "Alpine. Cold thin air and a sky so clear at noon you can see the curve of the horizon. The dragons sun themselves on the south-facing rock faces, flat as cats, and the shepherds count them from below with brass spyglasses. In summer the lightning storms come in fast off the ridge and the bonded ones come down to the byres to wait it out."
         },
         {
-          "name": "Volcanic lowlands",
-          "description": "The ground is warm under your boots and the wind smells of sulfur most days. The dragons nest in the rims of dead calderas, and the village is half-buried in old ash that nobody bothers to dig out anymore. Eggs are kept in the bakery's banked coals. Funerals are quick because the ground is easy."
+          "name": "The Ashlands",
+          "description": "Volcanic lowlands. The ground is warm under your boots and the wind smells of sulfur most days. The dragons nest in the rims of dead calderas, and the village is half-buried in old ash that nobody bothers to dig out anymore. Eggs are kept in the bakery's banked coals. Funerals are quick because the ground is easy."
         },
         {
-          "name": "Coastal cliffs",
-          "description": "The dragons here fish. They fold their wings and drop, and come up trailing salt water, and the shepherds row out to the breeding rocks in flat-bottomed boats every spring. The scales taste of brine. The bonded ones smell like the sea even indoors. In storm season everyone helps lash the byres."
+          "name": "The Breeding Rocks",
+          "description": "Coastal cliffs. The dragons here fish. They fold their wings and drop, and come up trailing salt water, and the shepherds row out to the breeding rocks in flat-bottomed boats every spring. The scales taste of brine. The bonded ones smell like the sea even indoors. In storm season everyone helps lash the byres."
         },
         {
-          "name": "Deep forest clearings",
-          "description": "These dragons are smaller, smoke-and-shadow, no bigger than a deer at full growth. The canopy is burned in clean rings where they sun themselves on the moss. The shepherds know the clearings by memory and travel between them on paths only the bonded ones can find. The trees have grown used to the scorching."
+          "name": "The Scorched Clearings",
+          "description": "Deep forest. These dragons are smaller, smoke-and-shadow, no bigger than a deer at full growth. The canopy is burned in clean rings where they sun themselves on the moss. The shepherds know the clearings by memory and travel between them on paths only the bonded ones can find. The trees have grown used to the scorching."
         }
       ]
     }

--- a/worlds/the-tenant.mvworld
+++ b/worlds/the-tenant.mvworld
@@ -14,19 +14,19 @@
       "label": "Communication channel",
       "choices": [
         {
-          "name": "Notes left in the apartment",
-          "description": "The handwriting is similar to yours and different in the loops. They appear on the backs of receipts you do not remember keeping, on napkins from places you have not been. The dates at the top are sometimes a day ahead and sometimes a week behind, and there is no apology for either."
+          "name": "The Apartment Notes",
+          "description": "Left around the apartment. The handwriting is similar to yours and different in the loops. They appear on the backs of receipts you do not remember keeping, on napkins from places you have not been. The dates at the top are sometimes a day ahead and sometimes a week behind, and there is no apology for either."
         },
         {
-          "name": "Voice memos on your phone",
-          "description": "The voice is yours, recorded at timestamps you were asleep. They are practical, mostly — what is in the fridge, who called, what the tenant told the neighbor about the dog. Occasionally, in the background, you can hear the city, and the city does not always sound like your city."
+          "name": "The Voice Memos",
+          "description": "On your phone. The voice is yours, recorded at timestamps you were asleep. They are practical, mostly — what is in the fridge, who called, what the tenant told the neighbor about the dog. Occasionally, in the background, you can hear the city, and the city does not always sound like your city."
         },
         {
-          "name": "A coworker who relays for both of you",
-          "description": "He has known you both for years. He used to know only one of you. He prefers the tenant, and is not subtle about it. He passes messages in the kitchen by the coffee machine and does not understand why this hurts. He thinks of himself as a friend to both of you, which is true."
+          "name": "The Coffee-Machine Relay",
+          "description": "A coworker who passes messages for both of you. He has known you both for years. He used to know only one of you. He prefers the tenant, and is not subtle about it. He passes messages in the kitchen by the coffee machine and does not understand why this hurts. He thinks of himself as a friend to both of you, which is true."
         },
         {
-          "name": "A small notebook by the bed",
+          "name": "The Bedside Notebook",
           "description": "It fills itself when neither of you is looking. The pages alternate. Sometimes the tenant draws — small, careful sketches of rooms you have not seen. Sometimes you wake to find your own entry continued in their hand, finishing the sentence you fell asleep mid-writing."
         }
       ]
@@ -35,20 +35,20 @@
       "label": "What they leave behind",
       "choices": [
         {
-          "name": "Money",
-          "description": "More than your salary. It appears in your checking account in deposits with bland descriptions. You do not know how the tenant earns it and you have not yet asked. The amount is increasing on a curve. The tax implications will eventually be your problem."
+          "name": "The Deposits",
+          "description": "Money — more than your salary. It appears in your checking account in deposits with bland descriptions. You do not know how the tenant earns it and you have not yet asked. The amount is increasing on a curve. The tax implications will eventually be your problem."
         },
         {
-          "name": "Wounds",
-          "description": "A bruise on the ribs you don't remember getting. A cut on the palm in a place you would not cut yourself working. Once, a stitched gash on the thigh, neatly dressed, with a small note pinned to the bandage saying sorry and naming an antibiotic. The tenant lives a more dangerous life than you do."
+          "name": "The Stitches",
+          "description": "Wounds. A bruise on the ribs you don't remember getting. A cut on the palm in a place you would not cut yourself working. Once, a stitched gash on the thigh, neatly dressed, with a small note pinned to the bandage saying sorry and naming an antibiotic. The tenant lives a more dangerous life than you do."
         },
         {
-          "name": "A relationship",
-          "description": "Someone loves the tenant. You have to keep meeting them, because the tenant cannot show up without you. They look at you the way no one has ever looked at you, and you cannot tell them why your eyes don't quite settle on theirs the way they remember."
+          "name": "The Borrowed Beloved",
+          "description": "A relationship. Someone loves the tenant. You have to keep meeting them, because the tenant cannot show up without you. They look at you the way no one has ever looked at you, and you cannot tell them why your eyes don't quite settle on theirs the way they remember."
         },
         {
-          "name": "A skill",
-          "description": "You can suddenly play piano, or speak Cantonese, or pick a lock. The knowledge is in your hands when you reach for it. It is not in your head when you try to explain it. The tenant practiced for years. You inherited the muscle and not the patience."
+          "name": "The Inherited Hands",
+          "description": "A skill. You can suddenly play piano, or speak Cantonese, or pick a lock. The knowledge is in your hands when you reach for it. It is not in your head when you try to explain it. The tenant practiced for years. You inherited the muscle and not the patience."
         }
       ]
     }

--- a/worlds/the-thaw.mvworld
+++ b/worlds/the-thaw.mvworld
@@ -13,20 +13,20 @@
       "label": "Who you are at the thaw",
       "choices": [
         {
-          "name": "Scavenger working the ice line",
+          "name": "The Ice-Line Scavenger",
           "description": "You work the receding edge for whatever the melt gives up. You have a sled and a partner and a route. You know which trading posts will pay for which finds. You have been doing this for six years and you have learned that some finds are worth less than the trouble of carrying them. The thing you found this week has changed your assumptions."
         },
         {
-          "name": "Scientist with the only working sensors",
-          "description": "You inherited an instrument array from a research station that closed when its parent institution did. You have the only ground-penetrating radar still operating within a thousand kilometers. You know things about what's under the ice that no one else has the equipment to know, and you have not yet decided who you are willing to share with."
+          "name": "The Last Radar",
+          "description": "Scientist with the only working sensors. You inherited an instrument array from a research station that closed when its parent institution did. You have the only ground-penetrating radar still operating within a thousand kilometers. You know things about what's under the ice that no one else has the equipment to know, and you have not yet decided who you are willing to share with."
         },
         {
-          "name": "Inheritor of a buried family vault",
-          "description": "Your family put something under the ice generations ago, intending it to be retrieved when conditions were right. The conditions are right. You have the key and the map and the family stories about what's inside, and the stories are inconsistent with each other in ways that suggest someone in the family was not telling the truth."
+          "name": "The Family Vault",
+          "description": "You are the inheritor. Your family put something under the ice generations ago, intending it to be retrieved when conditions were right. The conditions are right. You have the key and the map and the family stories about what's inside, and the stories are inconsistent with each other in ways that suggest someone in the family was not telling the truth."
         },
         {
-          "name": "Refugee — your home was on the ice",
-          "description": "You lived on a frozen surface. Your settlement was built to last the ice. The ice is going and your settlement is going with it. You are not here to investigate the thaw; you are here because the thaw is following you. What is coming up under your former home concerns you for entirely practical reasons."
+          "name": "The Melting Home",
+          "description": "Refugee — your home was on the ice. You lived on a frozen surface. Your settlement was built to last the ice. The ice is going and your settlement is going with it. You are not here to investigate the thaw; you are here because the thaw is following you. What is coming up under your former home concerns you for entirely practical reasons."
         }
       ]
     },
@@ -34,20 +34,20 @@
       "label": "The ice",
       "choices": [
         {
-          "name": "Arctic ice cap",
-          "description": "White horizon in every direction and a wind that does not change pitch from one day to the next. In summer the sun does not set and the light is the same at midnight as it is at noon. Time becomes a thing you have to measure on instruments. The melt is thirty centimeters a day in the bad weeks and you can hear it under your boots."
+          "name": "The White Horizon",
+          "description": "Arctic ice cap. White horizon in every direction and a wind that does not change pitch from one day to the next. In summer the sun does not set and the light is the same at midnight as it is at noon. Time becomes a thing you have to measure on instruments. The melt is thirty centimeters a day in the bad weeks and you can hear it under your boots."
         },
         {
-          "name": "Mountain glacier in a populated valley",
-          "description": "The village downstream depends on the meltwater for their fields and their drinking. The ice has begun to calve daily — table-sized blocks that fall and crack and float down the new lake at the toe. The villagers have started measuring the lake. The villagers have not yet noticed what the calves are exposing on the bedrock above."
+          "name": "The Calving Glacier",
+          "description": "A mountain glacier in a populated valley. The village downstream depends on the meltwater for their fields and their drinking. The ice has begun to calve daily — table-sized blocks that fall and crack and float down the new lake at the toe. The villagers have started measuring the lake. The villagers have not yet noticed what the calves are exposing on the bedrock above."
         },
         {
-          "name": "Antarctic shelf the size of a country",
-          "description": "The research stations have been abandoned for two generations. One signal still blinks on an old chart, a beacon that was never officially registered. The ice underfoot is one continuous howl — basal flow, pressure ridges, distant cracks — and you stop being able to sleep without it. The shelf is breaking up in pieces the size of cities."
+          "name": "The Howling Shelf",
+          "description": "An Antarctic shelf the size of a country. The research stations have been abandoned for two generations. One signal still blinks on an old chart, a beacon that was never officially registered. The ice underfoot is one continuous howl — basal flow, pressure ridges, distant cracks — and you stop being able to sleep without it. The shelf is breaking up in pieces the size of cities."
         },
         {
-          "name": "A frozen city, deliberately preserved",
-          "description": "Whole blocks under glass. The streets named in a script you cannot read. The streetlights working, on a timer that still keeps the day. The buildings inside the ice are intact down to the curtains in the upper windows. The thaw has begun to fog the glass from outside and there are figures moving on some of the lower floors."
+          "name": "The City Under Glass",
+          "description": "A frozen city, deliberately preserved. Whole blocks under glass. The streets named in a script you cannot read. The streetlights working, on a timer that still keeps the day. The buildings inside the ice are intact down to the curtains in the upper windows. The thaw has begun to fog the glass from outside and there are figures moving on some of the lower floors."
         }
       ]
     }

--- a/worlds/the-understudies.mvworld
+++ b/worlds/the-understudies.mvworld
@@ -15,16 +15,16 @@
       "label": "The story you've inherited",
       "choices": [
         {
-          "name": "Space opera",
-          "description": "The bridge crew of a flagship is dead. All of them — captain, first officer, science lead, the one who was definitely going to betray everyone in episode 7. You're the B-shift. The ensigns, the cargo handlers, the person who fixes the coffee machine. The galaxy-ending threat is still out there and it does not care about your qualifications."
+          "name": "The B-Shift",
+          "description": "Space opera. The bridge crew of a flagship is dead. All of them — captain, first officer, science lead, the one who was definitely going to betray everyone in episode 7. You're the B-shift. The ensigns, the cargo handlers, the person who fixes the coffee machine. The galaxy-ending threat is still out there and it does not care about your qualifications."
         },
         {
-          "name": "Sitcom",
-          "description": "A literal three-camera television show. The laugh track is real. The set walls wobble if you lean on them. The main cast — the wacky neighbor, the will-they-won't-they couple, the sarcastic best friend — are dead. The network needs a new cast by Monday or the show gets cancelled. You're the extras who just got promoted. The audience can see you. You can hear them."
+          "name": "The Laugh Track",
+          "description": "Sitcom — a literal three-camera television show. The laugh track is real. The set walls wobble if you lean on them. The main cast — the wacky neighbor, the will-they-won't-they couple, the sarcastic best friend — are dead. The network needs a new cast by Monday or the show gets cancelled. You're the extras who just got promoted. The audience can see you. You can hear them."
         },
         {
-          "name": "Gothic horror",
-          "description": "The monster hunters are dead. The Van Helsing, the psychic, the one with the family curse and the silver bullets — all gone, taken by the thing in the manor on the hill. The village hired them. The village paid in advance. The village would like a refund or a replacement. You are the replacement. You are not qualified."
+          "name": "The Village's Refund",
+          "description": "Gothic horror. The monster hunters are dead. The Van Helsing, the psychic, the one with the family curse and the silver bullets — all gone, taken by the thing in the manor on the hill. The village hired them. The village paid in advance. The village would like a refund or a replacement. You are the replacement. You are not qualified."
         }
       ]
     },

--- a/worlds/three-histories.mvworld
+++ b/worlds/three-histories.mvworld
@@ -51,7 +51,7 @@
         },
         {
           "name": "The Keeper of Keys",
-          "description": "Independent — you hold them and refuse to give them out. You belong to no faction and you have made a small principled career of belonging to no faction. The archive is technically yours to administer, and you have, twice, refused requests from people who could have ended your career for refusing them. Your independence is a public position. Your independence is also a target. All three factions have stopped asking you politely and are starting to ask you another way."
+          "description": "Independent — you hold the keys and refuse to give them out. You belong to no faction and you have made a small principled career of belonging to no faction. The archive is technically yours to administer, and you have, twice, refused requests from people who could have ended your career for refusing them. Your independence is a public position. Your independence is also a target. All three factions have stopped asking you politely and are starting to ask you another way."
         }
       ]
     }

--- a/worlds/three-histories.mvworld
+++ b/worlds/three-histories.mvworld
@@ -17,20 +17,20 @@
       "label": "Your discipline",
       "choices": [
         {
-          "name": "Translator of dead scripts",
-          "description": "You read what others cannot. Two languages most people in the city don't know are alive in your head, and a third is slowly assembling itself. Your translations are quoted in council meetings. Your translations decide what counts as a fact. You have not yet had to translate something whose meaning you would prefer to bury, but you can feel that day coming."
+          "name": "The Translator",
+          "description": "Of dead scripts. You read what others cannot. Two languages most people in the city don't know are alive in your head, and a third is slowly assembling itself. Your translations are quoted in council meetings. Your translations decide what counts as a fact. You have not yet had to translate something whose meaning you would prefer to bury, but you can feel that day coming."
         },
         {
-          "name": "Cartographer of the old quarter",
-          "description": "You map what used to be where. The records describe a city different in layout from the one above it; you are the person who matches the old street names to the new ones, the old foundations to the new walls. Three factions want your maps for three different reasons. The maps are also, increasingly, accurate descriptions of where the city's secrets are buried."
+          "name": "The Cartographer",
+          "description": "Of the old quarter. You map what used to be where. The records describe a city different in layout from the one above it; you are the person who matches the old street names to the new ones, the old foundations to the new walls. Three factions want your maps for three different reasons. The maps are also, increasingly, accurate descriptions of where the city's secrets are buried."
         },
         {
-          "name": "Oral historian",
+          "name": "The Oral Historian",
           "description": "You sit with the old people and you write down what they tell you, and you do it carefully because they are dying faster than you can interview them. You know what their grandparents told them about the years no records cover. You are the only person whose archive grew up with the people it documents — and the only one whose archive talks back."
         },
         {
-          "name": "Material conservator",
-          "description": "You are the one who can actually unfold the parchment, mount the disc, stabilize the microfilm without destroying it. Every other archivist in the city brings you the originals before they bring them to themselves. You have access nobody else has, because nobody else is allowed to touch the things. Your hands have been on every document that matters here."
+          "name": "The Conservator",
+          "description": "Material specialist. You are the one who can actually unfold the parchment, mount the disc, stabilize the microfilm without destroying it. Every other archivist in the city brings you the originals before they bring them to themselves. You have access nobody else has, because nobody else is allowed to touch the things. Your hands have been on every document that matters here."
         }
       ]
     },
@@ -38,20 +38,20 @@
       "label": "Where you sit on the factional map",
       "choices": [
         {
-          "name": "Reformist by sentiment, civil servant by paycheck",
-          "description": "Your sympathies are with the Council and you would say so if asked. You also work for the city archive, which is technically neutral and is in fact paid out of merchant levies. You like your job. You like your colleagues. You are aware that your sentiments and your salary are not in perfect alignment, and you have made small compromises already that you do not want to think about."
+          "name": "The Quiet Reformist",
+          "description": "Reformist by sentiment, civil servant by paycheck. Your sympathies are with the Council and you would say so if asked. You also work for the city archive, which is technically neutral and is in fact paid out of merchant levies. You like your job. You like your colleagues. You are aware that your sentiments and your salary are not in perfect alignment, and you have made small compromises already that you do not want to think about."
         },
         {
-          "name": "Preservationist by upbringing, conflicted now",
-          "description": "Your family were Order people. You grew up at their festivals, you know the calendar in your bones, you can still sing the old harvest round. You have spent your twenties quietly questioning some of it and not telling your father. The Order would welcome you back tomorrow if you walked through their doors. You have not walked through their doors. Yet."
+          "name": "The Lapsed Order-Child",
+          "description": "Preservationist by upbringing, conflicted now. Your family were Order people. You grew up at their festivals, you know the calendar in your bones, you can still sing the old harvest round. You have spent your twenties quietly questioning some of it and not telling your father. The Order would welcome you back tomorrow if you walked through their doors. You have not walked through their doors. Yet."
         },
         {
-          "name": "On the Merchant Coalition's payroll, but only barely",
-          "description": "They retain you for occasional consulting work and they pay extremely well for it. You tell yourself it's a few hours a month. You tell yourself you'd hear about anything serious before you were asked to do anything serious. You have a townhouse with one room more than you need and you are not certain anymore whether the townhouse is the reason you took the consulting work or the consulting work is the reason for the townhouse."
+          "name": "The Townhouse Consultant",
+          "description": "On the Merchant Coalition's payroll, but only barely. They retain you for occasional consulting work and they pay extremely well for it. You tell yourself it's a few hours a month. You tell yourself you'd hear about anything serious before you were asked to do anything serious. You have a townhouse with one room more than you need and you are not certain anymore whether the townhouse is the reason you took the consulting work or the consulting work is the reason for the townhouse."
         },
         {
-          "name": "Independent — you hold the keys and refuse to give them out",
-          "description": "You belong to no faction and you have made a small principled career of belonging to no faction. The archive is technically yours to administer, and you have, twice, refused requests from people who could have ended your career for refusing them. Your independence is a public position. Your independence is also a target. All three factions have stopped asking you politely and are starting to ask you another way."
+          "name": "The Keeper of Keys",
+          "description": "Independent — you hold them and refuse to give them out. You belong to no faction and you have made a small principled career of belonging to no faction. The archive is technically yours to administer, and you have, twice, refused requests from people who could have ended your career for refusing them. Your independence is a public position. Your independence is also a target. All three factions have stopped asking you politely and are starting to ask you another way."
         }
       ]
     }

--- a/worlds/warranty-void.mvworld
+++ b/worlds/warranty-void.mvworld
@@ -13,20 +13,20 @@
       "label": "Channel",
       "choices": [
         {
-          "name": "Phone",
-          "description": "Hold music is the screams of previous customers, looped, slightly tasteful. Tier escalation is literal — between each tier the player climbs a flight of stairs in a building that the support agent describes over the line. The on-hold timer counts up past sensible numbers. The agent thanks the player for their patience between every sentence."
+          "name": "The Hold Line",
+          "description": "Phone support. Hold music is the screams of previous customers, looped, slightly tasteful. Tier escalation is literal — between each tier the player climbs a flight of stairs in a building that the support agent describes over the line. The on-hold timer counts up past sensible numbers. The agent thanks the player for their patience between every sentence."
         },
         {
-          "name": "Chat",
-          "description": "The agent's avatar is the player's own face, smiling slightly differently. Canned responses arrive in the chat window before the player has finished asking the question. The chat history scrolls upward into messages the player has not yet sent. The typing indicator pulses in the player's own rhythm."
+          "name": "The Mirror Window",
+          "description": "Chat support. The agent's avatar is the player's own face, smiling slightly differently. Canned responses arrive in the chat window before the player has finished asking the question. The chat history scrolls upward into messages the player has not yet sent. The typing indicator pulses in the player's own rhythm."
         },
         {
-          "name": "Email",
-          "description": "Every reply quotes the entire prior chain back at the player. Some of the quoted messages are from threads the player has not sent. The signature block at the bottom of every reply contains the player's own home address. Replies arrive in batches and the timestamps are wrong."
+          "name": "The Quoted Chain",
+          "description": "Email support. Every reply quotes the entire prior chain back at the player. Some of the quoted messages are from threads the player has not sent. The signature block at the bottom of every reply contains the player's own home address. Replies arrive in batches and the timestamps are wrong."
         },
         {
-          "name": "In-person at a kiosk",
-          "description": "A mall that closed in 1997, fluorescent and echoing. The kiosk is staffed by yesterday — literally, the agent is the player as they were the day before. They are exactly as helpful as the player was. The food court is open. Nothing in it is for sale."
+          "name": "The Dead Mall Kiosk",
+          "description": "In-person support. A mall that closed in 1997, fluorescent and echoing. The kiosk is staffed by yesterday — literally, the agent is the player as they were the day before. They are exactly as helpful as the player was. The food court is open. Nothing in it is for sale."
         }
       ]
     },
@@ -34,20 +34,20 @@
       "label": "How you broke it",
       "choices": [
         {
-          "name": "Followed the manual exactly",
-          "description": "The manual was clear. Every step. The player can show their work. The agent agrees the player followed the manual, asks if the player has tried a different manual, and refers them to a supplementary document the player will never be able to find."
+          "name": "By the Manual",
+          "description": "You followed the manual exactly. It was clear. Every step. The player can show their work. The agent agrees the player followed the manual, asks if the player has tried a different manual, and refers them to a supplementary document the player will never be able to find."
         },
         {
-          "name": "A modification you swear was harmless",
-          "description": "A small after-market change. A workaround everyone online uses. The player knows three friends who did the same thing without incident. The agent notes that the warranty does not cover modifications, and the modifications appear to be in the player's permanent record."
+          "name": "The Harmless Mod",
+          "description": "A modification you swear was harmless. A small after-market change. A workaround everyone online uses. The player knows three friends who did the same thing without incident. The agent notes that the warranty does not cover modifications, and the modifications appear to be in the player's permanent record."
         },
         {
-          "name": "Inherited the broken reality from a previous owner",
-          "description": "It came like this. The player did not break it. The previous owner — possibly deceased, possibly fictional — voided the warranty before the transfer. The agent suggests the player contact the previous owner. The previous owner is one of the things that is broken."
+          "name": "The Previous Owner",
+          "description": "You inherited the broken reality. It came like this. The player did not break it. The previous owner — possibly deceased, possibly fictional — voided the warranty before the transfer. The agent suggests the player contact the previous owner. The previous owner is one of the things that is broken."
         },
         {
-          "name": "It was already broken when you got here",
-          "description": "It has been broken from the start. The player has been blamed for it the entire time, including by themselves. The agent's records show the player as the registered owner since a date that predates the player. The agent is sorry but the timestamps are authoritative."
+          "name": "The Authoritative Timestamp",
+          "description": "It was already broken when you got here. It has been broken from the start. The player has been blamed for it the entire time, including by themselves. The agent's records show the player as the registered owner since a date that predates the player. The agent is sorry but the timestamps are authoritative."
         }
       ]
     }


### PR DESCRIPTION
## Summary

Addresses #510 (campaign name collisions across player base) with an 80% solution: when a player picks a suboption from a seeded world, the setup agent now formats `campaign_name` as `<World> - <Suboption>` (e.g. `Palimpsest - The Dreaming Souk`). Slug inherits the suffix via the existing `slugify(campaignName)` path, so on-disk identity and the main-menu display name diverge together — both read from one source of truth.

- **Mechanism (prompt-only)**: one new bullet in `setup-conversation.md` and a tightened tool description on `campaign_name`. No schema or downstream code changes.
- **Content sweep**: rewrote suboption choice `name` fields across 67 of 72 `.mvworld` seeds. The pre-existing names were largely descriptive phrases ("A betrayal you didn't commit", "Conference attendee, badge still on") that wouldn't read well as suffixes. New names are punchy proper-noun-style labels; the original descriptive text moved into the choice's `description` field where needed. Skipped `palimpsest`, `the-shattered-crown` (already strong), and `heirloom`, `jettison`, `the-rumble-pit` (no suboptions).
- **Doesn't solve**: seed+suboption-equal collisions, but those are a much smaller bucket than the current shared LLM-naming problem.

## Test plan

- [x] `npm run check` clean
- [x] `npx tsc -b` clean
- [x] Golden-path e2e: setup agent picked "The Shepherds" → "The Junior Shepherd" suboption and the campaign landed on disk as `shepherds-the-junior-shepherd`. Display name in `config.json` carries the same suffix.
- [ ] Eyeball some `.mvworld` diffs for tonal fit — particularly the 5 files where the rewriter took larger creative liberties (`beneath-the-skin` invented town names; `the-instrument` invented "Hearthbinder")

🤖 Generated with [Claude Code](https://claude.com/claude-code)