### PR TITLE
Upgrade all release-notes summarizers Haiku 4.5 → Sonnet 4.6

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -319,9 +319,13 @@ jobs:
             printf '%s\n' "$CHANGES"
           } > /tmp/user-prompt.txt
 
-          # Build JSON request body safely via jq (reads file, no shell interpolation)
+          # Build JSON request body safely via jq (reads file, no shell interpolation).
+          # Sonnet (not Haiku) — Haiku's player-facing summaries had noticeable
+          # intelligence regressions at this prompt size. Nightlies are frequent
+          # so cost adds up faster than for stable, but the daily-token budget
+          # is still small relative to user value.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-haiku-4-5-20251001", max_tokens:1024,
+            '{model:"claude-sonnet-4-6", max_tokens:1024,
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           # Call the API

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,8 +335,11 @@ jobs:
             printf '%s\n' "$CHANGES"
           } > /tmp/user-prompt.txt
 
+          # Sonnet (not Haiku) for stable + RC release notes — we ship these
+          # to end users, the modest cost increase buys noticeably tighter
+          # phrasing and better signal/noise. Nightlies stay on Haiku.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-haiku-4-5-20251001", max_tokens:1024,
+            '{model:"claude-sonnet-4-6", max_tokens:1024,
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           RESPONSE=$(curl -sf https://api.anthropic.com/v1/messages \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,9 +335,9 @@ jobs:
             printf '%s\n' "$CHANGES"
           } > /tmp/user-prompt.txt
 
-          # Sonnet (not Haiku) for stable + RC release notes — we ship these
-          # to end users, the modest cost increase buys noticeably tighter
-          # phrasing and better signal/noise. Nightlies stay on Haiku.
+          # Sonnet (not Haiku) — Haiku's player-facing summaries had noticeable
+          # intelligence regressions at this prompt size. The cost bump for the
+          # few hundred input tokens per release is negligible.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
             '{model:"claude-sonnet-4-6", max_tokens:1024,
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json


### PR DESCRIPTION
## Summary

Bumps the release-notes generator from `claude-haiku-4-5-20251001` to `claude-sonnet-4-6` in **both** [`release.yml`](.github/workflows/release.yml) (stable + RC) and [`nightly.yml`](.github/workflows/nightly.yml) (nightly).

## Why

These notes are read by end users and posted to Discord. User reports noticeable intelligence regressions in Haiku's player-facing summaries at this prompt size. Token volume per release is small (a few hundred input tokens of PR titles + bodies), so cost delta is negligible.

## Test plan

- [ ] CI green on this PR.
- [ ] Will get organic tests on the next nightly build and on the v1.0.2 stable cut.

## Branch awareness

- [x] Not a bug fix. After merge, cherry-pick onto `release` so the next stable cut from there uses Sonnet too. (`nightly.yml` change is main-only effectively, but cherry-pick is harmless on release since nightly never runs from there.)