### PR TITLE
Fix broken Windows download links in stable + RC release bodies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,8 +401,8 @@ jobs:
           ### Windows
           | | File |
           |---|---|
-          | **Installer** (recommended) | [\`MachineViolet-Setup.exe\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Setup.exe) |
-          | Portable (no install) | [\`MachineViolet-Portable.zip\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Portable.zip) |
+          | **Installer** (recommended) | [\`MachineViolet-stable-Setup.exe\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-stable-Setup.exe) |
+          | Portable (no install) | [\`MachineViolet-stable-Portable.zip\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-stable-Portable.zip) |
 
           ### macOS (Apple Silicon)
           | | File |
@@ -456,8 +456,8 @@ jobs:
           ### Windows
           | | File |
           |---|---|
-          | **Installer** | [\`MachineViolet-Setup.exe\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Setup.exe) |
-          | Portable | [\`MachineViolet-Portable.zip\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-Portable.zip) |
+          | **Installer** | [\`MachineViolet-rc-Setup.exe\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-rc-Setup.exe) |
+          | Portable | [\`MachineViolet-rc-Portable.zip\`](https://github.com/${{ github.repository }}/releases/download/${TAG}/MachineViolet-rc-Portable.zip) |
 
           ### macOS (Apple Silicon)
           | | File |


### PR DESCRIPTION
## Summary

The release-body templates in [`release.yml`](.github/workflows/release.yml) for both the stable and RC paths reference `MachineViolet-Setup.exe` / `MachineViolet-Portable.zip` in the Windows download table — but Velopack actually emits filenames with the channel name baked in (e.g. `MachineViolet-rc-Setup.exe`, `MachineViolet-stable-Setup.exe`) whenever `--channel` is passed. Since #542 made `--channel` mandatory, every RC and stable release body has had broken Windows download links.

Confirmed by inspecting the v1.0.2-rc.1 release page; the user reported the Installer link 404s.

## Changes

- Stable body now links to `MachineViolet-stable-Setup.exe` / `MachineViolet-stable-Portable.zip`.
- RC body now links to `MachineViolet-rc-Setup.exe` / `MachineViolet-rc-Portable.zip`.
- macOS/Linux tarballs unchanged — their templates already use `\${VERSION}` which matches the actual filenames.
- Nightly unchanged — `nightly.yml` already had the `-nightly-` infix.

## Out-of-band cleanup

v1.0.2-rc.1's published release body was hand-patched (`gh release edit`) so playtesters currently on the RC aren't blocked.

## Test plan

- [ ] CI green.
- [ ] Organic test on the next RC and on v1.0.2 stable cut.

## Branch awareness

- [x] Bug fix. After merge, cherry-pick onto \`release\` so the v1.0.2 stable cut produces correct links.