### PR TITLE
Release model: stable/rc/nightly channels, release branch, doctrine

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,6 +43,20 @@ body:
       required: true
 
   - type: dropdown
+    id: channel
+    attributes:
+      label: Channel
+      description: Which release channel is this installation on?
+      options:
+        - Stable
+        - Nightly
+        - Release candidate (RC)
+        - Built from source
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
     id: install-method
     attributes:
       label: Install method

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!-- PR description goes here. -->
+
+## Test plan
+
+<!-- How did you verify this works? -->
+
+## Branch awareness
+
+- [ ] If this is a **bug fix**, I've checked whether the *other* long-lived branch (`main` or `release`) has the same code path and needs the same fix. We don't auto-back/forward-merge — small fixes get re-applied or cherry-picked deliberately.
+- [ ] If this PR targets `release`, the fix is scoped to the released line; new features land on `main` instead.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, two-tiers]
+    branches: [main, release, two-tiers]
   pull_request:
-    branches: [main]
+    branches: [main, release]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,13 +1,31 @@
 name: Cut Release
 
+# Cuts a release tag from the `release` branch. Two kinds:
+#   - stable: tags `v$VERSION`, packaged to Velopack `stable` channel
+#   - rc:     tags `v$VERSION-rc.$N`, packaged to Velopack `rc` channel
+# Both trigger release.yml via workflow_call.
+#
+# `bump` rules:
+#   - patch/minor/major: runs `npm version` on the release branch and commits.
+#   - none: re-uses the current package.json version. Required when cutting
+#     additional RCs of the same version, or when promoting RC → stable.
+
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: "Version bump type"
+      kind:
+        description: "Release kind"
         required: true
         type: choice
         options:
+          - stable
+          - rc
+      bump:
+        description: "Version bump (use 'none' to re-use current package.json version)"
+        required: true
+        type: choice
+        options:
+          - none
           - patch
           - minor
           - major
@@ -25,11 +43,19 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.bump.outputs.tag }}
+      tag: ${{ steps.compute.outputs.tag }}
       dry_run: ${{ inputs.dry_run }}
     steps:
+      - name: Refuse non-release source branch
+        if: github.ref != 'refs/heads/release'
+        run: |
+          echo "::error::cut-release must be dispatched against the 'release' branch (got ${{ github.ref }})."
+          echo "In the Actions UI, pick 'release' from the 'Use workflow from' branch selector."
+          exit 1
+
       - uses: actions/checkout@v4
         with:
+          ref: release
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
@@ -41,38 +67,59 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version
-        id: bump
+      - name: Bump version (if requested)
+        if: inputs.bump != 'none'
         run: |
           OLD_VERSION=$(node -p "require('./package.json').version")
-          npm version ${{ inputs.bump }} --no-git-tag-version
+          npm version "${{ inputs.bump }}" --no-git-tag-version
           NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "old=$OLD_VERSION" >> "$GITHUB_OUTPUT"
-          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo ""
           echo "Version: $OLD_VERSION → $NEW_VERSION"
-
-      - name: Commit and tag
-        run: |
           git add package.json package-lock.json
-          git commit -m "Release v${{ steps.bump.outputs.new }}"
-          git tag "v${{ steps.bump.outputs.new }}"
+          git commit -m "Bump version to $NEW_VERSION"
+
+      - name: Compute tag
+        id: compute
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+
+          if [ "${{ inputs.kind }}" = "stable" ]; then
+            TAG="v$VERSION"
+            # Fail if the stable tag already exists — we don't overwrite history.
+            if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "::error::Stable tag $TAG already exists. Pick a bump (patch/minor/major) instead."
+              exit 1
+            fi
+          else
+            # Find the highest existing rc counter for this version.
+            git fetch --tags
+            HIGHEST=$(git tag -l "v${VERSION}-rc.*" \
+              | sed -n "s/^v${VERSION}-rc\.\([0-9][0-9]*\)$/\1/p" \
+              | sort -n \
+              | tail -n1)
+            NEXT=$(( ${HIGHEST:-0} + 1 ))
+            TAG="v${VERSION}-rc.${NEXT}"
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Computed tag: $TAG"
+
+      - name: Tag
+        run: git tag "${{ steps.compute.outputs.tag }}"
 
       - name: Push
         if: ${{ !inputs.dry_run }}
         run: |
-          git push origin main
-          git push origin "v${{ steps.bump.outputs.new }}"
-          echo ""
-          echo "Tagged v${{ steps.bump.outputs.new }} — release build starting."
+          # Push the branch first (carries any bump commit), then the tag.
+          git push origin release
+          git push origin "${{ steps.compute.outputs.tag }}"
+          echo "Tagged ${{ steps.compute.outputs.tag }} — release build starting."
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}
         run: |
           echo "Dry run — no push."
-          echo "Would have tagged: v${{ steps.bump.outputs.new }}"
-          git log --oneline -1
+          echo "Would have tagged: ${{ steps.compute.outputs.tag }}"
+          git log --oneline -3
 
   build-and-release:
     needs: tag

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,13 +76,8 @@ jobs:
           curl -fSL -o wt-portable.zip "$WT_URL"
 
           # Verify integrity (update hash when bumping WT_VERSION)
-          WT_SHA256="SET_AFTER_FIRST_SUCCESSFUL_BUILD"
-          if [ "$WT_SHA256" != "SET_AFTER_FIRST_SUCCESSFUL_BUILD" ]; then
-            echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
-          else
-            echo "WARNING: SHA256 not pinned yet — skipping verification"
-            sha256sum wt-portable.zip
-          fi
+          WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
+          echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
 
           # Extract into dist/terminal/
           mkdir -p dist/terminal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,14 @@
 name: Release
 
+# Builds and publishes a release for any pushed `v*` tag.
+#
+# Channel routing (sticky — each installer only updates within its own channel):
+#   - v$X.$Y.$Z         → Velopack channel `stable`, public GitHub release.
+#   - v$X.$Y.$Z-rc.$N   → Velopack channel `rc`, prerelease GitHub release,
+#                         no Discord post, no Homebrew formula bump.
+#
+# Nightlies are handled by nightly.yml on channel `nightly` (also sticky).
+
 on:
   push:
     tags: ["v*"]
@@ -14,7 +23,34 @@ permissions:
   id-token: write
 
 jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+      version: ${{ steps.compute.outputs.version }}
+      channel: ${{ steps.compute.outputs.channel }}
+      prerelease: ${{ steps.compute.outputs.prerelease }}
+    steps:
+      - name: Compute channel from tag
+        id: compute
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          if [[ "$TAG" == *-rc.* ]]; then
+            CHANNEL="rc"
+            PRERELEASE="true"
+          else
+            CHANNEL="stable"
+            PRERELEASE="false"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Tag $TAG → channel=$CHANNEL prerelease=$PRERELEASE"
+
   build:
+    needs: prep
     strategy:
       matrix:
         include:
@@ -32,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ needs.prep.outputs.tag }}
 
       - uses: actions/setup-node@v4
         with:
@@ -47,8 +83,7 @@ jobs:
       - name: Build distribution
         shell: bash
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          VERSION="${TAG#v}"
+          VERSION="${{ needs.prep.outputs.version }}"
           RELEASE_DATE="$(date -u +'%Y-%m-%d %H:%M')"
           node scripts/build-dist.js --version="$VERSION" --release-date="$RELEASE_DATE"
 
@@ -68,13 +103,8 @@ jobs:
           curl -fSL -o wt-portable.zip "$WT_URL"
 
           # Verify integrity (update hash when bumping WT_VERSION)
-          WT_SHA256="SET_AFTER_FIRST_SUCCESSFUL_BUILD"
-          if [ "$WT_SHA256" != "SET_AFTER_FIRST_SUCCESSFUL_BUILD" ]; then
-            echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
-          else
-            echo "WARNING: SHA256 not pinned yet — skipping verification"
-            sha256sum wt-portable.zip
-          fi
+          WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
+          echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
 
           # Extract into dist/terminal/
           mkdir -p dist/terminal
@@ -109,25 +139,23 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          VERSION="${TAG#v}"
           vpk pack \
             --packId MachineViolet \
-            --packVersion "$VERSION" \
+            --packVersion "${{ needs.prep.outputs.version }}" \
             --packTitle "Machine Violet" \
             --packDir dist \
             --mainExe MachineViolet.exe \
             --icon assets/machine-violet.ico \
             --shortcuts StartMenuRoot \
             --azureTrustedSignFile assets/trusted-signing.json \
+            --channel "${{ needs.prep.outputs.channel }}" \
             --outputDir velopack-out
 
       - name: Package (tar.gz)
         if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          VERSION="${TAG#v}"
+          VERSION="${{ needs.prep.outputs.version }}"
           tar -czf "machine-violet-${VERSION}-${{ matrix.asset_suffix }}.tar.gz" -C dist .
 
       - name: Upload artifact (Windows)
@@ -145,12 +173,12 @@ jobs:
           path: machine-violet-*.${{ matrix.archive }}
 
   release:
-    needs: build
+    needs: [prep, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ needs.prep.outputs.tag }}
           fetch-depth: 0
 
       - uses: actions/download-artifact@v4
@@ -161,10 +189,21 @@ jobs:
       - name: Determine previous tag
         id: tags
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          # Find the most recent v* tag immediately before this one in version order
+          TAG="${{ needs.prep.outputs.tag }}"
+          CHANNEL="${{ needs.prep.outputs.channel }}"
+
+          # For stable releases, exclude RC tags from the "previous" search —
+          # users on stable haven't seen RCs, so changelog should be vs the
+          # previous stable. For RC releases, include all v* (stable + rc) so
+          # the changelog is vs whatever immediately preceded.
+          if [ "$CHANNEL" = "stable" ]; then
+            CANDIDATES=$(git tag -l 'v*' --sort=-version:refname | grep -v -- '-rc\.' || true)
+          else
+            CANDIDATES=$(git tag -l 'v*' --sort=-version:refname || true)
+          fi
+
           PREV_TAG=$(
-            git tag -l 'v*' --sort=-version:refname |
+            echo "$CANDIDATES" |
             awk -v current="$TAG" '
               $0 == current { seen=1; next }
               seen { print; exit }
@@ -176,7 +215,7 @@ jobs:
           if [ -n "$PREV_TAG" ]; then
             echo "Changelog range: ${PREV_TAG}..${TAG}"
           else
-            echo "No previous tag found — first release"
+            echo "No previous tag found — first release on channel $CHANNEL"
           fi
 
       - name: Collect changelog context
@@ -315,13 +354,14 @@ jobs:
           echo "$NOTES" >> "$GITHUB_OUTPUT"
           echo "NOTES_EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (stable)
+        if: needs.prep.outputs.channel == 'stable'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
         run: |
-          TAG="${{ steps.tags.outputs.tag }}"
-          VERSION="${TAG#v}"
+          TAG="${{ needs.prep.outputs.tag }}"
+          VERSION="${{ needs.prep.outputs.version }}"
 
           cat > release-body.md << BODYEOF
           ## Download
@@ -361,15 +401,71 @@ jobs:
             --notes-file release-body.md \
             artifacts/MachineViolet-* \
             artifacts/machine-violet-* \
-            artifacts/releases.win.json
+            artifacts/releases.stable.json \
+            artifacts/assets.stable.json
 
-      - name: Post to Discord
+      - name: Create GitHub Release (rc)
+        if: needs.prep.outputs.channel == 'rc'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
+        run: |
+          TAG="${{ needs.prep.outputs.tag }}"
+          VERSION="${{ needs.prep.outputs.version }}"
+
+          cat > release-body.md << BODYEOF
+          > **Release candidate.** Auto-updates only to later RCs of the same
+          > line — installing this does NOT auto-upgrade to the eventual stable.
+          > Try it out and report issues; uninstall + reinstall the stable when
+          > it ships.
+
+          ## Download
+
+          ### Windows
+          | | File |
+          |---|---|
+          | **Installer** | [\`MachineViolet-Setup.exe\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Setup.exe) |
+          | Portable | [\`MachineViolet-Portable.zip\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Portable.zip) |
+
+          ### macOS (Apple Silicon)
+          | | File |
+          |---|---|
+          | Tarball | [\`machine-violet-${VERSION}-darwin-arm64.tar.gz\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/machine-violet-${VERSION}-darwin-arm64.tar.gz) |
+
+          ### Linux (x64)
+          | | File |
+          |---|---|
+          | Tarball | [\`machine-violet-${VERSION}-linux-x64.tar.gz\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/machine-violet-${VERSION}-linux-x64.tar.gz) |
+          BODYEOF
+          sed -i 's/^          //' release-body.md
+
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Changes since previous RC / release"
+            echo ""
+            printf '%s\n' "$RELEASE_NOTES"
+          } >> release-body.md
+
+          gh release create "$TAG" \
+            --repo ${{ github.repository }} \
+            --title "Machine Violet ${VERSION}" \
+            --notes-file release-body.md \
+            --prerelease \
+            artifacts/MachineViolet-* \
+            artifacts/machine-violet-* \
+            artifacts/releases.rc.json \
+            artifacts/assets.rc.json
+
+      - name: Post to Discord (stable only)
+        if: needs.prep.outputs.channel == 'stable'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
           RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
         run: |
-          TAG="${{ steps.tags.outputs.tag }}"
-          VERSION="${TAG#v}"
+          TAG="${{ needs.prep.outputs.tag }}"
+          VERSION="${{ needs.prep.outputs.version }}"
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${TAG}"
 
           HEADER="**Machine Violet ${VERSION}** 🎉"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -52,6 +52,9 @@ jobs:
           WT_ZIP="Microsoft.WindowsTerminalPreview_${WT_VERSION}_x64.zip"
           WT_URL="https://github.com/microsoft/terminal/releases/download/${WT_TAG}/${WT_ZIP}"
           curl -fSL -o wt-portable.zip "$WT_URL"
+          # Verify integrity (update hash when bumping WT_VERSION)
+          WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
+          echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
           mkdir -p dist/terminal
           unzip -q wt-portable.zip -d dist/terminal
           touch dist/terminal/.portable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,18 @@ Launch it and continue with other work in the same turn (write the commit messag
 
 **Don't tail the background output in subsequent turns.** Just keep working. When the process exits, the harness re-invokes you with a `<task-notification>` containing the final output path. Read the tail of that file then — not before.
 
+## Release model
+
+Two long-lived branches: **`main`** (trunk, builds nightlies) and **`release`** (the released line, builds stable + RC). Three Velopack channels: `stable`, `rc`, `nightly` — all sticky (installers never auto-switch channels). Only the latest major is supported; no LTS.
+
+**`main` and `release` are not auto-merged into each other.** When fixing a bug:
+
+1. Pick the branch where the bug was reported. A 1.0 user's bug reproduces on `release`, not `main` — `main` may have rewritten the code path, and "can't repro" usually means "looking at the wrong tree."
+2. Fix on a branch from there, PR into that long-lived branch.
+3. Ask whether the *other* long-lived branch has the same code path. If yes, the fix needs to land there too — cherry-pick or re-apply by hand. Do this both directions (release→main *and* main→release as appropriate).
+
+Cuts go through the **Cut Release** workflow (kind=stable|rc, bump=none|patch|minor|major). Full flow + bootstrap notes in [docs/releases.md](docs/releases.md).
+
 ## Worktrees
 
 **Always use a worktree for code changes.** Multiple Claude instances may run concurrently against this repo. Working directly on `main` risks branch collisions and lost commits. Use `EnterWorktree` at the start of every task and `ExitWorktree` when done.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ Ink (React for CLI) + Anthropic Claude SDK + TypeScript.
 | Look up WebSocket event contracts | [websocket-api.md](websocket-api.md) |
 | Understand the openai-chatgpt provider (Codex app-server) | [openai-chatgpt-provider.md](openai-chatgpt-provider.md) |
 | Run an end-to-end smoke test against the full stack | [e2e-harness.md](e2e-harness.md) |
+| Cut a release / understand the branch + channel model | [releases.md](releases.md) |
 | Update documentation after a code change | [maintenance.md](maintenance.md) |
 
 ## Document Layers

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,85 @@
+# Releases
+
+How Machine Violet is shipped, and how to cut a release.
+
+## Channels
+
+Three Velopack update channels. Each is **sticky** — installers only auto-update within their own channel.
+
+| Channel | Source | Cadence | Audience |
+|---|---|---|---|
+| `stable` | `release` branch, `v$X.$Y.$Z` tags | When we ship | End users |
+| `rc` | `release` branch, `v$X.$Y.$Z-rc.$N` tags | When we want a soak | Technical testers (manual install) |
+| `nightly` | `main` branch, daily build | 06:00 UTC daily | Bleeding-edge testers |
+
+We support **only the latest major**. There is no LTS line.
+
+## Branches
+
+- **`main`** — trunk. All feature work lands here. Builds nightlies.
+- **`release`** — the released line. Bugfixes land here. Builds stable + RC.
+- Feature/fix branches merge into one of the above via PR.
+
+`main` and `release` are **not** auto-merged into each other. When a bug is found:
+
+- **Bug found via `release`** → fix on a branch from `release`, PR into `release`. Then evaluate whether `main` needs the same fix; if so, cherry-pick or re-apply by hand.
+- **Bug found on `main`** that also exists on `release` → fix on `main`, then cherry-pick (or re-apply) onto `release`.
+
+Reproduce against the correct branch — a 1.0 user's bug must be reproduced on `release`, not `main`. `main` may have rewritten the code path and "I can't repro" usually means "I'm looking at the wrong tree."
+
+## Cutting a release
+
+All cuts go through the [Cut Release](../.github/workflows/cut-release.yml) workflow (`Actions → Cut Release → Run workflow`).
+
+**You must select the `release` branch** in the "Use workflow from" dropdown — the workflow refuses to run from any other branch.
+
+Inputs:
+
+| Input | Choices | Meaning |
+|---|---|---|
+| `kind` | `stable`, `rc` | Which channel to ship to |
+| `bump` | `none`, `patch`, `minor`, `major` | Whether to bump `package.json` first |
+| `dry_run` | bool | Skip the tag push for verification |
+
+### Typical flows
+
+**Cut RC 1 of a new patch line** — `kind=rc, bump=patch`. Bumps `1.0.0` → `1.0.1` on `release`, tags `v1.0.1-rc.1`.
+
+**Cut RC 2 of the same line** — `kind=rc, bump=none`. Tags `v1.0.1-rc.2` (counter auto-increments).
+
+**Promote RC to stable** — `kind=stable, bump=none`. Tags `v1.0.1`.
+
+**Cut a stable directly without RCs** — `kind=stable, bump=patch`. Tags `v1.0.1`.
+
+**Cut a major release** — `kind=stable, bump=major`. Tags `v2.0.0`. Stable users auto-upgrade across major boundaries; communicate clearly in release notes (e.g. save-format migrations).
+
+The workflow:
+1. Bumps `package.json` if requested, commits to `release`.
+2. Computes the tag (failing if a stable tag already exists for the current version).
+3. Pushes branch + tag.
+4. The push of `v*` triggers [release.yml](../.github/workflows/release.yml), which builds Win/macOS/Linux, signs Windows via Velopack + Azure Trusted Signing, generates AI release notes (Haiku), and creates the GitHub release on the appropriate channel.
+
+RC releases are marked `--prerelease` on GitHub, skip Discord, and skip the Homebrew formula bump. Stable releases do all three.
+
+## First-time bootstrap (v1.0.0)
+
+Because `cut-release` bumps from current `package.json` (`1.0.1`), it cannot land *on* `1.0.0`. The first cut is manual:
+
+```bash
+git checkout release
+# Edit package.json version to 1.0.0 (committed in the branch setup PR)
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+`release.yml` fires on the tag push. Subsequent cuts go through `cut-release` normally.
+
+## Velopack channel notes
+
+- `vpk pack --channel <name>` produces `releases.<name>.json` and `assets.<name>.json` alongside the installer. These are uploaded as release assets and form the auto-update manifest the installed app polls.
+- An installer's channel is baked in at install time. The auto-updater **never** changes channels — moving from stable to nightly (or vice versa) requires an uninstall + reinstall.
+- The Windows Terminal portable bundle is pinned by SHA256 in [release.yml](../.github/workflows/release.yml), [nightly.yml](../.github/workflows/nightly.yml), and [test-build.yml](../.github/workflows/test-build.yml). Bump all three together when updating `WT_VERSION`.
+
+## Homebrew
+
+The Homebrew tap (`octopollux/homebrew-mv-tap`) currently tracks **nightly** only — the formula is overwritten on each nightly build by [nightly.yml](../.github/workflows/nightly.yml). A stable formula split is planned post-1.0; until then, `brew install octopollux/mv-tap/machine-violet` gets nightlies despite the stable release body advertising it.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -61,19 +61,6 @@ The workflow:
 
 RC releases are marked `--prerelease` on GitHub, skip Discord, and skip the Homebrew formula bump. Stable releases do all three.
 
-## First-time bootstrap (v1.0.0)
-
-Because `cut-release` bumps from current `package.json` (`1.0.1`), it cannot land *on* `1.0.0`. The first cut is manual:
-
-```bash
-git checkout release
-# Edit package.json version to 1.0.0 (committed in the branch setup PR)
-git tag v1.0.0
-git push origin v1.0.0
-```
-
-`release.yml` fires on the tag push. Subsequent cuts go through `cut-release` normally.
-
 ## Velopack channel notes
 
 - `vpk pack --channel <name>` produces `releases.<name>.json` and `assets.<name>.json` alongside the installer. These are uploaded as release assets and form the auto-update manifest the installed app polls.


### PR DESCRIPTION
## Summary

Sets up the branching + release model for shipping packaged builds. Trunk (`main`) keeps going to nightlies; a new long-lived `release` branch holds the released line and serves both stable and RC tags. Three sticky Velopack channels: `stable`, `rc`, `nightly`.

- **`cut-release.yml`** rewritten: `kind=stable|rc` × `bump=none|patch|minor|major`. Auto-increments RC counter, refuses to run from any branch but `release`, fails fast on duplicate stable tags.
- **`release.yml`** restructured around a `prep` job that derives `channel` and `prerelease` from the tag pattern. Velopack `--channel` wired through; manifest glob now `releases.$CHANNEL.json` / `assets.$CHANNEL.json`. RC path is a GitHub prerelease with a different body, no Discord post. Stable changelog excludes RC tags from the "previous" search.
- **`ci.yml`** now runs on `release` push/PR too.
- **`WT_SHA256`** pinned to `ba5b75eb…1b017` (Windows Terminal 1.25.622.0) in `release.yml`, `nightly.yml`, `test-build.yml`.
- **Doctrine**: new `Release model` section in `CLAUDE.md`, new `docs/releases.md`, PR template with a backport-awareness checkbox, bug report template gets a Channel dropdown.

`main` and `release` are deliberately **not** auto-merged. When a bug is fixed on one, the author considers whether the other branch has the same code path and cherry-picks by hand. See the new section in `CLAUDE.md` for the rule.

First release target: **v1.0.2** (skipping the v1.0.0 hand-bootstrap since `package.json` is already at 1.0.1).

## Test plan

- [x] YAML syntax validated for all five workflow files
- [ ] CI green on this PR (lint + tests)
- [ ] Follow-up: create `release` branch from `main`, configure branch protection, dispatch `cut-release` with `kind=rc bump=patch` to produce `v1.0.2-rc.1` (verifies the workflow end-to-end without committing to a stable release)

## Branch awareness

- [x] Not a bug fix — no backport consideration needed.
- [x] Targets `main`. The new `release` branch will be created from this commit after merge.