### PR TITLE
Release-list hygiene: 1 nightly, RCs collapse on stable cut

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -344,6 +344,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Default bash on ubuntu-latest is `-eo pipefail`, but state it
+          # explicitly so a `gh api` failure (rate limit, auth, network) at
+          # the head of the pipe fails the step instead of silently leaving
+          # old releases behind.
+          set -eo pipefail
+
           # Delete every release whose tag is "nightly" or starts with "nightly-".
           # This includes the existing rolling release, all dated nightly releases
           # (success or draft), and any orphan drafts left behind when tags were
@@ -356,6 +362,8 @@ jobs:
                 case "$tag" in
                   nightly|nightly-*)
                     echo "Deleting release $tag (id $id)"
+                    # Individual delete failures (404, race) are tolerated —
+                    # we want partial progress, not all-or-nothing.
                     gh api -X DELETE "repos/${{ github.repository }}/releases/$id" || true
                     ;;
                 esac

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -340,11 +340,31 @@ jobs:
           echo "$NOTES" >> "$GITHUB_OUTPUT"
           echo "NOTES_EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Create dated nightly release
+      - name: Purge previous nightly releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Delete every release whose tag is "nightly" or starts with "nightly-".
+          # This includes the existing rolling release, all dated nightly releases
+          # (success or draft), and any orphan drafts left behind when tags were
+          # pruned in earlier cycles. We always recreate exactly one rolling
+          # release in the next step, so the steady state is "1 nightly release
+          # visible in the UI."
+          gh api --paginate "repos/${{ github.repository }}/releases" \
+            --jq '.[] | "\(.id) \(.tag_name)"' \
+            | while read -r id tag; do
+                case "$tag" in
+                  nightly|nightly-*)
+                    echo "Deleting release $tag (id $id)"
+                    gh api -X DELETE "repos/${{ github.repository }}/releases/$id" || true
+                    ;;
+                esac
+              done
+
+      - name: Publish rolling nightly release
         env:
           GH_TOKEN: ${{ github.token }}
           NIGHTLY_TAG: ${{ steps.tags.outputs.tag }}
-          PREV_TAG: ${{ steps.tags.outputs.prev }}
           RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
         run: |
           DATE="${{ steps.tags.outputs.date }}"
@@ -355,29 +375,36 @@ jobs:
             RELEASE_NOTES="Internal improvements and maintenance."
           fi
 
+          # Force the rolling `nightly` git tag onto the build commit.
+          # The previous-step purge removed the corresponding release; the
+          # tag itself we re-point here so stable download URLs keep working.
+          git push --delete origin nightly 2>/dev/null || true
+          COMMIT=$(git rev-parse "$NIGHTLY_TAG")
+          git tag -f nightly "$COMMIT"
+          git push origin nightly
+
           cat > nightly-body.md << 'BODYEOF'
           ## Download
 
           ### Windows
           | | File |
           |---|---|
-          | **Installer** (recommended) | [`MachineViolet-nightly-Setup.exe`](https://github.com/REPO_PLACEHOLDER/releases/download/TAG_PLACEHOLDER/MachineViolet-nightly-Setup.exe) |
-          | Portable (no install) | [`MachineViolet-nightly-Portable.zip`](https://github.com/REPO_PLACEHOLDER/releases/download/TAG_PLACEHOLDER/MachineViolet-nightly-Portable.zip) |
+          | **Installer** (recommended) | [`MachineViolet-nightly-Setup.exe`](https://github.com/REPO_PLACEHOLDER/releases/download/nightly/MachineViolet-nightly-Setup.exe) |
+          | Portable (no install) | [`MachineViolet-nightly-Portable.zip`](https://github.com/REPO_PLACEHOLDER/releases/download/nightly/MachineViolet-nightly-Portable.zip) |
 
           ### macOS (Apple Silicon)
           | | File |
           |---|---|
-          | Tarball | [`machine-violet-nightly-darwin-arm64.tar.gz`](https://github.com/REPO_PLACEHOLDER/releases/download/TAG_PLACEHOLDER/machine-violet-nightly-darwin-arm64.tar.gz) |
+          | Tarball | [`machine-violet-nightly-darwin-arm64.tar.gz`](https://github.com/REPO_PLACEHOLDER/releases/download/nightly/machine-violet-nightly-darwin-arm64.tar.gz) |
 
           ### Linux (x64)
           | | File |
           |---|---|
-          | Tarball | [`machine-violet-nightly-linux-x64.tar.gz`](https://github.com/REPO_PLACEHOLDER/releases/download/TAG_PLACEHOLDER/machine-violet-nightly-linux-x64.tar.gz) |
+          | Tarball | [`machine-violet-nightly-linux-x64.tar.gz`](https://github.com/REPO_PLACEHOLDER/releases/download/nightly/machine-violet-nightly-linux-x64.tar.gz) |
 
           Also available via Homebrew: `brew install octopollux/mv-tap/machine-violet`
           BODYEOF
           sed -i 's/^          //' nightly-body.md
-          sed -i "s|TAG_PLACEHOLDER|${NIGHTLY_TAG}|g" nightly-body.md
           sed -i "s|REPO_PLACEHOLDER|${REPO}|g" nightly-body.md
 
           # Append release notes safely (no shell expansion of AI content)
@@ -391,40 +418,13 @@ jobs:
             echo ""
             echo "---"
             echo ""
-            echo "Automated nightly build from \`main\` · \`${NIGHTLY_TAG}\`. **Not a stable release.**"
+            echo "Automated nightly build from \`main\` · \`${NIGHTLY_TAG}\` (${DATE}). **Not a stable release.**"
           } >> nightly-body.md
 
-          # Attach artifacts to the dated tag (the real, permanent release)
-          gh release create "$NIGHTLY_TAG" \
+          gh release create nightly \
             --repo ${{ github.repository }} \
             --title "Nightly ($DATE)" \
             --notes-file nightly-body.md \
-            --prerelease \
-            artifacts/MachineViolet-* \
-            artifacts/machine-violet-nightly-* \
-            artifacts/releases.nightly.json \
-            artifacts/assets.nightly.json
-
-      - name: Update rolling nightly release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NIGHTLY_TAG: ${{ steps.tags.outputs.tag }}
-        run: |
-          # Delete existing rolling release + tag, then recreate pointing
-          # at the same commit as the dated tag. This keeps stable download
-          # URLs (e.g. .../download/nightly/...) working.
-          gh release delete nightly --yes --repo ${{ github.repository }} 2>/dev/null || true
-          git push --delete origin nightly 2>/dev/null || true
-
-          COMMIT=$(git rev-parse "$NIGHTLY_TAG")
-          git tag -f nightly "$COMMIT"
-          git push origin nightly
-
-          # Clone the dated release body for the rolling release
-          gh release create nightly \
-            --repo ${{ github.repository }} \
-            --title "Nightly (latest)" \
-            --notes "See [${NIGHTLY_TAG}](https://github.com/${{ github.repository }}/releases/tag/${NIGHTLY_TAG}) for full release notes." \
             --prerelease \
             --target "$COMMIT" \
             artifacts/MachineViolet-* \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,29 @@ jobs:
           echo "$NOTES" >> "$GITHUB_OUTPUT"
           echo "NOTES_EOF" >> "$GITHUB_OUTPUT"
 
+      - name: Purge RC prereleases for this version (stable cuts only)
+        if: needs.prep.outputs.channel == 'stable'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Once stable v$VERSION ships, the v$VERSION-rc.* prereleases that
+          # led up to it are dead weight in the release UI. Delete the GitHub
+          # releases (their tags stay — useful for `git checkout v$VERSION-rc.N`
+          # reproducibility). RCs for *other* versions are untouched.
+          VERSION="${{ needs.prep.outputs.version }}"
+          PREFIX="v${VERSION}-rc."
+          echo "Purging releases with tag prefix: $PREFIX"
+          gh api --paginate "repos/${{ github.repository }}/releases" \
+            --jq '.[] | "\(.id) \(.tag_name)"' \
+            | while read -r id tag; do
+                case "$tag" in
+                  "${PREFIX}"*)
+                    echo "Deleting release $tag (id $id)"
+                    gh api -X DELETE "repos/${{ github.repository }}/releases/$id" || true
+                    ;;
+                esac
+              done
+
       - name: Create GitHub Release (stable)
         if: needs.prep.outputs.channel == 'stable'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Default bash on ubuntu-latest is `-eo pipefail`, but state it
+          # explicitly so a `gh api` listing failure fails the step instead
+          # of silently leaving stale RC releases in the UI.
+          set -eo pipefail
+
           # Once stable v$VERSION ships, the v$VERSION-rc.* prereleases that
           # led up to it are dead weight in the release UI. Delete the GitHub
           # releases (their tags stay — useful for `git checkout v$VERSION-rc.N`
@@ -372,6 +377,7 @@ jobs:
                 case "$tag" in
                   "${PREFIX}"*)
                     echo "Deleting release $tag (id $id)"
+                    # Individual delete failures (404, race) are tolerated.
                     gh api -X DELETE "repos/${{ github.repository }}/releases/$id" || true
                     ;;
                 esac

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -61,6 +61,14 @@ The workflow:
 
 RC releases are marked `--prerelease` on GitHub, skip Discord, and skip the Homebrew formula bump. Stable releases do all three.
 
+## Release-list hygiene
+
+The release UI is kept lean so humans can scan it:
+
+- **Nightly** — exactly one release ever exists. Each nightly run purges every release whose tag is `nightly` or starts with `nightly-` (catches both the rolling release and any orphan drafts from earlier cycles), then publishes a single rolling `nightly` release with the day's full notes and artifacts. Dated `nightly-*` *tags* remain in git for `git checkout`/changelog reproducibility and are pruned at 30 days.
+- **RC** — every RC in an in-flight cycle stays visible (rc.1, rc.2, …) so testers can compare. They all vanish the moment the matching stable ships.
+- **Stable** — `v*` releases accumulate forever. Cutting `v$X.$Y.$Z` deletes any `v$X.$Y.$Z-rc.*` releases (their tags stay in git for reproducibility) but never touches releases for other versions.
+
 ## Velopack channel notes
 
 - `vpk pack --channel <name>` produces `releases.<name>.json` and `assets.<name>.json` alongside the installer. These are uploaded as release assets and form the auto-update manifest the installed app polls.


### PR DESCRIPTION
## Summary

Keeps the GitHub Releases UI scannable. Steady state:

- **Nightly**: exactly **1** release (the rolling `nightly`). Each nightly run purges every release whose tag is `nightly` or starts with `nightly-` — catches both the prior rolling release and the ~26 orphan drafts that accumulated from the April pruning issue (where tags were deleted but releases became drafts).
- **RC**: every RC in an in-flight cycle (rc.1, rc.2, …) stays visible during soak; cutting the matching stable `vX.Y.Z` purges all `vX.Y.Z-rc.*` releases at once.
- **Stable**: untouched. `v*` releases accumulate forever.

Git tags policy is unchanged: nightly tags pruned at 30 days, RC tags kept forever for `git checkout` reproducibility.

## Why the previous design produced drafts

`nightly.yml` previously created a dated `Nightly (YYYY-MM-DD)` release + maintained a rolling `Nightly (latest)` release. The tag-pruning step deleted `nightly-*` *tags* after 30 days but left their releases — GitHub auto-demotes a release whose tag has vanished to draft. April's nightlies are visible as drafts today because of this.

The new design publishes a single rolling release per run, so dated-release orphaning can't happen by construction.

## Velopack continuity

The `nightly` rolling tag is still force-pushed each run; download URLs like `releases/download/nightly/releases.nightly.json` keep working. Each nightly run briefly 404s while the release is recreated (seconds), which doesn't affect installed clients between polls.

## Test plan

- [ ] CI green on this PR.
- [ ] Once merged, one-off cleanup of the existing April drafts via `gh api` (the new nightly run would clean them too, but next nightly is ~6h away; faster to scrub now).
- [ ] Verify next nightly produces exactly 1 release.
- [ ] Verify a future stable cut purges the matching RC line (will get an organic test when v1.0.2 stable is cut).

## Branch awareness

- [x] Not a bug fix; doctrine + workflow refactor. No backport consideration.
- [x] Targets `main`. The new nightly will run from main; `release` keeps its existing `release.yml` so the next stable cut from `release` inherits the RC-purge logic only after this is merged + cherry-picked or after the next bump cycle. *(Note: `release.yml` lives on both branches — the merged version on main needs to make it onto release before the next stable cut, either via merge-back of this PR's release.yml change to release, or by simply cherry-picking that file. Will sort out before promoting v1.0.2.)*