### PR TITLE
howto_campaign_state: catch-all campaign-state reference tool

### DIFF
--- a/docs/tools-catalog.md
+++ b/docs/tools-catalog.md
@@ -155,6 +155,7 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 |---|---|---|---|---|
 | `howto_swap_pc` | T1 | DM / OOC | `({})` | Returns the step-by-step playbook for swapping the player character with a new or existing character (roster, character sheets, party.md, resources, modeline, theme). Backed by `prompts/howto-swap-pc.md`. |
 | `howto_swap_dm_personality` | T1 | DM / OOC | `({})` | Returns the playbook for changing the DM personality mid-campaign (list → present → swap → required in-fiction voice handoff). Backed by `prompts/howto-swap-dm-personality.md`. |
+| `howto_campaign_state` | T1 | DM / OOC | `({})` | Catch-all: returns a map of campaign on-disk state and **which tool edits which thing** — the fallback when no dedicated tool obviously fits a change (routes to the right tool, or flags that the edit needs Dev mode). Distilled from [format-spec.md](format-spec.md); backed by `prompts/howto-campaign-state.md`. |
 
 ---
 

--- a/packages/engine/src/agents/phase8.test.ts
+++ b/packages/engine/src/agents/phase8.test.ts
@@ -592,6 +592,19 @@ describe("new Phase 8 tools", () => {
     expect(JSON.stringify(state)).toBe(before); // pure knowledge tool
   });
 
+  it("howto_campaign_state returns the catch-all layout and changes nothing", () => {
+    const state = makeState([humanPlayer]);
+    const before = JSON.stringify(state);
+    const registry = createTestRegistry();
+    const result = registry.dispatch(state, "howto_campaign_state", {});
+
+    expect(result.is_error).toBeFalsy();
+    // Routes to tools and names the state dir — the catch-all's core job.
+    expect(result.content.toLowerCase()).toContain("which tool edits");
+    expect(result.content).toContain("state/");
+    expect(JSON.stringify(state)).toBe(before); // pure knowledge tool
+  });
+
   it("registers resolve_turn tool", () => {
     const registry = createTestRegistry();
     expect(registry.has("resolve_turn")).toBe(true);
@@ -602,13 +615,14 @@ describe("new Phase 8 tools", () => {
     expect(registry.has("promote_character")).toBe(true);
   });
 
-  it("registry has 40 tools total", () => {
+  it("registry has 41 tools total", () => {
     const registry = createTestRegistry();
     // Bumped from 29 → 35 by the entity-tool rework: entity, describe_entity_type,
     // list_entity_types, validate_entity, find_schema_drift, detect_orphans.
     // 35 → 37 by the PC-swap work: swap_pc, howto_swap_pc.
     // 37 → 40 by the DM-personality work: list_dm_personalities,
     // swap_dm_personality, howto_swap_dm_personality.
-    expect(registry.size).toBe(40);
+    // 40 → 41 by the catch-all: howto_campaign_state.
+    expect(registry.size).toBe(41);
   });
 });

--- a/packages/engine/src/agents/tool-registry.test.ts
+++ b/packages/engine/src/agents/tool-registry.test.ts
@@ -39,8 +39,9 @@ describe("ToolRegistry", () => {
     //   + Entity-narrative (5: scribe/dm_notes/resolve_turn/promote_character/search)
     //   + Entity-CRUD (6: entity/describe_entity_type/list_entity_types/validate_entity/find_schema_drift/detect_orphans)
     //   + Objectives (1) + Search (2) + Player (3: switch_player/swap_pc/howto_swap_pc)
-    //   + DM personality (3: list_dm_personalities/swap_dm_personality/howto_swap_dm_personality) = 40
-    expect(reg.size).toBe(40);
+    //   + DM personality (3: list_dm_personalities/swap_dm_personality/howto_swap_dm_personality)
+    //   + Catch-all (1: howto_campaign_state) = 41
+    expect(reg.size).toBe(41);
   });
 
   it("generates API-compatible tool definitions", () => {

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -870,6 +870,21 @@ const TOOL_DEFS: RegisteredTool[] = [
       return ok(loadPrompt("howto-swap-dm-personality"));
     },
   },
+  {
+    definition: {
+      name: "howto_campaign_state",
+      description:
+        "Knowledge tool (a 'skill'): the catch-all reference for campaign state. Returns a map of where everything lives on disk and WHICH TOOL edits each thing. Takes no arguments and changes nothing. Call this when you need to change something and there's no obvious dedicated tool for it — it routes you to the right tool (or tells you the change needs Dev mode).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+        required: [],
+      },
+    },
+    handler: () => {
+      return ok(loadPrompt("howto-campaign-state"));
+    },
+  },
 
   // ====== SCENE/SESSION ======
   {

--- a/packages/engine/src/prompts/howto-campaign-state.md
+++ b/packages/engine/src/prompts/howto-campaign-state.md
@@ -1,0 +1,115 @@
+# How campaign state is laid out (catch-all)
+
+This is the fallback reference for changing campaign state when there's **no
+dedicated tool** for what you want. It maps where everything lives on disk and,
+crucially, **which tool edits which thing**. For the common handoffs there are
+purpose-built playbooks — reach for those first:
+
+- Swapping the player character → `howto_swap_pc`
+- Changing the DM's voice → `howto_swap_dm_personality`
+
+If one of those fits, use it. This guide is for everything else.
+
+## What edits what
+
+| You want to change | Use |
+|---|---|
+| A character / location / faction / lore / item | `entity` (read / create / update / delete / list) |
+| The PC roster (who's played) | `swap_pc` (see `howto_swap_pc`) |
+| The DM's personality | `swap_dm_personality` (see `howto_swap_dm_personality`) |
+| Campaign or scene DM notes | `dm_notes` |
+| Combat / initiative | `start_combat`, `advance_turn`, `modify_initiative`, `end_combat` |
+| Clocks, calendar, alarms | `alarm`, `time` |
+| Maps & tokens | `map`, `map_entity`, `map_query` |
+| Card decks | `deck` |
+| Objectives / quests | `manage_objectives` |
+| Top-frame resources | `set_display_resources`, `set_resource_values` |
+| Modeline / theme | `update_modeline`, `style_scene` |
+| A new scene / session boundary | `scene_transition`, `session_end` |
+
+If a change maps to one of these, the tool owns the file and its persistence —
+don't hand-edit the underlying JSON.
+
+**No tool fits?** Most `state/*.json` files and the `campaign/` logs are owned by
+the engine and have no free-form editor on the DM/OOC surface. Arbitrary file
+edits (raw JSON surgery, repairing a corrupted file, bulk fixes) live in **Dev
+mode**, which adds `read_file` / `write_file` / `set_game_state` / `raw_entity_io`
+plus `validate_campaign` and `repair_state`. If you're on the DM/OOC surface and
+nothing above can make the change, say so and point the user at Dev mode rather
+than inventing a workaround.
+
+## The layout
+
+```
+campaign-root/
+├── config.json              # Campaign config (§ below). Edited in-play ONLY via swap_pc / swap_dm_personality.
+├── pending-operation.json   # Crash-recovery breadcrumb. Engine-owned.
+├── campaign/
+│   ├── log.json             # Structured campaign log (scene/session entries)
+│   ├── compendium.json      # Player-facing knowledge base
+│   ├── dm-notes.md          # Campaign-wide DM scratchpad → dm_notes
+│   ├── player-notes.md      # Campaign-wide player notes
+│   ├── scenes/NNN-slug/     # Per-scene: transcript.md, summary.md, dm-notes.md
+│   └── session-recaps/      # session-NNN.md (+ -narrative.md, player-facing)
+├── characters/              # Character entities → entity (type: character)
+│   ├── <slug>.md            #   PC/NPC role is the **Type:** field (PC|NPC|character)
+│   └── party.md             #   Party roster (Members list of [[wikilinks]])
+├── locations/<slug>/index.md  # Location entities (subdir co-locates map JSON) → entity (type: location)
+├── factions/<slug>.md       # → entity (type: faction)
+├── lore/<slug>.md           # → entity (type: lore)
+├── items/<slug>.md          # → entity (type: item)
+├── rules/<slug>.md          # System rule cards (copied from the system template)
+└── state/                   # Runtime state — each file owned by a tool (table below)
+```
+
+### `config.json`
+
+The campaign manifest: `name`, `system`, `genre`/`mood`/`difficulty`, `premise`,
+`campaign_detail` (DM-only), `dm_personality`, `players[]`, `combat`, `context`,
+`recovery`, `choices`. Written at creation and otherwise read-only in play — the
+only in-session mutations are `players[]` (via `swap_pc`) and `dm_personality`
+(via `swap_dm_personality`), both of which persist the file.
+
+### `state/` files and their owners
+
+| File | Holds | Owned by |
+|---|---|---|
+| `combat.json` | initiative order, round | combat tools |
+| `clocks.json` | calendar + combat clocks, alarms | `alarm`, `time` |
+| `maps.json` | map grids & tokens | map tools |
+| `decks.json` | card decks | `deck` |
+| `objectives.json` | quests/goals | `manage_objectives` |
+| `scene.json` | precis, open threads, `activePlayerIndex` | scene/precis updates, `switch_player`, `swap_pc` |
+| `conversation.json` | retained exchange history | engine |
+| `ui.json` | theme, key color, per-character modelines | `update_modeline`, `style_scene` |
+| `resources.json` | per-character display keys + values | `set_display_resources`, `set_resource_values` |
+| `usage.json` | token/cost accounting | engine |
+| `display-log.md` | rolling human-readable log | engine (append-only) |
+
+## Conventions
+
+- **Slugs:** entity filenames are the slugified display name (`Marta Voss` →
+  `marta-voss.md`). Locations are the only entities in subdirectories.
+- **Wikilinks:** `[[entity-slug]]` (or markdown `[Display](../type/slug.md)`),
+  tracked bidirectionally. The `entity` delete/rename tools keep them coherent.
+- **Entity `**Type:**`:** the category for non-characters (location/faction/…),
+  but on a character sheet it's the *role* (PC | NPC | character). The functional
+  PC is `config.players`, not this field.
+
+## Runtime gotchas
+
+- **`config.dm_personality` is read live every DM turn** — a `swap_dm_personality`
+  takes effect on the next turn, no reload.
+- **PC character sheets are snapshotted at session start** (`pcSheets`) and not
+  refreshed mid-session. Sheet edits via `entity` are correct on disk and visible
+  in the conversation, but the cached prompt copy stays stale until the next
+  session load. The same holds for the rules appendix.
+- **Persistence is per-tool and write-through.** A tool that owns a file persists
+  it when it mutates. There's no global "save" — if you bypass the owning tool,
+  the change may not survive a reload.
+
+## The exhaustive spec
+
+For full JSON shapes, null semantics, versioning, transcript/recap formats, git
+layout, and migration rules, the canonical reference is `docs/format-spec.md`
+(maintainer-facing). This guide is the in-play operator's summary of it.


### PR DESCRIPTION
## Why

Completes the `howto_*` "skill" family with a **catch-all** for the long tail: changes that don't (yet) have a dedicated tool. Instead of an agent guessing or hand-editing the wrong file, this surfaces a map of campaign state and routes the change to the right tool.

The content distills `docs/format-spec.md` — the maintainer-facing canonical spec — into an in-play operator's summary. (We can't surface `format-spec.md` directly: the build copies `src/prompts` into the bundle, not `docs/`, so a runtime tool reading `docs/` would fail in the compiled app. The howto lives in `src/prompts` and cross-references the full spec.)

## What it returns

- **A routing table** — "you want to change X → use tool Y" (entities → `entity`, roster → `swap_pc`, DM voice → `swap_dm_personality`, clocks → `alarm`/`time`, etc.), and pointers to `howto_swap_pc` / `howto_swap_dm_personality` for the common handoffs.
- **The directory layout** (config.json, campaign/, entity dirs, state/).
- **A `state/` file → owning-tool table.**
- **Conventions** (slugs, wikilinks, the `**Type:**` role nuance).
- **Runtime gotchas** we've hit this series: `config.dm_personality` read live each turn, `pcSheets` snapshot staleness, per-tool write-through persistence.
- **When nothing fits** → points at Dev mode (`write_file` / `set_game_state` / `raw_entity_io`) rather than inventing a workaround.

## Tests & docs

- Test: returns the routing table + `state/` map, mutates nothing. Tool counts bumped 40 → 41.
- `tools-catalog.md` How-To row added.
- `npm run check` green (3041 tests, lint clean), `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)