### PR TITLE
chore: gentle doc-sync commit hook + minimal tools/ docs

### DIFF
--- a/.claude/hooks/doc-sync-reminder.mjs
+++ b/.claude/hooks/doc-sync-reminder.mjs
@@ -82,7 +82,7 @@ function main() {
 
   const context =
     `📝 Doc-sync reminder — the commit you just made changed application code under ` +
-    `packages/*/src but updated no docs/ files:\n${fileList}\n\n` +
+    `\`packages/*/src\` but updated no \`docs/\` files:\n${fileList}\n\n` +
     `Per docs/maintenance.md, changes to game behavior, tool/subagent contracts, state shape, ` +
     `REST/WebSocket contracts, or on-disk formats should update the matching doc in the same commit.\n\n` +
     `This is only a nudge — use your judgment. If this change is an internal refactor, bug fix, ` +

--- a/.claude/hooks/doc-sync-reminder.mjs
+++ b/.claude/hooks/doc-sync-reminder.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Gentle, NON-BLOCKING doc-sync reminder.
+//
+// Fires as a PostToolUse hook on the Bash tool. It no-ops for everything except
+// a successful `git commit`. When a commit lands that changed application code
+// (packages/*/src/**.ts|tsx) but touched no docs/ files, it injects a soft
+// reminder into the model's context pointing at docs/maintenance.md.
+//
+// It is deliberately advisory: it never blocks, never fails a tool, and it
+// explicitly tells the agent that refactors / bug fixes / tests / internal
+// changes need no documentation. The goal is to catch the case where a
+// behavior/contract change shipped without its doc — not to tax every commit.
+//
+// Scope notes:
+//   - Only packages/*/src code counts. The tools/ helper apps are intentionally
+//     exempt (they carry their own light docs, not the maintenance.md loop).
+//   - Tests (*.test.*, *.spec.*) and declaration files (*.d.ts) never count.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+function main() {
+  let raw = "";
+  try {
+    raw = readFileSync(0, "utf8");
+  } catch {
+    process.exit(0);
+  }
+
+  let input;
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0); // not our concern — stay silent
+  }
+
+  const command = input?.tool_input?.command;
+  if (typeof command !== "string" || !command.includes("git commit")) {
+    process.exit(0);
+  }
+
+  // If the Bash tool reported failure, the commit likely didn't happen — don't
+  // nag based on a stale HEAD.
+  if (input?.tool_response && input.tool_response.success === false) {
+    process.exit(0);
+  }
+
+  // Inspect the files in the most recent commit.
+  const res = spawnSync(
+    "git",
+    ["show", "--name-only", "--pretty=format:", "HEAD"],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+  if (res.status !== 0 || typeof res.stdout !== "string") {
+    process.exit(0);
+  }
+
+  const files = res.stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (files.length === 0) process.exit(0);
+
+  const isCode = (f) =>
+    /^packages\/[^/]+\/src\/.+\.(ts|tsx)$/.test(f) &&
+    !/\.(test|spec)\.[tj]sx?$/.test(f) &&
+    !/\.d\.ts$/.test(f);
+  const isDocs = (f) => f.startsWith("docs/");
+
+  const codeFiles = files.filter(isCode);
+  const docsTouched = files.some(isDocs);
+
+  if (codeFiles.length === 0 || docsTouched) {
+    process.exit(0); // either no app code changed, or docs were updated alongside
+  }
+
+  const shown = codeFiles.slice(0, 10);
+  const more = codeFiles.length - shown.length;
+  const fileList =
+    shown.map((f) => `  - ${f}`).join("\n") +
+    (more > 0 ? `\n  …and ${more} more` : "");
+
+  const context =
+    `📝 Doc-sync reminder — the commit you just made changed application code under ` +
+    `packages/*/src but updated no docs/ files:\n${fileList}\n\n` +
+    `Per docs/maintenance.md, changes to game behavior, tool/subagent contracts, state shape, ` +
+    `REST/WebSocket contracts, or on-disk formats should update the matching doc in the same commit.\n\n` +
+    `This is only a nudge — use your judgment. If this change is an internal refactor, bug fix, ` +
+    `test, perf tweak, comment/formatting change, or otherwise doesn't alter documented behavior, ` +
+    `no docs are needed; don't write documentation that adds no value. If docs ARE warranted, ` +
+    `amend this commit (git commit --amend) or add a follow-up commit before moving on.`;
+
+  process.stdout.write(
+    JSON.stringify({
+      suppressOutput: true,
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: context,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/doc-sync-reminder.mjs",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,15 @@
+# Developer Tools
+
+Standalone helper apps for working **on** Machine Violet — not part of the shipped
+product and not bundled into the launcher. Each is its own npm workspace with its
+own `package.json`; `cd` into one and `npm install` before first use.
+
+| Tool | What it does |
+|---|---|
+| [campaign-explorer](campaign-explorer/README.md) | Real-time web viewer for a campaign's entity files, state JSON, transcripts, and context dumps — watch them update live during gameplay. |
+| [theme-editor](theme-editor/README.md) | Browser previewer for `.theme` / `.player-frame` assets, rendered with the real engine renderer; tweak colors and copy the source back. |
+
+> **Docs scope:** these tools are intentionally kept lightweight. A README that
+> explains what each is and how to run it is enough — they are exempt from the
+> code-and-docs-in-the-same-commit loop in [docs/maintenance.md](../docs/maintenance.md)
+> that governs the application packages.

--- a/tools/theme-editor/README.md
+++ b/tools/theme-editor/README.md
@@ -1,0 +1,63 @@
+# Theme Editor
+
+Browser-based live previewer for Machine Violet's terminal **themes**. It renders
+`.theme` and `.player-frame` assets exactly the way the TUI does — by importing the
+real engine renderer (`packages/client-ink/src/tui/themes/*`) — so what you see in
+the browser is what the game draws. Tweak color keys, watch the conversation frame,
+modals, and player pane update across every style variant, then copy the result
+back into the asset file.
+
+## Quick Start
+
+```bash
+cd tools/theme-editor
+npm install
+npm run dev:server   # Express API on :3998 (serves the asset files)
+npm run dev:client   # Vite dev server on :5198 (proxies /api to :3998)
+```
+
+Open http://localhost:5198 in your browser. (`npm run dev` starts both at once, but
+uses a bash `&`; on Windows run the two commands in separate terminals, or use the
+cross-platform launcher `node scripts/dev.js`.)
+
+## What it shows
+
+- The **conversation frame**, a **modal**, and the **player pane**, rendered from
+  the selected `.theme` / `.player-frame` with sample content.
+- All style **variants** — `exploration`, `combat`, `ooc`, `levelup`, `dev` — so you
+  can check variant color overrides at a glance.
+- Editable color keys with live re-render. Use the editor to dial in colors, then
+  **copy the updated source** and paste it back into the asset file by hand.
+
+## Editing workflow
+
+The server is **read-only** — it never writes asset files. The loop is:
+
+1. Pick a theme in the UI; edit color keys / source until it looks right.
+2. Copy the generated theme source from the editor.
+3. Paste it into the matching file under
+   `packages/client-ink/src/tui/themes/assets/<name>.theme`.
+
+Assets are discovered from `packages/client-ink/src/tui/themes/assets/` (both
+`.theme` and `.player-frame` files).
+
+## Validating assets
+
+To parse + resolve every asset and surface broken art, bad config keys, or unknown
+presets/gradients/harmonies before the TUI tries to render them:
+
+```bash
+# from the repo root
+node --import tsx/esm tools/theme-editor/scripts/validate.mjs
+```
+
+Exit code equals the number of files that failed, so it doubles as a CI check.
+
+## Ports
+
+| Service | Port | Notes |
+|---|---|---|
+| Express API | 3998 | Override with `PORT=…`. |
+| Vite client | 5198 | Pinned to match the `/api` proxy in `vite.config.ts`. |
+
+The two ports are coupled by the Vite proxy — change them together.


### PR DESCRIPTION
## Summary

Two follow-ups to the documentation audit ([#571](https://github.com/octopollux/machine-violet/pull/571)).

### 1. Gentle doc-sync commit hook

`.claude/hooks/doc-sync-reminder.mjs`, wired as a `PostToolUse`/`Bash` hook in project `settings.json`. After a `git commit` that changed `packages/*/src` code but touched no `docs/`, it injects a **non-blocking** nudge into the agent's context pointing at `docs/maintenance.md`.

- **Gentle by design** — it never blocks, denies, or fails the commit, and the message explicitly says refactors / bugfixes / tests / internal changes need no docs and the agent shouldn't force documentation that adds no value.
- **Fires at commit time**, matching maintenance.md's "code and docs in the same commit" principle, and only when app code shipped without docs (so it's quiet on the vast majority of commits).
- **Cross-platform Node script** — no shell/`jq` dependency (the user is on Windows). Tests (`*.test.*`/`*.spec.*`), `*.d.ts`, and the `tools/` helper apps are all excluded from the trigger.

Verified: silent on docs-only commits, non-commit Bash, and test/`.d.ts`/`tools/` changes; fires correctly on a code-only commit (tested with a throwaway probe commit, then reverted).

> Note: Claude Code's settings watcher only reloads `.claude/` config present at session start. Opening `/hooks` once (or restarting) guarantees the hook is live; it's correctly wired either way.

### 2. Minimal tools/ docs

- `tools/theme-editor/README.md` (new) — what it is (live `.theme`/`.player-frame` previewer rendered with the real engine renderer), how to run it, the copy-back editing workflow, the `validate.mjs` asset checker, and ports.
- `tools/README.md` (new) — short index of both helper apps, noting they're intentionally lightweight and exempt from the maintenance.md doc-sync loop.

`campaign-explorer` already had a thorough README, so it was left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)