### PR TITLE
DM personality: list / swap / howto tools (mid-campaign persona change)

### DIFF
--- a/docs/game-initialization.md
+++ b/docs/game-initialization.md
@@ -155,7 +155,17 @@ The "Enter your own" option in setup lets the player describe a DM personality i
 
 ### Storage
 
-The selected personality fragment is stored in `config.json` and loaded into the DM system prompt at session start. Changing personality mid-campaign is possible (via OOC mode) but unusual.
+The selected personality fragment is stored in `config.json` and woven into the DM system prompt by `buildDMPrefix`, which reads `config.dm_personality` **live at the start of every DM turn**.
+
+### Changing personality mid-campaign
+
+Supported via three registry tools (available to the DM and OOC):
+
+- `list_dm_personalities` — the same persona catalog the setup agent sees (`loadAllPersonalities`), surfaced in-game so the agent knows the options.
+- `swap_dm_personality({ name, prompt_fragment?, detail?, description? })` — switch to a preset by `name`, or invent a custom persona by also passing `prompt_fragment`. Writes `config.dm_personality` and persists `config.json`.
+- `howto_swap_dm_personality` — the playbook (list → present → swap → in-fiction handoff).
+
+Because the personality is read live each turn (not snapshotted like `pcSheets`), the swap takes effect on the **next** DM turn with no reload — that turn pays a one-time prompt-cache recreation, then re-caches at BP1. The incoming persona is expected to open with an in-fiction voice handoff so the shift reads as intentional. See [tools-catalog.md](tools-catalog.md#dm-personality-tools).
 
 ```jsonc
 // config.json (partial)

--- a/docs/state-atlas.md
+++ b/docs/state-atlas.md
@@ -77,7 +77,7 @@ GameState
 │   ├── name, system, genre, mood, difficulty, premise
 │   ├── campaign_scope?: CampaignScope       const ("one-shot" | "few-sessions" | "grand-campaign" | "open-ended")
 │   ├── setup_handoff?: string               const (postcard from setup agent, injected once into the first-turn priming; persists for resume-from-disk after a mid-first-turn crash)
-│   ├── dm_personality: DMPersonality
+│   ├── dm_personality: DMPersonality       mut   → config.json            DM/OOC (swap_dm_personality) — read live each DM turn
 │   ├── players: PlayerConfig[]              mut   → config.json            DM/OOC (swap_pc) — PC roster handoff
 │   ├── combat: CombatConfig
 │   ├── context: ContextConfig
@@ -174,7 +174,7 @@ All state files live under `<campaignRoot>/state/`.
 | `state/conversation.json` | `ConversationExchange[]` | `StatePersister.persistConversation` | After each exchange | [§4.7](format-spec.md#47-conversation-stateconversationjson) |
 | `state/resources.json` | `PersistedResourceState` | `StatePersister.persistResources` | React effect on `resources` state change (same pattern as modelines in `ui.json`) | [§4.10](format-spec.md#410-resources-stateresourcesjson) |
 | `state/ui.json` | `PersistedUIState` | `StatePersister.persistUI` | After theme/style/modeline changes | [§4.8](format-spec.md#48-ui-stateuijson) |
-| `config.json` | `CampaignConfig` | `buildCampaignConfig` / `createDefaultCampaignConfig`; `StatePersister.persistConfig` | Written at campaign creation. During play it is otherwise read-only — the **one** in-session mutation is the PC roster (`players[]`) via `swap_pc`, which calls `persistConfig` from `GameEngine.onToolSuccess`. Includes `version` (`CAMPAIGN_FORMAT_VERSION`) and `createdAt` (ISO 8601) manifest fields. | |
+| `config.json` | `CampaignConfig` | `buildCampaignConfig` / `createDefaultCampaignConfig`; `StatePersister.persistConfig` | Written at campaign creation. During play it is otherwise read-only — the in-session mutations are the PC roster (`players[]`) via `swap_pc` and the DM voice (`dm_personality`) via `swap_dm_personality`, both calling `persistConfig` from `GameEngine.onToolSuccess`. Includes `version` (`CAMPAIGN_FORMAT_VERSION`) and `createdAt` (ISO 8601) manifest fields. | |
 | `pending-operation.json` | `PendingOperation` | `SceneManager` | During scene transition cascade steps | [§4.11](format-spec.md#411-pending-operation-pending-operationjson) |
 
 `StatePersister` uses write-through: each `persist*` call is fire-and-forget with error swallowing. Recovery on next session load reads `loadAll()` and hydrates `GameState`.

--- a/docs/tools-catalog.md
+++ b/docs/tools-catalog.md
@@ -138,6 +138,15 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 
 ---
 
+## DM Personality Tools → [game-initialization.md](game-initialization.md#dm-personalities)
+
+| Tool | Tier | Caller | Signature | Effect |
+|---|---|---|---|---|
+| `list_dm_personalities` | T1 | DM / OOC | `({})` | List the personas available to swap to (bundled `.mvdm` presets + user additions), each with name + description, plus which is current. Borrows the setup agent's persona catalog (`loadAllPersonalities`) — the in-game agent doesn't otherwise have it in context. |
+| `swap_dm_personality` | T1 | DM / OOC | `({ name, prompt_fragment?, detail?, description? })` | Change the DM's narrative voice for the rest of the campaign. `name` matches a preset, or names a custom persona when `prompt_fragment` is supplied. The only tool that edits `config.dm_personality`; persists `config.json`. Read live each DM turn, so it takes effect next turn (no reload). Pair with `howto_swap_dm_personality` — the new voice must open with an in-fiction handoff. |
+
+---
+
 ## How-To / Knowledge Tools ("skills")
 
 `howto_*` tools take an empty arguments object and change nothing. They load a procedure into context — call one before a multi-step operation so you touch every piece of state.
@@ -145,6 +154,7 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 | Tool | Tier | Caller | Signature | Effect |
 |---|---|---|---|---|
 | `howto_swap_pc` | T1 | DM / OOC | `({})` | Returns the step-by-step playbook for swapping the player character with a new or existing character (roster, character sheets, party.md, resources, modeline, theme). Backed by `prompts/howto-swap-pc.md`. |
+| `howto_swap_dm_personality` | T1 | DM / OOC | `({})` | Returns the playbook for changing the DM personality mid-campaign (list → present → swap → required in-fiction voice handoff). Backed by `prompts/howto-swap-dm-personality.md`. |
 
 ---
 

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -245,6 +245,12 @@ export class GameEngine {
         this.persister?.persistConfig(state.config);
         this.persistCurrentScene();
       }
+      if (toolName === "swap_dm_personality") {
+        // swap_dm_personality rewrites config.dm_personality. buildDMPrefix
+        // reads it live each turn, so the new voice is in play next turn;
+        // persist so it also survives a reload.
+        this.persister?.persistConfig(state.config);
+      }
       if (toolName === "start_combat") {
         void this.initResolveSession(state);
       } else if (toolName === "end_combat") {

--- a/packages/engine/src/agents/phase8.test.ts
+++ b/packages/engine/src/agents/phase8.test.ts
@@ -512,6 +512,69 @@ describe("new Phase 8 tools", () => {
     expect(JSON.stringify(state)).toBe(before); // pure knowledge tool
   });
 
+  it("list_dm_personalities returns the bundled persona catalog", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "list_dm_personalities", {});
+
+    expect(result.is_error).toBeFalsy();
+    const parsed = JSON.parse(result.content);
+    expect(Array.isArray(parsed.personalities)).toBe(true);
+    expect(parsed.personalities.length).toBeGreaterThan(0);
+    expect(parsed.personalities[0]).toHaveProperty("name");
+  });
+
+  it("swap_dm_personality switches to a bundled preset by name", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    // Pull a real preset name from the catalog so the test isn't brittle.
+    const catalog = JSON.parse(
+      registry.dispatch(state, "list_dm_personalities", {}).content,
+    ).personalities as { name: string }[];
+    const target = catalog[0].name;
+
+    const result = registry.dispatch(state, "swap_dm_personality", { name: target });
+    expect(result.is_error).toBeFalsy();
+    expect(state.config.dm_personality.name).toBe(target);
+    expect(state.config.dm_personality.prompt_fragment.length).toBeGreaterThan(0);
+    // Reminds the caller about the required in-fiction handoff.
+    expect(result.content.toLowerCase()).toContain("handoff");
+  });
+
+  it("swap_dm_personality invents a custom persona from a prompt_fragment", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "swap_dm_personality", {
+      name: "The Lighthouse Keeper",
+      prompt_fragment: "You are The Lighthouse Keeper. You narrate in slow, salt-worn sentences.",
+      detail: "Signature: end scenes on a distant light.",
+    });
+
+    expect(result.is_error).toBeFalsy();
+    expect(state.config.dm_personality.name).toBe("The Lighthouse Keeper");
+    expect(state.config.dm_personality.detail).toContain("distant light");
+  });
+
+  it("swap_dm_personality errors on an unknown preset with no prompt_fragment", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "swap_dm_personality", { name: "Nobody In The List" });
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("prompt_fragment");
+  });
+
+  it("howto_swap_dm_personality returns the playbook and changes nothing", () => {
+    const state = makeState([humanPlayer]);
+    const before = JSON.stringify(state);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "howto_swap_dm_personality", {});
+
+    expect(result.is_error).toBeFalsy();
+    expect(result.content.toLowerCase()).toContain("handoff");
+    expect(JSON.stringify(state)).toBe(before); // pure knowledge tool
+  });
+
   it("registers resolve_turn tool", () => {
     const registry = createTestRegistry();
     expect(registry.has("resolve_turn")).toBe(true);
@@ -522,11 +585,13 @@ describe("new Phase 8 tools", () => {
     expect(registry.has("promote_character")).toBe(true);
   });
 
-  it("registry has 37 tools total", () => {
+  it("registry has 40 tools total", () => {
     const registry = createTestRegistry();
     // Bumped from 29 → 35 by the entity-tool rework: entity, describe_entity_type,
     // list_entity_types, validate_entity, find_schema_drift, detect_orphans.
     // 35 → 37 by the PC-swap work: swap_pc, howto_swap_pc.
-    expect(registry.size).toBe(37);
+    // 37 → 40 by the DM-personality work: list_dm_personalities,
+    // swap_dm_personality, howto_swap_dm_personality.
+    expect(registry.size).toBe(40);
   });
 });

--- a/packages/engine/src/agents/phase8.test.ts
+++ b/packages/engine/src/agents/phase8.test.ts
@@ -555,6 +555,23 @@ describe("new Phase 8 tools", () => {
     expect(state.config.dm_personality.detail).toContain("distant light");
   });
 
+  it("swap_dm_personality rejects custom fields when name matches a preset", () => {
+    const state = makeState([humanPlayer]);
+    const registry = createTestRegistry();
+    const preset = (JSON.parse(
+      registry.dispatch(state, "list_dm_personalities", {}).content,
+    ).personalities as { name: string }[])[0].name;
+
+    const result = registry.dispatch(state, "swap_dm_personality", {
+      name: preset,
+      prompt_fragment: "You are something else entirely.",
+    });
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("preset");
+    // The preset was not silently applied.
+    expect(state.config.dm_personality?.name).not.toBe(preset);
+  });
+
   it("swap_dm_personality errors on an unknown preset with no prompt_fragment", () => {
     const state = makeState([humanPlayer]);
     const registry = createTestRegistry();

--- a/packages/engine/src/agents/tool-registry.test.ts
+++ b/packages/engine/src/agents/tool-registry.test.ts
@@ -38,8 +38,9 @@ describe("ToolRegistry", () => {
     // Map (3) + Dice (1) + Deck (1) + Clocks (2) + Combat (4) + TUI (6) + Scene (3)
     //   + Entity-narrative (5: scribe/dm_notes/resolve_turn/promote_character/search)
     //   + Entity-CRUD (6: entity/describe_entity_type/list_entity_types/validate_entity/find_schema_drift/detect_orphans)
-    //   + Objectives (1) + Search (2) + Player (3: switch_player/swap_pc/howto_swap_pc) = 37
-    expect(reg.size).toBe(37);
+    //   + Objectives (1) + Search (2) + Player (3: switch_player/swap_pc/howto_swap_pc)
+    //   + DM personality (3: list_dm_personalities/swap_dm_personality/howto_swap_dm_personality) = 40
+    expect(reg.size).toBe(40);
   });
 
   it("generates API-compatible tool definitions", () => {

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -818,17 +818,25 @@ const TOOL_DEFS: RegisteredTool[] = [
       const promptFragment = (input.prompt_fragment as string | undefined)?.trim();
       const userDir = state.homeDir ? join(state.homeDir, "personalities") : undefined;
 
+      const detail = (input.detail as string | undefined)?.trim();
+      const description = (input.description as string | undefined)?.trim();
+
       let next: DMPersonality;
       const preset = getPersonality(name, userDir);
       if (preset) {
-        // Named an existing persona — use it verbatim. A stray prompt_fragment
-        // is ignored: presets are canonical, edit the .mvdm to change one.
+        // Named an existing persona. Custom-only fields alongside a preset are
+        // contradictory intent — reject rather than silently using the preset
+        // unchanged, which would leave the caller thinking they'd customized it.
+        if (promptFragment || detail || description) {
+          return err(
+            `'${name}' is an existing preset, so prompt_fragment/detail/description don't apply. ` +
+            `Pass just { name: "${name}" } to use it, or choose a different name to invent a custom persona.`,
+          );
+        }
         next = preset;
       } else if (promptFragment) {
         // Inventing a custom persona on the fly (setup's invent path).
         next = { name, prompt_fragment: promptFragment };
-        const detail = (input.detail as string | undefined)?.trim();
-        const description = (input.description as string | undefined)?.trim();
         if (description) next.description = description;
         if (detail) next.detail = detail;
       } else {

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -54,6 +54,9 @@ import { manageObjectives } from "../tools/objectives/index.js";
 import type { ManageObjectivesInput } from "../tools/objectives/index.js";
 import { ENTITY_TOOLS } from "../entities/tools.js";
 import { loadPrompt } from "../prompts/load-prompt.js";
+import { loadAllPersonalities, getPersonality } from "../config/personality-loader.js";
+import { join } from "node:path";
+import type { DMPersonality } from "@machine-violet/shared/types/config.js";
 
 // --- Helpers ---
 
@@ -768,6 +771,98 @@ const TOOL_DEFS: RegisteredTool[] = [
     },
   },
 
+  // ====== DM PERSONALITY ======
+  {
+    definition: {
+      name: "list_dm_personalities",
+      description:
+        "List the DM personalities (personas) available to swap to — bundled presets plus any the user has added. Returns each persona's name and description. Use this to learn the options before presenting choices to the player; the in-game agent doesn't otherwise have the persona catalog in context (only the setup agent does).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+        required: [],
+      },
+    },
+    handler: (state) => {
+      const userDir = state.homeDir ? join(state.homeDir, "personalities") : undefined;
+      const personalities = loadAllPersonalities(userDir);
+      const current = state.config.dm_personality?.name;
+      const list = personalities.map((p) => ({
+        name: p.name,
+        description: p.description ?? "",
+        current: p.name === current || undefined,
+      }));
+      return ok(JSON.stringify({ current, personalities: list }, null, 2));
+    },
+  },
+  {
+    definition: {
+      name: "swap_dm_personality",
+      description:
+        "Change the DM's personality (narrative voice) for the rest of the campaign. Pass a `name` from list_dm_personalities to switch to a preset, OR invent a custom persona by also passing `prompt_fragment` (and optionally `detail`). This is the only tool that edits config.dm_personality, and it persists the change. It takes effect on the NEXT DM turn (no reload needed) — so the incoming persona must open with an in-fiction handoff. Run howto_swap_dm_personality first.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          name: { type: "string", description: "Persona name. Matches a preset from list_dm_personalities, or names a new custom persona when prompt_fragment is supplied." },
+          prompt_fragment: { type: "string", description: "Custom personas only: 2-4 sentences describing the DM's voice and style, written in second person ('You are ... You narrate ...'). Omit to use a preset by name." },
+          detail: { type: "string", description: "Custom personas only: optional hidden tuning block — signature techniques, pacing rules, register notes. Not shown to the player." },
+          description: { type: "string", description: "Custom personas only: optional one-line player-facing flavor for the persona." },
+        },
+        required: ["name"],
+      },
+    },
+    handler: (state, input) => {
+      const name = (input.name as string | undefined)?.trim();
+      if (!name) return err("`name` is required.");
+
+      const promptFragment = (input.prompt_fragment as string | undefined)?.trim();
+      const userDir = state.homeDir ? join(state.homeDir, "personalities") : undefined;
+
+      let next: DMPersonality;
+      const preset = getPersonality(name, userDir);
+      if (preset) {
+        // Named an existing persona — use it verbatim. A stray prompt_fragment
+        // is ignored: presets are canonical, edit the .mvdm to change one.
+        next = preset;
+      } else if (promptFragment) {
+        // Inventing a custom persona on the fly (setup's invent path).
+        next = { name, prompt_fragment: promptFragment };
+        const detail = (input.detail as string | undefined)?.trim();
+        const description = (input.description as string | undefined)?.trim();
+        if (description) next.description = description;
+        if (detail) next.detail = detail;
+      } else {
+        const names = loadAllPersonalities(userDir).map((p) => p.name).join(", ");
+        return err(
+          `No preset persona named '${name}'. Either pick one of: ${names} — or invent it by passing a prompt_fragment (see howto_swap_dm_personality).`,
+        );
+      }
+
+      const previous = state.config.dm_personality?.name ?? "the previous DM";
+      state.config.dm_personality = next;
+
+      return ok(
+        `DM personality set to '${next.name}' (was '${previous}'). Persisted; takes effect on the next DM turn. ` +
+        `REQUIRED: the next DM narration must open with an in-fiction handoff that bridges ${previous}'s voice into ${next.name}'s — do not switch silently (see howto_swap_dm_personality).`,
+      );
+    },
+  },
+  {
+    definition: {
+      name: "howto_swap_dm_personality",
+      description:
+        "Knowledge tool (a 'skill'): returns the step-by-step procedure for changing the DM's personality mid-campaign. Takes no arguments and changes nothing. Call this BEFORE swapping so you present real options, persist the change, and perform the required in-fiction voice handoff.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+        required: [],
+      },
+    },
+    handler: () => {
+      return ok(loadPrompt("howto-swap-dm-personality"));
+    },
+  },
+
   // ====== SCENE/SESSION ======
   {
     definition: {
@@ -1045,10 +1140,12 @@ const TOOL_STATE_MAP: Record<string, StateSlice[]> = {
   deck: ["decks"],
   manage_objectives: ["objectives"],
   switch_player: [],
-  // swap_pc mutates config.players, which isn't a StateSlice — persistence is
-  // handled out-of-band by GameEngine.onToolSuccess (persistConfig). Listed
-  // here for completeness so the tool is recognized as state-mutating.
+  // swap_pc / swap_dm_personality mutate config (players / dm_personality),
+  // which isn't a StateSlice — persistence is handled out-of-band by
+  // GameEngine.onToolSuccess (persistConfig). Listed here so the tools are
+  // recognized as state-mutating.
   swap_pc: [],
+  swap_dm_personality: [],
   resolve_turn: [],
 };
 

--- a/packages/engine/src/prompts/howto-swap-dm-personality.md
+++ b/packages/engine/src/prompts/howto-swap-dm-personality.md
@@ -1,0 +1,60 @@
+# How to swap the DM personality
+
+This is a procedure, not an action. It explains how to change the DM's
+personality — the narrative voice running the table — mid-campaign, either to
+one of the available presets or to a custom persona you invent. It's a small
+mechanical change with one big craft requirement: the voice handoff.
+
+## The model
+
+The DM personality is a single field, `config.dm_personality`, with a `name`, a
+`prompt_fragment` (the voice/style instructions woven into your system prompt), an
+optional hidden `detail` block (signature techniques, pacing rules — never shown
+to the player), and an optional `description` (one-line player-facing flavor).
+
+It is read **live at the start of every DM turn**, so unlike a character sheet
+there's no reload lag: the moment you call `swap_dm_personality`, the *next* DM
+narration runs under the new voice. (That next turn pays a one-time prompt-cache
+recreation; cheap, and it re-caches immediately.)
+
+`swap_dm_personality` is the only tool that edits `config.dm_personality`, and it
+persists the change to `config.json`.
+
+## Steps
+
+1. **Decide: preset or custom?** Is the player choosing from the existing
+   personas, or asking for a bespoke voice?
+
+2. **Load the catalog.** Call `list_dm_personalities`. The in-game agent doesn't
+   carry the persona list in context (only the setup agent does), so this is how
+   you learn what's available — names and descriptions, plus which one is current.
+
+3. **Let the player choose** (unless they already named one). Use `present_choices`
+   with persona names as labels and descriptions as the per-choice text. Offer a
+   handful that fit the campaign's tone. If the player wants something not on the
+   list, you can invent one — craft a name and a 2-4 sentence `prompt_fragment` in
+   the same second-person style as the presets ("You are … You narrate …").
+
+4. **Swap.** Call `swap_dm_personality`:
+   - Preset: `{ name: "The Trickster" }` — the name must match a `list_dm_personalities`
+     entry; its prompt_fragment and detail come along automatically.
+   - Custom: `{ name, prompt_fragment, detail?, description? }` — your invented voice.
+
+5. **The handoff — required.** The new voice takes your *next* narration. Do not
+   switch silently: that next turn must open with a deliberate, in-fiction
+   transition that carries the player from the old voice into the new one — a
+   visible shift in register, acknowledged in the fiction, so it reads as
+   intentional rather than a glitch. Bridge first, then continue the scene fully
+   in the new persona. This handoff is what lets you proceed cleanly; skipping it
+   produces tonal whiplash.
+
+## Notes
+
+- The `detail` block is hidden tuning — it shapes how you narrate but is never
+  surfaced to the player. Presets carry their own; for a custom persona, supply
+  `detail` only if you want that extra steering.
+- The persona `name` shows up in session recaps and the Discord presence line, so
+  pick a name you're happy to see there.
+- Nothing else needs touching — no character sheets, no theme, no party. This is
+  purely the DM's voice. (If the new tone also calls for a visual mood change,
+  that's a separate, optional `style_scene` call.)


### PR DESCRIPTION
## Why

Lets a player change the DM's narrative voice mid-campaign — to a bundled `.mvdm` preset or a custom persona invented on the fly. Continues the `swap_*` / `howto_*` "skill" pattern from #557 / #568.

The persona catalog was only injected into the **setup agent's** prompt; an in-game OOC/DM agent had no idea what was available. The "fancier" part of this feature is borrowing that setup scaffolding (`loadAllPersonalities` / `getPersonality`) and surfacing it in-game.

## Changes

Three tools in the shared registry (DM + OOC + Dev — `buildOOCTools` pulls the whole registry, so no per-surface wiring needed):

- **`list_dm_personalities` ({})** — bundled presets + user `.mvdm` files (name + description + which is current). Keyed off `homeDir/personalities`, same as setup.
- **`swap_dm_personality` ({ name, prompt_fragment?, detail?, description? })** — resolve a preset by `name`, or invent a custom persona (library + invent). Writes `config.dm_personality`; persists `config.json` via `GameEngine.onToolSuccess`, reusing the `swap_pc` plumbing.
- **`howto_swap_dm_personality` ({})** — the playbook: list → `present_choices` → swap → **required in-fiction voice handoff**.

## Two notable properties

- **No reload needed.** `buildDMPrefix` reads `config.dm_personality` live every DM turn, so the new voice is in play on the *next* turn (one-time prompt-cache recreation, then re-caches at BP1). Cleaner than the snapshotted `pcSheets`.
- **Handoff enforced.** Both the tool's success message and the howto insist the incoming persona open with an in-fiction voice bridge — never a silent switch — so the tonal shift reads as intentional.

## Tests & docs

- Unit tests: preset swap, custom invent, unknown-name error, catalog listing, pure-knowledge howto. Tool counts bumped 37 → 40.
- Docs: `tools-catalog` (new DM Personality + How-To rows), `game-initialization` (mid-campaign section), `state-atlas` (`dm_personality` now mutable).
- `npm run check` green (3039 tests, lint clean), `tsc -b` clean.

Note: skipped the live smoketest — it walks setup + two turns and wouldn't exercise the new tools; the existing DM loop is untouched (the personality field was already read live each turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)