### PR TITLE
test: deterministic record/replay e2e (Tier-2) — tape infra + first golden

### DIFF
--- a/docs/e2e-harness-v2-plan.md
+++ b/docs/e2e-harness-v2-plan.md
@@ -58,8 +58,8 @@ working pattern; reuse its `ChatResult` fixtures as the tape schema reference.
 ## Hooks (final)
 
 - **pre-commit** (lefthook — net-new tooling): lint `--cache` + `vitest related $(git diff --cached
-  --name-only)` (Tier-1 + in-process Tier-2). Scoped, **blocking**, offline, seconds.
-- **pre-push:** full `npm run check` + `golden:verify`. ~80s, once before sharing.
+  --name-only)` — **Tier-1 + unit only** (cheap, a few seconds, offline). NOT Tier-2 goldens: cold-importing the engine module graph is ~20–30s, too heavy per commit.
+- **pre-push:** full `npm run check` (which includes Tier-2 `golden:verify`). This is where goldens run — ~80s+, once before sharing.
 - **No per-edit / per-turn hooks.** Live tiers (`smoketest`, `golden:record`) **never** auto-run.
 - npm scripts: `golden:record` (live, taping), `golden:verify` + `golden:verify:changed` (deterministic).
   Fold `golden:verify` into `check`, gated on tape existence.

--- a/docs/e2e-harness-v2-plan.md
+++ b/docs/e2e-harness-v2-plan.md
@@ -1,0 +1,104 @@
+# E2E Harness v2 — Implementation Plan
+
+> **Status:** in progress (started 2026-06-04). This is a temporary implementation tracker.
+> When the slices land, its content folds into a rewritten `e2e-harness.md` and this file is removed.
+
+## Why
+
+The old e2e backbone — keystroke injection over the agent sidecar + 200ms HTTP polling, driven through the
+live `/smoketest` against the real LLM — is flaky by construction. It races real async LLM/subagent
+activity (scribe dropping keystrokes, ESC-menu phantom-close, setup-overlay stickiness, poll latency). No
+framework fixes that; the fix is architectural: stop driving non-deterministic LLM flows through keystroke
+injection as the verification layer. Gemini CLI (same Ink/React stack) reached the same conclusion —
+golden/mocked model responses, assert on effects.
+
+## The model — three tiers, deterministic-first
+
+1. **Tier 1 — component/render.** `ink-testing-library`, in-process. Already healthy (~30 files in
+   `packages/client-ink`); just expand. Where modal bleed-through, overlay choreography, layout belong.
+2. **Tier 2 — full-stack deterministic (the backbone).** Record/replay "session tapes": wrap `LLMProvider`
+   to tape real request/response pairs; drive **logical inputs** (`said X`, `picked choice 2`) not raw
+   keystrokes; the **real engine runs**; replay needs **no API key, no network**. Implemented as
+   **in-process vitest tests** so goldens ride the same `vitest related` pass as Tier 1.
+3. **Tier 3 — thin live smoke.** Asserts on **behavior** (engine events + save files via REST/programmatic
+   seams), run rarely. The repurposed `/smoketest`. Not the backbone.
+
+**Load-bearing capability:** a Claude live-pilots the game **once** to record a golden tape (logical inputs
++ real LLM I/O + resulting events/frames). Replay thereafter needs no Claude and no API. Regenerating a
+stale golden = re-pilot once + review a **readable git diff** — never hand-edit a tape.
+
+## Wiring (new code)
+
+| File | Role |
+|---|---|
+| `packages/engine/src/providers/tape-provider.ts` | `LLMProvider` record/replay decorator. Record: forward + tape. Replay: serve from tape, no network, throw loudly on miss. Must cover `chat`/`stream` and `generateImage`; replay `getCapabilities` verbatim. |
+| `packages/engine/src/providers/tape.ts` | Tape format + serializer + matcher. Human-readable JSON, image bytes out-of-line (content-addressed) for diffable goldens. Lives in `engine` (not `test-harness`) so the dependency runs test-harness → engine. |
+| `packages/test-harness/src/replay-runner.ts` | Boots the real engine in-process in replay mode, injects logical inputs via a programmatic seam, asserts on engine events / save files / (optionally) frames. |
+| `packages/test-harness/tapes/<scenario>/` | Golden fixtures, one dir per scenario. |
+| `packages/test-harness/src/index.ts` | New barrel exports for the above. |
+
+**Seam:** wrap each `TierProvider.provider` at `buildTierProvidersWithCache`
+(`packages/engine/src/config/tier-resolver.ts`), env-gated (`MV_TAPE_MODE=record|replay` + `MV_TAPE_PATH`).
+One chokepoint covers DM + every subagent + setup + scribe + choice-gen + image-gen — no per-agent plumbing.
+The interface is already hand-mocked in `agent-loop-bridge.test.ts`, so the shim is a generalization of a
+working pattern; reuse its `ChatResult` fixtures as the tape schema reference.
+
+## Locked decisions
+
+- **Tape matching:** ordinal-per-agent-bucket + loose request validation. A benign prompt-wording tweak
+  yields a readable diff + one re-record, not a cache-miss storm.
+- **Record against the API-key provider, NOT codex.** The codex/app-server path runs the whole tool loop
+  inside one `chat()` (opaque to the bridge, unstable to serialize). Codex path is covered by Tier-3 only.
+- **Tier-2 = in-process vitest** (no per-test engine boot).
+- **Determinism normalization:** replay `tool_use` IDs verbatim (so the bridge re-pairs tool_use↔tool_result
+  and `normalizeTurn` is stable); thinking `signature` / `redacted_thinking` / reasoning blobs opaque
+  verbatim; image base64 out-of-line; record usage counts but exclude from matching; ignore
+  timestamps/`durationMs`; scope `engine.jsonl` reads by `launchedAt`.
+
+## Hooks (final)
+
+- **pre-commit** (lefthook — net-new tooling): lint `--cache` + `vitest related $(git diff --cached
+  --name-only)` (Tier-1 + in-process Tier-2). Scoped, **blocking**, offline, seconds.
+- **pre-push:** full `npm run check` + `golden:verify`. ~80s, once before sharing.
+- **No per-edit / per-turn hooks.** Live tiers (`smoketest`, `golden:record`) **never** auto-run.
+- npm scripts: `golden:record` (live, taping), `golden:verify` + `golden:verify:changed` (deterministic).
+  Fold `golden:verify` into `check`, gated on tape existence.
+
+## Surfaces to build / rewrite
+
+- **Skills:** `record-tape` (new, load-bearing), `replay-goldens` (new backbone — absorbs old "did I break
+  it" triggers), `smoketest` (rewrite → Tier-3), `play` (repurpose → record substrate), `dump-state` (keep).
+- **Docs:** rewrite `e2e-harness.md` in place + `CLAUDE.md` "Validating changes end-to-end"; new
+  `golden-tapes.md` + `tape-format.md`; retarget `maintenance.md`; recaption module-map/architecture/dev-plan.
+- **Memories:** rewrite `feedback_harness_design.md` (keep principles, re-scope framing); add
+  `project_tiered_e2e_testing.md`; update `MEMORY.md` lines.
+
+## Retirement
+
+Demote — not delete — the keystroke-injection + 200ms-polling **backbone status**. The sidecar/session-driver
+machinery survives as the record pilot's live-driving substrate. The smoketest probe body is the scenario
+blueprint; its keystroke choreography (`navigateToRealChoice`, stale-overlay/fingerprint dance) is retired.
+
+## Slices
+
+1. **Tier-2 core** — `tape.ts` + `tape-provider.ts` + env wiring at the seam.
+   1a. Prove **replay** against a hand-authored minimal tape, real engine in-process, **no API**.
+       (Surfaces edge #3 programmatic-input seam + edge #4 assertion target.)
+   1b. One **live record** → real golden → replays green offline.
+2. npm scripts + lefthook pre-commit/pre-push + permission entry.
+3. Skills: `record-tape` + `replay-goldens`; rewrite/demote `smoketest`; `play` record-mode.
+4. Docs rewrite (same commit as the code each describes).
+5. Memories.
+6. Record the initial corpus (10–15 scenarios).
+
+Main branch only — new infra, not a release bug.
+
+## Open edges (resolved during build / deferred)
+
+- **CI enforcement** of `golden:verify` on PRs — **deferred** until the pre-commit hook proves stable.
+- **Programmatic input seam** — replay injects via REST; `endSession()` exists, a "submit turn / select
+  choice" endpoint may need adding. Verify in slice 1a.
+- **Tier-2 assertion target** — engine-events + save-files (engine in-process, cheap) vs. frame snapshots
+  (needs the Ink client too). Lean: Tier-2 asserts on events/saves; leave frame-level to Tier-1. Confirm 1a.
+- **Freshness guard** — periodic real-API *structural* re-pilot (tool-calls/state-transitions still match
+  though text drifts) so tapes can't silently lie. Design after the rest is solid.

--- a/docs/e2e-harness-v2-plan.md
+++ b/docs/e2e-harness-v2-plan.md
@@ -1,6 +1,8 @@
 # E2E Harness v2 — Implementation Plan
 
-> **Status:** in progress (started 2026-06-04). This is a temporary implementation tracker.
+> **Status:** in progress (started 2026-06-04). Record→replay loop **CLOSED 2026-06-05** — first
+> golden (`dm-open-door`) recorded live and replaying offline through the real `GameEngine`. This is a
+> temporary implementation tracker.
 > When the slices land, its content folds into a rewritten `e2e-harness.md` and this file is removed.
 
 ## Why

--- a/packages/engine/src/agents/game-engine-replay.test.ts
+++ b/packages/engine/src/agents/game-engine-replay.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tier-2 deterministic backbone — proof of life.
+ *
+ * Drives a real {@link GameEngine} turn end-to-end through the record/replay
+ * provider shims with NO network and NO API key:
+ *   1. RECORD — a mock LLM stands in for the real provider; the taping decorator
+ *      captures whatever the engine actually sends (correct `conversationId`
+ *      buckets, no guessing).
+ *   2. REPLAY — a pure tape-backed provider drives a FRESH engine over the same
+ *      logical input and must produce identical narrative while making ZERO
+ *      live provider calls.
+ *
+ * This is the seam the full replay-runner generalizes (load a recorded scenario,
+ * inject the replay provider, drive logical inputs, assert). The scaffolding
+ * mirrors game-engine.test.ts; the replay-runner will factor it into a shared
+ * fixture so this duplication is temporary.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { GameEngine } from "./game-engine.js";
+import type { EngineCallbacks } from "./game-engine.js";
+import type { GameState } from "./game-state.js";
+import type { SceneState, FileIO } from "./scene-manager.js";
+import type { DMSessionState } from "./dm-prompt.js";
+import type { ChatResult, LLMProvider, TierProvider } from "../providers/types.js";
+import type { ModelTier } from "@machine-violet/shared/types/engine.js";
+import { createClocksState } from "../tools/clocks/index.js";
+import { createCombatState, createDefaultConfig } from "../tools/combat/index.js";
+import { createDecksState } from "../tools/cards/index.js";
+import { createObjectivesState } from "../tools/objectives/index.js";
+import { norm } from "../utils/paths.js";
+import { TapeReader, TapeWriter, deserializeTape, serializeTape } from "../providers/tape.js";
+import { createReplayProvider, createTapingProvider } from "../providers/tape-provider.js";
+
+// Mirror game-engine.test.ts's subagent mocks so a plain turn makes exactly one
+// (DM) provider call — keeps the deterministic surface we're proving minimal.
+vi.mock("./subagents/scribe.js", () => ({
+  runScribe: vi.fn(async () => ({
+    summary: "",
+    created: [],
+    updated: [],
+    entityDeltas: [],
+    removedSlugs: [],
+    usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  })),
+}));
+vi.mock("./subagents/scene-tracker.js", () => ({
+  SCENE_TRACKER_CADENCE: 4,
+  trackScene: vi.fn(async () => ({
+    text: "",
+    usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+    openThreads: "",
+  })),
+}));
+vi.mock("./subagents/ai-player.js", () => ({ aiPlayerTurn: vi.fn() }));
+vi.mock("./subagents/character-promotion.js", () => ({ promoteCharacter: vi.fn() }));
+
+function textMessage(text: string): ChatResult {
+  return {
+    text,
+    toolCalls: [],
+    usage: { inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 },
+    stopReason: "end",
+    assistantContent: [{ type: "text", text }],
+  };
+}
+
+/** A mock LLM that plays back canned responses; stands in for a real provider during RECORD. */
+function recordingMock(responses: ChatResult[]): LLMProvider {
+  let idx = 0;
+  return {
+    providerId: "mock",
+    getCapabilities: () => ({ imageGeneration: false }),
+    chat: vi.fn(async () => responses[idx++]),
+    stream: vi.fn(async () => responses[idx++]),
+    healthCheck: vi.fn(async () => ({ status: "valid", message: "ok" })),
+  };
+}
+
+function providerCallCount(p: LLMProvider): number {
+  return (
+    (p.chat as ReturnType<typeof vi.fn>).mock.calls.length +
+    (p.stream as ReturnType<typeof vi.fn>).mock.calls.length
+  );
+}
+
+function mockState(): GameState {
+  return {
+    maps: {},
+    clocks: createClocksState(),
+    combat: createCombatState(),
+    combatConfig: createDefaultConfig(),
+    decks: createDecksState(),
+    objectives: createObjectivesState(),
+    config: {
+      name: "Test",
+      dm_personality: { name: "grim", prompt_fragment: "Be terse." },
+      players: [{ name: "Alice", character: "Aldric", type: "human" }],
+      combat: createDefaultConfig(),
+      context: { retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 },
+      recovery: { auto_commit_interval: 300, max_commits: 100, enable_git: false },
+      choices: { campaign_default: "never", player_overrides: {} },
+    },
+    campaignRoot: "/tmp/test-campaign",
+    homeDir: "/tmp/home",
+    activePlayerIndex: 0,
+    displayResources: {},
+    resourceValues: {},
+  };
+}
+
+function mockScene(): SceneState {
+  return {
+    sceneNumber: 1,
+    slug: "test-scene",
+    transcript: [],
+    precis: "",
+    openThreads: "",
+    npcIntents: "",
+    playerReads: [],
+    sessionNumber: 1,
+    sessionRecapPending: false,
+  };
+}
+
+/** Each engine gets its own in-memory FileIO so record and replay don't share state. */
+function mockFileIO(): FileIO {
+  const files: Record<string, string> = {};
+  const dirs = new Set<string>();
+  return {
+    readFile: async (p) => files[norm(p)] ?? "",
+    writeFile: async (p, c) => { files[norm(p)] = c; },
+    appendFile: async (p, c) => { files[norm(p)] = (files[norm(p)] ?? "") + c; },
+    mkdir: async (p) => { dirs.add(norm(p)); },
+    exists: async (p) => norm(p) in files || dirs.has(norm(p)),
+    listDir: async () => [],
+  };
+}
+
+function tiers(provider: LLMProvider): Record<ModelTier, TierProvider> {
+  return {
+    large: { provider, model: "claude-opus-4-6" },
+    medium: { provider, model: "claude-sonnet-4-6" },
+    small: { provider, model: "claude-haiku-4-5-20251001" },
+  };
+}
+
+function captureCallbacks() {
+  const narrative: string[] = [];
+  const errors: Error[] = [];
+  const callbacks: EngineCallbacks = {
+    onNarrativeDelta: () => {},
+    onNarrativeComplete: (t) => narrative.push(t),
+    onStateChange: () => {},
+    onTuiCommand: () => {},
+    onToolStart: () => {},
+    onToolEnd: () => {},
+    onExchangeDropped: () => {},
+    onUsageUpdate: () => {},
+    onError: (e) => errors.push(e),
+    onDevLog: () => {},
+    onRetry: () => {},
+    onTurnStart: () => {},
+    onTurnEnd: () => {},
+  };
+  return { callbacks, narrative, errors };
+}
+
+function makeEngine(provider: LLMProvider, callbacks: EngineCallbacks): GameEngine {
+  return new GameEngine({
+    provider,
+    tierProviders: tiers(provider),
+    gameState: mockState(),
+    scene: mockScene(),
+    sessionState: {} as DMSessionState,
+    fileIO: mockFileIO(),
+    callbacks,
+  });
+}
+
+describe("GameEngine record/replay (Tier-2 deterministic backbone)", () => {
+  it("replays a DM turn through the real engine with no live provider calls", async () => {
+    const dmText = "The door creaks open, hinges groaning in the dark.";
+
+    // --- RECORD: mock LLM stands in; taping captures the engine's real traffic.
+    const mock = recordingMock([textMessage(dmText)]);
+    const writer = new TapeWriter("dm-open-door");
+    const taping = createTapingProvider(mock, writer);
+    const rec = captureCallbacks();
+    await makeEngine(taping, rec.callbacks).processInput("Aldric", "I open the door.");
+
+    expect(rec.errors).toEqual([]);
+    expect(rec.narrative).toContain(dmText);
+
+    const callsAfterRecord = providerCallCount(mock);
+    expect(callsAfterRecord).toBeGreaterThanOrEqual(1);
+
+    // --- REPLAY: serialize, then a pure tape-backed provider drives a fresh engine.
+    const tape = deserializeTape(serializeTape(writer.build()));
+    const replay = createReplayProvider(new TapeReader(tape));
+    const rep = captureCallbacks();
+    await makeEngine(replay, rep.callbacks).processInput("Aldric", "I open the door.");
+
+    expect(rep.errors).toEqual([]);
+    expect(rep.narrative).toEqual(rec.narrative); // identical behavior...
+    expect(providerCallCount(mock)).toBe(callsAfterRecord); // ...with ZERO live calls during replay
+  });
+});

--- a/packages/engine/src/providers/tape-mode.test.ts
+++ b/packages/engine/src/providers/tape-mode.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { ChatParams, ChatResult, LLMProvider, TierProvider } from "./types.js";
+import type { ModelTier } from "@machine-violet/shared/types/engine.js";
+import { __resetTapeModeForTest, getRecordedTape, wrapForRecording } from "./tape-mode.js";
+
+function result(text: string): ChatResult {
+  return {
+    text,
+    toolCalls: [],
+    usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 },
+    stopReason: "end",
+    assistantContent: [{ type: "text", text }],
+  };
+}
+
+function fakeProvider(id: string): LLMProvider {
+  return {
+    providerId: id,
+    getCapabilities: () => ({ imageGeneration: false }),
+    chat: vi.fn(async () => result(`${id}-reply`)),
+    stream: vi.fn(async () => result(`${id}-reply`)),
+    healthCheck: vi.fn(async () => ({ status: "valid", message: "ok" })),
+  };
+}
+
+function params(conversationId: string): ChatParams {
+  return { model: "m", systemPrompt: "s", messages: [{ role: "user", content: "hi" }], maxTokens: 10, conversationId };
+}
+
+function tiers(large: LLMProvider, medium: LLMProvider, small: LLMProvider): Record<ModelTier, TierProvider> {
+  return { large: { provider: large, model: "L" }, medium: { provider: medium, model: "M" }, small: { provider: small, model: "S" } };
+}
+
+describe("tape-mode record wiring", () => {
+  beforeEach(() => { __resetTapeModeForTest(); });
+  afterEach(() => {
+    delete process.env.MV_TAPE_MODE;
+    delete process.env.MV_TAPE_SCENARIO;
+    __resetTapeModeForTest();
+  });
+
+  it("is a pass-through no-op when MV_TAPE_MODE is not 'record'", () => {
+    const t = tiers(fakeProvider("a"), fakeProvider("b"), fakeProvider("c"));
+    expect(wrapForRecording(t)).toBe(t); // same object, untouched
+    expect(getRecordedTape()).toBeNull();
+  });
+
+  it("tapes calls across tiers into one tape, deduping a shared provider", async () => {
+    process.env.MV_TAPE_MODE = "record";
+    process.env.MV_TAPE_SCENARIO = "unit";
+
+    const large = fakeProvider("large");
+    const shared = fakeProvider("shared");
+    const w = wrapForRecording(tiers(large, shared, shared));
+
+    // medium + small share one inner provider → one wrapper instance.
+    expect(w.medium.provider).toBe(w.small.provider);
+    expect(w.large.provider).not.toBe(w.medium.provider);
+
+    await w.large.provider.chat(params("dm"));
+    await w.medium.provider.chat(params("scribe"));
+
+    const tape = getRecordedTape();
+    expect(tape?.scenario).toBe("unit");
+    expect(tape?.entries.map((e) => e.bucket)).toEqual(["dm", "scribe"]);
+  });
+});

--- a/packages/engine/src/providers/tape-mode.ts
+++ b/packages/engine/src/providers/tape-mode.ts
@@ -1,0 +1,66 @@
+/**
+ * Record-mode wiring for session tapes.
+ *
+ * When `MV_TAPE_MODE=record`, {@link wrapForRecording} decorates the per-tier
+ * providers so every LLM interaction across setup + gameplay is taped into one
+ * process-global {@link TapeWriter}. The recorded tape is read back out-of-band
+ * by the test-harness recorder (via a dev-only engine route) AFTER the live
+ * pilot finishes — we deliberately do NOT flush on process exit, because the
+ * harness force-kills the process tree (`taskkill /F`), which skips exit
+ * handlers (see packages/test-harness/src/harness.ts).
+ *
+ * Replay does NOT go through here: the deterministic Tier-2 runner constructs
+ * the engine in-process with a replay provider directly.
+ *
+ * Production never sets `MV_TAPE_MODE`, so `wrapForRecording` is an identity
+ * pass-through and these providers behave exactly as built.
+ */
+import type { ModelTier } from "@machine-violet/shared/types/engine.js";
+import type { LLMProvider, TierProvider } from "./types.js";
+import { TapeWriter, type Tape } from "./tape.js";
+import { createTapingProvider } from "./tape-provider.js";
+
+function recordingActive(): boolean {
+  return process.env.MV_TAPE_MODE === "record";
+}
+
+let writer: TapeWriter | null = null;
+function getWriter(): TapeWriter {
+  if (!writer) writer = new TapeWriter(process.env.MV_TAPE_SCENARIO ?? "session");
+  return writer;
+}
+
+// Dedupe by inner-provider identity: tiers commonly share one provider
+// instance (e.g. medium + small on the same connection), and wrapping each
+// TierProvider separately would tape the same calls twice.
+let wrapped = new WeakMap<LLMProvider, LLMProvider>();
+
+/**
+ * If recording is active, return a tier map whose providers tape every call
+ * into the shared writer; otherwise return `tiers` unchanged. Safe (and
+ * intended) to call unconditionally at every provider-resolution site.
+ */
+export function wrapForRecording(tiers: Record<ModelTier, TierProvider>): Record<ModelTier, TierProvider> {
+  if (!recordingActive()) return tiers;
+  const w = getWriter();
+  const wrap = (tp: TierProvider): TierProvider => {
+    let taping = wrapped.get(tp.provider);
+    if (!taping) {
+      taping = createTapingProvider(tp.provider, w);
+      wrapped.set(tp.provider, taping);
+    }
+    return { provider: taping, model: tp.model };
+  };
+  return { large: wrap(tiers.large), medium: wrap(tiers.medium), small: wrap(tiers.small) };
+}
+
+/** The tape recorded so far this process, or null if not recording. */
+export function getRecordedTape(): Tape | null {
+  return recordingActive() && writer ? writer.build() : null;
+}
+
+/** Test-only: clear the process-global recorder state between cases. */
+export function __resetTapeModeForTest(): void {
+  writer = null;
+  wrapped = new WeakMap<LLMProvider, LLMProvider>();
+}

--- a/packages/engine/src/providers/tape-provider.test.ts
+++ b/packages/engine/src/providers/tape-provider.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import type {
+  ChatParams,
+  ChatResult,
+  GenerateImageResult,
+  LLMProvider,
+  NormalizedMessage,
+  NormalizedUsage,
+  ProviderCapabilities,
+} from "./types.js";
+import { TapeReader, TapeWriter, deserializeTape, serializeTape } from "./tape.js";
+import { createReplayProvider, createTapingProvider } from "./tape-provider.js";
+
+function usage(): NormalizedUsage {
+  return { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 };
+}
+
+function result(text: string): ChatResult {
+  return { text, toolCalls: [], usage: usage(), stopReason: "end", assistantContent: [{ type: "text", text }] };
+}
+
+function params(messages: NormalizedMessage[], conversationId?: string): ChatParams {
+  return { model: "model-x", systemPrompt: "sys", messages, maxTokens: 100, conversationId };
+}
+
+function imageResult(): GenerateImageResult {
+  return { base64: "AAAA", mimeType: "image/png", effortUsed: "draft", aspectUsed: "square" };
+}
+
+/** A fake inner provider whose outputs encode the input so we can assert routing. */
+function fakeInner(): LLMProvider {
+  return {
+    providerId: "fake",
+    getCapabilities: (_model): ProviderCapabilities => ({ imageGeneration: true }),
+    chat: vi.fn(async (p: ChatParams) => result(`chat:${p.messages.length}`)),
+    stream: vi.fn(async (_p: ChatParams, onDelta: (t: string) => void) => {
+      onDelta("alpha");
+      onDelta("beta");
+      return result("streamed");
+    }),
+    healthCheck: vi.fn(async () => ({ status: "valid" as const, message: "ok" })),
+    generateImage: vi.fn(async () => imageResult()),
+  };
+}
+
+/** Record a representative session, then return a replay provider over the serialized tape. */
+function recordThenReplay() {
+  const inner = fakeInner();
+  const writer = new TapeWriter("unit");
+  const taping = createTapingProvider(inner, writer);
+  return { inner, writer, taping, build: () => createReplayProvider(new TapeReader(deserializeTape(serializeTape(writer.build())))) };
+}
+
+describe("createTapingProvider", () => {
+  it("forwards to the inner provider and records each interaction", async () => {
+    const { inner, taping, writer } = recordThenReplay();
+
+    expect(taping.getCapabilities("model-x")).toEqual({ imageGeneration: true });
+    await taping.chat(params([{ role: "user", content: "a" }], "dm"));
+    const deltas: string[] = [];
+    await taping.stream(params([{ role: "user", content: "b" }], "dm"), (d) => deltas.push(d));
+
+    expect(inner.chat).toHaveBeenCalledOnce();
+    expect(inner.stream).toHaveBeenCalledOnce();
+    expect(deltas).toEqual(["alpha", "beta"]); // deltas tee through to the caller
+
+    const tape = writer.build();
+    expect(tape.entries).toHaveLength(2);
+    expect(tape.entries[1]).toMatchObject({ kind: "chat", bucket: "dm", ordinal: 1, streamDeltas: ["alpha", "beta"] });
+    expect(tape.capabilities["model-x"]).toEqual({ imageGeneration: true });
+  });
+
+  it("only exposes generateImage when the inner provider does", () => {
+    const withImages = createTapingProvider(fakeInner(), new TapeWriter("s"));
+    expect(withImages.generateImage).toBeDefined();
+
+    const noImageInner: LLMProvider = { ...fakeInner(), generateImage: undefined };
+    const withoutImages = createTapingProvider(noImageInner, new TapeWriter("s"));
+    expect(withoutImages.generateImage).toBeUndefined();
+  });
+});
+
+describe("createReplayProvider", () => {
+  it("replays recorded results deterministically with no inner provider", async () => {
+    const rec = recordThenReplay();
+    const r1 = await rec.taping.chat(params([{ role: "user", content: "a" }], "dm"));
+    const sdeltas: string[] = [];
+    const r2 = await rec.taping.stream(params([{ role: "user", content: "b" }], "scribe"), (d) => sdeltas.push(d));
+
+    const replay = rec.build();
+    expect(replay.getCapabilities("model-x")).toEqual({ imageGeneration: true });
+
+    // Matching is by bucket + ordinal, so replay ignores request content.
+    expect(await replay.chat(params([{ role: "user", content: "ANYTHING" }], "dm"))).toEqual(r1);
+    const rdeltas: string[] = [];
+    expect(await replay.stream(params([{ role: "user", content: "ELSE" }], "scribe"), (d) => rdeltas.push(d))).toEqual(r2);
+    expect(rdeltas).toEqual(["alpha", "beta"]);
+  });
+
+  it("replays images in recorded order", async () => {
+    const rec = recordThenReplay();
+    await rec.taping.generateImage!({ prompt: "a portrait" });
+    const replay = rec.build();
+    expect(await replay.generateImage!({ prompt: "ignored" })).toEqual(imageResult());
+  });
+
+  it("throws a clear stale-tape error on a chat miss", async () => {
+    const rec = recordThenReplay();
+    await rec.taping.chat(params([{ role: "user", content: "only one" }], "dm"));
+    const replay = rec.build();
+    await replay.chat(params([{ role: "user", content: "x" }], "dm")); // ordinal 0 — ok
+    await expect(replay.chat(params([{ role: "user", content: "y" }], "dm"))).rejects.toThrow(/Tape miss/);
+  });
+
+  it("reports no image-gen capability for an unrecorded model", () => {
+    const replay = createReplayProvider(new TapeReader({ version: 1, scenario: "empty", capabilities: {}, entries: [] }));
+    expect(replay.getCapabilities("unknown-model")).toEqual({ imageGeneration: false });
+  });
+});

--- a/packages/engine/src/providers/tape-provider.ts
+++ b/packages/engine/src/providers/tape-provider.ts
@@ -1,0 +1,132 @@
+/**
+ * Record/replay decorators around {@link LLMProvider} — the Tier-2 seam.
+ *
+ * - {@link createTapingProvider} wraps a real provider and tapes every
+ *   `chat`/`stream`/`generateImage` result while forwarding to the inner
+ *   provider unchanged. Used during a live record pilot.
+ * - {@link createReplayProvider} satisfies the whole `LLMProvider` interface
+ *   from a {@link TapeReader} with NO inner provider and NO network — the
+ *   deterministic backbone. A request with no matching taped entry throws
+ *   loudly ("tape is stale, re-record") rather than falling back to the wire.
+ *
+ * Both are wired in at `buildTierProvidersWithCache` (the single chokepoint
+ * every engine LLM call resolves its provider through), gated by an env flag,
+ * so production never sees either.
+ */
+import type {
+  ChatParams,
+  ChatResult,
+  GenerateImageRequest,
+  GenerateImageResult,
+  HealthCheckResult,
+  LLMProvider,
+  ProviderCapabilities,
+} from "./types.js";
+import { bucketOf, type TapeReader, type TapeWriter } from "./tape.js";
+
+/** Wrap a real provider so every interaction is appended to `writer`. */
+export function createTapingProvider(inner: LLMProvider, writer: TapeWriter): LLMProvider {
+  const taping: LLMProvider = {
+    providerId: `taping:${inner.providerId}`,
+
+    getCapabilities(model: string): ProviderCapabilities {
+      const caps = inner.getCapabilities(model);
+      writer.recordCapabilities(model, caps);
+      return caps;
+    },
+
+    async chat(params: ChatParams): Promise<ChatResult> {
+      // Capture caps opportunistically (cheap + pure) so any chatted model is
+      // self-sufficient in the tape, even if nothing called getCapabilities.
+      writer.recordCapabilities(params.model, inner.getCapabilities(params.model));
+      const result = await inner.chat(params);
+      writer.recordChat(bucketOf(params), params, result);
+      return result;
+    },
+
+    async stream(params: ChatParams, onDelta: (text: string) => void): Promise<ChatResult> {
+      writer.recordCapabilities(params.model, inner.getCapabilities(params.model));
+      const deltas: string[] = [];
+      const result = await inner.stream(params, (d) => {
+        deltas.push(d);
+        onDelta(d);
+      });
+      writer.recordChat(bucketOf(params), params, result, deltas);
+      return result;
+    },
+
+    healthCheck: (model?: string) => inner.healthCheck(model),
+  };
+
+  // Forward optional members only when the inner provider supports them, so
+  // capability probes (e.g. `provider.generateImage != null`) stay accurate.
+  // Bind the narrowed reference rather than using `!` (forbidden by lint).
+  if (inner.generateImage) {
+    const generateImage = inner.generateImage.bind(inner);
+    taping.generateImage = async (req: GenerateImageRequest): Promise<GenerateImageResult> => {
+      const result = await generateImage(req);
+      writer.recordImage(req, result);
+      return result;
+    };
+  }
+  if (inner.getUsageStatus) taping.getUsageStatus = inner.getUsageStatus.bind(inner);
+  if (inner.subscribeUsage) taping.subscribeUsage = inner.subscribeUsage.bind(inner);
+  if (inner.dispose) taping.dispose = inner.dispose.bind(inner);
+
+  return taping;
+}
+
+/** Build a provider that serves entirely from a recorded tape (no network). */
+export function createReplayProvider(reader: TapeReader): LLMProvider {
+  const cursors = new Map<string, number>();
+  let imageCursor = 0;
+
+  function takeChat(params: ChatParams) {
+    const bucket = bucketOf(params);
+    const ordinal = cursors.get(bucket) ?? 0;
+    cursors.set(bucket, ordinal + 1);
+    const entry = reader.chatAt(bucket, ordinal);
+    if (!entry) {
+      throw new Error(
+        `Tape miss: no chat entry for bucket="${bucket}" ordinal=${ordinal}. ` +
+          `The tape is stale (request: model=${params.model}, messages=${params.messages.length}). Re-record the golden.`,
+      );
+    }
+    return entry;
+  }
+
+  return {
+    providerId: "replay",
+
+    getCapabilities(model: string): ProviderCapabilities {
+      // Unrecorded model → assume no image-gen so the engine omits that tooling.
+      return reader.capabilities(model) ?? { imageGeneration: false };
+    },
+
+    async chat(params: ChatParams): Promise<ChatResult> {
+      return takeChat(params).result;
+    },
+
+    async stream(params: ChatParams, onDelta: (text: string) => void): Promise<ChatResult> {
+      const entry = takeChat(params);
+      // Re-emit recorded deltas; fall back to one delta of the full text for
+      // entries taped via non-streaming chat().
+      for (const d of entry.streamDeltas ?? [entry.result.text]) onDelta(d);
+      return entry.result;
+    },
+
+    async healthCheck(): Promise<HealthCheckResult> {
+      return { status: "valid", message: "replay provider (no network)" };
+    },
+
+    async generateImage(_req: GenerateImageRequest): Promise<GenerateImageResult> {
+      const entry = reader.imageAt(imageCursor++);
+      if (!entry) {
+        throw new Error(
+          `Tape miss: no image entry at ordinal ${imageCursor - 1}. The tape is stale. Re-record the golden.`,
+        );
+      }
+      return entry.result;
+    },
+  };
+}

--- a/packages/engine/src/providers/tape.test.ts
+++ b/packages/engine/src/providers/tape.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type { ChatParams, ChatResult, NormalizedMessage, NormalizedUsage } from "./types.js";
+import {
+  TAPE_VERSION,
+  TapeReader,
+  TapeWriter,
+  bucketOf,
+  deserializeTape,
+  fingerprint,
+  serializeTape,
+} from "./tape.js";
+
+function usage(): NormalizedUsage {
+  return { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheCreationTokens: 0, reasoningTokens: 0 };
+}
+
+function result(text: string): ChatResult {
+  return { text, toolCalls: [], usage: usage(), stopReason: "end", assistantContent: [{ type: "text", text }] };
+}
+
+function params(messages: NormalizedMessage[], conversationId?: string): ChatParams {
+  return { model: "model-x", systemPrompt: "system prompt", messages, maxTokens: 100, conversationId };
+}
+
+describe("bucketOf", () => {
+  it("uses conversationId, falling back to 'default'", () => {
+    expect(bucketOf({ conversationId: "dm" })).toBe("dm");
+    expect(bucketOf({ conversationId: undefined })).toBe("default");
+  });
+});
+
+describe("fingerprint", () => {
+  it("captures model, message count, sorted tools, and a last-message preview", () => {
+    const fp = fingerprint({
+      model: "m",
+      systemPrompt: "sys",
+      messages: [{ role: "user", content: "first" }, { role: "user", content: "  the   last\nmessage " }],
+      maxTokens: 50,
+      tools: [{ name: "zebra", description: "", inputSchema: {} }, { name: "apple", description: "", inputSchema: {} }],
+      dispatchTool: async () => ({ content: "" }),
+    });
+    expect(fp.model).toBe("m");
+    expect(fp.messageCount).toBe(2);
+    expect(fp.tools).toEqual(["apple", "zebra"]);
+    expect(fp.lastMessagePreview).toBe("the last message");
+    expect(fp.systemHash).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it("hashes the system prompt stably across calls", () => {
+    const a = fingerprint(params([{ role: "user", content: "x" }]));
+    const b = fingerprint(params([{ role: "user", content: "y" }]));
+    expect(a.systemHash).toBe(b.systemHash); // same system → same hash
+  });
+});
+
+describe("TapeWriter / TapeReader ordinals", () => {
+  it("assigns independent ordinals per bucket", () => {
+    const w = new TapeWriter("s");
+    w.recordChat("dm", params([{ role: "user", content: "a" }], "dm"), result("dm0"));
+    w.recordChat("scribe", params([{ role: "user", content: "b" }], "scribe"), result("scribe0"));
+    w.recordChat("dm", params([{ role: "user", content: "c" }], "dm"), result("dm1"));
+
+    const r = new TapeReader(w.build());
+    expect(r.chatAt("dm", 0)?.result.text).toBe("dm0");
+    expect(r.chatAt("dm", 1)?.result.text).toBe("dm1");
+    expect(r.chatAt("scribe", 0)?.result.text).toBe("scribe0");
+    expect(r.chatAt("dm", 2)).toBeUndefined();
+  });
+});
+
+describe("serializeTape / deserializeTape", () => {
+  it("round-trips a tape through JSON", () => {
+    const w = new TapeWriter("round-trip");
+    w.recordCapabilities("model-x", { imageGeneration: true });
+    w.recordChat("dm", params([{ role: "user", content: "hello" }], "dm"), result("hi there"));
+    const tape = w.build();
+
+    const restored = deserializeTape(serializeTape(tape));
+    expect(restored).toEqual(tape);
+    expect(restored.version).toBe(TAPE_VERSION);
+  });
+
+  it("rejects an unknown tape version", () => {
+    expect(() => deserializeTape(JSON.stringify({ version: 999, scenario: "x", capabilities: {}, entries: [] }))).toThrow(
+      /Unsupported tape version/,
+    );
+  });
+});

--- a/packages/engine/src/providers/tape.ts
+++ b/packages/engine/src/providers/tape.ts
@@ -1,0 +1,207 @@
+/**
+ * Session-tape format for deterministic record/replay testing (Tier 2).
+ *
+ * A tape captures every LLM interaction a session made — `chat`/`stream`
+ * results and `generateImage` results — keyed so a later run can replay them
+ * with no network. Text turns are bucketed by `conversationId` (the agent
+ * name: "dm", "scribe", setup, …) and matched **ordinally** within a bucket:
+ * the Nth call in bucket B during replay returns the Nth recorded entry for B.
+ *
+ * Matching is deliberately loose. We do NOT hash the full request and demand
+ * an exact match — prompts churn constantly, and a benign wording tweak should
+ * yield a readable diff + one re-record, not a cache-miss storm. The stored
+ * {@link RequestFingerprint} is for human diff-legibility and soft validation,
+ * not for keying.
+ *
+ * Lives in `engine` (not `test-harness`) because it serializes engine-owned
+ * types (`ChatResult` et al.); the replay runner in `test-harness` imports it,
+ * keeping the dependency direction test-harness → engine.
+ */
+import { createHash } from "node:crypto";
+import type {
+  ChatParams,
+  ChatResult,
+  GenerateImageRequest,
+  GenerateImageResult,
+  ProviderCapabilities,
+  SystemBlock,
+} from "./types.js";
+
+export const TAPE_VERSION = 1 as const;
+
+/** Bucket used for `generateImage` calls (they carry no `conversationId`). */
+export const IMAGE_BUCKET = "__image__";
+
+/**
+ * Compact, readable fingerprint of a request. Stored for diff-legibility and
+ * soft validation — NEVER used as the match key (that's bucket + ordinal).
+ */
+export interface RequestFingerprint {
+  model: string;
+  /** Message count on this call (grows each turn). */
+  messageCount: number;
+  /** Short sha256 prefix of the system prompt text — catches system drift. */
+  systemHash: string;
+  /** Tool names offered on this call, sorted. */
+  tools: string[];
+  /** Truncated preview of the last message's text, for human scanning. */
+  lastMessagePreview: string;
+}
+
+export interface TapeChatEntry {
+  kind: "chat";
+  bucket: string;
+  ordinal: number;
+  request: RequestFingerprint;
+  result: ChatResult;
+  /** Deltas as recorded from `stream`; absent for non-streaming `chat` calls. */
+  streamDeltas?: string[];
+}
+
+export interface TapeImageEntry {
+  kind: "image";
+  bucket: typeof IMAGE_BUCKET;
+  ordinal: number;
+  request: GenerateImageRequest;
+  // TODO(corpus slice): move base64 out-of-line (content-addressed sidecar)
+  // so image-bearing goldens stay diffable. Inline is fine for text-only tapes.
+  result: GenerateImageResult;
+}
+
+export type TapeEntry = TapeChatEntry | TapeImageEntry;
+
+export interface Tape {
+  version: typeof TAPE_VERSION;
+  scenario: string;
+  /** Per-model capability snapshot captured at record time, replayed verbatim. */
+  capabilities: Record<string, ProviderCapabilities>;
+  entries: TapeEntry[];
+}
+
+/** The replay bucket for a request: its agent chain id, or "default". */
+export function bucketOf(params: Pick<ChatParams, "conversationId">): string {
+  return params.conversationId ?? "default";
+}
+
+function systemText(system: string | SystemBlock[]): string {
+  return typeof system === "string" ? system : system.map((b) => b.text).join("\n");
+}
+
+function shortHash(s: string): string {
+  return createHash("sha256").update(s).digest("hex").slice(0, 12);
+}
+
+function lastMessagePreview(params: ChatParams): string {
+  const last = params.messages.at(-1);
+  if (!last) return "";
+  const text =
+    typeof last.content === "string"
+      ? last.content
+      : last.content.map((p) => (p.type === "text" ? p.text : `[${p.type}]`)).join(" ");
+  return text.replace(/\s+/g, " ").trim().slice(0, 120);
+}
+
+export function fingerprint(params: ChatParams): RequestFingerprint {
+  return {
+    model: params.model,
+    messageCount: params.messages.length,
+    systemHash: shortHash(systemText(params.systemPrompt)),
+    tools: (params.tools ?? []).map((t) => t.name).sort(),
+    lastMessagePreview: lastMessagePreview(params),
+  };
+}
+
+/**
+ * Accumulates a tape during a record run. One writer spans the whole session
+ * (and, for a setup→game scenario, both sessions) so buckets stay continuous.
+ */
+export class TapeWriter {
+  private readonly entries: TapeEntry[] = [];
+  private readonly caps: Record<string, ProviderCapabilities> = {};
+  private readonly cursors = new Map<string, number>();
+
+  constructor(readonly scenario: string) {}
+
+  private nextOrdinal(bucket: string): number {
+    const ordinal = this.cursors.get(bucket) ?? 0;
+    this.cursors.set(bucket, ordinal + 1);
+    return ordinal;
+  }
+
+  recordCapabilities(model: string, caps: ProviderCapabilities): void {
+    this.caps[model] = caps;
+  }
+
+  recordChat(bucket: string, params: ChatParams, result: ChatResult, streamDeltas?: string[]): void {
+    this.entries.push({
+      kind: "chat",
+      bucket,
+      ordinal: this.nextOrdinal(bucket),
+      request: fingerprint(params),
+      result,
+      ...(streamDeltas ? { streamDeltas } : {}),
+    });
+  }
+
+  recordImage(request: GenerateImageRequest, result: GenerateImageResult): void {
+    this.entries.push({
+      kind: "image",
+      bucket: IMAGE_BUCKET,
+      ordinal: this.nextOrdinal(IMAGE_BUCKET),
+      request,
+      result,
+    });
+  }
+
+  build(): Tape {
+    return { version: TAPE_VERSION, scenario: this.scenario, capabilities: this.caps, entries: this.entries };
+  }
+}
+
+/** Indexed read access over a tape for the replay provider. */
+export class TapeReader {
+  private readonly chatsByBucket = new Map<string, TapeChatEntry[]>();
+  private readonly imageEntries: TapeImageEntry[] = [];
+
+  constructor(private readonly tape: Tape) {
+    for (const e of tape.entries) {
+      if (e.kind === "chat") {
+        const arr = this.chatsByBucket.get(e.bucket) ?? [];
+        arr.push(e);
+        this.chatsByBucket.set(e.bucket, arr);
+      } else {
+        this.imageEntries.push(e);
+      }
+    }
+    for (const arr of this.chatsByBucket.values()) arr.sort((a, b) => a.ordinal - b.ordinal);
+    this.imageEntries.sort((a, b) => a.ordinal - b.ordinal);
+  }
+
+  get scenario(): string {
+    return this.tape.scenario;
+  }
+
+  capabilities(model: string): ProviderCapabilities | undefined {
+    return this.tape.capabilities[model];
+  }
+
+  chatAt(bucket: string, ordinal: number): TapeChatEntry | undefined {
+    return this.chatsByBucket.get(bucket)?.[ordinal];
+  }
+
+  imageAt(ordinal: number): TapeImageEntry | undefined {
+    return this.imageEntries[ordinal];
+  }
+}
+
+export function serializeTape(tape: Tape): string {
+  return JSON.stringify(tape, null, 2) + "\n";
+}
+
+export function deserializeTape(json: string): Tape {
+  const parsed = JSON.parse(json) as Tape;
+  if (parsed.version !== TAPE_VERSION) {
+    throw new Error(`Unsupported tape version ${parsed.version} (expected ${TAPE_VERSION}); re-record the golden.`);
+  }
+  return parsed;
+}

--- a/packages/engine/src/providers/tape.ts
+++ b/packages/engine/src/providers/tape.ts
@@ -154,7 +154,9 @@ export class TapeWriter {
   }
 
   build(): Tape {
-    return { version: TAPE_VERSION, scenario: this.scenario, capabilities: this.caps, entries: this.entries };
+    // Snapshot: copy the array + object so a stored tape doesn't mutate if
+    // recording continues (e.g. getRecordedTape() read mid-session).
+    return { version: TAPE_VERSION, scenario: this.scenario, capabilities: { ...this.caps }, entries: [...this.entries] };
   }
 }
 

--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -26,6 +26,7 @@ import { getActivePlayer } from "../agents/player-manager.js";
 import { loadEnv } from "../config/first-launch.js";
 import { loadConnectionStore, buildEffectiveConnections } from "../config/connections.js";
 import { buildTierProvidersWithCache } from "../config/tier-resolver.js";
+import { wrapForRecording } from "../providers/tape-mode.js";
 import type { LLMProvider } from "../providers/types.js";
 import { configDir, norm } from "../utils/paths.js";
 import { processingPaths } from "../config/processing-paths.js";
@@ -574,7 +575,8 @@ export class SessionManager {
     const connStore = buildEffectiveConnections(loadConnectionStore(appConfigDir), appConfigDir);
     const { createAnthropicProvider } = await import("../providers/anthropic.js");
     const tierResolution = buildTierProvidersWithCache(connStore, () => createAnthropicProvider(), appConfigDir);
-    const tierProviders = tierResolution.tiers;
+    // Tapes every LLM call when MV_TAPE_MODE=record; identity pass-through otherwise.
+    const tierProviders = wrapForRecording(tierResolution.tiers);
 
     // Track unique providers for end-of-session disposal. Stateful providers
     // (openai-chatgpt) own subprocesses that linger across sessions otherwise.

--- a/packages/engine/src/server/setup-session.ts
+++ b/packages/engine/src/server/setup-session.ts
@@ -25,6 +25,7 @@ import { processingPaths } from "../config/processing-paths.js";
 import { readBundledRuleCard } from "../config/systems.js";
 import { loadConnectionStore, buildEffectiveConnections } from "../config/connections.js";
 import { buildTierProvidersWithCache } from "../config/tier-resolver.js";
+import { wrapForRecording } from "../providers/tape-mode.js";
 import { createAnthropicProvider } from "../providers/index.js";
 import type { LLMProvider, TierProvider } from "../providers/types.js";
 import type { ModelTier } from "../config/models.js";
@@ -84,7 +85,8 @@ export class SetupSession {
     // setup was missing it, breaking any campaign whose large tier
     // resolves to an openai-chatgpt connection.
     const resolution = buildTierProvidersWithCache(connStore, () => createAnthropicProvider(), appConfigDir);
-    this.tierProviders = resolution.tiers;
+    // Tapes every LLM call when MV_TAPE_MODE=record; identity pass-through otherwise.
+    this.tierProviders = wrapForRecording(resolution.tiers);
     this.providersByConnectionId = resolution.byConnectionId;
     this.provider = this.tierProviders.large.provider;
     this.model = this.tierProviders.large.model;

--- a/packages/engine/src/testing/dm-turn-golden.test.ts
+++ b/packages/engine/src/testing/dm-turn-golden.test.ts
@@ -1,0 +1,170 @@
+/**
+ * First golden: a real DM turn, recorded once against the live API, replayed
+ * deterministically forever after.
+ *
+ * Two halves, one scenario:
+ *  - RECORD (gated by RECORD_GOLDENS=1 + a live key): a real Anthropic provider
+ *    drives the scenario; the taping decorator captures the LLM I/O and we
+ *    persist {tape, expectedNarrative} as the golden. This is the only half
+ *    that spends API — run it to (re)generate the golden, then commit it.
+ *  - REPLAY (always, offline; skipped until the golden exists): a pure
+ *    tape-backed provider drives the SAME scenario and must reproduce the
+ *    recorded narrative with no network.
+ *
+ * Regenerating a stale golden = re-run with RECORD_GOLDENS=1 and review the
+ * git diff. This is the engine-level golden path; setup/full-stack goldens
+ * (which need the child-process stack) come later via a GET /tape recorder.
+ */
+import { describe, it, expect } from "vitest";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { GameEngine } from "../agents/game-engine.js";
+import type { EngineCallbacks } from "../agents/game-engine.js";
+import type { GameState } from "../agents/game-state.js";
+import type { SceneState, FileIO } from "../agents/scene-manager.js";
+import type { DMSessionState } from "../agents/dm-prompt.js";
+import type { LLMProvider, TierProvider } from "../providers/types.js";
+import type { ModelTier } from "@machine-violet/shared/types/engine.js";
+import { createClocksState } from "../tools/clocks/index.js";
+import { createCombatState, createDefaultConfig } from "../tools/combat/index.js";
+import { createDecksState } from "../tools/cards/index.js";
+import { createObjectivesState } from "../tools/objectives/index.js";
+import { norm } from "../utils/paths.js";
+import { TapeReader, deserializeTape, serializeTape, type Tape } from "../providers/tape.js";
+import { createReplayProvider, createTapingProvider } from "../providers/tape-provider.js";
+import { TapeWriter } from "../providers/tape.js";
+import { createAnthropicProvider } from "../providers/index.js";
+import { loadEnv } from "../config/first-launch.js";
+
+const GOLDEN_PATH = fileURLToPath(new URL("./goldens/dm-open-door.golden.json", import.meta.url));
+
+// The single source of truth for the scenario — record and replay MUST use it
+// identically, or the replay won't line up with the taped responses.
+const SCENARIO_MODEL = "claude-haiku-4-5-20251001"; // cheap; the golden replays regardless of model
+const SCENARIO_INPUT = { character: "Aldric", text: "I open the door." } as const;
+
+interface Golden {
+  tape: Tape;
+  expectedNarrative: string[];
+}
+
+function mockState(): GameState {
+  return {
+    maps: {},
+    clocks: createClocksState(),
+    combat: createCombatState(),
+    combatConfig: createDefaultConfig(),
+    decks: createDecksState(),
+    objectives: createObjectivesState(),
+    config: {
+      name: "Test",
+      dm_personality: { name: "grim", prompt_fragment: "Be terse." },
+      players: [{ name: "Alice", character: "Aldric", type: "human" }],
+      combat: createDefaultConfig(),
+      context: { retention_exchanges: 5, max_conversation_tokens: 8000, tool_result_stub_after: 2 },
+      recovery: { auto_commit_interval: 300, max_commits: 100, enable_git: false },
+      choices: { campaign_default: "never", player_overrides: {} },
+    },
+    campaignRoot: "/tmp/test-campaign",
+    homeDir: "/tmp/home",
+    activePlayerIndex: 0,
+    displayResources: {},
+    resourceValues: {},
+  };
+}
+
+function mockScene(): SceneState {
+  return {
+    sceneNumber: 1,
+    slug: "test-scene",
+    transcript: [],
+    precis: "",
+    openThreads: "",
+    npcIntents: "",
+    playerReads: [],
+    sessionNumber: 1,
+    sessionRecapPending: false,
+  };
+}
+
+function mockFileIO(): FileIO {
+  const files: Record<string, string> = {};
+  const dirs = new Set<string>();
+  return {
+    readFile: async (p) => files[norm(p)] ?? "",
+    writeFile: async (p, c) => { files[norm(p)] = c; },
+    appendFile: async (p, c) => { files[norm(p)] = (files[norm(p)] ?? "") + c; },
+    mkdir: async (p) => { dirs.add(norm(p)); },
+    exists: async (p) => norm(p) in files || dirs.has(norm(p)),
+    listDir: async () => [],
+  };
+}
+
+function tiers(provider: LLMProvider): Record<ModelTier, TierProvider> {
+  return {
+    large: { provider, model: SCENARIO_MODEL },
+    medium: { provider, model: SCENARIO_MODEL },
+    small: { provider, model: SCENARIO_MODEL },
+  };
+}
+
+function captureCallbacks() {
+  const narrative: string[] = [];
+  const errors: Error[] = [];
+  const callbacks: EngineCallbacks = {
+    onNarrativeDelta: () => {},
+    onNarrativeComplete: (t) => narrative.push(t),
+    onStateChange: () => {},
+    onTuiCommand: () => {},
+    onToolStart: () => {},
+    onToolEnd: () => {},
+    onExchangeDropped: () => {},
+    onUsageUpdate: () => {},
+    onError: (e) => errors.push(e),
+    onDevLog: () => {},
+    onRetry: () => {},
+    onTurnStart: () => {},
+    onTurnEnd: () => {},
+  };
+  return { callbacks, narrative, errors };
+}
+
+async function runScenario(provider: LLMProvider): Promise<{ narrative: string[]; errors: Error[] }> {
+  const cap = captureCallbacks();
+  const engine = new GameEngine({
+    provider,
+    tierProviders: tiers(provider),
+    gameState: mockState(),
+    scene: mockScene(),
+    sessionState: {} as DMSessionState,
+    fileIO: mockFileIO(),
+    callbacks: cap.callbacks,
+  });
+  await engine.processInput(SCENARIO_INPUT.character, SCENARIO_INPUT.text);
+  return { narrative: cap.narrative, errors: cap.errors };
+}
+
+describe("golden: dm-open-door", () => {
+  it.skipIf(!process.env.RECORD_GOLDENS)("records the golden (live API)", async () => {
+    loadEnv();
+    const writer = new TapeWriter("dm-open-door");
+    const { narrative, errors } = await runScenario(createTapingProvider(createAnthropicProvider(), writer));
+
+    expect(errors).toEqual([]);
+    expect(narrative.length).toBeGreaterThan(0);
+
+    const golden: Golden = { tape: writer.build(), expectedNarrative: narrative };
+    mkdirSync(dirname(GOLDEN_PATH), { recursive: true });
+    writeFileSync(GOLDEN_PATH, JSON.stringify(golden, null, 2) + "\n");
+  }, 120_000);
+
+  it.skipIf(!existsSync(GOLDEN_PATH))("replays the golden deterministically with no network", async () => {
+    const golden = JSON.parse(readFileSync(GOLDEN_PATH, "utf8")) as Golden;
+    const replay = createReplayProvider(new TapeReader(deserializeTape(serializeTape(golden.tape))));
+    const { narrative, errors } = await runScenario(replay);
+
+    expect(errors).toEqual([]);
+    expect(narrative).toEqual(golden.expectedNarrative);
+  });
+});

--- a/packages/engine/src/testing/dm-turn-golden.test.ts
+++ b/packages/engine/src/testing/dm-turn-golden.test.ts
@@ -146,7 +146,7 @@ async function runScenario(provider: LLMProvider): Promise<{ narrative: string[]
 }
 
 describe("golden: dm-open-door", () => {
-  it.skipIf(!process.env.RECORD_GOLDENS)("records the golden (live API)", async () => {
+  it.skipIf(process.env.RECORD_GOLDENS !== "1")("records the golden (live API)", async () => {
     loadEnv();
     const writer = new TapeWriter("dm-open-door");
     const { narrative, errors } = await runScenario(createTapingProvider(createAnthropicProvider(), writer));

--- a/packages/engine/src/testing/goldens/dm-open-door.golden.json
+++ b/packages/engine/src/testing/goldens/dm-open-door.golden.json
@@ -1,0 +1,94 @@
+{
+  "tape": {
+    "version": 1,
+    "scenario": "dm-open-door",
+    "capabilities": {
+      "claude-haiku-4-5-20251001": {
+        "imageGeneration": false
+      }
+    },
+    "entries": [
+      {
+        "kind": "chat",
+        "bucket": "dm",
+        "ordinal": 0,
+        "request": {
+          "model": "claude-haiku-4-5-20251001",
+          "messageCount": 1,
+          "systemHash": "77871a277edd",
+          "tools": [
+            "advance_turn",
+            "alarm",
+            "deck",
+            "describe_entity_type",
+            "detect_orphans",
+            "dm_notes",
+            "end_combat",
+            "enter_ooc",
+            "entity",
+            "find_schema_drift",
+            "list_entity_types",
+            "manage_objectives",
+            "map",
+            "map_entity",
+            "map_query",
+            "modify_initiative",
+            "present_choices",
+            "promote_character",
+            "resolve_turn",
+            "roll_dice",
+            "scene_transition",
+            "scribe",
+            "search_campaign",
+            "search_content",
+            "session_end",
+            "set_display_resources",
+            "set_resource_values",
+            "start_combat",
+            "style_scene",
+            "switch_player",
+            "time",
+            "update_modeline",
+            "validate_entity"
+          ],
+          "lastMessagePreview": "<context> ## Current State PCs: Aldric [length] Terminal: 80 cols × 16 visible rows. [stats] Turn: Aldric </context> [Al"
+        },
+        "result": {
+          "text": "I need context about where you are and what door you're opening. Let me check what's already been established.\n\nIt seems we're starting fresh! Let me set the scene.\n\n---\n\nYou push against the heavy wooden door. It swings inward with a creak, revealing a dimly lit <color=#009de5>tavern</color> that smells of spiced ale and woodsmoke. The common room stretches before you—rough-hewn beams overhead, a long bar along one wall where a <color=#cc8844>barkeep</color> with a scarred jaw wipes a glass. A few patrons nurse drinks in the corner booths, but most of the tables sit empty for this hour of the afternoon.\n\nThe door closes behind you with a soft *thud*. Warm air wraps around you.\n\nWhat do you do?",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 380,
+            "outputTokens": 191,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 9321,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "I need context about where you are and what door you're opening. Let me check what's already been established.\n\nIt seems we're starting fresh! Let me set the scene.\n\n---\n\nYou push against the heavy wooden door. It swings inward with a creak, revealing a dimly lit <color=#009de5>tavern</color> that smells of spiced ale and woodsmoke. The common room stretches before you—rough-hewn beams overhead, a long bar along one wall where a <color=#cc8844>barkeep</color> with a scarred jaw wipes a glass. A few patrons nurse drinks in the corner booths, but most of the tables sit empty for this hour of the afternoon.\n\nThe door closes behind you with a soft *thud*. Warm air wraps around you.\n\nWhat do you do?"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "I",
+          " need context about where you are and what door you're opening. Let me check what's already been established.\n\nIt",
+          " seems we're starting fresh! Let me set the scene.",
+          "\n\n---\n\nYou push against the heavy wooden door. It swings inward with a cr",
+          "eak, revealing a dimly lit <color=#009de5>tavern</color> that smells of spiced",
+          " ale and woodsmoke. The common room stretches before you—rough-hewn beams overhead, a long",
+          " bar along one wall where a <color=#cc8844>barkeep</color> with",
+          " a scarred jaw wipes a glass. A few patrons nurse",
+          " drinks in the corner booths, but most of the tables sit",
+          " empty for this hour of the afternoon.\n\nThe door closes behind you with a soft *",
+          "thud*. Warm air wraps around you.\n\nWhat",
+          " do you do?"
+        ]
+      }
+    ]
+  },
+  "expectedNarrative": [
+    "I need context about where you are and what door you're opening. Let me check what's already been established.\n\nIt seems we're starting fresh! Let me set the scene.\n\n---\n\nYou push against the heavy wooden door. It swings inward with a creak, revealing a dimly lit <color=#009de5>tavern</color> that smells of spiced ale and woodsmoke. The common room stretches before you—rough-hewn beams overhead, a long bar along one wall where a <color=#cc8844>barkeep</color> with a scarred jaw wipes a glass. A few patrons nurse drinks in the corner booths, but most of the tables sit empty for this hour of the afternoon.\n\nThe door closes behind you with a soft *thud*. Warm air wraps around you.\n\nWhat do you do?"
+  ]
+}


### PR DESCRIPTION
## What

The deterministic record/replay layer of the e2e testing redesign (Tier-2). Captures real LLM provider I/O as **session tapes** so full-stack flows re-run deterministically with **no API key and no network** — and lands the first golden proving the loop end-to-end.

## Why

The existing keystroke-injection + 200ms-polling harness (driven through the live `/smoketest` against the real LLM) is flaky by construction — it races async LLM/subagent activity. The fix is architectural: record the LLM once, replay deterministically, assert on effects. (Same conclusion Gemini CLI reached with golden model responses.) Full design + retirement plan in `docs/e2e-harness-v2-plan.md`.

## What's here

- **`providers/tape.ts`** — tape format + serializer + `TapeWriter`/`TapeReader`. Text turns are bucketed by `conversationId` (agent name) and matched **ordinally**, so prompt-content churn doesn't break replay; request fingerprints are stored for diff legibility only.
- **`providers/tape-provider.ts`** — `createTapingProvider` (record decorator) and `createReplayProvider` (pure tape-backed `LLMProvider`; loud stale-tape errors; opportunistic capability capture).
- **`providers/tape-mode.ts`** — env-gated `wrapForRecording`, wired at both `buildTierProvidersWithCache` call sites. **Dormant on `main`** (nothing sets `MV_TAPE_MODE` yet) — forward-looking infra for the child-process recorder that will capture setup/full-stack goldens. Identity pass-through in production.
- **`testing/dm-turn-golden.test.ts` + `testing/goldens/dm-open-door.golden.json`** — the first golden: a real Haiku DM turn recorded once against the live API; the replay half drives the same in-process `GameEngine` scenario from the tape with no network and asserts the narrative matches.
- **`agents/game-engine-replay.test.ts`** — proves a real `GameEngine.processInput` turn replays byte-identically with zero live provider calls.

## Regenerating a golden

`RECORD_GOLDENS=1 npx vitest run <golden>.test.ts` (needs a live key), review the diff, commit. The replay half skips until the golden exists, so fresh checkouts / CI never hard-fail.

## Production impact

None — all record/replay paths are env-gated; `wrapForRecording` is identity pass-through unless `MV_TAPE_MODE=record`.

## Deferred (follow-up PRs)

Skills (`record-tape`/`replay-goldens`, demoting `/smoketest`), docs rewrite + memory retirement, lefthook config (pre-commit Tier-1 / pre-push goldens), child-process recorder + `GET /tape` for setup/full-stack goldens, and the broader golden corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)