### PR TITLE
Default to a git commit on every player turn

### DIFF
--- a/packages/engine/src/tools/git/campaign-repo.ts
+++ b/packages/engine/src/tools/git/campaign-repo.ts
@@ -75,7 +75,7 @@ export class CampaignRepo {
     this.dir = params.dir;
     this.git = params.git;
     this.enabled = params.enabled ?? true;
-    this.autoCommitInterval = params.autoCommitInterval ?? 3;
+    this.autoCommitInterval = params.autoCommitInterval ?? 1;
     this.maxCommits = params.maxCommits ?? 500;
   }
 


### PR DESCRIPTION
## What

Align the `CampaignRepo` constructor's `autoCommitInterval` fallback from `3` → `1` so a git snapshot on **every player turn** is the guaranteed default everywhere — not just on the paths that thread campaign config through.

## Why

The campaign config default `recovery.auto_commit_interval` has been `1` (commit every exchange) since the setup→DM handoff work, and production always passes that through to the repo. The only stale spot was the constructor's hardcoded `3` fallback, which silently batched three exchanges per commit on any path that built a repo without an explicit interval. This removes that latent inconsistency.

Per-turn commits flow through `processInput()` → `repo.trackExchange()`, which commits when `exchangeCount >= autoCommitInterval`; with the interval at `1` that fires every turn, using the player's message as the commit subject.

## Note

Existing campaigns whose `config.json` already persisted a different value keep it — on-disk config wins over defaults, by design.

## Testing

`npm run check` — lint clean, 3055/3055 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)