### PR TITLE
rename_entity: prune empty source directories after move

### DIFF
--- a/packages/engine/src/tools/campaign-ops/rename-entity.test.ts
+++ b/packages/engine/src/tools/campaign-ops/rename-entity.test.ts
@@ -6,20 +6,42 @@ function mockFileIO(
   files: Record<string, string> = {},
   dirs: Record<string, string[]> = {},
 ): FileIO {
+  // Mutable copies so deleteFile/rmdir actually update state during a test run.
+  const filesState = { ...files };
+  const dirsState: Record<string, string[]> = {};
+  for (const k of Object.keys(dirs)) dirsState[k] = [...dirs[k]];
   return {
     readFile: vi.fn(async (p: string) => {
-      if (p in files) return files[p];
+      if (p in filesState) return filesState[p];
       throw new Error(`ENOENT: ${p}`);
     }),
     writeFile: vi.fn(async () => {}),
     appendFile: vi.fn(async () => {}),
     mkdir: vi.fn(async () => {}),
-    exists: vi.fn(async (p: string) => p in files || p in dirs),
+    exists: vi.fn(async (p: string) => p in filesState || p in dirsState),
     listDir: vi.fn(async (p: string) => {
-      if (p in dirs) return dirs[p];
+      if (p in dirsState) return dirsState[p];
       throw new Error(`ENOENT: ${p}`);
     }),
-    deleteFile: vi.fn(async () => {}),
+    deleteFile: vi.fn(async (p: string) => {
+      delete filesState[p];
+      const parent = p.split("/").slice(0, -1).join("/");
+      const name = p.split("/").pop();
+      if (name && parent in dirsState) {
+        dirsState[parent] = dirsState[parent].filter((e) => e !== name);
+      }
+    }),
+    rmdir: vi.fn(async (p: string) => {
+      if ((dirsState[p] ?? []).length > 0) {
+        throw new Error(`ENOTEMPTY: ${p}`);
+      }
+      delete dirsState[p];
+      const parent = p.split("/").slice(0, -1).join("/");
+      const name = p.split("/").pop();
+      if (name && parent in dirsState) {
+        dirsState[parent] = dirsState[parent].filter((e) => e !== name);
+      }
+    }),
   };
 }
 
@@ -151,6 +173,50 @@ describe("renameEntity", () => {
 
     // Should delete old entity file
     expect(fio.deleteFile).toHaveBeenCalledWith("/camp/characters/kael.md");
+  });
+
+  it("removes the now-empty source directory after renaming a nested entity", async () => {
+    // Repro: rename_entity moved locations/starting-location/index.md →
+    // locations/dovecote-relay-station/index.md but left
+    // locations/starting-location/ behind as an empty placeholder dir.
+    const fio = mockFileIO(
+      {
+        "/camp/locations/starting-location/index.md": "# Placeholder",
+      },
+      {
+        "/camp/locations": ["starting-location"],
+        "/camp/locations/starting-location": ["index.md"],
+      },
+    );
+
+    await renameEntity(
+      "/camp",
+      fio,
+      "locations/starting-location/index.md",
+      "locations/dovecote-relay-station/index.md",
+      false,
+    );
+
+    expect(fio.rmdir).toHaveBeenCalledWith("/camp/locations/starting-location");
+    // Top-level category dir must NEVER be removed.
+    expect(fio.rmdir).not.toHaveBeenCalledWith("/camp/locations");
+  });
+
+  it("does not call rmdir when renaming a top-level entity file", async () => {
+    const fio = mockFileIO(
+      {
+        "/camp/characters/kael.md": "# Kael",
+      },
+      {
+        "/camp/characters": ["kael.md"],
+      },
+    );
+
+    await renameEntity(
+      "/camp", fio, "characters/kael.md", "characters/kael-ranger.md", false,
+    );
+
+    expect(fio.rmdir).not.toHaveBeenCalled();
   });
 
   it("updates links from multiple files", async () => {

--- a/packages/engine/src/tools/campaign-ops/rename-entity.ts
+++ b/packages/engine/src/tools/campaign-ops/rename-entity.ts
@@ -129,7 +129,14 @@ export async function renameEntity(
     // "locations/", "characters/") — only nested placeholder dirs created by
     // an earlier mkdir during scene/entity bootstrap.
     if (fileIO.rmdir) {
-      const oldSegments = oldPath.split("/").slice(0, -1); // drop filename
+      // Normalize: strip leading/trailing slashes, convert backslashes, drop
+      // empty segments. Prevents a stray leading "/" or "\" from producing an
+      // empty first segment that would slip past the `length > 1` guard.
+      const oldSegments = oldPath
+        .replace(/\\/g, "/")
+        .split("/")
+        .filter(Boolean)
+        .slice(0, -1); // drop filename
       // Stop walking once we reach the first segment (the category dir).
       while (oldSegments.length > 1) {
         const dirPath = normalizedRoot + "/" + oldSegments.join("/");

--- a/packages/engine/src/tools/campaign-ops/rename-entity.ts
+++ b/packages/engine/src/tools/campaign-ops/rename-entity.ts
@@ -123,6 +123,31 @@ export async function renameEntity(
     if (fileIO.deleteFile) {
       await fileIO.deleteFile(absOld);
     }
+
+    // Prune now-empty source directories. Walk up from the old file's parent,
+    // removing empty dirs, but never touch the top-level category dir (e.g.
+    // "locations/", "characters/") — only nested placeholder dirs created by
+    // an earlier mkdir during scene/entity bootstrap.
+    if (fileIO.rmdir) {
+      const oldSegments = oldPath.split("/").slice(0, -1); // drop filename
+      // Stop walking once we reach the first segment (the category dir).
+      while (oldSegments.length > 1) {
+        const dirPath = normalizedRoot + "/" + oldSegments.join("/");
+        let entries: string[];
+        try {
+          entries = await fileIO.listDir(dirPath);
+        } catch {
+          break;
+        }
+        if (entries.length > 0) break;
+        try {
+          await fileIO.rmdir(dirPath);
+        } catch {
+          break;
+        }
+        oldSegments.pop();
+      }
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

`rename_entity` left an empty placeholder directory behind whenever the source entity lived in its own subdirectory. Reproduced in campaign `fallow-the-drift` (2026-05-29): after the world-builder renamed `locations/starting-location/index.md` → `locations/dovecote-relay-station/index.md`, the campaign ended up with both `starting-location/` (empty) and `dovecote-relay-station/` (real). Cosmetic, not session-breaking, but accumulates clutter over many campaigns.

## Fix

After deleting the old entity file, walk up from its parent dir calling `rmdir` on empty dirs — stop before the top-level category directory (`locations/`, `characters/`, …) so we never remove those. Listing or `rmdir` errors abort the walk defensively. Same idea as `pruneEmptyDirs` in `campaign-repo.ts`, but scoped to the just-moved file's chain rather than a global sweep.

## Tests

Two new regressions in [packages/engine/src/tools/campaign-ops/rename-entity.test.ts](packages/engine/src/tools/campaign-ops/rename-entity.test.ts):

- **nested placeholder rename** — asserts `rmdir` fires for the leaf placeholder dir and explicitly NOT for the category dir.
- **top-level entity rename** — asserts `rmdir` is never called for a flat `characters/kael.md` → `characters/kael-ranger.md` move.

The test's `mockFileIO` was upgraded to track deletes/rmdirs in mutable state so the walk-up logic exercises real directory transitions instead of a frozen snapshot. All 11 tests in the file pass.

## Follow-up

`merge_entities` has the same shape of bug — deleting the loser file when it lives in its own subdir leaves the dir behind. Captured separately; not bundled here to keep the diff scoped.

## Test plan

- [x] `npx vitest run packages/engine/src/tools/campaign-ops/rename-entity.test.ts` — 11/11 passing
- [ ] Reviewer sanity-check the walk-up bound (`segments.length > 1`) — intent is to never touch the top-level category dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)