### PR TITLE
Pin @openai/codex range to >=0.130.0 (GHSA-xrxf-jgv3-qmrm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9336,7 +9336,7 @@
         "@fastify/swagger": "^9.7.0",
         "@fastify/websocket": "^11.0.0",
         "@machine-violet/shared": "*",
-        "@openai/codex": "*",
+        "@openai/codex": ">=0.130.0",
         "@scalar/fastify-api-reference": "^1.49.7",
         "@sinclair/typebox": "^0.34.0",
         "dotenv": "^16.4.5",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -17,7 +17,7 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/websocket": "^11.0.0",
     "@machine-violet/shared": "*",
-    "@openai/codex": "*",
+    "@openai/codex": ">=0.130.0",
     "@scalar/fastify-api-reference": "^1.49.7",
     "@sinclair/typebox": "^0.34.0",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
- Closes Dependabot alert [#29](https://github.com/octopollux/machine-violet/security/dependabot/29) (CVE-2025-61260, GHSA-xrxf-jgv3-qmrm)
- Tighten `@openai/codex` range from `"*"` to `">=0.130.0"` in `packages/engine/package.json` so npm cannot resolve the vulnerable `<=0.23.0` range on a fresh install
- Lockfile resolution unchanged (still 0.133.0)

## Context
The CVE is about the interactive `codex` CLI auto-loading `.env` / `.codex/config.toml` from CWD without confirmation. We only spawn `codex app-server` as a JSON-RPC backend for the openai-chatgpt provider, so we weren't exposed in practice — but `"*"` could theoretically resolve to a vulnerable version on a fresh `npm install`, which is what Dependabot is objecting to. `>=0.130.0` still tracks OpenAI's roughly-daily codex releases (original motivation for `*` in [0d2786b](https://github.com/octopollux/machine-violet/commit/0d2786b)) while excluding the entire pre-0.130 range.

## Test plan
- [x] `npm install --package-lock-only` confirms lockfile still resolves to codex 0.133.0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)