### PR TITLE
Clean up dead phases barrel + revive excluded monolith-vestige tests

### DIFF
--- a/packages/client-ink/src/phases/ArchivedCampaignsPhase.test.tsx
+++ b/packages/client-ink/src/phases/ArchivedCampaignsPhase.test.tsx
@@ -4,11 +4,9 @@ import { render } from "ink-testing-library";
 import { ArchivedCampaignsPhase } from "./ArchivedCampaignsPhase.js";
 import type { ArchivedCampaignsPhaseProps } from "./ArchivedCampaignsPhase.js";
 import { resetThemeCache, resolveTheme, BUILTIN_DEFINITIONS } from "../tui/themes/index.js";
-import { resetPromptCache } from "../prompts/load-prompt.js";
 import type { ArchivedCampaignEntry } from "../config/campaign-archive.js";
 
 beforeEach(() => {
-  resetPromptCache();
   resetThemeCache();
 });
 

--- a/packages/client-ink/src/phases/index.ts
+++ b/packages/client-ink/src/phases/index.ts
@@ -1,4 +1,0 @@
-export { MainMenuPhase } from "./MainMenuPhase.js";
-export type { MainMenuPhaseProps } from "./MainMenuPhase.js";
-
-export { PlayingPhase } from "./PlayingPhase.js";

--- a/packages/client-ink/src/tui/modals/DeleteCampaignModal.test.tsx
+++ b/packages/client-ink/src/tui/modals/DeleteCampaignModal.test.tsx
@@ -4,11 +4,9 @@ import { render } from "ink-testing-library";
 import { DeleteCampaignModal } from "./DeleteCampaignModal.js";
 import type { DeleteCampaignModalProps } from "./DeleteCampaignModal.js";
 import { resetThemeCache, resolveTheme, BUILTIN_DEFINITIONS } from "../themes/index.js";
-import { resetPromptCache } from "../../prompts/load-prompt.js";
 import type { CampaignDeleteInfo } from "../../config/campaign-archive.js";
 
 beforeEach(() => {
-  resetPromptCache();
   resetThemeCache();
 });
 

--- a/packages/client-ink/tsconfig.json
+++ b/packages/client-ink/tsconfig.json
@@ -13,9 +13,7 @@
   "exclude": [
     "node_modules", "dist",
     "src/**/*.test.ts", "src/**/*.test.tsx",
-    "src/phases/index.ts",
-    "src/phases/AddContentPhase.tsx",
-    "src/tui/game-context.test.tsx"
+    "src/phases/AddContentPhase.tsx"
   ],
   "references": [
     { "path": "../shared" }

--- a/packages/client-ink/vitest.config.ts
+++ b/packages/client-ink/vitest.config.ts
@@ -13,13 +13,10 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: [
-      // Monolith vestiges — these test modules that have engine-only imports
-      // (campaignPaths, campaign-archive, content pipeline).
-      // They'll be fixed or removed during Phase 5 cleanup.
-      "src/commands/slash-commands.test.ts",
+      // AddContentPhase imports engine-only modules (content pipeline,
+      // config/systems) that haven't been migrated into client-ink yet, so
+      // its test can't run here. Re-enable once the feature is migrated.
       "src/phases/AddContentPhase.test.tsx",
-      "src/phases/ArchivedCampaignsPhase.test.tsx",
-      "src/tui/modals/DeleteCampaignModal.test.tsx",
     ],
   },
 });


### PR DESCRIPTION
Follow-up to #560 / #561 — codebase hygiene. Two adjacent cleanups.

## 1. Delete the dead `phases/index.ts` barrel

After #561 removed the `UpdatePhase` re-exports, the barrel only re-exported `MainMenuPhase`/`PlayingPhase` — but `app.tsx` imports both directly from their modules, and nothing imports the barrel. Deleted it and dropped its `tsconfig.json` exclude entry.

## 2. Resolve the "monolith vestige" excluded-test cluster

`vitest.config.ts` disabled a batch of tests wholesale, deferred to a "Phase 5 cleanup." Most just had a single leftover bad import from the pre-split monolith:

| File | Finding | Action |
|---|---|---|
| `slash-commands.test.ts` | source **and** test already deleted — exclude entry was stale | remove entry |
| `ArchivedCampaignsPhase.test.tsx` | source live/wired; only broken import was `resetPromptCache` from a `prompts/load-prompt.js` absent in client-ink | strip import + `beforeEach` call, un-exclude |
| `DeleteCampaignModal.test.tsx` | same as above | strip import + `beforeEach` call, un-exclude |
| `game-context.test.tsx` | already runs in vitest; tsconfig exclude was redundant (`src/**/*.test.tsx` glob covers it) | drop redundant tsconfig entry |

The two revived tests (`ArchivedCampaignsPhase`, `DeleteCampaignModal`) now run — **12 tests of recovered coverage** on live, user-facing components.

## Intentionally left alone

`AddContentPhase` (source + test) stays excluded — it imports content-pipeline / `config/systems` modules **not yet migrated** into client-ink, and the feature is slated to be revived. Trimmed the exclude comment to describe just that remaining case.

## Verification

- `tsc -b` clean
- `eslint` clean
- Full client-ink suite: **60 files / 1095 tests** pass (now including the two recovered files)

No live app code path touched (no `app.tsx` / runtime changes), so unit + typecheck coverage is sufficient — no smoke test needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)