### PR TITLE
fix(resume): make narrative-log population robust to a missing scene transcript

### DIFF
--- a/docs/error-recovery.md
+++ b/docs/error-recovery.md
@@ -34,7 +34,9 @@ rollback({
 })
 ```
 
-**Every rollback backs the campaign up first.** `performRollback` (the single canonical entry every path funnels through) calls `snapshotCampaign` before touching git — a verified zip of the whole campaign (including `.git`) written to `archivedcampaigns/` with an always-timestamped `pre-rollback` name. So the discarded turns are never lost: the backup appears in the **Archived Campaigns** list and restores via the normal unarchive path. If the backup fails, the rollback aborts rather than performing a destructive reset with no safety net.
+**Every rollback backs the campaign up first.** `performRollback` (the single canonical entry every path funnels through) calls `snapshotCampaign` before touching git — a verified zip of the whole campaign (including `.git`, but excluding the regenerable `.debug/` dir) written to `archivedcampaigns/` with an always-timestamped `pre-rollback` name. So the discarded turns are never lost: the backup appears in the **Archived Campaigns** list and restores via the normal unarchive path. Because the zip captures `.git` at the pre-rollback tip (before the reset), restoring it yields a fully working campaign in a fresh slot where the rollback never happened. If the backup fails, the rollback aborts rather than performing a destructive reset with no safety net.
+
+**Don't roll back by hand.** A campaign's on-disk files are a *serialization* of the game, not the game itself — the engine reconstructs "where we are" by inference over the directory tree and replays the narrative log only on the resume path. A bare `git checkout <commit>` leaves HEAD detached (the branch ref doesn't move, so the "future" is still canonical and the next turn either strands work on a dangling commit or overwrites your checkout) and can leave the tree in a shape the resume inference doesn't recognize (blank narrative pane). Use the in-app rollback above to go back, and restore a `pre-rollback` zip from Archived Campaigns to undo one.
 
 After rollback completes, a `RollbackSummaryModal` displays what was restored and waits for the player to press Enter. Internally, rollback restores the target commit, emits a `show_rollback_summary` TUI command, then throws a `RollbackCompleteError` (from `@machine-violet/shared/types/errors.ts`). The session-manager catches it and calls `endSession("rollback")`, which **skips the usual flush + checkpoint** — disk has just been reset to the target commit, but the engine's in-memory state is still ahead by the rolled-back turns, so persisting it would silently undo the rollback. The `show_rollback_summary` command rides the `activity:update` channel to the client ahead of `session:ended`; the client stashes the summary, and when `session:ended` lands it raises `RollbackSummaryModal` (over the now-defunct playing phase) instead of bouncing straight to the menu. Dismissing the modal returns to the main menu; re-entering the campaign loads the restored state via `session_resume`.
 
@@ -50,6 +52,14 @@ After rollback completes, a `RollbackSummaryModal` displays what was restored an
   }
 }
 ```
+
+## Resume vs. new game
+
+On session start the engine decides whether to **resume** an existing campaign (load persisted state, seed the DM's conversation, replay the narrative log) or **start a new game** (generate a fresh opening scene). Getting this wrong in the new-game direction is destructive: the opening narration is appended and committed *on top of* the existing campaign, grafting a new beginning onto old history. Players experience the various ways this can trigger as a single symptom — a **completely missing narrative log**.
+
+The primary signal is the current scene's transcript (`detectSceneState` → `scene.transcript.length > 0`). But that's the *weakest* durable evidence of prior play: a crash between the opening narration and the first transcript flush, a hand-checked-out commit, or a missing scene directory can leave it empty while the campaign plainly has history.
+
+So the decision has a backstop: `hasPriorPlay` ([state-persistence.ts](../packages/engine/src/context/state-persistence.ts)) checks the two signals that outlast any single scene file — `state/conversation.json` (the DM's persisted memory, what resume literally seeds from) and `state/display-log.md` (the human scrollback). If either is non-empty, the session resumes regardless of the transcript, and a `session:resume_recovered` event is logged. Neither file is written during setup, so a genuinely new campaign (no conversation, no scrollback) still starts fresh. This makes narrative-log population robust against the whole class of partial/inconsistent on-disk states, rather than depending on one fragile signal.
 
 ## API Failures
 

--- a/packages/engine/src/config/campaign-archive.test.ts
+++ b/packages/engine/src/config/campaign-archive.test.ts
@@ -206,6 +206,24 @@ describe("snapshotCampaign", () => {
     expect(restored.ok).toBe(true);
     expect(await io.exists(norm(`${restored.zipPath}/config.json`))).toBe(true);
   });
+
+  it("excludes the regenerable .debug/ dir from the snapshot", async () => {
+    const io = createMockIO();
+    const campaignsDir = "/home/user/campaigns";
+    const campaignPath = `${campaignsDir}/test-campaign`;
+    seedCampaign(io, campaignPath);
+    // Seed a .debug/ dir as the live app would (gitignored context dumps).
+    io.fs[norm(`${campaignPath}/.debug/context/dump-1.txt`)] = "huge context dump";
+    io.fs[norm(`${campaignPath}/.debug/crash-1.txt`)] = "stack trace";
+
+    const snap = await snapshotCampaign(campaignPath, campaignsDir, io, { label: "pre-rollback" });
+    const restored = await unarchiveCampaign(snap.zipPath!, campaignsDir, io);
+    expect(restored.ok).toBe(true);
+    // Real campaign content survives; the .debug/ dir is dropped.
+    expect(await io.exists(norm(`${restored.zipPath}/config.json`))).toBe(true);
+    expect(await io.exists(norm(`${restored.zipPath}/.debug/context/dump-1.txt`))).toBe(false);
+    expect(await io.exists(norm(`${restored.zipPath}/.debug/crash-1.txt`))).toBe(false);
+  });
 });
 
 describe("unarchiveCampaign", () => {

--- a/packages/engine/src/config/campaign-archive.ts
+++ b/packages/engine/src/config/campaign-archive.ts
@@ -96,6 +96,12 @@ async function walkAllBinary(
   }
 
   for (const entry of entries) {
+    // Skip the regenerable `.debug/` dir at the campaign root — gitignored
+    // context dumps + crash traces that bloat the (synchronous, rollback-
+    // blocking) snapshot and aren't part of the campaign. Unarchive simply
+    // omits it; the engine recreates it on demand. The /diagnostics bundler
+    // has its own walk (server/diagnostics.ts) and still captures it.
+    if (prefix === "" && entry === ".debug") continue;
     const abs = norm(join(root, entry));
     const rel = prefix ? `${prefix}/${entry}` : entry;
     if (await io.isDirectory(abs)) {
@@ -152,7 +158,8 @@ function fileStamp(): string {
  * Walk → zip → verify-in-memory → write → read-back-verify. Does NOT modify the
  * source folder. Shared by `archiveCampaign` (which then deletes the source)
  * and `snapshotCampaign` (which leaves it in place). `.git` is included, so a
- * round-tripped zip restores the full repo history.
+ * round-tripped zip restores the full repo history; the regenerable `.debug/`
+ * dir is excluded (see `walkAllBinary`).
  */
 async function buildAndWriteVerifiedZip(
   campaignPath: string,

--- a/packages/engine/src/context/state-persistence.test.ts
+++ b/packages/engine/src/context/state-persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { StatePersister, STATE_FILES, CONFIG_FILE } from "./state-persistence.js";
+import { StatePersister, STATE_FILES, CONFIG_FILE, hasPriorPlay } from "./state-persistence.js";
 import type { FileIO } from "../agents/scene-manager.js";
 import type { CombatState } from "@machine-violet/shared/types/combat.js";
 import type { MapData } from "@machine-violet/shared/types/maps.js";
@@ -863,5 +863,40 @@ describe("format spec compliance: JSON formatting (§4)", () => {
     const raw = files[norm(`/tmp/campaign/${STATE_FILES.conversation}`)];
     // Compact JSON has no newlines (single line)
     expect(raw.split("\n")).toHaveLength(1);
+  });
+});
+
+describe("hasPriorPlay", () => {
+  const ROOT = "/tmp/campaign";
+  const convPath = norm(`${ROOT}/${STATE_FILES.conversation}`);
+  const logPath = norm(`${ROOT}/${STATE_FILES.displayLog}`);
+
+  it("returns false for a fresh campaign with no state files", async () => {
+    expect(await hasPriorPlay(ROOT, mockFileIO())).toBe(false);
+  });
+
+  it("returns true when conversation.json has exchanges", async () => {
+    files[convPath] = JSON.stringify([{ user: { role: "user", content: "hi" } }]);
+    expect(await hasPriorPlay(ROOT, mockFileIO())).toBe(true);
+  });
+
+  it("returns true when display-log.md has scrollback (even with no transcript)", async () => {
+    files[logPath] = "The tavern door creaks open.\n> I step inside.\n";
+    expect(await hasPriorPlay(ROOT, mockFileIO())).toBe(true);
+  });
+
+  it("treats an empty conversation array as no prior play", async () => {
+    files[convPath] = "[]";
+    expect(await hasPriorPlay(ROOT, mockFileIO())).toBe(false);
+  });
+
+  it("treats whitespace-only display-log as no prior play", async () => {
+    files[logPath] = "  \n\n";
+    expect(await hasPriorPlay(ROOT, mockFileIO())).toBe(false);
+  });
+
+  it("does not throw on malformed conversation.json — reads as no prior play", async () => {
+    files[convPath] = "{not valid json";
+    expect(await hasPriorPlay(ROOT, mockFileIO())).toBe(false);
   });
 });

--- a/packages/engine/src/context/state-persistence.ts
+++ b/packages/engine/src/context/state-persistence.ts
@@ -266,3 +266,38 @@ export class StatePersister {
     return { combat, clocks, maps, decks, objectives, scene, conversation, ui, usage, resources };
   }
 }
+
+/**
+ * True when a campaign shows durable evidence of prior play, independent of any
+ * single scene's transcript. `conversation.json` (the DM's persisted memory) and
+ * `display-log.md` (the human scrollback) outlast individual scene files: either
+ * being non-empty means the campaign has been played and must be RESUMED, never
+ * reopened as a fresh game over existing data.
+ *
+ * The resume decision otherwise keys solely on the *current* scene's transcript
+ * (`detectSceneState`), which a crash between opening narration and the first
+ * transcript flush — or a hand-checked-out commit, or a missing scene dir — can
+ * leave empty while the campaign plainly has history. Treating those as new
+ * games silently grafts a fresh opening onto the existing campaign, which
+ * players experience as a "completely missing narrative log." This is the
+ * durable backstop against that whole class of failure.
+ *
+ * Best-effort: missing / unreadable / malformed files read as "no prior play".
+ */
+export async function hasPriorPlay(campaignRoot: string, io: FileIO): Promise<boolean> {
+  // conversation.json — a non-empty JSON array of exchanges is the strongest
+  // signal (it's literally what the DM resumes from).
+  try {
+    const raw = await io.readFile(norm(join(campaignRoot, STATE_FILES.conversation)));
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (Array.isArray(parsed) && parsed.length > 0) return true;
+  } catch { /* missing / unreadable / invalid JSON — fall through */ }
+
+  // display-log.md — any non-whitespace scrollback means turns were narrated.
+  try {
+    const raw = await io.readFile(norm(join(campaignRoot, STATE_FILES.displayLog)));
+    if (raw && raw.trim().length > 0) return true;
+  } catch { /* missing / unreadable — fall through */ }
+
+  return false;
+}

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -40,6 +40,7 @@ import { createCombatState } from "../tools/combat/index.js";
 import { createDecksState } from "../tools/cards/index.js";
 import { createObjectivesState } from "../tools/objectives/index.js";
 import { markdownToNarrativeLines, iterDisplayLogReplay } from "../context/display-log.js";
+import { hasPriorPlay } from "../context/state-persistence.js";
 import { CostTracker } from "../context/cost-tracker.js";
 import { TurnManager } from "./turn-manager.js";
 import type { StyleVariant } from "@machine-violet/shared/types/tui.js";
@@ -660,6 +661,20 @@ export class SessionManager {
         sessionNumber: 1,
         sessionRecapPending: false,
       };
+    }
+
+    // The current-scene transcript is the weakest signal of prior play. If it's
+    // empty but conversation.json / display-log.md show history — a crash before
+    // the first transcript flush, a hand-checked-out commit, a missing scene dir
+    // — RESUME anyway. Starting a fresh opening over an existing campaign
+    // silently grafts a new beginning onto old history, which players see as a
+    // vanished narrative log. See hasPriorPlay() and docs/error-recovery.md.
+    if (!isResume && await hasPriorPlay(campaignRoot, fileIO)) {
+      isResume = true;
+      logEvent("session:resume_recovered", {
+        campaignId,
+        reason: "prior-play-without-current-scene-transcript",
+      });
     }
 
     // --- Load DM session state ---

--- a/packages/engine/src/tools/git/campaign-repo.ts
+++ b/packages/engine/src/tools/git/campaign-repo.ts
@@ -376,6 +376,8 @@ interface PruneFileIO {
   exists(path: string): Promise<boolean>;
   listDir(path: string): Promise<string[]>;
   rmdir?(path: string): Promise<void>;
+  /** Real directory check, used when available in place of a name heuristic. */
+  isDirectory?(path: string): Promise<boolean>;
 }
 
 /**
@@ -440,8 +442,14 @@ export async function pruneEmptyDirs(root: string, io: PruneFileIO): Promise<num
       const child = norm(dir) + "/" + entry;
       // Skip dotfiles/dirs (e.g. .git)
       if (entry.startsWith(".")) continue;
-      // Heuristic: entries without a dot extension are likely directories
-      if (!entry.includes(".")) {
+      // Prefer a real directory check; fall back to a name heuristic (entries
+      // without a dot extension). The heuristic is safe for campaign data —
+      // all directory names are slugified, hence dot-free — but a real check
+      // is used whenever the IO exposes one.
+      const isDir = io.isDirectory
+        ? await io.isDirectory(child)
+        : !entry.includes(".");
+      if (isDir) {
         await walk(child);
       }
     }


### PR DESCRIPTION
## Why

Playtesters report that a whole class of minor failure modes surfaces as a single symptom: a **completely missing narrative log** on resume.

Root cause: the resume-vs-new-game decision keyed *solely* on the current scene's transcript (`detectSceneState().transcript.length > 0`) — the weakest durable signal of prior play. A crash between opening narration and the first transcript flush, a hand-checked-out commit, or a missing scene dir leaves it empty while the campaign plainly has history. The engine then started a fresh opening, grafted it onto the existing campaign, and skipped the display-log replay (→ blank pane).

## What

**Primary fix — robust resume detection**
- New `hasPriorPlay(campaignRoot, io)` in `state-persistence.ts` checks the durable signals that outlast any single scene file: `conversation.json` (the DM's persisted memory, what resume seeds from) and `display-log.md` (the human scrollback).
- `session-manager` now resumes when either is non-empty even if the current-scene transcript is absent, logging `session:resume_recovered`. Neither file is written during setup, so genuinely-new campaigns still start fresh.

**Opportunistic cleanups noticed in the same code**
- `campaign-archive`: exclude the regenerable `.debug/` dir from the archive / pre-rollback snapshot walk (gitignored context dumps that bloat the synchronous, rollback-blocking zip). `/diagnostics` has its own walk and still captures it.
- `campaign-repo` `pruneEmptyDirs`: use a real `isDirectory` check when the IO exposes one, falling back to the (slugify-guaranteed dot-free) name heuristic. Production IO currently lacks `isDirectory`, so prod uses the safe fallback; the invariant is now documented.
- `docs/error-recovery.md`: document resume-vs-new-game robustness, the `.debug` exclusion, restore-from-`pre-rollback`-zip recovery, and that a bare `git checkout` is **not** a supported way to roll back.

## Tests
- `hasPriorPlay`: conversation/display-log signals, plus empty-array / whitespace-only / malformed-JSON edge cases.
- `.debug/` snapshot exclusion round-trip.
- Full `npm run check` green (one unrelated flaky `server.test.ts` `beforeEach` timeout under parallel load; passes in isolation).

## Validation
Resume exercised manually in the worktree — works as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)