### PR TITLE
fix(tests): seek-and-destroy flaky tests (shuffle- and load-stable)

### DIFF
--- a/packages/client-ink/src/agent-sidecar.test.ts
+++ b/packages/client-ink/src/agent-sidecar.test.ts
@@ -42,19 +42,19 @@ describe("agent sidecar HTTP", () => {
     }
   });
 
-  async function start(port: number): Promise<void> {
+  async function start(): Promise<void> {
     const state = initialClientState();
     state.engineState = "idle";
     state.mode = "play";
-    handle = await startAgentSidecar(port, () => state);
-    baseUrl = `http://127.0.0.1:${port}`;
+    // Port 0 → OS assigns a free port. Hardcoding a fixed port made these
+    // sequential bind/close cycles flake under load: a rebind could hit
+    // EADDRINUSE while the prior server's port lingered in TIME_WAIT.
+    handle = await startAgentSidecar(0, () => state);
+    baseUrl = `http://127.0.0.1:${handle.port}`;
   }
 
-  // Use a random high port to minimize collisions.
-  const TEST_PORT = 19876;
-
   it("GET /screen returns 200 with text content", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/screen`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/plain");
@@ -63,7 +63,7 @@ describe("agent sidecar HTTP", () => {
   });
 
   it("GET /screen?ansi=true returns 200", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/screen?ansi=true`);
     expect(res.status).toBe(200);
     const text = await res.text();
@@ -71,7 +71,7 @@ describe("agent sidecar HTTP", () => {
   });
 
   it("GET /state returns valid ClientState JSON", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/state`);
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -81,7 +81,7 @@ describe("agent sidecar HTTP", () => {
   });
 
   it("POST /input/key with known key returns 204", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/input/key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -91,7 +91,7 @@ describe("agent sidecar HTTP", () => {
   });
 
   it("POST /input/key with unknown key returns 400 with known list", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/input/key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -105,7 +105,7 @@ describe("agent sidecar HTTP", () => {
   });
 
   it("POST /input/key with invalid JSON returns 400", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/input/key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -115,7 +115,7 @@ describe("agent sidecar HTTP", () => {
   });
 
   it("POST /input with raw body returns 204", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/input`, {
       method: "POST",
       body: "hello",
@@ -124,7 +124,7 @@ describe("agent sidecar HTTP", () => {
   });
 
   it("unknown route returns 404", async () => {
-    await start(TEST_PORT);
+    await start();
     const res = await fetch(`${baseUrl}/nope`);
     expect(res.status).toBe(404);
   });
@@ -150,9 +150,8 @@ describe("agent sidecar stdout tee", () => {
   });
 
   it("installs and restores the process.stdout.write wrapper", async () => {
-    const TEST_PORT = 19877;
     const originalWrite = process.stdout.write;
-    handle = await startAgentSidecar(TEST_PORT, () => initialClientState());
+    handle = await startAgentSidecar(0, () => initialClientState());
 
     // After startAgentSidecar, process.stdout.write must be a different
     // function — that's our tee. If this assertion ever flips back to

--- a/packages/client-ink/src/agent-sidecar.ts
+++ b/packages/client-ink/src/agent-sidecar.ts
@@ -66,6 +66,8 @@ function readBody(req: IncomingMessage): Promise<Buffer> {
 // ---------------------------------------------------------------------------
 
 export interface SidecarHandle {
+  /** Port the server actually bound to — authoritative when `port: 0` (OS-assigned) is passed. */
+  readonly port: number;
   close(): Promise<void>;
 }
 
@@ -96,19 +98,6 @@ export async function startAgentSidecar(
   // Track terminal resize.
   const onResize = () => term.resize(process.stdout.columns || 80, process.stdout.rows || 24);
   process.stdout.on("resize", onResize);
-
-  // --- Stdout tee ---
-  // Installed AFTER syncWriteCombiner so we see atomic frames.
-  const originalWrite: NodeJS.WriteStream["write"] = process.stdout.write;
-  process.stdout.write = function (
-    chunk: string | Uint8Array,
-    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
-    cb?: (err?: Error | null) => void,
-  ): boolean {
-    const str = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
-    term.write(str);
-    return originalWrite.call(process.stdout, chunk, encodingOrCb as BufferEncoding, cb) as boolean;
-  } as NodeJS.WriteStream["write"];
 
   // --- Screen reading ---
   function readScreen(): string {
@@ -185,19 +174,44 @@ export async function startAgentSidecar(
     }
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(port, "127.0.0.1", () => {
-      server.removeListener("error", reject);
-      resolve();
+  // Bind BEFORE touching global process.stdout. A failed listen (e.g. the port
+  // is briefly held in TIME_WAIT after a previous server on the same port
+  // closed) must not leave the stdout tee — or the resize listener — installed
+  // process-wide, which would silently corrupt unrelated renders/output.
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, "127.0.0.1", () => {
+        server.removeListener("error", reject);
+        resolve();
+      });
     });
-  });
+  } catch (err) {
+    process.stdout.removeListener("resize", onResize);
+    term.dispose();
+    throw err;
+  }
 
   const addr = server.address();
   const boundPort = typeof addr === "object" && addr ? addr.port : port;
   process.stderr.write(`Agent sidecar listening on http://127.0.0.1:${boundPort}\n`);
 
+  // --- Stdout tee ---
+  // Installed only AFTER a successful listen (and AFTER syncWriteCombiner) so
+  // we see atomic frames and never leak the global wrapper on a failed start.
+  const originalWrite: NodeJS.WriteStream["write"] = process.stdout.write;
+  process.stdout.write = function (
+    chunk: string | Uint8Array,
+    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void,
+  ): boolean {
+    const str = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+    term.write(str);
+    return originalWrite.call(process.stdout, chunk, encodingOrCb as BufferEncoding, cb) as boolean;
+  } as NodeJS.WriteStream["write"];
+
   return {
+    port: boundPort,
     async close() {
       process.stdout.write = originalWrite;
       process.stdout.removeListener("resize", onResize);

--- a/packages/client-ink/src/tui/hooks/useBatchedNarrativeLines.test.tsx
+++ b/packages/client-ink/src/tui/hooks/useBatchedNarrativeLines.test.tsx
@@ -34,8 +34,9 @@ describe("useBatchedNarrativeLines", () => {
       return <Text>{lines.map((l) => l.text).join("|") || "empty"}</Text>;
     }
     const { lastFrame } = render(<C />);
-    await sleep(50);
-    expect(lastFrame()!).toContain("Hello");
+    // Direct set flushes immediately, but the render still needs an effect
+    // cycle — waitFor instead of a fixed sleep so it can't flake under load.
+    await vi.waitFor(() => expect(lastFrame()!).toContain("Hello"));
   });
 
   it("batches functional updates and flushes on timer", async () => {
@@ -78,9 +79,9 @@ describe("useBatchedNarrativeLines", () => {
       return <Text>{lines.map((l) => l.text).join("|") || "empty"}</Text>;
     }
     const { lastFrame } = render(<C />);
-    await sleep(50);
-    expect(lastFrame()!).toContain("new");
-    // After the original flush interval, should still show "new" not "old"
+    await vi.waitFor(() => expect(lastFrame()!).toContain("new"));
+    // After the original flush interval (200ms) the cleared functional update
+    // must not resurface — wait past it, then confirm it's still "new", not "old".
     await sleep(250);
     expect(lastFrame()!).toContain("new");
   });

--- a/packages/engine/src/config/context-dump.test.ts
+++ b/packages/engine/src/config/context-dump.test.ts
@@ -13,8 +13,16 @@ vi.mock("node:fs/promises", () => ({
   mkdir: vi.fn(async () => {}),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   resetContextDump();
+  // The mocked fs/promises module exposes ONE writeFile/mkdir spy shared by the
+  // whole file. dump*() records its writeFile call synchronously, so a prior
+  // test's call lingers in mock.calls. Clear here — not just in the tests that
+  // remember to — so the no-op guards that assert `not.toHaveBeenCalled()` pass
+  // regardless of execution order (shuffle-safe).
+  const fs = await import("node:fs/promises");
+  (fs.writeFile as ReturnType<typeof vi.fn>).mockClear();
+  (fs.mkdir as ReturnType<typeof vi.fn>).mockClear();
 });
 
 // --- dumpContext guards ---

--- a/packages/engine/src/context/state-persistence.test.ts
+++ b/packages/engine/src/context/state-persistence.test.ts
@@ -508,15 +508,19 @@ describe("write serialization", () => {
   });
 
   it("concurrent writes to different files proceed independently", async () => {
-    const callTimes: Record<string, number[]> = {};
+    // Record a start/end event log instead of wall-clock timestamps: a
+    // wall-clock delta threshold flakes under load (GC pauses, parallel test
+    // workers) and on coarse clocks. Event ordering distinguishes concurrent
+    // from serialized deterministically.
+    const events: string[] = [];
     const fio = mockFileIO();
     (fio.writeFile as ReturnType<typeof vi.fn>).mockImplementation(
       async (path: string, content: string) => {
         const key = norm(path);
-        if (!callTimes[key]) callTimes[key] = [];
-        callTimes[key].push(Date.now());
+        events.push(`start:${key}`);
         await new Promise((r) => setTimeout(r, 20));
         files[key] = content;
+        events.push(`end:${key}`);
       },
     );
 
@@ -525,13 +529,15 @@ describe("write serialization", () => {
     persister.persistClocks(createClocksState());
 
     await persister.flush();
-    // Both files were written
+    // Both files were written exactly once.
     const combatKey = norm("/tmp/campaign/state/combat.json");
     const clocksKey = norm("/tmp/campaign/state/clocks.json");
-    expect(callTimes[combatKey]).toHaveLength(1);
-    expect(callTimes[clocksKey]).toHaveLength(1);
-    // They started concurrently (within 5ms of each other)
-    expect(Math.abs(callTimes[combatKey][0] - callTimes[clocksKey][0])).toBeLessThan(15);
+    expect(events.filter((e) => e === `start:${combatKey}`)).toHaveLength(1);
+    expect(events.filter((e) => e === `start:${clocksKey}`)).toHaveLength(1);
+    // Writes to different files are concurrent, not per-file serialized: both
+    // START before either FINISHES. A serialized scheduler would instead
+    // produce start→end→start→end.
+    expect(events.slice(0, 2).every((e) => e.startsWith("start:"))).toBe(true);
   });
 
   it("error in one write does not block subsequent writes", async () => {


### PR DESCRIPTION
## Summary

Hunted intermittent test failures with **shuffled-order** runs (order-dependence; `vi.mock` is file-scoped) and full-suite runs under sustained **`tsc -b --force` contention** (the load condition that actually surfaces timing flakes — plain CPU stress and fixed-seed/no-load runs both hid them). Four root-cause fixes:

### 1. `context-dump.test.ts` — the dominant flake (reproduced 3/5 shuffled suite runs)
The `dumpContext` "is a no-op" guard was the only test that never cleared the shared module-level `fs/promises` `writeFile` mock. vitest sets no global `clearMocks`, so under shuffled order a prior writing test's recorded call lingered and tripped `not.toHaveBeenCalled()`. Now cleared in `beforeEach`.

### 2. `agent-sidecar` — strongest candidate for the rare "2 files failed" event
- The test hardcoded a fixed port across **8 sequential bind/close cycles** (its own comment called for a random one) → `EADDRINUSE` under load (TIME_WAIT).
- Worse, `startAgentSidecar` installed the global `process.stdout.write` tee **before** binding and never restored it on a failed `listen` — leaking the wrapper process-wide, which can corrupt unrelated renders (a plausible two-file cascade).

Fix: OS-assigned port (`0`), expose the bound port on `SidecarHandle`, install the tee **only after** a successful listen, and clean up (`removeListener`/`dispose`) on failure.

### 3. `state-persistence.test.ts`
"concurrent writes" asserted a `<15ms` wall-clock delta between two `Date.now()` reads — flaky under load and on coarse clocks. Now asserts deterministic start/end **event ordering** instead.

### 4. `useBatchedNarrativeLines.test.tsx`
Two tests used a bare `sleep(50)` before a positive assertion; converted the appearance checks to `vi.waitFor` (the file's own existing precedent), keeping the post-interval absence wait.

## Validation
- **172 files / 3072 tests green** across many shuffled runs and **5 full-suite runs under sustained `tsc -b --force` contention** (the original trigger).
- `typecheck` + `lint` clean.
- Per-fix stress: context-dump+state-persistence 12/12 shuffled seeds; agent-sidecar 10/10; useBatchedNarrativeLines 12/12.

## Note
The two rare load-failures observed once could not be deterministically re-triggered; #1 is empirically confirmed-and-fixed, #2 is a clear structural root cause, #3/#4 are preventive hardening of unambiguous fragilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)