### PR TITLE
Exclude swap_*/howto_* meta tools from the DM tool list

### DIFF
--- a/docs/tools-catalog.md
+++ b/docs/tools-catalog.md
@@ -157,7 +157,7 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 | Tool | Tier | Caller | Signature | Effect |
 |---|---|---|---|---|
 | `switch_player` | T1 | DM | `({ player })` | Pass the turn between characters **already in the roster** during free play (outside combat). During combat, initiative controls turn order automatically. Rejects a name not in `config.players` — use `swap_pc` to hand control to a new/existing character. |
-| `swap_pc` | T1 | DM / OOC | `({ character, replaces?, color?, player_name? })` | Reassign a roster slot to `character` and make it the active PC (a "PC swap" / handoff). The only tool that edits `config.players`, and it persists `config.json` so the new PC survives reload. Moves the pointer only — pair with `howto_swap_pc` to also fix sheets, party.md, resources, modeline, theme. |
+| `swap_pc` | T1 | OOC, Dev | `({ character, replaces?, color?, player_name? })` | Reassign a roster slot to `character` and make it the active PC (a "PC swap" / handoff). The only tool that edits `config.players`, and it persists `config.json` so the new PC survives reload. Moves the pointer only — pair with `howto_swap_pc` to also fix sheets, party.md, resources, modeline, theme. |
 
 ---
 
@@ -165,8 +165,8 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 
 | Tool | Tier | Caller | Signature | Effect |
 |---|---|---|---|---|
-| `list_dm_personalities` | T1 | DM / OOC | `({})` | List the personas available to swap to (bundled `.mvdm` presets + user additions), each with name + description, plus which is current. Borrows the setup agent's persona catalog (`loadAllPersonalities`) — the in-game agent doesn't otherwise have it in context. |
-| `swap_dm_personality` | T1 | DM / OOC | `({ name, prompt_fragment?, detail?, description? })` | Change the DM's narrative voice for the rest of the campaign. `name` matches a preset, or names a custom persona when `prompt_fragment` is supplied. The only tool that edits `config.dm_personality`; persists `config.json`. Read live each DM turn, so it takes effect next turn (no reload). Pair with `howto_swap_dm_personality` — the new voice must open with an in-fiction handoff. |
+| `list_dm_personalities` | T1 | OOC, Dev | `({})` | List the personas available to swap to (bundled `.mvdm` presets + user additions), each with name + description, plus which is current. Borrows the setup agent's persona catalog (`loadAllPersonalities`) — the in-game agent doesn't otherwise have it in context. |
+| `swap_dm_personality` | T1 | OOC, Dev | `({ name, prompt_fragment?, detail?, description? })` | Change the DM's narrative voice for the rest of the campaign. `name` matches a preset, or names a custom persona when `prompt_fragment` is supplied. The only tool that edits `config.dm_personality`; persists `config.json`. Read live each DM turn, so it takes effect next turn (no reload). Pair with `howto_swap_dm_personality` — the new voice must open with an in-fiction handoff. |
 
 ---
 
@@ -176,9 +176,9 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 
 | Tool | Tier | Caller | Signature | Effect |
 |---|---|---|---|---|
-| `howto_swap_pc` | T1 | DM / OOC | `({})` | Returns the step-by-step playbook for swapping the player character with a new or existing character (roster, character sheets, party.md, resources, modeline, theme). Backed by `prompts/howto-swap-pc.md`. |
-| `howto_swap_dm_personality` | T1 | DM / OOC | `({})` | Returns the playbook for changing the DM personality mid-campaign (list → present → swap → required in-fiction voice handoff). Backed by `prompts/howto-swap-dm-personality.md`. |
-| `howto_campaign_state` | T1 | DM / OOC | `({})` | Catch-all: returns a map of campaign on-disk state and **which tool edits which thing** — the fallback when no dedicated tool obviously fits a change (routes to the right tool, or flags that the edit needs Dev mode). Distilled from [format-spec.md](format-spec.md); backed by `prompts/howto-campaign-state.md`. |
+| `howto_swap_pc` | T1 | OOC, Dev | `({})` | Returns the step-by-step playbook for swapping the player character with a new or existing character (roster, character sheets, party.md, resources, modeline, theme). Backed by `prompts/howto-swap-pc.md`. |
+| `howto_swap_dm_personality` | T1 | OOC, Dev | `({})` | Returns the playbook for changing the DM personality mid-campaign (list → present → swap → required in-fiction voice handoff). Backed by `prompts/howto-swap-dm-personality.md`. |
+| `howto_campaign_state` | T1 | OOC, Dev | `({})` | Catch-all: returns a map of campaign on-disk state and **which tool edits which thing** — the fallback when no dedicated tool obviously fits a change (routes to the right tool, or flags that the edit needs Dev mode). Distilled from [format-spec.md](format-spec.md); backed by `prompts/howto-campaign-state.md`. |
 
 ---
 

--- a/docs/tools-catalog.md
+++ b/docs/tools-catalog.md
@@ -156,7 +156,7 @@ TUI tools are **fire-and-forget**: their results drive engine/UI state but the D
 
 | Tool | Tier | Caller | Signature | Effect |
 |---|---|---|---|---|
-| `switch_player` | T1 | DM | `({ player })` | Pass the turn between characters **already in the roster** during free play (outside combat). During combat, initiative controls turn order automatically. Rejects a name not in `config.players` — use `swap_pc` to hand control to a new/existing character. |
+| `switch_player` | T1 | DM | `({ player })` | Pass the turn between characters **already in the roster** during free play (outside combat). During combat, initiative controls turn order automatically. Rejects a name not in `config.players` — handing control to a new/existing character is a PC swap, done via `swap_pc` on the OOC surface (the DM hands off to OOC to perform it). |
 | `swap_pc` | T1 | OOC, Dev | `({ character, replaces?, color?, player_name? })` | Reassign a roster slot to `character` and make it the active PC (a "PC swap" / handoff). The only tool that edits `config.players`, and it persists `config.json` so the new PC survives reload. Moves the pointer only — pair with `howto_swap_pc` to also fix sheets, party.md, resources, modeline, theme. |
 
 ---

--- a/packages/engine/src/agents/agent-loop.test.ts
+++ b/packages/engine/src/agents/agent-loop.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import type { LLMProvider, ChatResult, ContentPart, NormalizedUsage } from "../providers/types.js";
-import { agentLoop, TUI_TOOLS } from "./agent-loop.js";
+import { agentLoop, TUI_TOOLS, DM_EXCLUDED_TOOLS } from "./agent-loop.js";
 import { extractStatus, retryDelay } from "../utils/retry.js";
 import type { AgentLoopConfig } from "./agent-loop.js";
-import { createTestRegistry } from "./tool-registry.js";
+import { createTestRegistry, registry } from "./tool-registry.js";
 import type { GameState } from "./game-state.js";
 import { createClocksState } from "../tools/clocks/index.js";
 import { createCombatState, createDefaultConfig } from "../tools/combat/index.js";
@@ -470,6 +470,34 @@ describe("thinking block filtering", () => {
     );
     expect(blockTypes).not.toContain("thinking");
     expect(blockTypes).toContain("tool_use");
+  });
+});
+
+describe("DM_EXCLUDED_TOOLS", () => {
+  // The operator-facing meta tools (PC handoff, DM-voice swap, campaign-state
+  // catch-all) live on the OOC/Dev surface, not the in-character narrator's.
+  const META_TOOLS = [
+    "swap_pc",
+    "howto_swap_pc",
+    "list_dm_personalities",
+    "swap_dm_personality",
+    "howto_swap_dm_personality",
+    "howto_campaign_state",
+  ];
+
+  it("excludes the swap_*/howto_* meta tools from the DM tool list", () => {
+    const dmTools = registry.getDefinitions(DM_EXCLUDED_TOOLS).map((t) => t.name);
+    for (const name of META_TOOLS) {
+      expect(dmTools).not.toContain(name);
+    }
+  });
+
+  it("still registers the meta tools (they remain available to OOC/Dev)", () => {
+    // Excluding from the DM view must not unregister them — OOC pulls the
+    // whole registry, so they have to stay in it.
+    for (const name of META_TOOLS) {
+      expect(registry.has(name)).toBe(true);
+    }
   });
 });
 

--- a/packages/engine/src/agents/agent-loop.ts
+++ b/packages/engine/src/agents/agent-loop.ts
@@ -28,8 +28,20 @@ export const TUI_TOOLS = new Set([
   "generate_image",
 ]);
 
-/** Tools registered in the ToolRegistry but only exposed to OOC / Dev Mode agents. */
-const DM_EXCLUDED_TOOLS = new Set(["show_character_sheet", "rollback"]);
+/** Tools registered in the ToolRegistry but only exposed to OOC / Dev Mode agents.
+ *  The `swap_*` / `howto_*` family are operator-facing meta tools (PC handoff,
+ *  DM-voice swap, campaign-state catch-all) — they belong to the OOC surface,
+ *  not the in-character narrator's tool list. */
+export const DM_EXCLUDED_TOOLS = new Set([
+  "show_character_sheet",
+  "rollback",
+  "swap_pc",
+  "howto_swap_pc",
+  "list_dm_personalities",
+  "swap_dm_personality",
+  "howto_swap_dm_personality",
+  "howto_campaign_state",
+]);
 
 // --- Types (canonical definitions) ---
 

--- a/packages/engine/src/agents/subagents/ooc-mode.test.ts
+++ b/packages/engine/src/agents/subagents/ooc-mode.test.ts
@@ -389,6 +389,14 @@ describe("enterOOC with gameState + DM registry", () => {
     expect(names).not.toContain("enter_ooc");
     expect(names).toContain("rollback");
     expect(names).toContain("show_character_sheet");
+    // The swap_*/howto_* meta tools are excluded from the DM list but must
+    // remain on the OOC surface — that's where the operator drives them.
+    expect(names).toContain("swap_pc");
+    expect(names).toContain("swap_dm_personality");
+    expect(names).toContain("list_dm_personalities");
+    expect(names).toContain("howto_swap_pc");
+    expect(names).toContain("howto_swap_dm_personality");
+    expect(names).toContain("howto_campaign_state");
     // Entity surface replaces raw read_file in OOC.
     expect(names).toContain("entity");
     expect(names).toContain("describe_entity_type");

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -682,7 +682,7 @@ const TOOL_DEFS: RegisteredTool[] = [
         const roster = state.config.players.map((p) => p.character).join(", ") || "(none)";
         return err(
           `Player '${input.player}' not found. switch_player only passes the turn between characters already in the roster (${roster}). ` +
-          `To make a character that ISN'T in the roster the player's PC — a handoff to a new or existing character — use swap_pc instead (see howto_swap_pc for the full procedure).`,
+          `Making a character that ISN'T in the roster the player's PC — a handoff to a new or existing character — is a PC swap, performed with swap_pc on the OOC surface (see howto_swap_pc). If you're the DM, hand off to OOC to do it.`,
         );
       }
       state.activePlayerIndex = idx;


### PR DESCRIPTION
## What

The `swap_*` / `howto_*` family (PC handoff, DM-voice swap, campaign-state catch-all) are **operator-facing meta tools** — they belong to the OOC surface, not the in-character narrator's tool list. This pulls all six out of the DM's view:

- `swap_pc`, `howto_swap_pc`
- `list_dm_personalities`, `swap_dm_personality`, `howto_swap_dm_personality`
- `howto_campaign_state`

## How

- **`agent-loop.ts`**: add the six to `DM_EXCLUDED_TOOLS` (now exported). The DM tool list is `registry.getDefinitions(DM_EXCLUDED_TOOLS)`, so they vanish from the DM. OOC pulls the whole registry (minus `enter_ooc`) and Dev Mode pulls it unfiltered, so both keep them.
- **`docs/tools-catalog.md`**: relabel the six rows `DM / OOC` → `OOC, Dev`, matching how `show_character_sheet` is labeled.
- **Tests**: new `DM_EXCLUDED_TOOLS` describe block asserts the DM list omits them while the registry still registers them; the OOC hard-contract test now asserts they remain on the OOC surface.

The tools stay fully registered — this only filters the DM's *view*. No prompt referenced them, so there are no dangling references.

## Validation

`npm run check` + `npx tsc -b` clean. Skipped the live smoketest: this is a static tool-list filter with no session-lifecycle / WebSocket / save-load impact, fully covered by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)