### PR TITLE
PC swap: swap_pc tool + howto_swap_pc skill + config persistence

### DIFF
--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -147,7 +147,9 @@ Everything else is created during play.
     "detail": "Hidden tuning notes..."    // DM-only detail block.
   },
 
-  // Players
+  // Players — the PC roster. Normally written once at creation, but the
+  // `swap_pc` tool may rewrite a slot's `character`/`color`/`name` in-session
+  // (a PC handoff) and persists config.json so it survives reload.
   "players": [
     {
       "name": "Alex",                     // Required. Player display name.

--- a/docs/multiplayer-and-initiative.md
+++ b/docs/multiplayer-and-initiative.md
@@ -35,6 +35,28 @@ When multiple players are in the session, the bottom of the TUI shows a player b
 
 **During initiative:** The TUI automatically activates the player whose turn it is. Human players type their action; AI players act automatically. The player bar shows turn order highlighting.
 
+The `switch_player` tool is the agent-side equivalent of Tab: it only moves `activePlayerIndex` between characters that are **already** in `config.players`. It does not change who controls what.
+
+### Swapping the PC (handoff to a new or existing character)
+
+Who a player controls is a roster entry: `config.json` → `players[]`, each with a `character` field, selected by `activePlayerIndex` (persisted in `state/scene.json`). `config.json` is loaded fresh at every session start, so changing the PC means rewriting that roster entry on disk — not just flipping the active index.
+
+A PC swap (retiring a PC to continue as an NPC, or introducing a brand-new PC) spans several pieces of state:
+
+| Piece | Where | Tool |
+|---|---|---|
+| Roster entry + active index | `config.json` `players[]`, `scene.json` `activePlayerIndex` | **`swap_pc`** (persists `config.json`) |
+| New PC's sheet | `characters/<slug>.md` (`Type: PC`, `Player`, `Display Resources`, `Theme Color`) | `entity` (create/update) |
+| Outgoing PC demotion | `characters/<old>.md` (`Type: character`, clear `Player`) | `entity` (update) |
+| Party roster | `characters/party.md` Members | `entity` / scribe |
+| Top-frame resources | `state/resources.json` | `set_display_resources`, `set_resource_values` |
+| Modeline | `state/ui.json` | `update_modeline` |
+| Theme color | `state/ui.json` | `style_scene` |
+
+`swap_pc` is the only tool that edits `config.players`, and it is the step that persists the roster — without it the swap reverts to the old PC on the next load. `switch_player` will **not** do a swap: it rejects any character not already in the roster. The `howto_swap_pc` knowledge tool returns the full procedure above; call it before swapping so nothing is left half-done.
+
+> Note: the DM's in-context PC sheet block (`pcSheets`) is loaded once at session start and intentionally not refreshed mid-session, so it still shows the old sheet after a swap until the next reload. The on-disk state — which is what the next load reads — is correct.
+
 ### Multiple Players in the Agent Loop
 
 From the DM's perspective, multiple players are just multiple characters. The DM's narration goes to everyone (it's one screen). Player inputs are tagged with who said them:

--- a/docs/state-atlas.md
+++ b/docs/state-atlas.md
@@ -78,7 +78,7 @@ GameState
 │   ├── campaign_scope?: CampaignScope       const ("one-shot" | "few-sessions" | "grand-campaign" | "open-ended")
 │   ├── setup_handoff?: string               const (postcard from setup agent, injected once into the first-turn priming; persists for resume-from-disk after a mid-first-turn crash)
 │   ├── dm_personality: DMPersonality
-│   ├── players: PlayerConfig[]
+│   ├── players: PlayerConfig[]              mut   → config.json            DM/OOC (swap_pc) — PC roster handoff
 │   ├── combat: CombatConfig
 │   ├── context: ContextConfig
 │   ├── recovery: RecoveryConfig
@@ -86,7 +86,7 @@ GameState
 │   └── calendar_display_format?: string
 │
 ├── campaignRoot: string                   const                          Session init
-├── activePlayerIndex: number              mut   → state/scene.json      DM (switch_player)
+├── activePlayerIndex: number              mut   → state/scene.json      DM (switch_player, swap_pc)
 ├── displayResources: Record<string, string[]>     mut   → state/resources.json (via React effect)  DM (set_display_resources)
 └── resourceValues: Record<string, Record<string, string>>  mut   → state/resources.json (via React effect)  DM (set_resource_values)
 ```
@@ -174,7 +174,7 @@ All state files live under `<campaignRoot>/state/`.
 | `state/conversation.json` | `ConversationExchange[]` | `StatePersister.persistConversation` | After each exchange | [§4.7](format-spec.md#47-conversation-stateconversationjson) |
 | `state/resources.json` | `PersistedResourceState` | `StatePersister.persistResources` | React effect on `resources` state change (same pattern as modelines in `ui.json`) | [§4.10](format-spec.md#410-resources-stateresourcesjson) |
 | `state/ui.json` | `PersistedUIState` | `StatePersister.persistUI` | After theme/style/modeline changes | [§4.8](format-spec.md#48-ui-stateuijson) |
-| `config.json` | `CampaignConfig` | `buildCampaignConfig` / `createDefaultCampaignConfig` | Campaign creation only. Read-only during play. Includes `version` (`CAMPAIGN_FORMAT_VERSION`) and `createdAt` (ISO 8601) manifest fields. | |
+| `config.json` | `CampaignConfig` | `buildCampaignConfig` / `createDefaultCampaignConfig`; `StatePersister.persistConfig` | Written at campaign creation. During play it is otherwise read-only — the **one** in-session mutation is the PC roster (`players[]`) via `swap_pc`, which calls `persistConfig` from `GameEngine.onToolSuccess`. Includes `version` (`CAMPAIGN_FORMAT_VERSION`) and `createdAt` (ISO 8601) manifest fields. | |
 | `pending-operation.json` | `PendingOperation` | `SceneManager` | During scene transition cascade steps | [§4.11](format-spec.md#411-pending-operation-pending-operationjson) |
 
 `StatePersister` uses write-through: each `persist*` call is fire-and-forget with error swallowing. Recovery on next session load reads `loadAll()` and hydrates `GameState`.

--- a/docs/tools-catalog.md
+++ b/docs/tools-catalog.md
@@ -122,7 +122,18 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 
 | Tool | Tier | Caller | Signature | Effect |
 |---|---|---|---|---|
-| `switch_player` | T1 | DM | `({ player })` | Switch the active player character during free play (outside combat). During combat, initiative controls turn order automatically. |
+| `switch_player` | T1 | DM | `({ player })` | Pass the turn between characters **already in the roster** during free play (outside combat). During combat, initiative controls turn order automatically. Rejects a name not in `config.players` — use `swap_pc` to hand control to a new/existing character. |
+| `swap_pc` | T1 | DM / OOC | `({ character, replaces?, color?, player_name? })` | Reassign a roster slot to `character` and make it the active PC (a "PC swap" / handoff). The only tool that edits `config.players`, and it persists `config.json` so the new PC survives reload. Moves the pointer only — pair with `howto_swap_pc` to also fix sheets, party.md, resources, modeline, theme. |
+
+---
+
+## How-To / Knowledge Tools ("skills")
+
+`howto_*` tools take no arguments and change nothing. They load a procedure into context — call one before a multi-step operation so you touch every piece of state.
+
+| Tool | Tier | Caller | Signature | Effect |
+|---|---|---|---|---|
+| `howto_swap_pc` | T1 | DM / OOC | `()` | Returns the step-by-step playbook for swapping the player character with a new or existing character (roster, character sheets, party.md, resources, modeline, theme). Backed by `prompts/howto-swap-pc.md`. |
 
 ---
 

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -239,6 +239,12 @@ export class GameEngine {
       if (toolName === "switch_player") {
         this.persistCurrentScene();
       }
+      if (toolName === "swap_pc") {
+        // swap_pc rewrites the PC roster (config.players) and the active
+        // index. Both must reach disk or the next load resurrects the old PC.
+        this.persister?.persistConfig(state.config);
+        this.persistCurrentScene();
+      }
       if (toolName === "start_combat") {
         void this.initResolveSession(state);
       } else if (toolName === "end_combat") {

--- a/packages/engine/src/agents/phase8.test.ts
+++ b/packages/engine/src/agents/phase8.test.ts
@@ -65,7 +65,10 @@ function makeConfig(players: PlayerConfig[]): CampaignConfig {
   return {
     name: "Test Campaign",
     dm_personality: { name: "Test", prompt_fragment: "Test DM" },
-    players,
+    // Clone slots so swap_pc (which mutates players in place, mirroring a
+    // freshly-parsed config per session) can't leak into the shared module-
+    // level player constants across tests.
+    players: players.map((p) => ({ ...p })),
     combat: {
       initiative_method: "d20_dex",
       round_structure: "individual",
@@ -437,6 +440,68 @@ describe("new Phase 8 tools", () => {
     expect(result.content).toContain("not found");
   });
 
+  it("switch_player's unknown-player error points at swap_pc", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "switch_player", { player: "Maren" });
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("swap_pc");
+  });
+
+  it("swap_pc reassigns the active slot to a character not in the roster", () => {
+    const state = makeState([humanPlayer]); // Alex plays Aldric
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "swap_pc", { character: "Maren", color: "#b33f5d" });
+
+    expect(result.is_error).toBeFalsy();
+    expect(state.config.players[0].character).toBe("Maren");
+    expect(state.config.players[0].color).toBe("#b33f5d");
+    expect(state.config.players[0].name).toBe("Alex"); // player label unchanged
+    expect(state.activePlayerIndex).toBe(0);
+  });
+
+  it("swap_pc with `replaces` targets the slot controlling that character", () => {
+    const state = makeState([humanPlayer, secondHuman], 0); // Alex/Aldric, Sam/Sable
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "swap_pc", { character: "Vesper", replaces: "Sable" });
+
+    expect(result.is_error).toBeFalsy();
+    expect(state.config.players[0].character).toBe("Aldric"); // untouched
+    expect(state.config.players[1].character).toBe("Vesper");
+    expect(state.activePlayerIndex).toBe(1); // active follows the swap
+  });
+
+  it("swap_pc errors when `replaces` names no current PC", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "swap_pc", { character: "Maren", replaces: "Ghost" });
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("Ghost");
+  });
+
+  it("swap_pc can relabel the human player", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    registry.dispatch(state, "swap_pc", { character: "Maren", player_name: "Beep" });
+
+    expect(state.config.players[0].name).toBe("Beep");
+    expect(state.config.players[0].character).toBe("Maren");
+  });
+
+  it("howto_swap_pc returns the playbook and changes nothing", () => {
+    const state = makeState([humanPlayer]);
+    const before = JSON.stringify(state);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "howto_swap_pc", {});
+
+    expect(result.is_error).toBeFalsy();
+    expect(result.content).toContain("swap_pc");
+    expect(result.content.toLowerCase()).toContain("player character");
+    expect(JSON.stringify(state)).toBe(before); // pure knowledge tool
+  });
+
   it("registers resolve_turn tool", () => {
     const registry = createTestRegistry();
     expect(registry.has("resolve_turn")).toBe(true);
@@ -447,10 +512,11 @@ describe("new Phase 8 tools", () => {
     expect(registry.has("promote_character")).toBe(true);
   });
 
-  it("registry has 35 tools total", () => {
+  it("registry has 37 tools total", () => {
     const registry = createTestRegistry();
     // Bumped from 29 → 35 by the entity-tool rework: entity, describe_entity_type,
     // list_entity_types, validate_entity, find_schema_drift, detect_orphans.
-    expect(registry.size).toBe(35);
+    // 35 → 37 by the PC-swap work: swap_pc, howto_swap_pc.
+    expect(registry.size).toBe(37);
   });
 });

--- a/packages/engine/src/agents/tool-registry.test.ts
+++ b/packages/engine/src/agents/tool-registry.test.ts
@@ -38,8 +38,8 @@ describe("ToolRegistry", () => {
     // Map (3) + Dice (1) + Deck (1) + Clocks (2) + Combat (4) + TUI (6) + Scene (3)
     //   + Entity-narrative (5: scribe/dm_notes/resolve_turn/promote_character/search)
     //   + Entity-CRUD (6: entity/describe_entity_type/list_entity_types/validate_entity/find_schema_drift/detect_orphans)
-    //   + Objectives (1) + Search (2) + Player (1) = 35
-    expect(reg.size).toBe(35);
+    //   + Objectives (1) + Search (2) + Player (3: switch_player/swap_pc/howto_swap_pc) = 37
+    expect(reg.size).toBe(37);
   });
 
   it("generates API-compatible tool definitions", () => {

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -53,6 +53,7 @@ import {
 import { manageObjectives } from "../tools/objectives/index.js";
 import type { ManageObjectivesInput } from "../tools/objectives/index.js";
 import { ENTITY_TOOLS } from "../entities/tools.js";
+import { loadPrompt } from "../prompts/load-prompt.js";
 
 // --- Helpers ---
 
@@ -674,10 +675,92 @@ const TOOL_DEFS: RegisteredTool[] = [
       const idx = state.config.players.findIndex(
         (p) => p.character.toLowerCase() === target,
       );
-      if (idx === -1) return err(`Player '${input.player}' not found.`);
+      if (idx === -1) {
+        const roster = state.config.players.map((p) => p.character).join(", ") || "(none)";
+        return err(
+          `Player '${input.player}' not found. switch_player only passes the turn between characters already in the roster (${roster}). ` +
+          `To make a character that ISN'T in the roster the player's PC — a handoff to a new or existing character — use swap_pc instead (see howto_swap_pc for the full procedure).`,
+        );
+      }
       state.activePlayerIndex = idx;
       const p = state.config.players[idx];
       return ok(`Active player: ${p.character} (${p.type})`);
+    },
+  },
+  {
+    definition: {
+      name: "swap_pc",
+      description:
+        "Hand player control from the current PC to a different character (a 'PC swap'). Reassigns a player slot in the roster to `character` and makes it the active PC — this is the only tool that edits config.players, and it persists the change so the new PC survives a reload. Use for retiring a PC and continuing as an NPC/ally, or introducing a brand-new PC. Run howto_swap_pc first: this tool only moves the roster pointer — you must also create/locate the character sheet, demote the outgoing PC, and refresh party.md, resources, modeline, and theme.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          character: { type: "string", description: "Name of the character who becomes the player's PC (new or existing)." },
+          replaces: { type: "string", description: "Name of the current PC being handed off. Defaults to the active player's current character." },
+          color: { type: "string", description: "Theme/display color for the new PC as a hex string (e.g. #b33f5d). Optional." },
+          player_name: { type: "string", description: "New label for the human player behind this slot. Optional — defaults to keeping the existing player name." },
+        },
+        required: ["character"],
+      },
+    },
+    handler: (state, input) => {
+      const players = state.config.players;
+      if (players.length === 0) return err("No players in the roster to reassign.");
+
+      const character = (input.character as string).trim();
+      if (!character) return err("`character` is required.");
+
+      // Resolve which roster slot to reassign. `replaces` names the outgoing
+      // character explicitly; otherwise we hand off the active slot.
+      let idx: number;
+      const replaces = (input.replaces as string | undefined)?.trim();
+      if (replaces) {
+        idx = players.findIndex((p) => p.character.toLowerCase() === replaces.toLowerCase());
+        if (idx === -1) {
+          const roster = players.map((p) => p.character).join(", ") || "(none)";
+          return err(`Cannot swap: no player currently controls '${replaces}'. Current PCs: ${roster}.`);
+        }
+      } else {
+        idx = state.activePlayerIndex;
+      }
+
+      const slot = players[idx];
+      const outgoing = slot.character;
+
+      // Warn (but allow) if another slot already controls the incoming
+      // character — two players sharing one PC is almost always a mistake.
+      const dup = players.findIndex(
+        (p, i) => i !== idx && p.character.toLowerCase() === character.toLowerCase(),
+      );
+
+      slot.character = character;
+      if (typeof input.color === "string" && input.color.trim()) slot.color = input.color.trim();
+      if (typeof input.player_name === "string" && input.player_name.trim()) slot.name = input.player_name.trim();
+      state.activePlayerIndex = idx;
+
+      const note = dup !== -1
+        ? ` Warning: '${players[dup].name}' also controls '${character}' — you likely want to swap or retire that slot too.`
+        : "";
+      return ok(
+        `PC swapped: '${slot.name}' now plays ${character} (was ${outgoing}). ` +
+        `${outgoing} is no longer player-controlled. Active PC set to ${character}.${note} ` +
+        `Reminder: demote ${outgoing}'s sheet to a character/NPC, set up ${character}'s sheet + party.md + resources + modeline + theme (see howto_swap_pc).`,
+      );
+    },
+  },
+  {
+    definition: {
+      name: "howto_swap_pc",
+      description:
+        "Knowledge tool (a 'skill'): returns the step-by-step procedure for swapping the player character with a new or existing character. Takes no arguments and changes nothing — it just loads the playbook into context. Call this BEFORE doing a PC swap so you touch every piece of state (config roster, character sheets, party.md, resources, modeline, theme) and nothing loads stale.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+        required: [],
+      },
+    },
+    handler: () => {
+      return ok(loadPrompt("howto-swap-pc"));
     },
   },
 
@@ -958,6 +1041,10 @@ export const TOOL_STATE_MAP: Record<string, StateSlice[]> = {
   deck: ["decks"],
   manage_objectives: ["objectives"],
   switch_player: [],
+  // swap_pc mutates config.players, which isn't a StateSlice — persistence is
+  // handled out-of-band by GameEngine.onToolSuccess (persistConfig). Listed
+  // here for completeness so the tool is recognized as state-mutating.
+  swap_pc: [],
   resolve_turn: [],
 };
 

--- a/packages/engine/src/context/state-persistence.test.ts
+++ b/packages/engine/src/context/state-persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { StatePersister, STATE_FILES } from "./state-persistence.js";
+import { StatePersister, STATE_FILES, CONFIG_FILE } from "./state-persistence.js";
 import type { FileIO } from "../agents/scene-manager.js";
 import type { CombatState } from "@machine-violet/shared/types/combat.js";
 import type { MapData } from "@machine-violet/shared/types/maps.js";
@@ -195,6 +195,28 @@ describe("StatePersister", () => {
 
     const loaded = await persister.loadAll();
     expect(loaded.resources).toEqual(resources);
+  });
+
+  it("persistConfig writes config.json at campaign root", async () => {
+    const fio = mockFileIO();
+    const persister = new StatePersister("/tmp/campaign", fio);
+    const config = {
+      name: "Test Campaign",
+      dm_personality: { name: "DM", prompt_fragment: "be a DM" },
+      players: [{ name: "Beep", character: "Maren", type: "human" as const }],
+      combat: { initiative_method: "d20_dex", round_structure: "individual", surprise_rules: false },
+      context: { retention_exchanges: 5, max_conversation_tokens: 0 },
+      recovery: { auto_commit_interval: 3, max_commits: 500, enable_git: true },
+      choices: { campaign_default: "never" as const, player_overrides: {} },
+    };
+
+    persister.persistConfig(config);
+    await persister.flush();
+
+    const written = files[norm("/tmp/campaign/config.json")];
+    expect(written).toBeDefined();
+    expect(JSON.parse(written)).toEqual(config);
+    expect(CONFIG_FILE).toBe("config.json");
   });
 
   it("loadAll returns undefined for missing files", async () => {

--- a/packages/engine/src/context/state-persistence.ts
+++ b/packages/engine/src/context/state-persistence.ts
@@ -9,8 +9,17 @@ import type { MapData } from "@machine-violet/shared/types/maps.js";
 import type { SceneState } from "../agents/scene-manager.js";
 import type { ConversationExchange } from "./conversation.js";
 import type { StyleVariant } from "@machine-violet/shared/types/tui.js";
+import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
 import type { TokenBreakdown } from "./cost-tracker.js";
 import { tailLines } from "./display-log.js";
+
+/**
+ * Campaign config file, at the campaign root (NOT under `state/`).
+ * Deliberately kept out of `STATE_FILES` — that set is contractually the
+ * `state/` directory the Campaign Explorer categorizes, and config.json is a
+ * different category (campaign manifest, normally written only at creation).
+ */
+export const CONFIG_FILE = "config.json";
 
 /** Paths within campaign root for persisted state files */
 export const STATE_FILES = {
@@ -183,6 +192,20 @@ export class StatePersister {
 
   persistUsage(breakdown: TokenBreakdown): void {
     this.enqueueWrite(STATE_FILES.usage, JSON.stringify(breakdown, null, 2));
+  }
+
+  /**
+   * Write the campaign config back to `config.json`.
+   *
+   * `config.json` is normally treated as read-only after creation — it's the
+   * source of truth loaded fresh at every session start. The one mutation we
+   * support in-session is the PC roster (`players[]`): swapping which character
+   * a player controls. That change has to round-trip to disk or the next load
+   * resurrects the old PC. `state.config` is the full parsed object, so
+   * stringifying it preserves every field (premise, dm_personality, etc.).
+   */
+  persistConfig(config: CampaignConfig): void {
+    this.enqueueWrite(CONFIG_FILE, JSON.stringify(config, null, 2));
   }
 
   /** Append text to the rolling display log (human-readable, never cleared). */

--- a/packages/engine/src/prompts/howto-swap-pc.md
+++ b/packages/engine/src/prompts/howto-swap-pc.md
@@ -1,0 +1,87 @@
+# How to swap the player character
+
+This is a procedure, not an action. It explains how to hand player control from
+the current PC to a different character — either an existing one already in the
+story (an NPC, an ally) or a brand-new character. Follow every step: a PC swap
+touches several independent pieces of state, and skipping one leaves the game
+half-swapped (the classic failure is the roster reverting to the old PC on the
+next load).
+
+## The model
+
+A "PC" is just a roster slot in `config.json` → `players[]` whose `character`
+field names a character. The active slot is chosen by `activePlayerIndex`. The
+character's *sheet* (`characters/<slug>.md`), the *party* (`characters/party.md`),
+the top-frame *resources*, the *modeline*, and the *theme color* all key off
+that character's name. A swap means pointing the slot at a new character **and**
+bringing all of those satellites along.
+
+`swap_pc` is the only tool that edits the roster, and it is the only step that
+persists `config.json`. Everything else is ordinary sheet/UI editing.
+
+## Steps
+
+1. **Confirm the intent.** Who is retiring, and who takes over? Is the incoming
+   character brand-new, or already an entity in the campaign? If the player is
+   present, make sure this is what they want — a swap is a big narrative move.
+
+2. **Make sure the incoming character has a PC sheet.**
+   - *Existing character* (e.g. an NPC being promoted): `entity` with
+     `op: "update"`, `type: "character"`, `id: "<name>"`, and a `frontMatter`
+     patch setting `Type: PC`, `Player: <player name>`, `Display Resources`
+     (the keys to show in the top frame, e.g. `HP, Memory`), and a
+     `Theme Color`. Fill out stats/skills/abilities in the body if the sheet was
+     a thin NPC stub. Add a `changelogEntry` noting the promotion.
+   - *Brand-new character*: `entity` with `op: "create"`, `type: "character"`,
+     and a full sheet (same PC frontMatter as above). If the player should help
+     build it, you can route the build through the normal character-creation
+     flow first, then come back here.
+
+3. **Demote the outgoing PC to a character/NPC.** `entity` `op: "update"`,
+   `type: "character"`, `id: "<old PC>"`, `frontMatter` setting `Type: character`
+   (and clearing `Player` by setting it to `null`). In the body, note that they
+   were retired from player control and may recur at DM discretion, and update
+   any relationship lines that referred to them as "the PC". Add a changelog
+   entry. The outgoing character is NOT deleted — they stay in the world.
+
+4. **Swap the roster pointer.** Call `swap_pc({ character: "<new PC>",
+   replaces: "<old PC>", color: "#hex" })`. Omit `replaces` to hand off the
+   currently-active slot. This reassigns the slot, sets the active PC, and
+   persists `config.json` — this is the step that makes the swap survive a
+   reload. (`switch_player` will NOT work here: it only passes the turn between
+   characters already in the roster and rejects an unknown name.)
+
+5. **Update the party roster.** Edit `characters/party.md` so the Members list
+   links the new PC (`- [[new-slug]]`) instead of the old one. Move the old PC
+   out of Members (you can mention them elsewhere as a retired character).
+
+6. **Bring the top-frame resources across.**
+   - `set_display_resources({ character: "<new PC>", resources: [...] })` — which
+     keys show (e.g. `["HP", "Memory"]`).
+   - `set_resource_values({ character: "<new PC>", values: { "HP": "9/9", ... } })`
+     — their current values.
+   The old PC's resource entries can be left or cleared; they no longer display
+   once the slot points elsewhere.
+
+7. **Set the new PC's modeline.** `update_modeline({ character: "<new PC>",
+   text: "..." })` so the status line reflects who you're now playing.
+
+8. **Re-theme to the new PC (optional but expected).** If the new PC has a
+   distinct theme color, `style_scene({ key_color: "#hex" })` (or a mood
+   `description`) so the UI matches.
+
+9. **Handle combat if active.** If a fight is in progress, the initiative order
+   still lists the old PC as a combatant. End or rebuild combat so turn order
+   tracks the new PC; don't leave a retired PC holding initiative.
+
+## Notes
+
+- The DM's in-context PC sheet block (`pcSheets`) is loaded once at session
+  start and is intentionally not refreshed mid-session. After a swap it will
+  still show the old sheet until the next reload — that's expected. You can see
+  the new sheet via the conversation and `entity`/`show_character_sheet`. The
+  on-disk state is correct, which is what matters for the next load.
+- Do the file edits (steps 2, 3, 5) and the `swap_pc` call (step 4) together in
+  one pass. A swap that updates the sheets but never calls `swap_pc` looks done
+  on screen but reverts to the old PC on reload; a `swap_pc` with no sheet work
+  leaves a PC with no real sheet.


### PR DESCRIPTION
## Why

Swapping the player character (retire a PC and continue as an NPC, or introduce a brand-new PC) didn't stick. The PC's identity lives in `config.json` → `players[]`, loaded fresh at every session start and selected by `activePlayerIndex`. But:

- **`switch_player` rejects any name not already in the roster** — it only passes the turn between registered players. So `switch_player({player: "Maren..."})` errored.
- **Nothing during play ever wrote `config.json`** — there was no `persistConfig` at all.

Net effect: an agent asked to hand off control could update the character sheets, resources, and UI, but the roster reverted to the old PC on the next load.

## Changes

**Objective 1 — fix the tooling**
- `StatePersister.persistConfig` writes `config.json` (new `CONFIG_FILE` const, kept *out* of `STATE_FILES` — that set is the contractual `state/` directory the Campaign Explorer categorizes).
- New **`swap_pc`** tool — the only tool that edits `config.players`. Reassigns a roster slot to a new/existing character, sets it active, and persists `config.json` via `GameEngine.onToolSuccess` so the swap survives reload. Signature: `{ character, replaces?, color?, player_name? }`.
- `switch_player`'s unknown-player error now redirects to `swap_pc`.

**Objective 2 — knowledge tool ("skill")**
- New **`howto_swap_pc`** — first of the `howto_*` convention: takes no args, changes nothing, just loads the full PC-swap playbook into context (roster → sheets → `party.md` → resources → modeline → theme). Backed by `prompts/howto-swap-pc.md`.

## Tests & docs
- Unit tests for `swap_pc`, `howto_swap_pc`, and `persistConfig`; tool-count contracts bumped 35 → 37.
- Docs updated: `tools-catalog` (incl. new How-To/Knowledge Tools section), `multiplayer-and-initiative` (PC-swap state map), `state-atlas`, `format-spec`.
- `npm run check` green (3038 tests, lint clean), `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)