### PR TITLE
test(golden): in-process setup corpus — replay the setup agent + handoff offline

### DIFF
--- a/.claude/skills/record-tape/SKILL.md
+++ b/.claude/skills/record-tape/SKILL.md
@@ -13,24 +13,33 @@ tape and review the diff. **Never hand-edit a tape.** If a tape is wrong, re-rec
 
 There are two kinds of golden, with two record paths.
 
-## A. In-process engine goldens (the corpus) — the common case
+## A. In-process corpora (the common case)
 
-These drive the real `GameEngine` directly (DM turns, tool loops, multi-turn
-context). They live in
-[`packages/engine/src/testing/corpus.golden.test.ts`](../../../packages/engine/src/testing/corpus.golden.test.ts),
-one entry per scenario in the `SCENARIOS` array, each with its tape under
-`goldens/<name>.golden.json`.
+Two co-located corpora inject a provider directly and replay offline. Both gate
+their record half behind `RECORD_GOLDENS=1` (without it, normal `npm test` runs
+only the offline replay); the key is sourced from `.env`.
 
-**Re-record a stale golden** (you changed DM behavior on purpose):
+**The DM corpus** —
+[`corpus.golden.test.ts`](../../../packages/engine/src/testing/corpus.golden.test.ts):
+drives the real `GameEngine` (DM turns, tool loops, multi-turn context), one
+entry per scenario in `SCENARIOS`, tape at `goldens/<name>.golden.json`.
+
+**The setup corpus** —
+[`setup-corpus.golden.test.ts`](../../../packages/engine/src/testing/setup-corpus.golden.test.ts):
+drives the real `createSetupConversation` to `finalize_setup`, then the real
+`buildCampaignWorld` handoff. One entry per scenario in `SETUP_SCENARIOS`.
+
+**Re-record a stale golden** (you changed behavior on purpose):
 
 ```bash
-npm run golden:record                       # re-records ALL goldens (live)
+npm run golden:record                       # re-records ALL goldens, both corpora (live)
 # or a subset:
 npx cross-env RECORD_GOLDENS=1 npx vitest run golden -t "dm-skill-check"
+npx cross-env RECORD_GOLDENS=1 npx vitest run setup-corpus -t "setup-custom-noir"
 ```
 
-Then **review the git diff** on the `.golden.json` files — confirm the narrative
-change is what you intended — and verify it replays:
+Then **review the git diff** on the `.golden.json` files — confirm the change is
+what you intended — and verify it replays:
 
 ```bash
 npm run golden:verify     # offline, must pass
@@ -38,20 +47,21 @@ npm run golden:verify     # offline, must pass
 
 Commit the test + the regenerated tapes together.
 
-**Add a new scenario:** add one entry to `SCENARIOS` (a `name` + a `play(engine)`
-that drives `processInput`), record it (`-t "<name>"`), verify, commit. Keep the
-mock scene/state coherent with the player input so the DM narrates in character
-rather than asking for context — see the seeded scene at the top of the file.
+**Add a DM scenario:** one entry in `SCENARIOS` (a `name` + a `play(engine)` that
+drives `processInput`); keep the mock scene/state coherent with the input so the
+DM narrates in character. **Add a setup scenario:** one entry in
+`SETUP_SCENARIOS` — front-load the content the agent gates on (crucially the
+player's *name*); the bounded finalize loop confirms until the tool fires. Set
+`MV_SETUP_TRACE=1` to print the turn-by-turn flow when authoring/recording.
+Record (`-t "<name>"`), verify, commit.
 
-> The record half is gated behind `RECORD_GOLDENS=1`; without it (i.e. in normal
-> `npm test`) only the offline replay runs. The key is sourced from `.env`.
+## B. Full-stack goldens — live-pilot with mvplay
 
-## B. Full-stack / setup goldens — live-pilot with mvplay
-
-The in-process path can't reach the **setup agent**, the setup→game handoff, or
-the TUI. To capture those you live-pilot the real stack in record mode and pull
-the tape out afterward. This is the load-bearing "a Claude live-pilots once to
-record" capability.
+The in-process corpora cover the setup *agent conversation* and the DM loop. What
+they can't reach is the live stack: the setup→game handoff through the real
+`SessionManager` loader, the WebSocket events, the TUI render. To capture those
+you live-pilot the real stack in record mode and pull the tape out afterward.
+This is the load-bearing "a Claude live-pilots once to record" capability.
 
 ```bash
 mvplay record <scenario> [--player NAME] [--fresh]   # boots in record mode
@@ -68,12 +78,12 @@ expectedNarrative }`. Pull the tape **before** `mvplay stop` — teardown
 force-kills the engine and its in-memory tape with it.
 
 > **Capture works today; deterministic auto-replay of full-stack tapes is the
-> open edge.** The in-process corpus is the replay backbone. A captured
-> full-stack tape is a real artifact (inspect it, seed a future replay test from
-> it), but there is not yet an in-process driver that replays a setup→game tape
-> end to end. Setup-agent calls currently bucket as `"default"` (no
-> `conversationId`) — the future replay-runner must account for that. Don't
-> commit a full-stack tape as a passing golden until that runner exists.
+> open edge.** The in-process corpora are the replay backbone (the setup agent
+> now replays offline via the setup corpus). A captured full-stack tape is a real
+> artifact (inspect it, seed a future test from it), but there is not yet a
+> driver that replays one through the server stack — the capture records neither
+> the player inputs nor a replayable narrative segmentation. Don't commit a
+> full-stack tape as a passing golden until that runner exists.
 
 ## The discipline (both paths)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Live API key in `.env` with limited credit. Default dev override uses Sonnet for
 Type checks and unit tests do not prove a cross-cutting flow works — anything touching UI flow, session lifecycle, the setup agent, the DM loop, save/load, or a path that spans server + client + WebSocket. The e2e strategy is **three tiers, deterministic-first** (full picture: [docs/e2e-harness.md](docs/e2e-harness.md), [docs/golden-tapes.md](docs/golden-tapes.md)):
 
 1. **Tier 1 — component/render:** `ink-testing-library`, co-located in `packages/client-ink`.
-2. **Tier 2 — deterministic golden replay (the regression backbone):** real `GameEngine` replaying recorded **golden tapes**, offline, ~4s. **This is the everyday "did I break it?" gate.**
+2. **Tier 2 — deterministic golden replay (the regression backbone):** the real `GameEngine` (DM loop) and `createSetupConversation` (setup agent → finalize → handoff) replaying recorded **golden tapes**, offline, ~4s. **This is the everyday "did I break it?" gate.** Touch the DM loop or the setup agent → expect to re-record the matching corpus.
 
    ```bash
    npm run golden:verify     # replay goldens offline (no API key)

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -9,7 +9,7 @@ LLM flows through keystroke injection as the verification layer.
 | Tier | What | Where | Speed / API |
 |---|---|---|---|
 | **1 — component/render** | Ink render + interaction (modals, overlays, layout) | `ink-testing-library`, co-located in `packages/client-ink` | fast, offline |
-| **2 — full-stack deterministic** | Real `GameEngine` replaying recorded **golden tapes** | `packages/engine/src/testing/corpus.golden.test.ts` | ~4s, **offline** |
+| **2 — full-stack deterministic** | Real `GameEngine` + `createSetupConversation` replaying recorded **golden tapes** | `packages/engine/src/testing/{corpus,setup-corpus}.golden.test.ts` | ~4s, **offline** |
 | **3 — live smoke** | The real launcher stack against the real API | `packages/test-harness` (this doc) | 7-12 min, **live** |
 
 **Tier 2 is the regression backbone** — the honest "did I break it?" signal.
@@ -18,9 +18,11 @@ See [golden-tapes.md](golden-tapes.md) (operating model) and
 
 **This doc is Tier 3 (+ the interactive/record substrate):** the live harness in
 [`packages/test-harness`](../packages/test-harness/). Reach for it only when you
-specifically need the *live* stack — exercising the setup agent, the setup→game
-handoff, server+client+WebSocket boot — against the real model. It is **not** the
-everyday gate; that's Tier 2.
+specifically need the *live* stack — the setup→game handoff through the real
+`SessionManager` loader, server+client+WebSocket boot, the TUI render — against
+the real model. (The setup *agent conversation* itself now has deterministic
+offline coverage via the Tier-2 setup corpus.) It is **not** the everyday gate;
+that's Tier 2.
 
 ## Two ways to use the live harness: scripted probes vs. interactive play
 

--- a/docs/golden-tapes.md
+++ b/docs/golden-tapes.md
@@ -33,27 +33,46 @@ review a readable git diff. **Never hand-edit a tape.**
 
 ### A. In-process engine goldens (the corpus)
 
-The common case. Scenarios drive the real `GameEngine` directly — DM turns, tool
-loops, multi-turn context — in
-[`packages/engine/src/testing/corpus.golden.test.ts`](../packages/engine/src/testing/corpus.golden.test.ts).
-Each entry in the `SCENARIOS` array is a `name` + a `play(engine)` that calls
-`processInput`, with its tape at `goldens/<name>.golden.json`.
+The common case — and the offline backbone for **both** halves of a session.
+Two co-located corpora drive the real engine objects directly with an injected
+provider (taping at record time, replay otherwise); the record half of each is
+gated behind `RECORD_GOLDENS=1` (it spends API), and without it only the offline
+replay runs. A taping decorator (`createTapingProvider`) captures the I/O;
+replay uses `createReplayProvider` over the saved tape.
 
-Recording: the test's record half is gated behind `RECORD_GOLDENS=1` (it spends
-API); without it, only the offline replay runs. A taping decorator
-(`createTapingProvider`) wraps a real provider and captures the I/O; replay uses
-`createReplayProvider` over the saved tape.
+**The DM corpus** —
+[`corpus.golden.test.ts`](../packages/engine/src/testing/corpus.golden.test.ts).
+Scenarios drive the real `GameEngine` — DM turns, tool loops, multi-turn context.
+Each `SCENARIOS` entry is a `name` + a `play(engine)` that calls `processInput`.
+Subagents (scribe / scene-tracker / ai-player / character-promotion) are mocked
+to no-ops so each golden is a single deterministic `"dm"` bucket — the golden's
+job is the DM turn and its tool loop, not subagent behavior (which has its own
+tests). Keep the seeded scene coherent with each player input so the DM narrates
+in character rather than asking for context.
+
+**The setup corpus** —
+[`setup-corpus.golden.test.ts`](../packages/engine/src/testing/setup-corpus.golden.test.ts).
+The setup-side complement: scenarios drive the real `createSetupConversation`
+through a scripted sequence of player turns to `finalize_setup`, then run the
+real `buildCampaignWorld` handoff against an in-memory `FileIO`. Replay asserts
+the conversation reproduces verbatim, the finalized `SetupResult` derives
+identically, *and* the scaffolded campaign config matches. This is the
+in-process setup→handoff replay — the setup agent had no offline coverage
+before. No subagents to mock (the conversation only calls the provider +
+dispatches its tools locally); setup calls carry no `conversationId`, so they
+all land in the `"default"` bucket and match ordinally. Each `SetupScenario`
+front-loads the content the agent gates on (crucially the player's name) and a
+bounded finalize loop confirms until the tool fires; set `MV_SETUP_TRACE=1` to
+print the turn-by-turn flow when re-recording.
 
 ```bash
-npm run golden:record                                   # all
-npx cross-env RECORD_GOLDENS=1 npx vitest run golden -t "dm-skill-check"   # one
+npm run golden:record                                          # all corpora
+npx cross-env RECORD_GOLDENS=1 npx vitest run golden -t "dm-skill-check"      # one DM golden
+npx cross-env RECORD_GOLDENS=1 npx vitest run setup-corpus -t "setup-custom-noir"   # one setup golden
 ```
 
-Subagents (scribe / scene-tracker / ai-player / character-promotion) are mocked
-to no-ops in the corpus so each golden is a single deterministic DM bucket — the
-golden's job is the DM turn and its tool loop, not subagent behavior (which has
-its own tests). Keep the seeded scene coherent with each player input so the DM
-narrates in character rather than asking for context.
+Setup goldens record against the **large** tier (Sonnet) so the conversation
+finalizes coherently; replay is model-agnostic and free.
 
 ### B. Full-stack / setup goldens (live-pilot via mvplay)
 
@@ -74,13 +93,16 @@ teardown force-kills the engine (and its in-memory tape) without running exit
 handlers, which is exactly why the tape is read over an HTTP route rather than
 flushed on exit (see `packages/engine/src/providers/tape-mode.ts`).
 
-> **Capture works; deterministic auto-replay of full-stack tapes is the open
-> edge.** A captured full-stack tape is a real artifact you can inspect or seed a
-> future replay test from, but there is not yet an in-process driver that
-> replays a setup→game tape end to end. Setup-agent calls currently carry no
-> `conversationId`, so they bucket as `"default"` — the future replay-runner must
-> account for that. Don't commit a full-stack tape as a passing golden until that
-> runner exists; the in-process corpus is the replay backbone.
+> **The setup *agent* now replays offline via the in-process setup corpus
+> (path A).** Reach for `mvplay record` only when you need the parts the
+> in-process path can't construct: the actual TUI render, the WebSocket events,
+> or the setup→game handoff through the **real** `SessionManager` loader.
+> Auto-replaying *those* captured full-stack tapes is the remaining edge — the
+> capture records neither the player inputs nor a replayable narrative
+> segmentation (its `expectedNarrative` is the sidecar's accumulated
+> `narrativeLines`), so re-driving the HTTP/sidecar session isn't wired. A
+> captured full-stack tape is still a real artifact to inspect or seed a future
+> test from; just don't commit one as a passing golden yet.
 
 ## How recording is wired
 
@@ -119,11 +141,15 @@ Activated by `npm install` (the root `prepare` runs `lefthook install`).
 
 ## Deferred / open edges
 
-- **Full-stack replay-runner** — capturing a setup→game tape works (`mvplay
-  save-tape`); replaying one deterministically in-process does not exist yet. The
-  in-process corpus is the backbone; full-stack tapes are capture-only until a
-  runner that drives `SetupSession` + `GameEngine` from a tape is built (and
-  handles the `"default"` setup bucket).
+- **Full-stack capture replay** — the setup *agent* and the DM loop both replay
+  offline via the in-process corpora. What's still capture-only is the *mvplay
+  full-stack tape*: replaying a real setup→game session through the **server
+  stack** (TUI render, WebSocket events, the `SessionManager` campaign loader at
+  the handoff) isn't wired, because the capture records neither the player inputs
+  nor a replayable narrative segmentation. Building that runner means adding
+  input capture to `mvplay record` + a replay-provider seam in the stack
+  (symmetric to `wrapForRecording`); Tier-3 live smoke covers that path in the
+  meantime.
 - **CI enforcement** of `golden:verify` on PRs — deferred until the pre-commit
   hook has proven stable in practice.
 - **Freshness guard** — a periodic real-API *structural* re-pilot (tool calls /

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -87,7 +87,7 @@ The tape schema (`packages/engine/src/providers/tape.ts`) is the data contract f
 
 ### Changing the golden corpus / record-replay wiring
 
-The corpus lives in `packages/engine/src/testing/corpus.golden.test.ts` (+ `goldens/`). The record seam is `wrapForRecording` in `packages/engine/src/providers/tape-mode.ts`, called at `session-manager.ts` / `setup-session.ts`; the full-stack readback is `GET /tape` (`packages/engine/src/server/routes/dev.ts`) + `mvplay record`/`save-tape`. If you change the operating model (record paths, when to re-record, hooks), update [golden-tapes.md](golden-tapes.md) and the `/record-tape` + `/replay-goldens` skills.
+Two co-located corpora: the DM corpus (`packages/engine/src/testing/corpus.golden.test.ts`) and the setup corpus (`setup-corpus.golden.test.ts`), sharing `goldens/`. Both inject a provider directly (record via `createTapingProvider`, replay via `createReplayProvider`) — the in-process path skips the `wrapForRecording` seam. That seam (`packages/engine/src/providers/tape-mode.ts`, called at `session-manager.ts` / `setup-session.ts`) plus `GET /tape` (`packages/engine/src/server/routes/dev.ts`) + `mvplay record`/`save-tape` is the *full-stack* capture path. Adding a setup scenario = one `SetupScenario` entry + a record run (front-load the player name; `MV_SETUP_TRACE=1` prints the flow). If you change the operating model (record paths, when to re-record, hooks), update [golden-tapes.md](golden-tapes.md) and the `/record-tape` + `/replay-goldens` skills.
 
 ### Changing what the live `smoketest` probe walks through
 

--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -282,7 +282,7 @@ The **Tier-3 live** harness (the regression backbone is Tier-2 golden replay —
 | `src/engine-log.ts` | Engine-log breadcrumb reader (`image_gen:*`, `subagent:*`, `api:call`, ...). |
 | `src/client-state.ts` | Mirror of client-side state for assertion. |
 
-The **Tier-2 record/replay** code lives in `engine`, not here: `packages/engine/src/providers/{tape,tape-provider,tape-mode}.ts` (format + record/replay shims + record wiring), `packages/engine/src/server/routes/dev.ts` (`GET /tape` readback), and the corpus at `packages/engine/src/testing/corpus.golden.test.ts` (+ `goldens/`).
+The **Tier-2 record/replay** code lives in `engine`, not here: `packages/engine/src/providers/{tape,tape-provider,tape-mode}.ts` (format + record/replay shims + record wiring), `packages/engine/src/server/routes/dev.ts` (`GET /tape` readback), and the corpora at `packages/engine/src/testing/{corpus,setup-corpus}.golden.test.ts` (DM loop + setup agent; shared `goldens/`).
 
 See [e2e-harness.md](e2e-harness.md) (three-tier strategy, live harness), [golden-tapes.md](golden-tapes.md) (record/replay model), and [tape-format.md](tape-format.md) (tape schema).
 

--- a/docs/tape-format.md
+++ b/docs/tape-format.md
@@ -22,14 +22,27 @@ engine.
 }
 ```
 
-A committed golden file wraps the tape with its replay assertion:
+A committed golden file wraps the tape with its replay assertion. The DM corpus
+asserts the narrative:
 
 ```jsonc
 { "scenario": "...", "tape": { /* Tape */ }, "expectedNarrative": ["...", "..."] }
 ```
 
-`expectedNarrative` is the DM/non-player narrative the scenario produced at record
-time — the deterministic replay target.
+The setup corpus adds the finalized blueprint, since a setup scenario's payoff is
+the campaign it produces, not just the prose:
+
+```jsonc
+{ "scenario": "...", "tape": { /* Tape */ },
+  "expectedNarrative": ["...", "..."],   // per-turn setup-agent narrative
+  "expectedSetup": { /* SetupResult */ } // finalize_setup output, replayed verbatim
+}
+```
+
+`expectedNarrative` is the non-player narrative the scenario produced at record
+time — the deterministic replay target. `expectedSetup` (setup goldens only) is
+the `SetupResult` the agent finalized; replay re-derives it and the handoff
+scaffolds a campaign from it.
 
 ## Bucketing + matching
 
@@ -37,8 +50,9 @@ Every chat call is filed into a **bucket** and matched **ordinally** within it:
 
 - **Bucket** = `ChatParams.conversationId` (the agent name — `"dm"`, `"scribe"`,
   …) or `"default"` when absent. `generateImage` calls use the `"__image__"`
-  bucket. (Setup-agent calls currently carry no `conversationId`, so they land in
-  `"default"`.)
+  bucket. Setup-agent calls carry no `conversationId`, so an entire setup
+  conversation lands in `"default"` and matches ordinally — which is exactly what
+  the setup corpus relies on (its calls are a single in-order sequence).
 - **Ordinal** = position within the bucket. The Nth chat call in bucket B during
   replay returns the Nth recorded entry for B.
 

--- a/packages/engine/src/testing/goldens/setup-custom-noir.golden.json
+++ b/packages/engine/src/testing/goldens/setup-custom-noir.golden.json
@@ -1,0 +1,470 @@
+{
+  "scenario": "setup-custom-noir",
+  "tape": {
+    "version": 1,
+    "scenario": "setup-custom-noir",
+    "capabilities": {
+      "claude-sonnet-4-6": {
+        "imageGeneration": false
+      }
+    },
+    "entries": [
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 0,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 1,
+          "systemHash": "712386ca9618",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "I'd like to set up a new campaign."
+        },
+        "result": {
+          "text": "<center><b>⚑ THE CURTAIN RISES ⚑</b></center>\n\n<i>Somewhere, a candle flickers to life. A map unfurls across a table worn smooth by a thousand sessions. Dice wait in silence, heavy with possibility.</i>\n\nWelcome, traveler. You've come to the right place.\n\nWhat unfolds here will be entirely yours — a world built to your specifications, a story shaped by your choices, a character who exists nowhere else in the universe.\n\nBut before we light the torches and open the gates...\n\n<i>What should I call you?</i>",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 198,
+            "cacheReadTokens": 7511,
+            "cacheCreationTokens": 7257,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "thinkingText": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no Known Players listed, so I'll ask freeform.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no Known Players listed, so I'll ask freeform.",
+              "signature": "Eu8CCmUIDhgCKkC33Ixwfups1Qntgf0hIuSp8b7lNW5lTcMD29a8MSsw6JD42jDNQq2dx0Fs7uys63g5mjVTypecUshlF/QCYPkNMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMJPPnfPrL0J5R4nxBGgwlSp6Ir4vv+CxjIe8iMISIB43cL9wBEHV2+WuHBXnbbQ1Vm0daJBXmrtVRWArHFtv92L50peGIj5lS+ufQkCq3Ach25xB7RJC8tTXyVduv2nl/+h9xUGiDh3/5dr5bGko4wW4IYqoGo0y4dm2h6SmOCor4bswB2A0JXy79IQUA5JIq72f6uOCCcVLerrwWh0lKrhFmnPe7CS0zCp1R/1OFayQ1JuTGIbhhWZb+9EO50FpzLc5YXTj+vXXDawZhpYeZRynCLdu8bgxG+7YZbT1MP4J5OW9+UTGXvTRvupigT+9CNAKzZ/LpD1JMgnsGj1/xaIdQHswWEhgB"
+            },
+            {
+              "type": "text",
+              "text": "<center><b>⚑ THE CURTAIN RISES ⚑</b></center>\n\n<i>Somewhere, a candle flickers to life. A map unfurls across a table worn smooth by a thousand sessions. Dice wait in silence, heavy with possibility.</i>\n\nWelcome, traveler. You've come to the right place.\n\nWhat unfolds here will be entirely yours — a world built to your specifications, a story shaped by your choices, a character who exists nowhere else in the universe.\n\nBut before we light the torches and open the gates...\n\n<i>What should I call you?</i>"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<center><b>⚑ THE CURT",
+          "AIN RISES ⚑</b></center>\n\n<i>Somewhere, a",
+          " candle flickers to life. A map unfurls across a",
+          " table worn smooth by a thousand sessions. Dice wait in silence,",
+          " heavy with possibility.</i>\n\nWelcome, traveler. You've come",
+          " to the right place.\n\nWhat unfolds here will be entirely yours —",
+          " a world built to your specifications, a story",
+          " shaped by your choices, a character who exists nowhere else in the universe.\n\nBut",
+          " before we light the torches and open the gates...\n\n<i>What",
+          " should I call you?</i>"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 1,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 3,
+          "systemHash": "712386ca9618",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "I'm Sam, an adult. I want a fully custom game: 1970s occult noir in a rain-soaked city. Pure narrative, no rules system."
+        },
+        "result": {
+          "text": "<b>Sam.</b> An adult. A rain-soaked city, 1970s, occult noir. Pure narrative.\n\n*I can already smell the cigarette smoke and wet asphalt.*\n\nYou've given me the bones of something atmospheric and dangerous. Now let's put flesh on it.\n\nWhat kind of case does this city hide?",
+          "toolCalls": [
+            {
+              "id": "toolu_015Zn2vLfbz8nYfaiNfZsNAn",
+              "name": "present_choices",
+              "input": {
+                "prompt": "What's the dark heart of this campaign?",
+                "choices": [
+                  "◆ The Bleeding Eye — A detective uncovers a cult that's been running the city's shadows since Prohibition",
+                  "◆ The Unmourned — People are vanishing from the city's margins. Something is collecting souls.",
+                  "◆ Dead Letters — A journalist receives messages from a murdered source. The murder hasn't happened yet.",
+                  "◆ The God in the Pipes — Something old is waking up under the city. The plumbers know. They're not talking.",
+                  "◆ Cabinet of Mirrors — A series of identical suicides. Each victim saw something in a mirror they couldn't unsee.",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Conspiracy and corruption. The occult has been woven into the city's power structure for decades. Your character pulls on one thread and unravels everything.",
+                  "Grief and hunger. The missing are the forgotten — drifters, runaways, the ones no one files reports for. Something feeds on the unwitnessed.",
+                  "Time, journalism, and dread. The scoop of a lifetime becomes a race against a fate already in motion.",
+                  "Body horror and civic rot. The infrastructure itself is alive, or something is living in it. Blue-collar horror with cosmic stakes.",
+                  "Psychological horror and obsession. A mirror cult, a spreading madness, and a killer who may not know they're killing."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 909,
+            "cacheReadTokens": 14768,
+            "cacheCreationTokens": 237,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "The player is Sam, an adult, and they want a fully custom game with a 1970s occult noir setting in a rain-soaked city. Pure narrative, no rules system. They've given me a lot to work with already. Let me proceed with the Full Campaign Setup flow.\n\nSince Sam has given me genre/setting information already, I can move forward. I need to cover:\n- Campaign concept (premise and name)\n- Mood\n- Difficulty\n- Campaign scope\n- DM personality\n- Character (name, concept)\n\nThey've told me: 1970s occult noir, rain-soaked city, pure narrative. That's genre/setting covered.\nI still need to nail down the campaign concept and mood, then move through difficulty, scope, and DM personality before we get to character creation. I could ask about the campaign premise and mood together since they're related, or tackle them separately depending on how much detail Sam wants to provide.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "The player is Sam, an adult, and they want a fully custom game with a 1970s occult noir setting in a rain-soaked city. Pure narrative, no rules system. They've given me a lot to work with already. Let me proceed with the Full Campaign Setup flow.\n\nSince Sam has given me genre/setting information already, I can move forward. I need to cover:\n- Campaign concept (premise and name)\n- Mood\n- Difficulty\n- Campaign scope\n- DM personality\n- Character (name, concept)\n\nThey've told me: 1970s occult noir, rain-soaked city, pure narrative. That's genre/setting covered.\nI still need to nail down the campaign concept and mood, then move through difficulty, scope, and DM personality before we get to character creation. I could ask about the campaign premise and mood together since they're related, or tackle them separately depending on how much detail Sam wants to provide.",
+              "signature": "EuYOCmUIDhgCKkCnXdvzIQVu1g29PhUKei4JVCTZ4BZ0mPDp664F7Hs2HacNFaUgFuSZBup9RhZZ/Z4r19hjSO8po5G+U7Xa3XhSMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMj9/JfoUtC3STBt9ZGgz+S5zH5xX+/nUS3PAiMBAmsjSk+3fldJwU7cShlNgwAjXIggdgW80oJu/bdrR3DeeIwEW6eDOsJWhBTGnJuyquDfq2xwSfcDeOZyGLTfB6XHWhRjcvi61ZiH7K3zS00BcdczdKNuaBNNH+GgTeV4pHXMdC2u0sWQbObv3zRA1dDWsm71da8yMa5cQEi59vDah/mnhQPD+fJaxuBiCfRwCVPDkkMFIFtVcBqFG8OhcEDPBaXJTnB4+jzaYVwE7m5pE3rv9Zj/TasTo01iqXOjbc6q98U4LLrwp0mobARY9J25GUwU08o6+KJN/zsDAuugbaSRH3qRxlE1cfHO97u5aDDq49qlPyeMi8vT9gIvNCFUrNwDm2h+pG/WOWUNqS9n6xnGuMOJ6XYcWnqTN2gEDAtHsvf1lzikUMiEFVomRuRYX8h3i7lu6u7eOm6v2Wo5yofDtqu1sf/+HLFsKGZS6qkLlq3BGpH/xgfxeVkbIzk7wyEZFYr+P9DibBQ/jYtI+uoMJqZoEChJFlCyg9w47aG336jfbloY5p219g+Siyo79xV2Gvd2G0eWVbrNZvxjjkBjJjP4WrgZfeBYVzVvep+VbsyFOqfY1pBR37Bacd5GNe1NS1ORU2pFn2GxyiOIz4H1hdPy4H0f08B35ah7sh4aUaHaISsPiXcdLHjYpp+PwC3I2nxlafnC+mCyyqmIo6MVckqwCpVBCbcjpNLffGTY5G7TlPPK7T54Ue0Zy/Set3mTqiUcRzIz8sUArCV12ImLbVDBjJ+Y+V8s8QXNxgQbMwFa5n4D9qNVZ9UHNSzf8U/wUJV+H79D8q9mFXFupd/J3whTYRKGg6FFasPQ0DImZZObA3EiV84XhEMYSC0ibC5cWMBSY+nfHSbxGDyOHRU6RyBwxqTjecLFcI8x/E/wN+aYWPeCRbAGurHB4cxz9nWmbzzWQ4cgJ92JXvV8mJP89WU6zlfK3Sjjx/emkgjcqL4shrrtIgVcf9Xoq4p+m6WKGrVihq32PbRlaiUc5DmRMpsNLvDune0/G56N7BocMBymvQ5rBdfXqqIv4y6LXqMXshtjxM8RuaRZhKrRLHXgbxcC+JvnL7f8wDm8zTV38QUlhQJ7osVYPkfcPBxGD5SIglrGNp+8jELEGC5oUqFgFSZtc3HLv0/v+jGHq0g8n9E8DH5qNH+oBbJdaL3Hd8zbeQ5kX6e0LJw4P84taGz+vbJ5RZxgER+k80eVhm4q5Nm8YNu8AOLSJi009mietmdMsljGHbqBfoG0VHn3xR3OgtkqRJwJi4+8yd9msjFFYBiK8t1lWKm1ZBwzv0UnG67N7Eixu97iAm5PdvKPIn1bgJW01MBIACCuhAbjh5jblFtIUJzf744pB4xM6Z31Is0PSLdKkSpNJcWj0k8DgKF0fwjhN5wP6MXgE+qfM5IgD29olLizS6dAf0muESsGnw4nf/1DfuMT2e120pfihFTd9iRvPwe/Fgmoc7Vn4J6EJMCh3qcI4PxaPWBqxQu5EOsR2vI5CMGmQHltwM57QJWo+w/XMPUSgakM7rEFEq0jaQQcjSNCIF0GETtuebOz0JqVzGff5vy4MtH34vYiW7rVOKEhXNyfcqUPQGFX9sugli4QMM46yblOzEnBys3MubLyK/LYrhGiDAJkm9eP8k8OTbzjBMlakaR3p8kNq/AnZ1FKVp00/N3Bk5B/fHWeAbc/GwBn39ovXdPpldTC8N95z0TjoN4HfI+/xDtz0viEVIklNBzxPr2tHA2vaqla6nyUNiN8xcoq4ehRsM6mtItdOppHhxRr0IxjlZIYb1hY6BHzZdlewWZCaCtb7Ux1FLjNPPCBbLbkqfw+q9aT5odtFrA86LNMg3gZygRmYHnpgTe41xqWYw93b/49QXXqV8oHzVQ61CXAbmTvSkSlRoxgISI+zT2iuQjecXxEXw5ZMjOWs8WFbVIw6SliLCnojJR+LYZcV9bstA8bdjPzxlrdz0avKMyrR9EghgpUz6aMV3dNqustIkXevfFJmCoDPMvpVq2sCpS8ymvRq7glax/7HvSHtNDakZZfObSVXSv+TAdoZNBgd3W7/AMImWPGMjb7UAFeowVDPjZmxQxhvFwfa1OXfch6nKTChviPTae4EgNYy1oKf0fzev5JBJrXQ6az94xAfyjOo57VXzLyLayuNg/NrFtSdBiWSBFLhN0jxlNSR0mp1FfRjYASRRUVMRYjhrp96uSY+Vci5EKr8DS39LRnfa6BlQNW+CytltDsl+PQ7e7koVmk1S3Gfy6hv8CR1b754bfNqupU/G3ddIokEbT2HQAaeXP5HfHI1FwalLTasC6VoPNBqPyavSTEASFe65zJPpbQEsHwoh3RgB"
+            },
+            {
+              "type": "text",
+              "text": "<b>Sam.</b> An adult. A rain-soaked city, 1970s, occult noir. Pure narrative.\n\n*I can already smell the cigarette smoke and wet asphalt.*\n\nYou've given me the bones of something atmospheric and dangerous. Now let's put flesh on it.\n\nWhat kind of case does this city hide?"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_015Zn2vLfbz8nYfaiNfZsNAn",
+              "name": "present_choices",
+              "input": {
+                "prompt": "What's the dark heart of this campaign?",
+                "choices": [
+                  "◆ The Bleeding Eye — A detective uncovers a cult that's been running the city's shadows since Prohibition",
+                  "◆ The Unmourned — People are vanishing from the city's margins. Something is collecting souls.",
+                  "◆ Dead Letters — A journalist receives messages from a murdered source. The murder hasn't happened yet.",
+                  "◆ The God in the Pipes — Something old is waking up under the city. The plumbers know. They're not talking.",
+                  "◆ Cabinet of Mirrors — A series of identical suicides. Each victim saw something in a mirror they couldn't unsee.",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Conspiracy and corruption. The occult has been woven into the city's power structure for decades. Your character pulls on one thread and unravels everything.",
+                  "Grief and hunger. The missing are the forgotten — drifters, runaways, the ones no one files reports for. Something feeds on the unwitnessed.",
+                  "Time, journalism, and dread. The scoop of a lifetime becomes a race against a fate already in motion.",
+                  "Body horror and civic rot. The infrastructure itself is alive, or something is living in it. Blue-collar horror with cosmic stakes.",
+                  "Psychological horror and obsession. A mirror cult, a spreading madness, and a killer who may not know they're killing."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<b",
+          ">Sam.</b> An adult. A rain-soaked city, 1970s, occ",
+          "ult noir. Pure narrative.\n\n*I can already smell the cigarette smoke and wet as",
+          "phalt.*\n\nYou've given me the bones of something atmospheric and",
+          " dangerous. Now let's put flesh on it.\n\nWhat kind of case",
+          " does this city hide?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 2,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 5,
+          "systemHash": "712386ca9618",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<b><i>Neon Requiem.</i></b> Tense, melancholy, unforgiving.\n\n*That title lands like a body on wet pavement. Perfect.*\n\nNow — what's the case? What dark current runs through this city that your character is about to wade into?\n\nGive me anything: a one-line hook, a vibe, a scene you've already imagined. Or pick from above if one caught your eye. I'll shape it into something to remember.",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 401,
+            "cacheReadTokens": 15005,
+            "cacheCreationTokens": 992,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "thinkingText": "Interesting! The player typed their own response instead of selecting one of the choices. They want:\n- Mood: Tense and melancholy\n- Difficulty: Unforgiving\n- Campaign name: \"Neon Requiem\"\n\nBut they didn't give me a campaign premise/concept yet. Let me ask about that next, and also move toward DM personality, campaign scope, and character. I still need a campaign premise and character details.\n\nLet me ask for the campaign premise/concept and then move to character. Actually, I should also ask about campaign scope and DM personality.\nI'll focus on the campaign premise first—what's the central mystery or hook that drives the story? Then I can tackle scope and DM personality together before moving on to character creation.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Interesting! The player typed their own response instead of selecting one of the choices. They want:\n- Mood: Tense and melancholy\n- Difficulty: Unforgiving\n- Campaign name: \"Neon Requiem\"\n\nBut they didn't give me a campaign premise/concept yet. Let me ask about that next, and also move toward DM personality, campaign scope, and character. I still need a campaign premise and character details.\n\nLet me ask for the campaign premise/concept and then move to character. Actually, I should also ask about campaign scope and DM personality.\nI'll focus on the campaign premise first—what's the central mystery or hook that drives the story? Then I can tackle scope and DM personality together before moving on to character creation.",
+              "signature": "EoEKCmUIDhgCKkBOu0+pSAqxLEq8+ETGaAHaCsbYzjZJWvSpuYQHJwHQz8krF7Z4+D0Z//HfxDsqaCd/C2pu1q/KKr4yR2WaD40tMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMRs06pVFVfsTTPhJ4Ggwx3+9izMqP4Ezh1k4iMH6heC5P9A9ik9jENMx5XbF3tdYv3FtMRzPOA/27gPBqonSfD+QNXBQQ/Tv71VtzvyrJCHO1b5IcjZnAda3jD0yhiYJitIQUB8uL0VrsYjFNbi2vHKgFcYPF+5hS/+BjRKnyY/IZwa4FC5W4a/MeMImFYenO1p7uezLPFpG20yPQCh5nEKE1rWDVE6FSdW5LI8Xkbm277pgVd3DMKEu9IlPwYr/smxNXCTyjPhwz0tyvOcR+l9p3KWPQXVB54NV3TBBjYIeiU1mJIYd4wAE3N/WvNZeRhfgVlj7IZICaaZ425hDyFOr/FLAfODNSjpBblgJhLBDxUKv4Ib/jLQrxKiW1iZhfkW+C30bJPYxHqElJvDPop3hmmuRn51bc65vMt9BE7EA+PyCTJEIgMF1Pq1iazQWPN1QyMy4VR272yZWOJnu8apubzqTQNpEot/D2suAEkplPK9wDmRsjXTr3NbKGN1KaUq00aOxfB+t7l7XxOf0B2ErzgRT5vkZtJUC2cNTVCr3vsOX3QefynoRxwPRt5jG3uQME6n+oeKUelLlq2fyS5C32WuFcm1QKnpyfl/aur6VzqA37ymV1E30WvCOUWEh/MWoTY9WKWbRHMY7YUG5oQMuCTz5Q71PZB7y3J9Z4yGLd8rIeZHjHBWgosm6Wjr/bpTltBvAjcQ4OyIlzFImGppLRcZIMMTjrF0xFP/htsdlZPSp+dvrhJ3S7mVdg1lsVnNQBaF/JevCcAsuisxMvPEhj+TzoH5swDwLDNO64H5jWad0x6rMito9FOsEqeTo81eKOv9PzCeHOpv9Vc5n22b33A8j8bErY0MdHiCJwb/iruX0YzT/cYkbSPvQZgmLJazoYm2szKXJrOMM5Ick+9SPgMt0Yh1KDRtlCMpjgAbRoXwjryyA2XAmD7ZTjkbAZDWGMchIbJFfygE4Xd7qTeWSgoIrFt2fWHDNcw2WoGKm8KGA4EvfFNv9r6cN2rBY+xioDvyJPLQGb1AOwnhubXkycyZQaJbpDPIw4FKK8M9FR/qdFv+m3FJwoI3Exk9iyY8Zfeair29nT/YDnwlTgVReC8KMzKuJTlSEfIoB/DsJXOEwm+wX0wBtpS+TTPqfeCpLmbay0aZa3CVTCZXHHk0rsDMAbOd7kxuQm3+P/tFfW8XkyfhBczNIoeiDg5Xj7q/eydIWh/OKFxcrGU/FSeitcyl4bMgLNAK7DhBUSsq+hQEDuXtLqh2VBp7mhzLuJxZLdQ3O4TSqvKLQ3pQpCbfss2WbI6ZuIQQudU+6901zlOe0wviU8kDLlNn0B0lIZGoLQTDS5DDjmsKl9FNyoeA0elzUXXl5TVPzROOZ9eu2B4N0e9Y2r4EF2xEpxl7Rhwnxd3ZF6+AgHfTE2sqBq9k217oC4dWtu1ycuMab2kvDODSKukRgibspOSnktVCSnq2fZgNnIIxfYDIeGeKmvsW5av20xQupuvqaJUcGliPJ5BMUbLeX1y7JfS4f4tfXv6bvSemf/rG4ZddSougcXgZc90ucrMqo5GAE="
+            },
+            {
+              "type": "text",
+              "text": "<b><i>Neon Requiem.</i></b> Tense, melancholy, unforgiving.\n\n*That title lands like a body on wet pavement. Perfect.*\n\nNow — what's the case? What dark current runs through this city that your character is about to wade into?\n\nGive me anything: a one-line hook, a vibe, a scene you've already imagined. Or pick from above if one caught your eye. I'll shape it into something to remember."
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<b><i>Neon Requiem.</i></b> Tense,",
+          " melancholy, unforgiving.\n\n*That title lands like a body on wet",
+          " pavement. Perfect.*\n\nNow — what's the case? What dark current runs through this city that",
+          " your character is about to wade into?\n\nGive me anything: a one",
+          "-line hook, a vibe, a scene you've already imag",
+          "ined. Or pick from above if one caught your eye.",
+          " I'll shape it into something to remember."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 3,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 7,
+          "systemHash": "712386ca9618",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "I'm playing Marlowe Cray, a burned-out PI who can see the dead."
+        },
+        "result": {
+          "text": "*Marlowe Cray. A gift he didn't ask for, in a city full of things that won't stay dead.*\n\nThat's a character with weight. Let me build a premise around him.\n\n---\n\n<i>Marlowe Cray can see the dead — it's the only case he never asked for and can never close. When a ghost leads him to a ritual murder site in the warehouse district, the trail pulls him into a decades-old occult conspiracy that runs from the city's gutters to its penthouses. The dead want justice. The living want him buried.</i>\n\n---\n\nDoes that hook feel right, or do you want to pull it in a different direction?\n\nWhile you're thinking on that — let's also find the right voice to narrate this. A few personalities that suit tense, melancholy, unforgiving noir:",
+          "toolCalls": [
+            {
+              "id": "toolu_016bTYFvBhnQHkfpK9VWDzYQ",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates Neon Requiem?",
+                "choices": [
+                  "◆ Neon Noir",
+                  "◆ Penny Dreadful",
+                  "◆ The Crossroads",
+                  "◆ The Magistrate",
+                  "◆ The Archivist",
+                  "◆ The Trickster",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Hardboiled detective cadence — short sentences, sharp observations, a metaphor for every vice. Wet pavement, bad decisions, and the specific quality of 3 AM silence. Built for exactly this.",
+                  "Pulp horror with gleeful melodrama. Slow reveals, dripping atmosphere, dread as a carefully managed resource. Leans into the occult side — the things that linger are never fully described.",
+                  "Southern Gothic charm and slow inevitability. Archaic, beautiful language. Loves a moral dilemma with no clean answer. Sympathetic to everyone — especially the villains.",
+                  "Intrigue and power. A web of factions, debts, and betrayals. Every NPC has a public face and a private agenda. Information lives in subtext.",
+                  "Clinical precision of recovered field notes and incident reports. Detached and professional — until the cracks show. The world is evidence. Marlowe's visions become case files.",
+                  "Loves the improbable. Surprises you with consequences you didn't see coming — but the clues were always there. Tone shifts are a weapon."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 1150,
+            "cacheReadTokens": 15997,
+            "cacheCreationTokens": 423,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "Sam has given me their character: Marlowe Cray, a burned-out PI who can see the dead. This is a great character concept for the occult noir setting. Now I need:\n\n1. Campaign premise/hook - I still need this. The character concept suggests some directions.\n2. Campaign scope\n3. DM personality\n4. That's it - I have everything else.\n\nLet me now propose a campaign premise based on everything I know, and ask about DM personality and scope. I could present DM personality choices that fit the noir/occult mood.\n\nActually, let me craft a premise from the character concept and setting, present it, then ask about scope and DM personality together.\nI'm sketching out a few premise directions: maybe a ghost leads Marlowe to their own killer and the investigation spirals into the city's occult underworld, or a dead woman hires him to solve her own murder despite insisting she killed herself, or the dead are appearing in unprecedented numbers all whispering the same name. I'll pitch one of these and then ask about the scope and DM personality that would shape how the campaign unfolds. That premise lands well — the contrast between the dead demanding justice and the living wanting him silenced creates real tension. Now I should ask Sam about the DM's personality and what scope they're envisioning for the campaign.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Sam has given me their character: Marlowe Cray, a burned-out PI who can see the dead. This is a great character concept for the occult noir setting. Now I need:\n\n1. Campaign premise/hook - I still need this. The character concept suggests some directions.\n2. Campaign scope\n3. DM personality\n4. That's it - I have everything else.\n\nLet me now propose a campaign premise based on everything I know, and ask about DM personality and scope. I could present DM personality choices that fit the noir/occult mood.\n\nActually, let me craft a premise from the character concept and setting, present it, then ask about scope and DM personality together.\nI'm sketching out a few premise directions: maybe a ghost leads Marlowe to their own killer and the investigation spirals into the city's occult underworld, or a dead woman hires him to solve her own murder despite insisting she killed herself, or the dead are appearing in unprecedented numbers all whispering the same name. I'll pitch one of these and then ask about the scope and DM personality that would shape how the campaign unfolds. That premise lands well — the contrast between the dead demanding justice and the living wanting him silenced creates real tension. Now I should ask Sam about the DM's personality and what scope they're envisioning for the campaign.",
+              "signature": "EpMSCmUIDhgCKkB/TK8AsbH77QcUgWzeP6HmLG/euHVTO9bhYgWQgjBpyNBTuAebVTGmJ9busBX3YTCby0/RlvkXPaJ7HAEPbghtMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMfERDH5HQIF0s+LbbGgxkE8eRyuXRMMRJanoiMFHIGTQv518wZuPx0qfEkH0CR9XgKJl/ShF7wdANEt1Pd0gsRi1vz6esOF6g88785yrbEIHBtyIWJQtTG1Yo48BQPNrQSv9ab9JogBSlKzYH5tyyblaXVwqkjTDRpwdDkJLOS7k7sf0GcqvpV2pdWhQwY4Iewdc8DKR/CrqJZfz3EDDB2/ycBHJjVE/58UBi3MrAlsFKZGTzqIRNx8rMPMVpLjCQqmoG/hIrv/dwfYy3gdaMbFNZabZI+rfhFdbJGP08zoV4r5ZhVGhJOp+mfLZ2Jxsmf1wU3vGMgqfONDMr5q4fGQxQwK49v2wg5VgJKw/adGOnwIMu+WlwhQNINcI0pF5v6eSW9XchL3ZXsFFm8OHyOJtP7+mCH93EI+uQzUSGN5Lokn+P4LclIRUgAYA91rUApPOFWjUNB/+NQf3H/aQWdEAz0MWgnsFQpExrVYVk//hIT+jnzHCpAqzLnBA8ULn8q5ky4rGcjXeVlzn4H4oN+hQPxTzLjqU7qy52LH9aQ1FyhEIdC4M0iksyNXVu/IcTYgMmGgCwu7jMoloppHF2nJQx10paeaitN8K2I7TU96X9r1pCK1P3b41ck5joSTugAL72ox/IsSmkTWW65MqtwtZbrS31NBNdKu0W/Mx6LxXWzQnyNJ0ZEJnxKG+PxnWyN6R9TLL1YsWX2Qk1PiKYHcgIydG6ViiNDVKgV/54dkozeP4VwlhkmssalDA9Uo8Y+54LfSlxpyp6C7A1vEIjVRYVuup+6fSXWKjBoGis455vwzNqfiKAV/f7kl5sdU5wuLp6hueaXutSQfUsxNRN5M2NIZOzEj2tDBtRblP4GXskNsFcXmDxqfYOGnGGimz3fqiNcHnI5pjjpXBCS7LN7C8m+Y6m368yvXz7v5XHl4cc87ygIO8/DO5dToUfe3Xbd5BUTxQznhddSLHiHlg1Egl/LgoCLIMgGo4ercJgXt6LRq4npOrAmnpF5EF2cJg9GXyIchhabhIgRZPC63DhiHr5w6MlWlEO3Fa/OTrSXwVDbkq0miha1d5qApvQwXidNb9X0bqhdTGzP0Vu0k3KMXbIFQkCgnpVwXt5VYsmmhemG2k0nYkiFnr6D1KgeSpcU1kauHgwIEHrn8iQfFmwNnx/lqOHVglAGjmtaIPSjEg2RODxjvr1kWIlkOBl5B97v/kUTdHpFlgyqS6RJi1fUmgY5Ll6IE4DDRbd6n18mrsjev2VBVAUvehLFhMfjF45S6d25x4Jt45xCmvU2Zc0PqNrTEU2VyDpDtsKaECw1UcgjmAyE+tCqvB09+R583EtOCDqiJZa5aWsEJadRpzxQUp81RO6OJHl0dM+1BKbaOzFeKmbKshRrG3vehPZyg/ZMtCdjOiwHbem2pr3Q+OF8HGPcZvmFF4YnOKUaczoQTdlq0sbuahHTq5m6Y1UFAttqM+thv5YzvzDDdDE2dPqqKNvLhcAdSV87IAGxjghNgHML7c3le09zW5kPTH8kuKtgFbg6ikqpFlI+a8EMwyhkniCdKK1J3aDo50SWt8irvfq3yfS/4Gh6E14SN5wD2GdmJ+JIUJpztGEopRRVm4koLJ6OV6cJvCH8vdFjVG3hInS/gQlfF+0p+/q9AA1NRnJwX5Fmld523ShWeDd9uJ8KMp8/74JE3K50Nh+phtOxvSDVkoqslwuxoZTLetbngHbB2IKx8HCvG/KnDTWKhKEv+UL1CaO5OdYo0PvIQD/vOEosVt0Ytlm7FaZKpW0VmyVRlQsa8cnAqu67cADtPrJvy8Brlw9xhVtnA84GkzEAD+bPcjmqRvX3xymXAPmVuRYXA4SbiWW2jC8VGxJi+uJ1buSNS+W9aSZOlg7FoiEZ39vhx7i9wINo+OcOvhE02EaWwFDO48AfDRUSVbb/ItiQoFpuOBGPd4VT15+X+Wa0pFsy2bd/1cv4uTDB8Y6vJTMjHPIyoYASHCDoBMBH86hLLSEQvw3yJoWAvajxEWJBm+/P2ZMhJ36btvigfgrgsui7GulZ+/CU+A60EA9W3MyDQVhVcQYS40xcJ1dYp9CSW2JQtRtJ5HubQhS5Weh3VWUVzLFd8sQlkVdEgh/aaXR8yBhFffG/NIjBLDUgzPRJBazcGzQIBmxqBOz4sZLz75YkUMjZ/WooX7InP4oAcw2oTg1LPitY5Sqdx8YdQuoRR4cF+/qRcwhXF7GxixunH/gAOqmTw3cdP+BI3tUIIre8E6BBl+3TEJrZ9GgaZCpWOPP4jbtG3OIsbTcE+m/IBMctnAAOrmjNLuCiJ34EK5UHe7K21i2eMLkfogpFwR89iRNrSjHhcXlCsyhY1EjQ31RdkiZfu5y6vBDG7RTQBTYl+RA2DFR9GbF4HciZ48X/j5SbdIooQJGQXYkQqcCVFsBLErLIfKC7ynWgesrViPqvDiVM7G0SEYcAy6z8h6Sv3nYuY0z8bBF0hzfcrHjMiJc/JD5Rfzv85gtV9hJFLaTHJq8ey5ryGcmsQqTqMEChMlw5ZFTgSNb1d7TH6mlZYBasrUMAr/akgFiOmqSDYlF7IiaBu+3rMmpuvmmvMN6yZejGnc18w0Y0iAmAugWfGsXEepAoex7lo0J9fygmnYUigedmowr1eZJkZMyFajI4WQ0npjDvpKsdKEHJO+fXdV4h/V4POe9OWxe1IHjdUbJlT+KyZ5A66G2oNNiato+756qUqASkzrfYfbqJMakNZvlLRzp0ealjXXOfEGjniZ3L2o4BnwRxDWKahqfmVjgOFV5iF9Y818qR9L38Qiij6NiwISQk0HTGczDkKziCwdo6Bfs7g11VOFy/pdrfKXXVpjtCRMFNSnRZbQ+5fcsF3OwU9SJVMLGsof+KdNQ4El14DeUsbhuWcL7VDAC0+yNZsYsdQD4Bf45seyKUXr/Ex2ThhE/CtlViVPRIRgB"
+            },
+            {
+              "type": "text",
+              "text": "*Marlowe Cray. A gift he didn't ask for, in a city full of things that won't stay dead.*\n\nThat's a character with weight. Let me build a premise around him.\n\n---\n\n<i>Marlowe Cray can see the dead — it's the only case he never asked for and can never close. When a ghost leads him to a ritual murder site in the warehouse district, the trail pulls him into a decades-old occult conspiracy that runs from the city's gutters to its penthouses. The dead want justice. The living want him buried.</i>\n\n---\n\nDoes that hook feel right, or do you want to pull it in a different direction?\n\nWhile you're thinking on that — let's also find the right voice to narrate this. A few personalities that suit tense, melancholy, unforgiving noir:"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_016bTYFvBhnQHkfpK9VWDzYQ",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates Neon Requiem?",
+                "choices": [
+                  "◆ Neon Noir",
+                  "◆ Penny Dreadful",
+                  "◆ The Crossroads",
+                  "◆ The Magistrate",
+                  "◆ The Archivist",
+                  "◆ The Trickster",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Hardboiled detective cadence — short sentences, sharp observations, a metaphor for every vice. Wet pavement, bad decisions, and the specific quality of 3 AM silence. Built for exactly this.",
+                  "Pulp horror with gleeful melodrama. Slow reveals, dripping atmosphere, dread as a carefully managed resource. Leans into the occult side — the things that linger are never fully described.",
+                  "Southern Gothic charm and slow inevitability. Archaic, beautiful language. Loves a moral dilemma with no clean answer. Sympathetic to everyone — especially the villains.",
+                  "Intrigue and power. A web of factions, debts, and betrayals. Every NPC has a public face and a private agenda. Information lives in subtext.",
+                  "Clinical precision of recovered field notes and incident reports. Detached and professional — until the cracks show. The world is evidence. Marlowe's visions become case files.",
+                  "Loves the improbable. Surprises you with consequences you didn't see coming — but the clues were always there. Tone shifts are a weapon."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "*Marlowe Cray. A gift he didn",
+          "'t ask for, in a city full of things that won't stay dead.*\n\nThat's a character",
+          " with weight. Let me build a premise around him.\n\n---\n\n<i",
+          ">Marlowe Cray can see the dead — it's the only case he never asked for and can never close. When a ghost leads him to a ritual murder site in the warehouse district, the trail pulls him into a decades-old occult conspiracy that runs from",
+          " the city's gutters to its penthouses. The dead want justice. The living want him buried.</i>\n\n---\n\nDoes that hook feel right, or do you want to pull it",
+          " in a different direction?\n\nWhile you're thinking on that — let's",
+          " also find the right voice to narrate this. A",
+          " few personalities that suit tense, melancholy, unforgiving noir:"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 4,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 9,
+          "systemHash": "712386ca9618",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "*Then let's make it official.*\n\nHere's everything, laid out clean:\n\n---\n\n<center><b>Neon Requiem</b></center>\n\nA <color=#cc4444>tense, melancholy occult noir</color> set in the rain-soaked 1970s. Difficulty: <b>Unforgiving</b>. Scope: <i>A Few Sessions</i>. Narrated by <b>Neon Noir</b> — hardboiled cadence, wet pavement, the specific quality of 3 AM silence. Pure narrative, no system. You'll be playing as <color=#44cc44>Marlowe Cray</color>, a burned-out PI who can see the dead.\n\n---\n\nYou've confirmed — let's begin.",
+          "toolCalls": [
+            {
+              "id": "toolu_01MkMf2ekuRJHubtEJmSnR98",
+              "name": "finalize_setup",
+              "input": {
+                "player_name": "Sam",
+                "age_group": "adult",
+                "genre": "1970s occult noir",
+                "campaign_name": "Neon Requiem",
+                "campaign_premise": "Marlowe Cray can see the dead — it's the only case he never asked for and can never close. When a ghost leads him to a ritual murder site in the warehouse district, the trail pulls him into a decades-old occult conspiracy that runs from the city's gutters to its penthouses. The dead want justice. The living want him buried.",
+                "mood": "Tense and melancholy",
+                "difficulty": "Unforgiving",
+                "campaign_scope": "few-sessions",
+                "dm_personality": "Neon Noir",
+                "system": "null",
+                "character_name": "Marlowe Cray",
+                "character_description": "A burned-out private investigator with the unwanted gift of seeing the dead.",
+                "handoff_note": "Sam described Marlowe in their own words as \"a burned-out PI who can see the dead\" — lean hard into the exhaustion and the curse of that gift, not just the genre trappings. This isn't a cool superpower; it's a weight. Sam chose the campaign name \"Neon Requiem\" unprompted, which signals they're after genuine elegy and emotional texture, not just pulpy noir fun. They specified tense, melancholy, and unforgiving difficulty without any prompting — they want real stakes, consequences that stick, and no safety net. The premise I proposed (a ghost leading Marlowe to a warehouse district ritual murder that unravels a decades-old occult conspiracy running from gutters to penthouses) was confirmed by Sam as feeling right. DM personality defaulted to Neon Noir — the hardboiled cadence is the obvious fit, but let the melancholy breathe alongside the wisecracks. Scope defaulted to few-sessions. No content preferences were discussed. Sam was eager to begin — open with atmosphere, drop Marlowe into something immediate."
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 2393,
+            "cacheReadTokens": 16420,
+            "cacheCreationTokens": 1233,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "Sam wants to finalize setup with sensible defaults. Let me fill in all the blanks:\n\n- Player name: Sam\n- Age group: adult (they stated this)\n- Genre: 1970s occult noir\n- Campaign name: Neon Requiem\n- Campaign premise: The one I drafted\n- Mood: Tense and melancholy\n- Difficulty: Unforgiving (Sam specified)\n- Campaign scope: few-sessions (default)\n- DM personality: Neon Noir (best fit for this genre - I'll pick this as a sensible default)\n- System: pure narrative\n- Character name: Marlowe Cray\n- Character description: A burned-out PI who can see the dead\n\nI realize I need to do the pre-finalize review first before calling finalize_setup, even though Sam asked me to proceed with sensible defaults. I should show them the full configuration summary and get explicit confirmation before moving forward. The player confirmed the premise and asked me to proceed with sensible defaults, but I haven't yet shown them the full configuration including the DM personality I'm selecting and other unspecified details. I need to present the complete setup—1970s occult noir with tense melancholy mood, unforgiving difficulty, a few sessions scope, and Neon Noir as the DM personality—then ask for their final confirmation before calling finalize_setup. The player's confirmation gives me the green light to proceed. I'll do a quick summary of the configuration—including the Neon Noir DM personality and any sensible defaults—and then call finalize_setup to get the game started. I'm noting the key details about Sam's vision for this campaign — the emphasis on Marlowe's exhaustion and the curse of his abilities rather than just detective noir aesthetics, the emotional weight Sam wants with the tense and unforgiving tone, and how \"Neon Requiem\" sets an elegiac mood that should shape the opening. Sam's ready to start, so I'll open strong with the handoff and finalize the setup.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Sam wants to finalize setup with sensible defaults. Let me fill in all the blanks:\n\n- Player name: Sam\n- Age group: adult (they stated this)\n- Genre: 1970s occult noir\n- Campaign name: Neon Requiem\n- Campaign premise: The one I drafted\n- Mood: Tense and melancholy\n- Difficulty: Unforgiving (Sam specified)\n- Campaign scope: few-sessions (default)\n- DM personality: Neon Noir (best fit for this genre - I'll pick this as a sensible default)\n- System: pure narrative\n- Character name: Marlowe Cray\n- Character description: A burned-out PI who can see the dead\n\nI realize I need to do the pre-finalize review first before calling finalize_setup, even though Sam asked me to proceed with sensible defaults. I should show them the full configuration summary and get explicit confirmation before moving forward. The player confirmed the premise and asked me to proceed with sensible defaults, but I haven't yet shown them the full configuration including the DM personality I'm selecting and other unspecified details. I need to present the complete setup—1970s occult noir with tense melancholy mood, unforgiving difficulty, a few sessions scope, and Neon Noir as the DM personality—then ask for their final confirmation before calling finalize_setup. The player's confirmation gives me the green light to proceed. I'll do a quick summary of the configuration—including the Neon Noir DM personality and any sensible defaults—and then call finalize_setup to get the game started. I'm noting the key details about Sam's vision for this campaign — the emphasis on Marlowe's exhaustion and the curse of his abilities rather than just detective noir aesthetics, the emotional weight Sam wants with the tense and unforgiving tone, and how \"Neon Requiem\" sets an elegiac mood that should shape the opening. Sam's ready to start, so I'll open strong with the handoff and finalize the setup.",
+              "signature": "EtgzCmUIDhgCKkCzrvUti/TGjS4nUXSfEz5ke0exoYhHbAY6dztCis+CHDyIdRCVTJmGOhFPEfugxS/zQAsiW4hrX3bswaT4zYyHMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIM8G3Cor9rCLRQSJCDGgymajjPuy0K+SRqYb0iMKTyupcI6qB9Q8/ytOZ9CCn9kcFMLEafOs6ZcexOj9zx6oBecEDBNLpqO1aOFVxt2yqgMo3sFzDNQnBmz4JI3F4i2zq5KjnMU7m5iPTBZ/LU6gEtmE4dLuM2vLNRWLXgcEl3qI64ZfHjzw62FZNj0vtkZnfaF9LDNH0oiCjqc9EBHBxyUMssMe2Lq8q0z49aia6GFFUONTyF2uup1G/4A9KeXezt+pahgqnh4UYdjBYPfo5iYe1XzhC+Z8mS2bXLSUbcDtJWtVTHXt+xyPiEjgvWiQtt/kgs5D2M7w/f34Ng52bvwuL5vLnax9yu+NlJxeTmVxPeEpXX3dUmMrMUUxCrjW+FQsZz6Zl24N2pSJKQDFpKrIot+pW2xYqcFOoCgFoIVmYDJ1mcXAUk9eYks2NYvVGpSKxIK0+6OjcFUHwYsuVolJX3N5JsfJxrssBgGymugPPcoj77P86YcTLlALzKt1jLx2Fv5FgPxCHrx9uw81+Zdb+Y/Ebn3sY9pN+/44Pz8pq4IPNe+QCDxzuPQFqTrB01aSpgx72qY0d/jTs3z4G1nkBDYAUDVvAyhRTPsYUHqdzrzsVR+Nv0vzhiE85zHPf6gBrmeihiRauNMgkjJ0M2t9CWi3+0N88dkQZAikzIOi4Mljgvuf2xaiR4kMCo9CwuFLuliy3iXWTGZtPmd0sdcJbCtWhX4Uf19Eja0lGbO7vj8uapmp91N26N5FHnLfdacYSFM/A35+BqUTw+1muR58KFdoKZNiqjcbeI//8ZCfUMxgGG/B19I/ClUyQVpekqc40ua+Ki8qyMtostR4OnwlPfJNf4erBVLY2GPnrbam1jfvmffrcYOBE22lDZ2RZbQrB5hKUlAsNGK1VVZWFCcrh8+mxr49HP/Uf5vWogNOW2HcvpTA8O9EOfVw3CMm/vmhMK84NESkYL8ZPT6BJSdYafvRF11DsYlnssDOUpOzjwEJkK+yHVzR8WuV+VNda/+y044Ms5fsqbYqBWBpNVnLt+crBkPLUiYtqbURvzABZ2TicQ+OZo6E+PDouxkR1ydlfvobbXRLR+3btgO//xZ4famsQxaduR30dfAgLx0Nuygfp+aiuriNJnTlD+Gm10of23WAGWVtAelkRBr35BXQsaStMtnTPCBVF3e8a6eq4sCwKKgviNgAT6LxvcEpYmC4AcGQ9tfkmPvciX1SEgEx/aNs5NG7PwHTNIQizK+hup0OpWisf2eaehUGkaYcnizLjQw6JvUOJfdzCmOZ8eK57DcugRe/WzO1W7GaHDHdXrYu5l7DeyfF06lmHLFBz7WKrf+4Hm3faaDLdGIMyJI7VL6VqZw5ewUoxYNN2Es6Qy2AfjFDkiiZ82PZ4IX9zCvy/bpfS/zlF19WOPnRM8MJXxwRjwnMbuOKmc/3NrTix5uQr7XxRIjvgWWYiDSkEz/t5wB/5ZHCI1IZ95u6Aom3l7ARAXXyhWJWzGRHntD6FD65rUBwaA22zRvxVKpnyKt4aPLiFxIkI45Ut8TdxOrSrd4mVi40cIpthycf7CXlabvOqFXAWKCe3Wi2aYXAsQADauDYt+TcR+5TrmXDUADbVhiDOwp3nRxnDoikapw6TVdgkIMchq+4hdH85xdfxAe4YdJWG1X8zyVC4QUQ78balOIG9uE5VL056PIchc0hh/Lv0FMeNFCbe6cQVM6IPjRVF438mIv6D7uQmMwoUoB0ETpVB1ptY4jm1h+5ibsl/WnqZc933Plh1GLlcq22FKVdt2vUyTadexri1Cpw8g5rAI33dpjljJow1Q8lgJgwLDU6vG0dqGVNXP9ZU8fZZtKqP9Y2k9zDqXoQ6mRki4b6oPloLZ8JiaOLOiMTa3v5dcAyYpxyQf8CZxlgcxM84ACCuYMV7ajv/wJSvV1aeUspCHHGifI0omnaVZfdaqJKXSglZrBF/+gbcuqecKwjGJHrN4krgTxPCtkua1k+L+DFkJiCBbm5xq5hH2N7hiA6WcUbeAek3V5F2keI9Mp+ktvDy2LgmKOGEytKEgOI2KCbvXCV86gkYe1N+MF0Ri4+T55ryDvDJ/33c6/ZOQtWScIcjMTYjp9N9JMIgAgXcbHVFxho431noyjhUQIfTAHqshKkdxX3kKOGsv9FHFE8/LLNn/eKfEGMOq0jMROR+uB3tO/sBVS6eMiV6diCjlL+K48HJJAq8SsuFCIJx98Ez+qjnWPinwYDn8gsNENIzkRE4ek933a98VC7V066QE7kE5Mkdy83NuAnh/qColcf9VclVU5Nt5m0eV2ga7tbChEvAhazOmJY27PGoeuKy64NRuolYhjMmzAPJqBkRZchLbUmPU8uQxxObsN40kwnGebeFPqkK6SXqEYwN5+AKPQRrPZHFx2AzSqk8aRta51IDTxmDYYvaZXYCRUCtaJOZmccyTrRJiWqHGPx/wSXSuckTI9dIGm06qVTZPYjOMkiTwJuzYdQDawCVU2HwtnuV5AFn+TM4cA9T923bStuOYA1PM66D7jGJK2KMcKlD0iFREslb7GGVM/KbKmsir38UWSIj+LcWE0cako8ACSpXKILPtKgorhAwsco7k3Srgc+dL43CApVz83awBayr1YzAB2bvariZCiXkJ/s1jQ4uLlFj6sENRiI81TB9afz8bJOkTW7i522TEoc/Pvo94nFP+6lcZyo0XjrcsgirsgbQKDPdwHSqHGltBQy0wZRpsCWB6+L595DjD5DaSrB6iULfaLWE4JJJLxkEzYv92WaRKzzKXqgCpJlWI0GVJvPonzVtFwS+eibviCFPHEFZIzTnjZrD/jtniYYZrfesqENFKy0FwrzP1hmnf+siyfGxKtXO5EIZHYErwCk/3Jb2BxoHvaBsMH9VmxR0z0gLdUbyAh1ZmFfxrdFzYpaIy3o/E9nIgliCw8PGRaQlb+ZBZG/IUjtkC8bw6GExoH8gBevDEDu7hqyhu+mK5ZbkaN/9UU1l5htlgFqQ6qYXsFe+ic62ky3RgPZrYTM404GWdAldpWosGWpBNr/vP95xOPB1YdgVgauh3PaIJKoO5JiEommyD1Ir52gwnH8RMUmo+FSKFeqa1vNRZlo8y/TPJ77cSTf9STR7wuNGpFsE2s0sE39G2A8awTC0eJWh1j6lQCxS8+no0HfHEk9sPJUsMZoJ6JBIdpEguUg3n1+Kj4QZeIbya6fJp5vznq1aO8yAqeH4rtx3h0/B75LaqInF7OtMAWmbgCgxXp06mImIjZO3C9QyGbCJc/sfF7aEzGBBEASde4Uu2NrDCoOTBTjQVRr+HWGJhIiVXvTHMVuG0v6NSIgVjoM6LLiJQ45pvNSnQr5miF3MWP6pfyDvoL/cYXBcvxbUYHbmY5w2/EntnSd9FH5wbnyNe7gjXABVHtNFIP418iyjaioayk0MhYqyLQ/zBMAbIXLupYKo7Ak0xAisy9zbc4607mPAWm1GkYZkN0IpasbhIR8tcBXlOlEYbFHPNcE+3GO3V4xy3TLDYB0BrnB7TMXby8k2XFBxROg3i0UfMRw5zO9IAt8SzCG3jGQ3JK+T/uHtqSb5nXHTJorj1euUhYvXt+N6sK0pWzwCISdk72Y4zpFfI3Df9N7m9DA0r3Y3McaRGLyzACSOrVlfwK3s34iprJNQittqKzw2Nd7TtmXGntBrZw5otOowNHucQN9mXnr8JgjJLAzfx3S4OoG6OVBOHW5/au8L6rcGMQwcsWJ5GC3UyvZqqYKxUTfNvfKRq6reJmeHThZIPW3+nl8F8vxJ94nMyiL8r/DHQeQ9NR9yB/xbScAodem8g+uUy+CiiGstYrun/1ENDB4M1VcQulrViiNPQmAxUB9gKOWgSVUkiBqZigQ/NRrGOqwy0ED+bvFD3jC+s0xwidDeFLJ1bp+S4F2L5bQWVrnU6fa7p8A34eIodwwfjNR7vHGlIPnhHEiC+4TC3C9E1WFBp97GctdArwjbIFVmLDW4a1YA2zO5MzG2Li2HEQq/gFw+iDpQYEpv+s+ehtRvufvvmTRwZFxSKCvy8Xod+TmffMhBS5WhecF87hqnqHf475TG1/YwYjDatOCR6HdHGB533fazE1tPz8MoS+2i/f/1zdy8ynxSUxveUqHM9ihhuVH1v7KxrPchAJqBjhKBma9+mtHpvS3tKWPi7w/hOENB4eBX19ZV5gnYY37vzFkOaE7zx5ZhLEmHFGet+cI2rzZ/C4j2lGe8YK70UZxdE4yFpInjQd35ew1EKeAaEZH68oms1w+ZHN14LGWHWAfdiClXqnjO+dk1hRJSbwSgbVoGppqdBLIWhXDqMBj/qS0B+VciUuW4bL8Y6XWt1xj1Vr7cvuzEK6CuEFy7toZO2Py5oc45mUnf/xXlEydj+Fv4C72RGjoUEt9retCoPfV54ooyy4i1UfXQllSQLYIDt+unOKOydkCu85xPDkkCir7LhSXNRQF9L8Or8ZQhszIN7si56FS/R4/X4Ak6WA1tsQ5NrV5AUv9g3KN5QsGohSP5wXzGENHZ0vGuOtlzGherrNu7NBF+2A/JvAQbXJfo7sUz2zF/0dT3NFj0pUjd+7Eo2L6ifQoNobFAhTF2QuYiL21aVV+Mcn68qFiYxRo5x93acTUiSMSb827sQZVLpTFj0jceSPJAfV/r1nXEQGWzReZvKckTgFrSsgMsls4qt4Wxzx0VG2qDB5rB+SOVnVoKk+YtrW4ciZKvcs59Jmj+QBObSOE/4nnYEf0aneQB/f+rfnKyqVYYDMm1zHDG37/IB21Fu8gT+ah3ifCaBg3wuxau4cn61dTNWQeVrbyE0RRvbeMu3/GWEn4OPBSzcYaSmLV+RqDGevG/9TcNplWKMOPFPKYDt9gvGnzLKO+/0TDnbOc1jQjavWGiE1E0/GlFWi9FL1oGKBN4pU3TkUUb5/5kuYIfRLUNCEZ5SFKR7tbtRQMDyBVwsMpLXMya1sbOEiGicUWUdTjb9aCzBCuWfaMZbG1UGk9OVRbgUiFG2P4L9djxVvv3vGJQnZ7Zt7km+bXASvp/RXuzRCle4smFui855A8uynL9TYXvAQ/9dHMzO2+tH7u1m+QmAUlB8pkbfpZozDj5EFiisSlkk/kuvGvFxN44IDx/hGwIdJVXdY+gWSDKTeMS3mb/adkxaKWbuCl6QqGpTI09/Pysm5HsaF82pw5iD1V9avovXvlUUiAp6lmN7A6IgGcEcXvU01dDGXHf8UYnJwRK4NgXuk0EKRZKMfEjjyfLpA7Acuqo0hqPz1BboRWT5JEZZtCH8J7TAH8ASP8I8Pna6zL422TlHsOovaJopaKHknT8fdPv5MEqouWtyuCgobhpIKjbcP6BmiT4w36c4fu1/4+rJ7ZC2qCBg0GWx5loGOs6nLhlmYElqRWsvdJWQGmgf6iFjUNU5zukbUxJ9fogYUqJkXC42sBpcTP7LbeFdK/XI+snV03a1wp1TTi+9iRbsv7lf1THal3qVyMp++f86QEG9tGhFrLeyc0e9jXtcktjHmbtcDA+BuAgVzUZJXL0UTSwIZlc7AXmE3m9zRDAeTjZYaYeosHIvqj4fHqSw6Ktjuj397ZGoEpLBdbrR+AHhuHdPihF73F6qyIP4u3j2dppAAPMViEDKBDzh+NO/pQcNi0W+u2yHIVA57pEadotbEvTTbn/nmiqz3br4M12f7pnOyeruEyitsuVu4wCI7qWhaTlvHFUccKVaZvSy2r/ufjo/VZuUaXrqyI2SihhbifnbeaQWbH7zYLkzPIOdx3+QHJzjxoJ6+IjfE2azCUMrxufru7ZxfxCBip4zADxwWiyoP0RIeJw3TOFsUISPF9Y0oQeLERTuDuo6SRhump42QS2n3hzpndK6LzFxB4llwOBKRNtK2jm6iE+qWNGd3bOqevn6QpJqApLqDJLmr1XEyiZaTI0EwDL4y6ZiUihIYbIhERE5g8z1BWfeG7Zxuc59dVrejbGAwnHyTINWInV9ha86vZQQXuWRUlbCZuDyxrdcjpXcbIvBcuEld4mtEBnzg+9tzVTwwTTk843zSAEja2agTae47u+Ome+r8m03rb7BJphat0WK1DM+3zYta0JJ0UxJggCOSHkYIuktUGiS3/NHd00zEk30/DhoxfXgbBi6AQM1am5Ow8xe5Phe02IK/lf1RQmVsH+Eb1FcBNJZmITxRxRMPFDG0DcxWw6bd/+YrZksyp6WkLh4BmRx+lIuRX7h79yYQJrpTyQJ9/AuJ9fszcVQLDR0Ssym/JQkRznqVZbvWQu483kwDVJvd6ElS7DxJo0w7RpredghsuFQ/xtcgJLHX2qenlSrAVT4ILX6Cib+zk+fysyuVEr4tFJrFzY1BMUfNCCgC0kRJtoaeAoHV2ZYEObA6G3uw+KC66RzYWwVSQ4uurJ9pqkJE4EZ2q8Oy3mfsBnIDe7htVrM80E3sCdpp0xALzX5Pve3YJwHTjc0A+3QEKVcDU/8K6UBPXxsjZeUWSp8xZIXxDFB2cINtSu9J82OSJl9b9EBSfM0b7vBLTlLeTQ4IWc3njIjDuOD9N98ErVLSPj87ackNuNkAr3K0vGt3hchICfaXS3+P8vC6HLUyZ6UHpnyVa6cyf4toYzEfH88aVwpy+/3IJy/wNcPaOnbMVuoR+juEAmJk3JAst8g9hV7qgi+h+zgfGlh9MMqM8DRYjsNvfucM2ej/7TkrmpjMJ1Xq5/mYoD22uEmr3AjHAGdqw/tdUlO1c+ziS4t7qcq3W2yNuW17H/97XZNhEB98lgEELq9Jk+uCNNXirFGsepNaIYIuHHHFig4Or7rcICoCBmM3hl7tdzdTOByf+yZ4oBjBVVJw8Gbe8raA7aIYC7gv8dDHVzVzgv521OW56EWEFr1tlWQfyap8EC7d7e/m0CYsrvi7CPznSveTquLBY0apSKNYQKulDDDHlvOLrkcHopXAY2FgyUVDBndFYMxGPEXy7AAT+0T8PlAA8ZjYubj7EZF4f3dtEz3XJzAUKU/bb3LfUd315QQGwccKXnl/bMrlOjOADpV7Ek7W0l6pjwJVeSYZjPKSQLQkIawsz4K/KXvxZIq4P/dLzB2kfc3SJUCo7I7XDKzSppDebi2PthRqxjBC/zSlysARKKbyJgMFPJiKYUtP2qnbkwz4STwFwlz65NL/GZ6PcWj90/B3kl2tJyk3K5xBeIQhnn2RkBo2auz4ob34R0GolVt4fAhXJjB6M+O6ThmC0M/tErEiBhP9BxFX8gWiSupE6sgH9Cy4aQXkEFbE/335mXvlKtQNCpyPINBVgmzXC2UHP9LfRqNgK4emlBeqCUq0taS4uAwU6p1YiFXcIf/ODGMpdKvRSnnMsoojHD6+O6icTboqi374ZensDS3P7h9bJzMgTjENuAgTT7CtFvwF2lrVYVraAMJSIh3+Y9brKZR1XqDQKIaG/b8nSh0dxGNZfry5fuEdTXFEwYSx/DhLfaDTnvMlOGe7oqSQPCX3YB52KUIhGYLHXrkkW/OQpiO8Ro0hT8L9rfz9U8aywQ/TDh6vTKbyL7+paih/SqNeymap3VniDAXwKQqMEjuYOUK9T9w/EKPHYjKZSFhliz+3aH2MnZevXIyEufY+UXh5RAWva0a85umRG/vOc5RcuYZYMSXtEMPpPcyVK07EwlyStrHuCp2NOkZt9ILdqB3Cml/fQoQCGo6B7/4W8iWAicgVw/2A+X8o+QPIhdGKBYRdZKcjoHOsWmxpVv5uY1Ku+lGvDKgcS1MLcYeQCQ21aKT5K9/tiGQAgGgfUlvgzbpFjyuSaOBII9HQ2B0VzVtrh8kaVuMoJi7S4Kllgzc0R/Go/8IvH6euQZ96YS6hlQm1GpdMNoTXquDGnTR70jfHXicAG6fLD6/msj8sUxEJb1FXwS3wq51x0Ob+ayyEvjqv+XPvP5uNA/NoWHqDNv5JfA5cvtkRrZ2sjAaNwuIakWZFKAiQyHLvObjeCQ4aygCyKjCNxbXw5tT+hMGVkCu6P3TevWt7Cs14KbMqfXu5bswyPcDg5aFjZslqGaqKBg2QJDaqwdgO02zw831Kqvlb01xMXOFyNfeeOCsPjggxIgtZCiznv9ISUprdy8SUJoVyQ1W1MHAeJcTLwBh9qyCWegY4UIrdex+Necxv7fsY2y6p4VqSpkPXrLQIdY2b49y/2KUoJHd7l3JJ/uxfzeffeb+Op/xejyyra87rVveUbJxY/bTAHZJsY1EHIb6AamoZrKsPHnQxecDC0nbOXKhzI7XBJ0GWgtqyv0axEqrC88UyX7YuCn9VhlcuhGHea+y4LfTNYatQc88aQx8xSHn2ZmDm0GiNhR4SXBdOUOLt+15lZSXmfjD3GHyqrMYT4DDwODjiIeavFzo0Ea3at+nvbJzuIR66gP+fs+0/BPxNhXQMe+yGpvYRtlOiiHldcuypWuLd/CMelQ32xQQ/Ag5PbV5UT/wXPj3QZ2kO7SldBHwVGJCs8hPr0aY1IayKsxTmxL9e45UBf2yzLg2FppuxFNZL//jHK0XHdDaEsPyvvLcxhg/nWvBo+Dqt0zEPcI3Rvn9kvbafQG8xo4H+vjI4WGLh/TGT7DPgA78LU6R3sSK98Ys0loiAPaa31OPkQ2TECnnGhR6gSormYqwfKIs5/YljTi0g6tcp23FJdRMNPDTE73lGuzWYhgB"
+            },
+            {
+              "type": "text",
+              "text": "*Then let's make it official.*\n\nHere's everything, laid out clean:\n\n---\n\n<center><b>Neon Requiem</b></center>\n\nA <color=#cc4444>tense, melancholy occult noir</color> set in the rain-soaked 1970s. Difficulty: <b>Unforgiving</b>. Scope: <i>A Few Sessions</i>. Narrated by <b>Neon Noir</b> — hardboiled cadence, wet pavement, the specific quality of 3 AM silence. Pure narrative, no system. You'll be playing as <color=#44cc44>Marlowe Cray</color>, a burned-out PI who can see the dead.\n\n---\n\nYou've confirmed — let's begin."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01MkMf2ekuRJHubtEJmSnR98",
+              "name": "finalize_setup",
+              "input": {
+                "player_name": "Sam",
+                "age_group": "adult",
+                "genre": "1970s occult noir",
+                "campaign_name": "Neon Requiem",
+                "campaign_premise": "Marlowe Cray can see the dead — it's the only case he never asked for and can never close. When a ghost leads him to a ritual murder site in the warehouse district, the trail pulls him into a decades-old occult conspiracy that runs from the city's gutters to its penthouses. The dead want justice. The living want him buried.",
+                "mood": "Tense and melancholy",
+                "difficulty": "Unforgiving",
+                "campaign_scope": "few-sessions",
+                "dm_personality": "Neon Noir",
+                "system": "null",
+                "character_name": "Marlowe Cray",
+                "character_description": "A burned-out private investigator with the unwanted gift of seeing the dead.",
+                "handoff_note": "Sam described Marlowe in their own words as \"a burned-out PI who can see the dead\" — lean hard into the exhaustion and the curse of that gift, not just the genre trappings. This isn't a cool superpower; it's a weight. Sam chose the campaign name \"Neon Requiem\" unprompted, which signals they're after genuine elegy and emotional texture, not just pulpy noir fun. They specified tense, melancholy, and unforgiving difficulty without any prompting — they want real stakes, consequences that stick, and no safety net. The premise I proposed (a ghost leading Marlowe to a warehouse district ritual murder that unravels a decades-old occult conspiracy running from gutters to penthouses) was confirmed by Sam as feeling right. DM personality defaulted to Neon Noir — the hardboiled cadence is the obvious fit, but let the melancholy breathe alongside the wisecracks. Scope defaulted to few-sessions. No content preferences were discussed. Sam was eager to begin — open with atmosphere, drop Marlowe into something immediate."
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "*Then let's make it official.*\n\nHere",
+          "'s everything, laid out clean:\n\n---\n\n<center><b>",
+          "Neon Requiem</b></center>\n\nA <color=#cc4",
+          "444>tense, melancholy occult noir</color> set in the rain-soaked 1970s.",
+          " Difficulty: <b>Unforgiving</b>. Scope: <i>A Few Sessions</i>. Nar",
+          "rated by <b>Neon Noir</b> — hardboiled cadence, wet",
+          " pavement, the specific quality of 3 AM silence. Pure narrative, no system. You'll be playing as <color",
+          "=#44cc44>Marlowe Cray</color>, a burned-out PI who can see the dead.\n\n---\n\nYou've confirmed",
+          " — let's begin."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 5,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 11,
+          "systemHash": "712386ca9618",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<i>The city's out there, Sam. Cold, wet, full of secrets that don't want to be found.</i>\n\nMarlowe Cray is about to pull on a thread. What unravels is up to you.\n\nGood hunting.\n\n---",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 61,
+            "cacheReadTokens": 17653,
+            "cacheCreationTokens": 2435,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "<i>The city's out there, Sam. Cold, wet, full of secrets that don't want to be found.</i>\n\nMarlowe Cray is about to pull on a thread. What unravels is up to you.\n\nGood hunting.\n\n---"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i",
+          ">The city's out there, Sam. Cold, wet, full",
+          " of secrets that don't want to be found.</i>\n\nMarlowe Cray is about to pull on a",
+          " thread. What unravels is up to you.\n\nGood",
+          " hunting.\n\n---"
+        ]
+      }
+    ]
+  },
+  "expectedNarrative": [
+    "<center><b>⚑ THE CURTAIN RISES ⚑</b></center>\n\n<i>Somewhere, a candle flickers to life. A map unfurls across a table worn smooth by a thousand sessions. Dice wait in silence, heavy with possibility.</i>\n\nWelcome, traveler. You've come to the right place.\n\nWhat unfolds here will be entirely yours — a world built to your specifications, a story shaped by your choices, a character who exists nowhere else in the universe.\n\nBut before we light the torches and open the gates...\n\n<i>What should I call you?</i>",
+    "<b>Sam.</b> An adult. A rain-soaked city, 1970s, occult noir. Pure narrative.\n\n*I can already smell the cigarette smoke and wet asphalt.*\n\nYou've given me the bones of something atmospheric and dangerous. Now let's put flesh on it.\n\nWhat kind of case does this city hide?",
+    "<b><i>Neon Requiem.</i></b> Tense, melancholy, unforgiving.\n\n*That title lands like a body on wet pavement. Perfect.*\n\nNow — what's the case? What dark current runs through this city that your character is about to wade into?\n\nGive me anything: a one-line hook, a vibe, a scene you've already imagined. Or pick from above if one caught your eye. I'll shape it into something to remember.",
+    "*Marlowe Cray. A gift he didn't ask for, in a city full of things that won't stay dead.*\n\nThat's a character with weight. Let me build a premise around him.\n\n---\n\n<i>Marlowe Cray can see the dead — it's the only case he never asked for and can never close. When a ghost leads him to a ritual murder site in the warehouse district, the trail pulls him into a decades-old occult conspiracy that runs from the city's gutters to its penthouses. The dead want justice. The living want him buried.</i>\n\n---\n\nDoes that hook feel right, or do you want to pull it in a different direction?\n\nWhile you're thinking on that — let's also find the right voice to narrate this. A few personalities that suit tense, melancholy, unforgiving noir:",
+    "*Then let's make it official.*\n\nHere's everything, laid out clean:\n\n---\n\n<center><b>Neon Requiem</b></center>\n\nA <color=#cc4444>tense, melancholy occult noir</color> set in the rain-soaked 1970s. Difficulty: <b>Unforgiving</b>. Scope: <i>A Few Sessions</i>. Narrated by <b>Neon Noir</b> — hardboiled cadence, wet pavement, the specific quality of 3 AM silence. Pure narrative, no system. You'll be playing as <color=#44cc44>Marlowe Cray</color>, a burned-out PI who can see the dead.\n\n---\n\nYou've confirmed — let's begin.<i>The city's out there, Sam. Cold, wet, full of secrets that don't want to be found.</i>\n\nMarlowe Cray is about to pull on a thread. What unravels is up to you.\n\nGood hunting.\n\n---"
+  ],
+  "expectedSetup": {
+    "genre": "1970s occult noir",
+    "system": null,
+    "campaignName": "Neon Requiem",
+    "campaignPremise": "Marlowe Cray can see the dead — it's the only case he never asked for and can never close. When a ghost leads him to a ritual murder site in the warehouse district, the trail pulls him into a decades-old occult conspiracy that runs from the city's gutters to its penthouses. The dead want justice. The living want him buried.",
+    "campaignDetail": null,
+    "mood": "Tense and melancholy",
+    "difficulty": "Unforgiving",
+    "campaignScope": "few-sessions",
+    "personality": {
+      "name": "Neon Noir",
+      "prompt_fragment": "You are Neon Noir. You narrate in the clipped, world-weary cadence of a hardboiled detective — short sentences, sharp observations, a metaphor for every vice. Your world is wet pavement and bad decisions. Neon reflects off everything. Nobody's clean. Your NPCs talk fast and lie faster, and the ones who seem honest are the most dangerous. You serve atmosphere thick: the hum of a sign, the taste of cheap coffee, the specific quality of 3 AM silence. The plot is a knot, and there is always another thread.",
+      "description": "Hardboiled detective cadence — short sentences, sharp observations, a metaphor for every vice. Wet pavement, bad decisions, and the specific quality of 3 AM silence."
+    },
+    "playerName": "Sam",
+    "characterName": "Marlowe Cray",
+    "characterDescription": "A burned-out private investigator with the unwanted gift of seeing the dead.",
+    "characterDetails": null,
+    "themeColor": "#8fb2e5",
+    "ageGroup": "adult",
+    "handoffNote": "Sam described Marlowe in their own words as \"a burned-out PI who can see the dead\" — lean hard into the exhaustion and the curse of that gift, not just the genre trappings. This isn't a cool superpower; it's a weight. Sam chose the campaign name \"Neon Requiem\" unprompted, which signals they're after genuine elegy and emotional texture, not just pulpy noir fun. They specified tense, melancholy, and unforgiving difficulty without any prompting — they want real stakes, consequences that stick, and no safety net. The premise I proposed (a ghost leading Marlowe to a warehouse district ritual murder that unravels a decades-old occult conspiracy running from gutters to penthouses) was confirmed by Sam as feeling right. DM personality defaulted to Neon Noir — the hardboiled cadence is the obvious fit, but let the melancholy breathe alongside the wisecracks. Scope defaulted to few-sessions. No content preferences were discussed. Sam was eager to begin — open with atmosphere, drop Marlowe into something immediate."
+  }
+}

--- a/packages/engine/src/testing/goldens/setup-dnd-character.golden.json
+++ b/packages/engine/src/testing/goldens/setup-dnd-character.golden.json
@@ -1,0 +1,529 @@
+{
+  "scenario": "setup-dnd-character",
+  "tape": {
+    "version": 1,
+    "scenario": "setup-dnd-character",
+    "capabilities": {
+      "claude-sonnet-4-6": {
+        "imageGeneration": false
+      }
+    },
+    "entries": [
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 0,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 1,
+          "systemHash": "5d55b40b5b9d",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "I'd like to set up a new campaign."
+        },
+        "result": {
+          "text": "<center><b>✦ THE CURTAIN RISES ✦</b></center>\n\n<i>Somewhere, a candle flickers to life. A map unfurls across a worn table. Dice wait, silent and full of potential.</i>\n\nA new adventure is about to begin — unwritten, uncharted, and entirely yours.\n\nWhether you're here for a single blazing session or a saga that spans months of play, we'll build something worth remembering. All it takes is a few choices and a spark of imagination.\n\nBut before we open the book...\n\n<b>What should I call you?</b>",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 199,
+            "cacheReadTokens": 7511,
+            "cacheCreationTokens": 7257,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "thinkingText": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no known players listed, so I'll ask freeform.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no known players listed, so I'll ask freeform.",
+              "signature": "Eu8CCmUIDhgCKkChQj5ygMC1mDdozOJMT0UbNHDC5kgTa24QLHe6IXePL6YZINoNDuEXZd+knXG4R1J9vtG6jRkLk2BjcRPH8auUMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMKzSpwbxqhzw4fWuDGgzQ/sobH7maVefEjfciMCNG8b1318K8fNG+0U9k6EuQAE4vysiJTsQk7RL4qJdH5otJcZvF4aQlNCZQxNKPVSq3AQqyVXnFf2XHxKcodasIEEd0igZ5XCGYIGVi6svqkaJLR+iywZttOJKVOi5t7u5kce0GgI0U4iXikqz0ymonBIyX66nu5LuANGKo/sLWuXM+041nGwqObHANTWF+zE048X1yGbORhapv1HqqMKwH01nAGZcqhmTwV098P/iemYrNab3BLO7s7sTQdZRdNG1CHGVGy/+QLZ4D+eqXZcujeH3S7tQoGl2NS/fLvb0+AUwfFku6eYvrNBgB"
+            },
+            {
+              "type": "text",
+              "text": "<center><b>✦ THE CURTAIN RISES ✦</b></center>\n\n<i>Somewhere, a candle flickers to life. A map unfurls across a worn table. Dice wait, silent and full of potential.</i>\n\nA new adventure is about to begin — unwritten, uncharted, and entirely yours.\n\nWhether you're here for a single blazing session or a saga that spans months of play, we'll build something worth remembering. All it takes is a few choices and a spark of imagination.\n\nBut before we open the book...\n\n<b>What should I call you?</b>"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<center",
+          "><b>✦ THE CURTAIN RISES ✦</b></center>",
+          "\n\n<i>Somewhere, a candle flickers to life. A map",
+          " unfurls across a worn table. Dice wait",
+          ", silent and full of potential.</i>\n\nA new adventure is",
+          " about to begin — unwritten, uncharted, and entirely yours",
+          ".\n\nWhether you're here for a single blazing session or a saga",
+          " that spans months of play, we'll build something worth rememb",
+          "ering. All it takes is a few choices and a spark of imagination.\n\nBut before",
+          " we open the book...\n\n<b>What should I call you?</b>"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 1,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 3,
+          "systemHash": "5d55b40b5b9d",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "I'm Sam, an adult. Let's play D&D 5e — classic heroic fantasy."
+        },
+        "result": {
+          "text": "<b>Sam</b> — welcome to the table! Classic heroic fantasy and D&D 5e. A bold and time-honored choice.\n\nI've got your genre and system locked in. Now — how would you like to build this campaign?",
+          "toolCalls": [
+            {
+              "id": "toolu_01YYQihYtKC5wna1Xr3c5kRs",
+              "name": "present_choices",
+              "input": {
+                "prompt": "How do we build this adventure?",
+                "choices": [
+                  "◆ Quick Start — Pick a world, build a hero, play!",
+                  "◆ Full Campaign Setup — We craft every detail together"
+                ],
+                "descriptions": [
+                  "I'll present a curated list of campaign worlds that fit classic heroic fantasy. Pick one that sparks something, name your character, and we're off. Fast and fun.",
+                  "We go through genre, premise, mood, difficulty, scope, and character step by step — full creative control, nothing left to chance."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 559,
+            "cacheReadTokens": 14768,
+            "cacheCreationTokens": 224,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "Sam has given me a lot of information right away! Let me note:\n- Player name: Sam\n- Age group: adult\n- System: D&D 5e\n- Genre: Classic heroic fantasy\n\nSince Sam is a new player (not in the Known Players list), I would normally ask about age group, but they've already told me they're an adult. \n\nNow I should offer Quick Start or Full Campaign Setup. But actually, Sam has also told me they want D&D 5e and classic heroic fantasy, so they've essentially started the Full Campaign Setup path already. I should acknowledge what they've told me and either:\nI can now offer them the choice between Quick Start and Full Campaign Setup, keeping in mind they've already specified they want classic heroic fantasy D&D 5e. Since they've given me those preferences upfront, I'll present both options but can tailor my guidance knowing their system and genre interests.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Sam has given me a lot of information right away! Let me note:\n- Player name: Sam\n- Age group: adult\n- System: D&D 5e\n- Genre: Classic heroic fantasy\n\nSince Sam is a new player (not in the Known Players list), I would normally ask about age group, but they've already told me they're an adult. \n\nNow I should offer Quick Start or Full Campaign Setup. But actually, Sam has also told me they want D&D 5e and classic heroic fantasy, so they've essentially started the Full Campaign Setup path already. I should acknowledge what they've told me and either:\nI can now offer them the choice between Quick Start and Full Campaign Setup, keeping in mind they've already specified they want classic heroic fantasy D&D 5e. Since they've given me those preferences upfront, I'll present both options but can tailor my guidance knowing their system and genre interests.",
+              "signature": "EpoLCmUIDhgCKkBCJCZJinZnEjZxCLxfKdA4S3KRAAcG9iX11xQ/w9R00UrpGD43J0tLw3vazIN0W8vb3AzUKsqR3R/OuoV5P3F+MhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMoDrG9wehaRB5m9NaGgzun79cvVYKhKH3WBIiMM+YVdCAaYd+wlb6rJisIEVSzEjzmE/odyGSS8jGOb/6KXpL7VC5g1p6ClOz0RmjQSriCVrAoLhRggEGQVlJPVGGZphlo/SvI4SigMiKTImBiSpp2cfs9KsAGZ5vuzCko3PlXGKUT/iJQs88U6fsMku7soT9Ep0KDyIOabzcsYNM/KrmfXFunRoUs3f4ivfuK/veyQo8pszpUOg3Jv4dlyHPeH/joK2CC0sE4Epmf22ZJgJ8+C7w+S4Un+aRsBQSPAL1xW3lFyY76GqFSdGC9g3wW4h8f6mn/TSWhFV2r/3eTZ2y8k491sETGg5BKfL8IdzPrVD7oKpD3tMV/+UU7qt5PEAPOajYXGjABeD4w6qRrzklF+RepLmwjrr2E2nsa6UhiBxbXUhKZXfTXcWM/TilszzTqXZOzdvcRNYcYO7zeYdnPSGUJzH3lWvVt49i1IAvhh5PQDhNABIgoWPm2GqUicHEWXLAToOpvzQeKDjQ70wVDJksiZAnhpoaQ6jaS/Bp3ZsYdn2Dk4I2zpbinDK8fwrVXwzjvtSqJnt6NcJiKbJfJiW/T399xSpYMtQ2regpGWCfNmrk907VLC6M2GJd4CuuYpw7J3SH0a+pnIRTxp4ywAjNy7TH2TeGObpdiJKfyBioAmLbVxBdaK0Avg2ybs7lI8341TukoyxtL+A4M/NOAJaDlV1393ZvR3qvkLBpzCTqcTX9bFZEiyFYWxLNM19LlscdTvhQ0BczsNqFNDMimb2HTPud/0zAIn1e+ETzdjLR2c3pSMR2dvCfm0waxmehJ64xe0GUdRuJrYoWLTP4eSTQuwmUgK/qTO4k+PV0VxUDE2w2jugIRwQdi2oqLo7ZW5AfoRb9peeT6FqveY+65TGdtK0EZPBxLqN0c4akzJq5rUWqx5sLGfdGxBtWcZ1sf59EbwfY9M1gAnUZYZb3qAju1UZeoTxxmMYdB7V7DmiQoNOre4rQWZ6DZAychhlZ4mmKxFomuqaFc5eI4L2iczf+4l1bs77kl8/twuExhZuqJyQZaRHPr74tYVkEBFw9rWOlJB8OPSaNWCahnqs8kEtLkg0/w0QaH/ri2Sc16w7nwqNhXZu0qGwg11550VCp3BNEWca9I11et6wYHkfvD7GIfZMRxxeHzgeWlGJl7c0xyIgyTTPKY1ZQ1v8KJsut589sVPLR9LrZn/ak77JCQtUP78PNTWUwHEGMxRLaG538Xfjls0A7yOALWtMUSM1xFTfhuUWw2ZvGZYG1eHsH5e0TDSEJ6SpyoLD3/Blz4HkOT7MU3Iz13jmyyUQJrJUqTGZmznTLtScEvsZA3DbmtIH42f64E3ueXzZ9TjJKSMMzSSxh1YCxFgtNzvLe4pYa/rg+JVsvtERXafXhzcE3oCwYp7vB9SYgq20mDtIZzQ2LS9Lto18j8Jt+/X/HD8nASSASru6LWl/H1ekGaUlB8tjECHzgK+2gnDdIGVKsKaMpz9Lpv2q82XNfexC+ExMPY5OS/1TExbE27vRoE9cIciiEOmjL30l/wRVLthvEkd2MFgstGoVNs7bNwC+LMYnr4RF5wHmyrghlKcxxSqKKk/xsxsY1xK9QsBbZGP1pPW9G7OGn1QCaDKfilWzznhaGqFso+ALk9qx8FDP3C9/lRq9hQTIhtIVy3iwddp2aAdfUg4tf+kmNJJ6H79oJNLFJY+uFuM29Saax17K1F+gnmx6ksOafURayYDVn25hSpOTrGAE="
+            },
+            {
+              "type": "text",
+              "text": "<b>Sam</b> — welcome to the table! Classic heroic fantasy and D&D 5e. A bold and time-honored choice.\n\nI've got your genre and system locked in. Now — how would you like to build this campaign?"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01YYQihYtKC5wna1Xr3c5kRs",
+              "name": "present_choices",
+              "input": {
+                "prompt": "How do we build this adventure?",
+                "choices": [
+                  "◆ Quick Start — Pick a world, build a hero, play!",
+                  "◆ Full Campaign Setup — We craft every detail together"
+                ],
+                "descriptions": [
+                  "I'll present a curated list of campaign worlds that fit classic heroic fantasy. Pick one that sparks something, name your character, and we're off. Fast and fun.",
+                  "We go through genre, premise, mood, difficulty, scope, and character step by step — full creative control, nothing left to chance."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<b>Sam</b>",
+          " — welcome to the table! Classic heroic fantasy and D&D 5e. A bold and",
+          " time-honored choice.\n\nI've got your genre and system locked in. Now",
+          " — how would you like to build this campaign?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 2,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 5,
+          "systemHash": "5d55b40b5b9d",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<i>A sly half-elf with nimble fingers and a silver tongue</i> — Vesper Quill sounds like someone who always knows which pocket to pick and which door to leave unlocked. Wonderful.\n\nNow let's find her a world worth stealing from. Here are some classic heroic fantasy settings that suit a rogue of her particular talents:",
+          "toolCalls": [
+            {
+              "id": "toolu_01Cw91nMWXHbNenYPELDD8JD",
+              "name": "present_choices",
+              "input": {
+                "prompt": "What world does Vesper Quill call home?",
+                "choices": [
+                  "◆ The Shattered Crown",
+                  "◆ A Throne of Salt",
+                  "◆ The Oath Eaters",
+                  "◆ Iron Saints",
+                  "◆ Fallow",
+                  "◆ Teeth of the World",
+                  "◆ The Hound and the Fox",
+                  "◆ Blackwater Bay",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A kingdom's heir is dead. Three factions claim the throne. Perfect for intrigue, loyalty tests, and a rogue who knows how to play all sides.",
+                  "The empire's heartland is turning to desert. The emperor says it's on purpose. Politics, power, and a secret that could unravel everything.",
+                  "Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. A shadowy threat that a rogue might be uniquely placed to track.",
+                  "The church's holy warriors have stopped answering prayers. They still answer to someone. A mystery wrapped in religious power and buried secrets.",
+                  "Magic left the world a century ago. It's trickling back — and the old rules don't apply. A world in flux, ripe for someone who thrives in the grey areas.",
+                  "The mountains are moving. Slowly, but they are moving. Ancient forces awakening, civilizations scrambling — and someone in the middle who knows too much.",
+                  "A detective and a thief keep ending up at the same crime scenes. Neither of them did it. Sharp, character-driven mystery with serious rogue energy.",
+                  "A port town where everyone's running from something. Smugglers, sailors, secrets, and shadows. A rogue's natural habitat."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 970,
+            "cacheReadTokens": 14992,
+            "cacheCreationTokens": 636,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "Interesting! The player skipped the modal selection and just jumped straight into describing their character. They want to play a half-elf rogue named Vesper Quill. They're using the standard array (15/14/13/12/10/8) and want me to pick sensible skills.\n\nSince they've given me their character, I should now figure out the rest of the campaign details. They've told me:\n- System: D&D 5e\n- Genre: Classic heroic fantasy\n- Character: Vesper Quill, half-elf rogue, light on her feet, sly and charming\nNow I need to nail down the campaign world and premise. For classic heroic fantasy, I'm thinking through some solid options that would give us a good foundation—something with kingdom intrigue, adventure, and room for a cunning rogue to shine.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Interesting! The player skipped the modal selection and just jumped straight into describing their character. They want to play a half-elf rogue named Vesper Quill. They're using the standard array (15/14/13/12/10/8) and want me to pick sensible skills.\n\nSince they've given me their character, I should now figure out the rest of the campaign details. They've told me:\n- System: D&D 5e\n- Genre: Classic heroic fantasy\n- Character: Vesper Quill, half-elf rogue, light on her feet, sly and charming\nNow I need to nail down the campaign world and premise. For classic heroic fantasy, I'm thinking through some solid options that would give us a good foundation—something with kingdom intrigue, adventure, and room for a cunning rogue to shine.",
+              "signature": "EssNCmUIDhgCKkC+T5VvjmpqN1ztRfx0qk9fUBB3A1j/3WUzmR4RsWSrV2vN7i8DrLuBJT3qtBIChJuVa3MJf2L+IR4fxABA10ebMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIM7ILPPGK6qAhNI6DnGgxuJ1WO2hhuGCVmitkiMCh91+8qD3jBIKGUH1fEeyAB5CXIvSuf+DbuUeGjSDiQIlSpd4CmDOI5x5HM7Qyh0yqTDNWYPa+biEOdoazCU6QQViToFruNmlNO/an8AI1K+T00mO2Or86AVgk7/vGqgUtSbVsIbBqjssplWfMV2sFcy2WP+Y+uSFbJePVa4AQ7okRJb2qgfk9tAZm6rwyIsSi+tOkJ55P4iFIUyUC4CgqO2GyVte8Z+T3QDcloiG2cNVNjT+yOq7PRD5Z8g5ibknhIAgE8UbLCVu33dFfU4Auk+U8cVlnjIc8fmyAiaR3Y2SroQZXJxp2aY8Ea6N1S70KY51wA15j/bVLanVzrZbzYCGPpr5gp6oeSoZo2QUDpCcM7KtQnjBMoyUgDQQOL/5Rwnv4H8D+T0Y2D1Wbu6TQxcy0jWYctJmFeuq7rLO1UNteVXPvGXgT8OtpbVbVEBZzPMFDPglCUGqF/cGRCD8/cmrIa7ckGOpQFfjpk7qXeljDU5wREo1D2SQd5PpZ2RXZ3gU5T+cXjPNJgtvMRTDrSj+3biEjJiCLvtQf+aF86I49sSTXXLCu7YJCDplHDmX44rlT0TuOHeobxURo6Nffkbs8KM15u++VwNLKKQ6v+r1QhW4lJiOBZMtjVOudF0Z0saj4PKi0UIYgc4SLELI22jUxaAWJlcIvqrK8qw/pnr4K7iywVbr1a18yyb6gTM01J2atwDzl38KKWMRwR0pzySNc1PBEEM1LTnLNApDGSES9LaftZuTpSSccWhewuaVQbvu9u6fh3pY21/KHLmvPwx+dbH2rLk8MxLMwXynfg8ORjKWKcuJH8Sjc9kHjuq6y3uzPh/torLZZXg6fP6yI6O7I+uFKudP4Nk8/2sdlsi2wG7cD+XD6TxdT1WWpCaarsTtth+7hwq/EC6qWYvYRgeK81C9eNsRyG5JdlK8Yl7f3mszBw2jjjWEMDScEra6/4jTe7LeIEsZo4H/bGbe1H781R+gDIqYaTHIJzSOYHDvd1t5uIm2floOQtB05eThJvNuBE7xwuYBaJMwu/6HDfI9A9EQ7L42I9baJaOdSHwLBaFASQjLLt/fUzGUcptqnC6SwfG2oxExqBZfhQzXaIZAZIN5vICDrm86YSbQTn+a++HQQNeNLUmrp50WUSaLPGpwpujdGNxWtgLFttCDlVmdOQG0GYRgwA32moHKirswBmL3nwmLAMp56C8I7ihMXWZpFgDZkd+s8VcgMoTnIgD9dW576ydhl4rIr3vaM8QFEPmRJ596AakSk/hjygav7CO8IUOqVU9FOF2CbzgvzTRRNnBX1UKZYTXVnLsvpaXNZ6Q7I/jVxDiYo2HGb/RfvtIh3sKEazH3m2f/qPy9ADDzncR28jlx1XtqaYS72awl0Ry2xXWkCtiLgSeCWS7ySIjU1DuMy7VT2FbnUkhEMCXX6NRCkRThHlriARM4byYG7wbPl3UorM8/AXHNYQHu/K16jAL5mE4RmVRR5xszqsd/TObL7mwwkC6l985YPV03O/fiL1W3p4gCFJeXh6uWM9huX0cCVs2qR/mNPCbBUjRZ9QTeyRlRqOFwDiaiJz0dhMbEchDPk+OsJ4/3dPK59ftbP/+/KmRTNx3kMsI9HFw6rBpIPC9Ujq5nEbIxZK+S1jJsib0ivyM/wy8oAfzdLEhwV6VS0i8ACjmPJVbghQARlzeu1EfH3pGvBb/cwilPp7EtAAPs8YPSW1sPeuI+PWa/l2lJGuz2quy/Y4SwNMC6aXNcztwW4sfr1EIBo7z3S9vxWZ95Tp4kgwxd90sX9ISsN4I9EBkUHQpfXrex91tbY23tmot9mFVY6f9DKvT+mmPGBGduIGaLEzfjJcuVlQPupz9iUhhloTKRUrvRgUN3CHDtYWwo7Z79SeRSM3CQd7MOPdS0B/uo9rvXqQu7T/Uv2J8aGkeUr+PkSVojU4q8BEG2YULGdi6o2H52xL/F0LTEaUwkmdsfABqFZa3+KpvjmacIm9C/ESWTEyP86NkxSUGW3cVXYsY9HAs+r/hlx1aLGCP1/LO40rgjeOMeBWdg1q7WHEgmxHwYSv8NEqGJXlLGa34l5P2VZKbK09iZVvbHfXc7xGE1W5DGz6H5GeJ+8wAIK3dpOzQ4eX/W2rMACP2oQYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "<i>A sly half-elf with nimble fingers and a silver tongue</i> — Vesper Quill sounds like someone who always knows which pocket to pick and which door to leave unlocked. Wonderful.\n\nNow let's find her a world worth stealing from. Here are some classic heroic fantasy settings that suit a rogue of her particular talents:"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01Cw91nMWXHbNenYPELDD8JD",
+              "name": "present_choices",
+              "input": {
+                "prompt": "What world does Vesper Quill call home?",
+                "choices": [
+                  "◆ The Shattered Crown",
+                  "◆ A Throne of Salt",
+                  "◆ The Oath Eaters",
+                  "◆ Iron Saints",
+                  "◆ Fallow",
+                  "◆ Teeth of the World",
+                  "◆ The Hound and the Fox",
+                  "◆ Blackwater Bay",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A kingdom's heir is dead. Three factions claim the throne. Perfect for intrigue, loyalty tests, and a rogue who knows how to play all sides.",
+                  "The empire's heartland is turning to desert. The emperor says it's on purpose. Politics, power, and a secret that could unravel everything.",
+                  "Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. A shadowy threat that a rogue might be uniquely placed to track.",
+                  "The church's holy warriors have stopped answering prayers. They still answer to someone. A mystery wrapped in religious power and buried secrets.",
+                  "Magic left the world a century ago. It's trickling back — and the old rules don't apply. A world in flux, ripe for someone who thrives in the grey areas.",
+                  "The mountains are moving. Slowly, but they are moving. Ancient forces awakening, civilizations scrambling — and someone in the middle who knows too much.",
+                  "A detective and a thief keep ending up at the same crime scenes. Neither of them did it. Sharp, character-driven mystery with serious rogue energy.",
+                  "A port town where everyone's running from something. Smugglers, sailors, secrets, and shadows. A rogue's natural habitat."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i>A",
+          " sly half-elf with nimble fingers and a silver tongue</i>",
+          " — Vesper Quill sounds like someone who always knows which pocket to pick and which door to leave unlocked.",
+          " Wonderful.\n\nNow let's find her a world worth",
+          " stealing from. Here are some classic heroic fantasy settings that suit a rogue of her particular",
+          " talents:"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 3,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 7,
+          "systemHash": "5d55b40b5b9d",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<i>Sensible defaults it is.</i> Let me grab the details on the best-fitting world for Vesper's skillset — one moment...",
+          "toolCalls": [
+            {
+              "id": "toolu_01CnwFeGJVmuFjDVFXaCGF9L",
+              "name": "load_world",
+              "input": {
+                "slug": "the-shattered-crown"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 596,
+            "cacheReadTokens": 15628,
+            "cacheCreationTokens": 1035,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "The player seems to have selected some text that's not one of the choices I presented. They're just saying \"yes, that all sounds perfect\" and asking me to finalize. But I haven't gotten all the information I need yet. I don't have:\n- Campaign world\n- Mood\n- Difficulty\n- Scope\n- DM personality\n\nThe player wants me to use sensible defaults. Let me pick the ones that make sense for \"classic heroic fantasy\" with a rogue named Vesper Quill:\n\n- World: I'll pick The Shattered Crown since it's the most classic heroic fantasy option and great for a rogue character\n- Mood: Heroic fits perfectly\n- Difficulty: Balanced as the default\n- Scope: A few sessions works well\n- DM personality: The Magistrate would be excellent for intrigue-heavy rogue gameplay\n- System: D&D 5e\n\nI should load The Shattered Crown to get its details and any suboptions before finalizing, but the player explicitly asked me to finalize now with sensible defaults. I need to make a decision on the world since they didn't actually select one from my options.\n\nI'll go with The Shattered Crown—it's the best fit for classic heroic fantasy with a rogue character. Let me load it to get the details, then I can do the mandatory pre-finalize review and move forward with finalization.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "The player seems to have selected some text that's not one of the choices I presented. They're just saying \"yes, that all sounds perfect\" and asking me to finalize. But I haven't gotten all the information I need yet. I don't have:\n- Campaign world\n- Mood\n- Difficulty\n- Scope\n- DM personality\n\nThe player wants me to use sensible defaults. Let me pick the ones that make sense for \"classic heroic fantasy\" with a rogue named Vesper Quill:\n\n- World: I'll pick The Shattered Crown since it's the most classic heroic fantasy option and great for a rogue character\n- Mood: Heroic fits perfectly\n- Difficulty: Balanced as the default\n- Scope: A few sessions works well\n- DM personality: The Magistrate would be excellent for intrigue-heavy rogue gameplay\n- System: D&D 5e\n\nI should load The Shattered Crown to get its details and any suboptions before finalizing, but the player explicitly asked me to finalize now with sensible defaults. I need to make a decision on the world since they didn't actually select one from my options.\n\nI'll go with The Shattered Crown—it's the best fit for classic heroic fantasy with a rogue character. Let me load it to get the details, then I can do the mandatory pre-finalize review and move forward with finalization.",
+              "signature": "EpMQCmUIDhgCKkAYr3ymDX1wVoNJ+2v+OGwjlQH/HQt8+yne6YPnWbkh7EOEEYWt6cMLMlV2c+bBLSF2M9ggb5mh6EQonWA7KKaiMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMrE9po1r7jaivTiFUGgxQ+0cFN3b9k4xDg08iME8ENeMdeckE4PZ25K0JLirq2vVw3lQxgR7eOBOGhMMPZBuVw+E34Eio0BZyVtbBRyrbDorH9VQhz6xubqCx6BtL/vTVTYuelu5wXfVfkKgw7li+Ny9KLyzEdZERJZtUNJ6EvhHlZCYj8HTm8Rndszdy8HMu/hQCEs+T5L/RwV6Ctxgpzw7IwuEfLY3z2IpWX4gVHQ/Crw5JMTO3FQse5S3yeo2yh3i5W9lGs9/eMvB/qINP0geBu6WGWt//v3Hgw30L30HUMfvnS9qRjrg6H0bPnAWSEi3HQgHkCW4OZrSVtIabnQjjrmIXw+zocQAOGBCfcG9tIrr2VR6d4eE7Q22w0yzGMvbswcwfBoBakrKlBhij31TuWXnZtrJtA2uSKDNeD1Q4OUpg+7CzbB7nhCCRNdDDOGRnZY3NBmyHRI6k6CR+OrxDRjoWB237rZInbPrKdNbInwS3W9i2W/NvNr4dwjwb9MF4f/GxVNE4wmuWpSRrEnaNBwza1XV8FDUXBMF/Iwqja3TglIgCaWCy0Uzvf08YocM3951VsPdfeZ7+K+53bv389/wrGwiHldSzn3Xa8OemZEQeKCvKYPYxQNHHDN5DDPxcVGvNqDjcMwbbtdGwYwvnF/0hRLbPgu1aHlLwRfhdm35iM4jTNKXHW941GdaTmYa/sr0cNhBMbU57vzVJg5d6hW5Ipq9G95g0MDvVPzrjfuHbfPueak+0o1Yy4LHdDUAaXuQDUnsv568N44qIKn0PwpcD8xj2RQzPqv4MpjIuMWDYEtXcgJ3Zx9kTxWauxgQRglsiXutn0nM9DTxeXFOtwNGT9pKxR8GAwafW9FS/jqNcubdOnNZELFA9fp30/fC7Ac3fYDQfntcDpW+Q2wuo7n/OcUQ/sHcE3CgXuSo1rSrQULXtbRZM3joTqz04BCu9xsaypdfjtk+dRcBMZk6bLeQFokMZNleuSc8RuSzPd94GKrYsiJ+8Txg8o+1aDKEX/kSRfHvxVeIRIdqdiS+o1zYDt5uQbJZqyobi1NaA+03pXXfHaNz5ZhpulvoO+OoOkPID5HkloMo2zeilQkATsK5hc2374sAqgpvSVXzOCnIl2TnsL0un5MDCzx3AqYDJLz4E4ZggcPVjEnixcuifqRhIZTbR3mb86c6+AuyVSM/OI/hXIlsWBYC2d1QJVTHpddVSuqa2ebM4ToetT2CYQrkMZjW7tNKosuLxnm67jLfo/OsQiI6bkFrtrATcsCDzuXdNzDbEshokFxLkHgPQBA0O14xqzy3rLpofTot3sk1of/l2mRCUM9T30x3KPClm8WGOYAX8dE8Mcp1VKecLwIkGTAY8wRKmm8eS3cDk5N8DDdVUuhsZQYSgw0CWw/IkQ/BjofauO0OdzJREJfgwMFUROH/lyk/wM6EVb4erfb5Gz1zDuhcPSBb9xjH11E4nZGNzqEkxMbh7rmHXoumwY2L08UxY+VvkRs0n4jX+B5+UGMS1CBqCWL/r1MlS7bI9JJNKqEIu84ohT63R25OIWohLzrNblHHXojARA683wIeNueD32W/iofFZfWL+XTJiATKWrN62KPGzQcDxQ2eWnO8UiYnNKnnWDlObKQIF0/UhlMrToHcrk7S/csRKCzpxtTzu245iyYR5XLIbo2GZyrELfs3R04iHDvAxEnXZ4g1XGkkd5hxG5V1reB7JN8+/EX3Am3jRj75kPjiZGW6NVed1eOeA3//xv/cBP/7kDsuvOlcceJ7xUH91qxVVwVu3yHRwczVewFsvU7LYLE6We1MVwo67YClXwUqjwe70ZQxK0muoyNh4v/zLDinHGbDqpuwJupFbJIcEQD6bkoIJpfUKlq4SvEBVv+4SccByhOhAlm6zFMqEnrJMj6VOVrSVc6XTQFrSk/R6evBtKL9kCIg9uydwuwolNg2+31kOEO5+IntxMFMjwJXxaQKIwdDjoo+CARDFZI7vx1Bi/1bEh4jo0kxeASiXMdeiW94wbgqBsJP/5mvDYGwtJX7c27fNMCMwup86/tyC/7WxRkojOB4pKazu41f1q7/mSsSWWGv/ByIVmWkM75BNMvRL85bAd9fnxVLaEl4jjW2e3AEuS5W+Wcm91pnWUHzZIbsQevBwM5GF8UUq6GvdLJ5khkpf+NETSyBK0GCsVNd+gZ1cM2glJY7CsUwaepTGFSK8uncO67kxytiRIrwNLgkCOYup6QCE6w90awQOABSEYn5U35JdmzLj6UCIIM37NFRYbY9a6aDXZ3TCX605tcwEomwpFbWCJ9qfv6msduQV9IRRvpAK5aRzFjauw8IscX+ciR8uCKVJo4MYMh2z0gTWER9v5EIkhtSCSRs5iKwuqyqqG1T4WwUF6O1Yqf8Y2KjSH/5itmbXYVz4AyCwmYL2/n1XMvZXsZfsy0l+2heIGcLDys9iyBxPAItueO0jlGKtEtAvro5ByiNHNDn5ywz52dNSw4kMo5tdxa2FUob6EZTjUE/+TzKwFQI0iSH4EWPf3muFX/J1BRlx3bfeOat1HK+Lh4gVL+2cTgZdBIQZuyeGcNd3AGBXR8W0/MkcZJYVBr4JWy/UvUPRGAE="
+            },
+            {
+              "type": "text",
+              "text": "<i>Sensible defaults it is.</i> Let me grab the details on the best-fitting world for Vesper's skillset — one moment..."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01CnwFeGJVmuFjDVFXaCGF9L",
+              "name": "load_world",
+              "input": {
+                "slug": "the-shattered-crown"
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i>Sensible defaults it is.",
+          "</i> Let me grab the details on the best-",
+          "fitting world for Vesper's skillset — one moment..."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 4,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 9,
+          "systemHash": "5d55b40b5b9d",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<i>Perfect world for a charming rogue.</i> Here's what I'm putting together for you, Sam — all defaults chosen to fit a sly half-elf with fingers in every pie:\n\n---\n\n<center><b>The Shattered Crown — The Gilded Compact</b></center>\n\nA <color=#cc8800>classic heroic fantasy</color>, <color=#44cc88>Balanced</color> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of intrigue, layered loyalties, and subtext-heavy NPCs, perfect for a faction-politics thriller.\n\nRunning on <b>D&D 5th Edition</b>.\n\nYou'll be playing as <color=#44cc44>Vesper Quill</color>, a sly, charming half-elf rogue — entangled from the start with <b>The Gilded Compact</b>, a merchant coalition that views the succession crisis as a business opportunity. Backroom deals, leverage, and dangerous information are her native terrain.\n\n<b>Character sheet at a glance:</b>\nHalf-Elf Rogue 1 | Background: Spy | HP: 10 | AC: 13\nSTR 8, DEX 15, CON 14, INT 12, WIS 10, CHA 17\nSkills: Deception✦, Stealth✦, Acrobatics, Sleight of Hand, Persuasion, Perception\n<i>(✦ = Expertise — double proficiency)</i>\nSneak Attack: 1d6 | Thieves' Cant | Cunning Action\n\n---\n\nSound good, or want to tweak anything before we raise the curtain?",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 2670,
+            "cacheReadTokens": 16663,
+            "cacheCreationTokens": 1014,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "thinkingText": "Now I have the world details. The Shattered Crown has a suboption for starting faction. The player said \"sensible defaults for anything unspecified\" - so I should pick a faction that makes sense for a rogue. \n\nThe Gilded Compact (merchant coalition - ledgers, leverage, backroom deals) or The Iron Circle (military, honorable) or The Hallowed See (religious).\n\nFor a sly, charming half-elf rogue who's light on her feet - The Gilded Compact makes the most sense. A rogue would fit well in the merchant coalition with its backroom deals and leverage.\nNow I'm pulling together the full campaign setup: The Shattered Crown campaign with The Gilded Compact faction, classic fantasy with a heroic mood, balanced difficulty, and The Magistrate as the DM personality since that works perfectly for intrigue and faction politics. The character is Vesper Quill, a half-elf rogue played by Sam, and I need to flesh out her D&D 5e specifics next.\n\nFor the mechanics, I'm working with half-elf racial traits—the +2 to Charisma and +1 to two other abilities, plus Darkvision and Fey Ancestry—combined with rogue class features like Expertise, Sneak Attack, and Cunning Action. For her background, Charlatan or Spy both fit her sly, charming personality well, giving her proficiencies in Deception and Sleight of Hand. Using the standard array, I'm prioritizing Charisma at 17 (15 base plus the racial bonus) and Dexterity high as well since she's light on her feet.\n\nI'm mapping out her skill proficiencies now—rogues get four skills, and I'm leaning toward Deception, Persuasion, Stealth, and Sleight of Hand to match her charming, sly nature. The half-elf racial bonus gives her two more skills, which I'd put into Perception and Insight. For her background skills, I'm picking Investigation and Performance to round things out. Then I'll use her Expertise feature to double down on Stealth and Deception, making her especially good at sneaking and lying.\n\nNow I'm setting up the campaign details for the pre-finalize review—The Shattered Crown world with The Gilded Compact as the faction, creating a campaign called \"The Shattered Crown - The Gilded Compact.\" I need to nail down the genre as classic fantasy, set the mood to heroic, keep difficulty balanced, scope it to a few sessions, and establish The Magistrate as the DM. Once I have the campaign premise written out, I'll present this for confirmation before finalizing. The Empty Throne works perfectly for this setup—the heir faked their death and is orchestrating events from the shadows, which gives Vesper plenty of room to uncover secrets as a rogue. For her character, I'm settling on half-elf rogue with the Charlatan background, which fits her silver-tongued nature and gives her the deception skills that define her role in this intrigue-heavy campaign.\n\nNow I'm working through her ability scores using the standard array, placing her highest stat (15) into Charisma, then applying the half-elf bonuses strategically—adding the +2 to Charisma for a solid 17, and distributing the two +1s between Dexterity and Constitution to round out her survivability and combat effectiveness.\n\nWith 10 hit points and AC 13, she's reasonably durable for a rogue. For skills, I'm picking Deception, Persuasion, Stealth, and Sleight of Hand to lean into her con artist angle, then using her half-elf versatility to grab Perception and Insight. But I'm realizing the Charlatan background overlaps with skills she already has, so I should swap to a background that fills different gaps. - Half-elf rogue with 17 Charisma and 16 Dexterity, 10 HP, and 13 AC in leather armor\n- Six skills total including expertise in Deception and Stealth, plus Acrobatics, Sleight of Hand, Persuasion, and Perception\n- 1d6 Sneak Attack damage at level 1\n- Equipped with a rapier, shortbow, leather armor, thieves' tools, burglar's pack, and daggers, plus Thieves' Cant and Cunning Action\n- Now I'm ready to do a final review before locking in the character.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Now I have the world details. The Shattered Crown has a suboption for starting faction. The player said \"sensible defaults for anything unspecified\" - so I should pick a faction that makes sense for a rogue. \n\nThe Gilded Compact (merchant coalition - ledgers, leverage, backroom deals) or The Iron Circle (military, honorable) or The Hallowed See (religious).\n\nFor a sly, charming half-elf rogue who's light on her feet - The Gilded Compact makes the most sense. A rogue would fit well in the merchant coalition with its backroom deals and leverage.\nNow I'm pulling together the full campaign setup: The Shattered Crown campaign with The Gilded Compact faction, classic fantasy with a heroic mood, balanced difficulty, and The Magistrate as the DM personality since that works perfectly for intrigue and faction politics. The character is Vesper Quill, a half-elf rogue played by Sam, and I need to flesh out her D&D 5e specifics next.\n\nFor the mechanics, I'm working with half-elf racial traits—the +2 to Charisma and +1 to two other abilities, plus Darkvision and Fey Ancestry—combined with rogue class features like Expertise, Sneak Attack, and Cunning Action. For her background, Charlatan or Spy both fit her sly, charming personality well, giving her proficiencies in Deception and Sleight of Hand. Using the standard array, I'm prioritizing Charisma at 17 (15 base plus the racial bonus) and Dexterity high as well since she's light on her feet.\n\nI'm mapping out her skill proficiencies now—rogues get four skills, and I'm leaning toward Deception, Persuasion, Stealth, and Sleight of Hand to match her charming, sly nature. The half-elf racial bonus gives her two more skills, which I'd put into Perception and Insight. For her background skills, I'm picking Investigation and Performance to round things out. Then I'll use her Expertise feature to double down on Stealth and Deception, making her especially good at sneaking and lying.\n\nNow I'm setting up the campaign details for the pre-finalize review—The Shattered Crown world with The Gilded Compact as the faction, creating a campaign called \"The Shattered Crown - The Gilded Compact.\" I need to nail down the genre as classic fantasy, set the mood to heroic, keep difficulty balanced, scope it to a few sessions, and establish The Magistrate as the DM. Once I have the campaign premise written out, I'll present this for confirmation before finalizing. The Empty Throne works perfectly for this setup—the heir faked their death and is orchestrating events from the shadows, which gives Vesper plenty of room to uncover secrets as a rogue. For her character, I'm settling on half-elf rogue with the Charlatan background, which fits her silver-tongued nature and gives her the deception skills that define her role in this intrigue-heavy campaign.\n\nNow I'm working through her ability scores using the standard array, placing her highest stat (15) into Charisma, then applying the half-elf bonuses strategically—adding the +2 to Charisma for a solid 17, and distributing the two +1s between Dexterity and Constitution to round out her survivability and combat effectiveness.\n\nWith 10 hit points and AC 13, she's reasonably durable for a rogue. For skills, I'm picking Deception, Persuasion, Stealth, and Sleight of Hand to lean into her con artist angle, then using her half-elf versatility to grab Perception and Insight. But I'm realizing the Charlatan background overlaps with skills she already has, so I should swap to a background that fills different gaps. - Half-elf rogue with 17 Charisma and 16 Dexterity, 10 HP, and 13 AC in leather armor\n- Six skills total including expertise in Deception and Stealth, plus Acrobatics, Sleight of Hand, Persuasion, and Perception\n- 1d6 Sneak Attack damage at level 1\n- Equipped with a rapier, shortbow, leather armor, thieves' tools, burglar's pack, and daggers, plus Thieves' Cant and Cunning Action\n- Now I'm ready to do a final review before locking in the character.",
+              "signature": "EuI3CmUIDhgCKkDuueuLaERjJZ0K+Rh6QvTGH2sieMzDot69mhTWf0jSsrSMjI+sWvrkT2RUxJrmmLl4sqZvWqwizHCPcSbJkbFMMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMkb1gQYP3o6wLI2kFGgxwiJDkcUioHerXLUsiMA2eAJSLCTEyJKujFLUlEkBQKzDIGDPNVNf4I8FCO85It19tIIyNy+YMqvQT/SF1KyqqNjbab2MBh/OR88BA+TOoU59EjIrDYcDFz6szsyX4h8LVVzVbospydSf2irg8YZ7CPoYi9C+hiWw/FMy8XzD5wjWGMqS6QSZrGOuZafAf9jju//hDPN+NVxnyceuLm9Skl0bAYr0F7u5YOTHd/tUEb1yQBostlhRduxhnqUWiWEdWzsypOplQG72oZG2JGFbt0r7Vc0en1YdLiyIpFzGc6XSzhpT2C4HHtOCIHMmkO48tTbkHDbz6Q1fpQMvfxbu5rIRHXxnzDIINoS+x/7UdKqMtAEM9uOnY/AH8pIse7SxS2kWK9sQgJrrVTZwfz4CUttYEKa2QDq3OvLjHMQmGkRtRDSfMmbW+BDepIn3so3YwR7bh6tP2pAulBhwSeiLX1kozklDtJlJ/O5oYVBhdgrMdagvQAlPsPtX8y1zhNIjDbwbM+3EC0OMvlwvbA5WjIcm2UDhBNMvD96kGFwiaZsThGnWDtIQ0znYsofj9j4V1za+CbJWY2Lf+llwwrjTyYfJZLF6QODEXI3bfNH59dyNvWiHfA5zNsfP/KfqasjRBxLWy/nxgzrlPIySHZy8UhGHuAWt2jBSF+RDCGo5ys9Q5stHGRvcmPwOqlbxuCxevo4efWG2KClemz+le7buucxHGjdCB1+UEx8cyMcR/YY9HJlWIzS63zxLL7/a9Z+Za9vyKMxYFwlKv+7t1BGA0BbzRALDiunKTegvjli4TrRqKrDe7lz4giWRoOK7F20fon+i/dZdwKS2CxHsLSKPUOuBnO8MX3gY+e0b95AzEc6VapVGnvRszmJytHYBdHbnlV36rqaqqrdq+3/+xphclaBt2GCkm/+jfL16hkONcnncJQ+wylUEYUepDmOfIx4I6yGNKssyyc759eJr7zgloCmfXmQdoLTzM+HMKkPP85iCKdvx7Ulvv40A0Nm3eAfw4cGZhCPK34lCOVZ8U7B48InOrEW1r9j7sIzl3FX85kqNzCTHBe0zbPbC/3OFZ3t6tBzXHMCdCiilERP8jcJtvw4ZpcLc/iB6myTGgR35rRXfV60nFSlK7LuiN1mhFVV+Z/UD1700s04gErFVjkflwljDFYoprV7dbH8pMFDCn7uRvAfXcesWuTYHrh2famHumxetpKOsiJdGq0myt/StOJZxqzXt7kXb/mF0O8gb69L+ykngtN7v63JDwR6hgWJRyIKA6BOYVuXBr/3KjVQxRaQ3SGHFvRLlhecWKM/FfV8+srPHoUnfky5BsYmvWTaJOrUm4V8GWWll5e3zi70irLT4DKWxm/9SwO48cc6c/pyuAJA+Oc0+qRV7oRJoO0nf3HMde5ahb1m5JuPjR9P+4/CvvOoiE/BOsFOztRTolgAZodIcH/V2WULAd+4wyLJrXadKbSLhHx8O0O74jlvOVXi66yaNBMLdzEubyWauKeb5qOUU2i1E3rOMrfYo6yp2Fy7nRvZ86iUcqny8yuwGfEVaFGP3TomgxIXZp6mk2jBn/1L4YF1W7Zs9xglucEJqG491lcujFdeXHvmUhw8mPmSRAkTIEPs1raJt2ngGCylLYn0g8Wl7A9uNCo1Hg9BnhZrBq71PyMymrHtm89IWTkDu7ynu270ZIAyMb+S9qrI7THiNFn9W+HAC2aQKSFemkN/7bgrgSi+miX0T0YBJSzCfuDXVBOQE+sK2Mt9fdI5vh5kP8Hs08WRNHh4KCwDwkHNTmcDzP3wE3rPjxKzspF5BZZ6Ad0YYqI73v/VVCbpLgy9gXW9vkkZ+uASWdTtHdU6zzJorcm9+gl2UPItyD06nFSbe2DOKTLttleA+zpnDhd6bcwq09N2qIBy/+R6x4RqrjSvbBftrlLpnTjhf/szRYJxQpQv3k62ydRdv2ceScY6cJD4NfKdBrW1f7/DM+uNZYTeUz+Ev0KP361Wqts/KIpbwm2orK0MxpCpZ4T8TWrl7moClpj30ZPavp502131nGHXualMGbZE2O9gADjFkEXlfL2zwqlh44g+gzImPgkB63oNKfk4JCD0PGqyMQCGaPAzKuNfQjtS/bFCEr2b5RSj4LUwsfz1HBjL1qqvYtZryi9AKUgMsg0pIC7/wXXssixbJsZrGeLOgZIavKO+oGpfbisuP5SBsqvEgaQTLT4YtkXCiWOL3Cq1R+erl1WtZnKGAZFidZet6NKgKgQbkOuOoEJyNUOOSGnUCS8F8yYYGb369fQEcYx1pS+GhmRD6w4bvMuHdWvUbZ3vHGMXJaVXMl5K7gU7AMBrnHymFzw4MfT12dkrnmvMjSxgLjj+lLLAKhqgpcEmXfQeueoe489f+vrFrzjYX6BtmmIkfDk5xtRBnDp3LWBr+Z+WrbouXsJKXhe3flntMqrFP4BOad4q1q10MVaC3EdfDnWTa0SiW6XpVy0f+6kgGkOCBmd4CgHg8JZ8vA8ieaYb09KYhLYmQaos3xELZIbEAYo6Y9ODq6cRzFiZ3v16cpRql1xd4TGDYkfX32q1mk0H0EDxQEqhmtFcFcXl/hLiIuypDM+XmVYRgaiCCf5jvLISZYFndiLenkGTCa/DIePwnT9TXq+pMILgVv/QFLY5GBIQ/Fk6ICDdRGGoIIGGFZ7MwSJ/hQdq1igkApXxgyyBPW8iby66UYF3WAiDZBBPBqCOA+ox4pp5Ae4tvW08P6lputVYFezmoEfpPoVOdi2tBiMUO7hkCqTMKYYw9h5vy0oX8pbPZ9tAanMmqV00ghpsM6Gb3qwklSM+0duPdYxA9g/ZkuMhkuC2uR0UZXmiZYoFIzClxHRxHe8NpFI+OSKcEvTQhAbH3XsLwLzOf4UzHzyeaw7DouknwyquISQ41gycDuMA5WfvLYRdASsHIfhIHEOeLPPeb7pi03Ll7RaGzLU0rra8KmbEmKNYvjL7tNxrAA5gAbn1Sww8evff7BZs9jPxlKT2F/fo7oX8XF1Ew3u1PaWjDjbq4wQYcVto7wEyaLKPUpCV4ZPthKcUdoySjHFReTuyH6/KgyHQBoTzg0t8EZ3hdYzicuhc8383sQujcVeYIeLy06sYhAhuyV2eERGArpd2a7T6t1LyJJfMUTYLNeyJj+ALfoYFRiKlQ0qq/ZHZcnZC4VSsPMesP0ZKAeCguJX6rlbAaOQJSe+seDyqvIz2fHpwzgcxkYEwrQ8cSD1dkO4qje/Pm+OQyTHdweYD0l5jUzUWZ6FJBnoYIUQJ+S+UjTZCY8DdQWERCEOJLnIsFOnwiR0I8AWtXmwuaC7jeCSPlpNFMYyIpmGd9MRti7G1NYefjZ4Jq4Qbob73AwYVlPI347nGr/ALGTYRXF1BIpx6aTJ+kCqlUMbWWG+xJqm8ecBxEJMRa32teQp+Rl9oP4+4usJV3ySrUFx5zbiL1SkKmQ9Pbe5KmOASVm2oHvyUZ6wfesVwJGuUG8YWO4Pny1DkoslHwt3GDzyJepECblxBRWYeIQ2RThZmrisHYPFBSGQx0sauGOMuIdcRPLZI+sMbTTULAqcGgrtxQacHroVB6VXbPT/S6hUL90GCd32d8m7/ERxVLJdVv9dQqJ9NB9dPVTRIYSElisTSfQbGUUtux4+OcoyIgRCeNm0HRnjbGcSS/QECyNXGG0cQetRqxz97twfN3KOyvQE+MCoIQMfd94X/NyD6OVDH09+Ualg71a2UJ7NLIneGJM3xWJK8JsyrSYX3oD4ERnRHqy3lkxpi5XVErsVDJHWCmDQxt1Zqdf23qqe9+AJkawe4CBCx0wjLmqmFoo9n4lW5zuP9UiYxi4/eAZAvbVuoN6lX74JuduV99VvRdU81JSYR7+WICtVQA2Kty5OsIhDs85TzYvL1+bjt96L+osclRKSRo0ggzesw49ere8H7p3X3bcEURW5C/X20NTOD2uvBTtWOyaC0zuhiwti2d4muJPpHOGMMA3tha/iEX4qCL/t+tVxD+RCfFcm26xu+nu56d06KYVSmKeUjEuU0z74tLXoZRg1cKE/+sNh+ot3j1yY5Tc4+jDt+LvvWu2tXk+lsXtqGEDNWJzNkWQu1V483XMObWavzRx7KYc8iEfoA1UW3u2gFbEKT4h5Nw17oMv9Nl5c4chsrhskJ3yhTcZB+haj7OogGZ/2L5XTK5IeLCe6nH0un0zMGQ0v1HslKUDD1JIAIPsD3957bCKJMLoSt2e48XBTA5zUvazUQRX5/o0iP1jDrkyKvbcY2SeCaQIQS6zFMX91OlUGAwwyYi/M6qAhKA0HDy3mlei0V+04OSpGX851Vudd/LDkyzJlaJDSO8B6fIVkISPAvybMrpauuIdfQsrV0qyfzdpjgJk7nExmw775XjPuUowSvttYbYxTtXrxVzJa5QXjv/Y4UQf0tjQYZGOTA8CJPbfk+ln1AYMmdgFcd/wTEiVUnJTs72vjry06u0v7Movp9ekXVPEv9DaQ/zqWcmRr84EXHX8fMBVlI9zjbjSyIySd488KyWe1NH9O03aFFHl4E7vcdqNiH+CXlT55C3kKgOeyJHiwVa4gQW/pEj3SYJIVFK4GYKJxoK1ST5j3/st7TGchaFToY2go/yJ1NU9bbxKAGWsTk3k6JaBhJpspoPguj5gCyZISiXgBVz1Fwkzk3ysXT2+8FfUnZVpw0wjU7CxkzimbEILWgrESsk4bB1nNNbigWy3ijfqrhMBzHzb0SN/L/najAbnMCGAijKiM+Yc1+zo4gV18aVVXry17OwvqBpjx0CWDsWOvTxmhon5acPFRmoALeXQbLuxoW6DCk5+z9gGP04zVD17IXjG9fFkiAKvJr8xJNGcUaZrv0rJxElZBcETFan730SSFXd1tMHAt62g36raxmc9Ux84XcA7C65QGctSlJW0rKUAhgmA3vxUHF/LH7huoeh7K8iX7eoEwQD1PzFHVJVEWz+K6AhW5ZNlxoLr3haM+OAGJdL0f5YVgIhNjz0XSIjg9Fib5RWM/L8cxAu3qBCCFL79k6bcFHzqOgTst1zjH/xDnTmz306UXSk3CHg1PaQ3gT4wHiGHGcTUdwJVVDArV6gfiDfJkWKIoRJKOHoAEP5NQm+DDdgWL2NPrvzjqwRGDW0V0HqQuyYgETlxbO1ES1thdOZ5i4p+F3DqytssfH+XFPyZUshLpSaMrH3vjf3uHxefu/Y7rJN1OGxNlMo7Nih7r6b0Jvgt4d1HZUMtz4ECjZNXiu+i8ra9O5RTwW+JoKb6IsYcwgP8lDiAgFLSftcjuUvLcugj7Rx8CwjmBiPHcCD0vzDFunQ+RpHQSjkLwRkM32UacfiDvE7+YLTgdK2nxR4IzFeny4Uxk0RoTjtsZhbN9iU/KnvO9Qw+VvE4yWtYWrizubH0rRMDNUE9E+Ia1nRy7RXP1kq0DVPNpy4b51cSzhF6bzKZmsQK2p9mD0INNWFt5JvUjAnRsQv2hMr2YJ3wnFPcDPB8cVGlf1oFkXYXdgxKt5CQBzoEVmx9eCCQ293NOM2HNnTpSplzhM5VtmqwWXJ0LQZFUEmZjj0aZ+Sceg2qJGneq1cVE7KXqMNLW6yRlkwXCRU9SnErtM9lVAFjOroVaFT6jSlCTH3QVdINVdlbuFqDQboiE6HUU1gB4cHyEUZOQ+udUmTxuOesTuMoOvpoBuZNqtxekBueUhNQb3GZNvkct0zc/2MmN5aHIgvSFtaumfMGGUG0NcrPv7xfIk+4sxEKs614gojrO8qN1AFC7FiqbFKfQQZjaQU7hM/46rfb9N6HVF0KWXXC7XbWkzXuGOsqkfkCu4u24tR3jgHVp1r0FFpTvwq4U8U6cSU68/aNQ57Z5sH/rl1/ZdwWWPgZNTfvgfQvAsq715/ulB2WjfL5+8xmUJgtAO2QOye+/RGHc2eFHcMopU9eHGS13CljKgJjmQ1JQ1VzwIf40C2VoLAS+tRcKvV/wCbYr7rIXOYwemYQTj2sO0TyKdUy+2xSkcvz9jRWM/SnsfZX73GAOXl5ZQjtubGK8VvshQqQaLLydvosq7LQp8fKzNOSQNJ7ymnp/oy9+Anww7Z28Yy2AEWXAxnfCmrPEwiA68bg1fpt9Rg3oSk0/aY50ambwrnpBjZuZ2714xjorjPXttzbZ3F/8S52r2sKEyP4MqX+5xG8ExFtyUyiuulEfQuiIXkaWHsuifD9El1ENneBPupRqdjco2u5E4yIIaBfMSYTngLFJx7HTObO1TmjMOhy86ijgXWNWjIHABTJSYrdTtwQh5b3renjbbFNUy1+V0Oi9ZsRd3vlDyzbe8ALerTCKNse6j/0wIKJMdvIvNCJWxR+ouzGH7a733VZYyvvlIIhKVctB3IxZo0jG3xauieiQ3RC/3IhcKfgNXH/JHKFcQD06mvOoAw1SAG9y8vXoC7T6t/N/gvZUsLwkQIiHKFeqTwxSAXf+a9IWptYdsGE2njj5fj/EvzZQYilNtEbRzxo5FWnzYaFO50DsGjQdiwzb51AptXW6lBW2j/0p10peD7wK3m6sWi/ySoE8WYS5KFD0Xq3ybt0iZ0RWbpL40bE1b7fv5XLzRfe+HMqEosWI7ErgFjdIYi5Vc+OekJ7kR2Kle1DZLNyC6R3KX0YOFM9AJ4F/ny4x7V4ado5rIXLa6yQS9x2BurRdFr1r6BV8dWxWBJzRWCNL9kz4pdIQPIOGUMAzFjyI1Gd1f8k6hg040bqm58p2V28Ke5uVNnefG2OeiEvtwqPBx9jdyMmCSUHsgrqAb72ibKsQSWvqvTwe0xMlcAWRX0OIgDkSUAtv54r9B7m6LQwK1SRKDTHaR15R5+KFQxmmSNCPw5lyxL4JHX0ih+ztU5YyqoDLmWd6Z6Jl9bI6luEEeZ3T8LeFT2cPllK+VnRVCqmj0xIPfQImfg3K6/yOCkHrrKvI0J6wnv3zRXJFbEgavRPMXWQ+X0GK1EuQDo/x6cO53WHBxXskGUT+jkHAOI7EAUaFznn8nrm/BPYOLZiHey1PH8tQjrUWtJnneberJsKOmskWLNzsshJnE1fq/2k6hAlDL9xWDdEGGF69arYTp2TUW49WjKDgd+s7kpeB2FDKO0YDrd8VsEPanVx54yRJNidJsrGCt8fKlzNZ6CG+zXApVIwTYdIKwLd7hVoqxX8kZUPQ9UP/BpZHr+/iVTBfkibO4y9e2/Rn9LyFzH++LkXb19C2+0MKNs9OMpHGF5mCdbaKgmthqTiEO+5IUKYFK6tZyb9/gErGOXBA6zSktp+xF8zeqzOw+x8Poke0GK+9Q5neKc9x5KEeo2t5bTzHZs17jkZkd3gAn9rwTKJ6zGSNn0QTjx8z/Ef83vX17Db1d/eKtLH5kT5FpMrCkXoBxgNV7eQ5b95rJ5eArWi04mbDFTkr0rBrapI3LIHLV2qvMZ/JEhcz6X36oN8vLVHS56ChzybcNw6BL9rSbcB4B/NmpwR+E5MufJSLq1IEm0QIf/opgCYSYC2qFzYom7+O3AByXC2CdbDZFuIZq6HxPRi9/axkV0VYnv153yHMdCBduuKkRf53oiACObajRzYYRSkyqq97qyCfxK5GHxguhzu92BO+JYDxETdLcPAaAOT08liOv/l0js6qY40HxoRhaleiuBywTUJPLSsNcQzh2QaKIN2582WwUXP0W0DFRQ8isd1vHICHKdbZHgP5H0f9kASLB/bKw40n5paTpNE3JRh5k6h0Kw/xLhFMtcNaN7CdBDVXageGhfEEFQg2hmn+JJkn9VIQvW0wHDMUW7wFMnMsRxvAVg0qxFNvmbr9h7KnlAyx/GxOxa9nQyMu0kdltfnO+cel57g7fuM9D6AYern2OMOJvpS0lgrMnxyNPpBPs/2AXsvi6ipKqHKrFVVdRPHQl8Eini660gCWTBdBTvp3DvdjH7F/4h9sg5e7wxswp+awcDlguYsvAg7tUnNVGEq3F46lRRn495HwtZ9vXPLvykbu3ptr/N8+V8cieZ+pqqB61NeazyOOHZ3gFauYVffg9//7pM1lM35Ao15Ce+NQMeF3xs8ApmrEF08BkFy4m2zJ1/JWAR8bnddbyrPFp9jfEIq6RyHx5bvDi3fr/GSgAkwYEJdGE1a4/XvRADor+ODWm+lmCWLJzper8tGK9iNHE4CyAWinXs0XHjncpVV6z7CSzr6Tdk8vxI+L/9tDyCyp04KRLc6nkOSktdH2+ZM6jSqfJrJyVRbu7Zs6OrZsO54ZZootoUr0GikWWuiHynLvSzZFZ2iGEuBNDcqsVfiVHvS0VJONKSKc6vGicCs+bE71hNxUG9zDHiL2LuHgxhb754v3/EL8U1kTbo5vnmoX2n3IDKDqLagewcjgcVIgp4xy7tz00TPy1tu9IrSo1dhYALh8EGPlEp/y+LacInWf+ZArN+swpwjpGFoCngMmYT+DNr2ilow4NQfkwy07nqJRutkWWSHoyo4SQq/DTl+kRQPbbjmSXxjJ1rv+vQZHOOfUOpdcJntnda9PwkMSShbU+IxIJjKZbxBDE9XrAyniwMdW8+6PTplEBV5202Icscr1mwu9cW9KW1ApyIT6JBERje8cq46NYAS8N4CeGAED4X5ufHgaJM6g6u+WpWSMn89MCd5Jo1mWhfQMeqWYpOzO6nTeWOL1uuJ81vfwuPP475Ig5A7RM8rPBnoA5lWuTTVM8BExUAmOKtsrxyak7pC/QLWjUh5eJlHMML+92KLHRgC7nYxrAXqsefOOIL1hMCibk99+CKtoOnWNjfO0epGAtNFqK7YSoaGTqXsL8xzEuUsGC3ehLO/7BS8mTHdKTRv1B8VlSXt0OtTMVLtPdUIJmHBAgifIdRcNXcjyBZNfA8Oxpws/n7JrLouat/k2EdGkvLmNfDLxns7NKKsEWbRoCX8COVUvO10RG6LmnfBOqn/GlFAVxumGi1svmjv54YBWOQNnPaN0Mf/m/Hcuc8nBtTeUat4u1fH6fvs9dJ2pUtunfDMan1NrklDNpo+exfVAcqO6ADf5Tm20SHQpNoyc1NqUuu+gVae0htP+jAu4pSV0SuNrQwORKbHTpIRr/6ZZywtxoEJs7Jcp/GBn0EO7eUoJMf70lhENFhq/+/wEEVn4JVKmJWjLZ0ZCXF8AueAx6Pmd3nZnOHulr9WXdb3WfaHeWH+sc/LeSqWPGW0dAwmo6IxDRCjHIKa8F/KwRp++3QlcI2qQd8hBiDsAzatXRbAzDo/M6eVy4NIa/Wm8m7Gt26CgVe/oDEO+hF78Db7Kw/LJ/ZKmvlIBsisFvsIjtvHGeidPyhCrSCIMBmLX0rDS9QezpadnZTgRekROWLAIr0vFLcXhAnx4i5YZoiF9w8L0PJumhgB"
+            },
+            {
+              "type": "text",
+              "text": "<i>Perfect world for a charming rogue.</i> Here's what I'm putting together for you, Sam — all defaults chosen to fit a sly half-elf with fingers in every pie:\n\n---\n\n<center><b>The Shattered Crown — The Gilded Compact</b></center>\n\nA <color=#cc8800>classic heroic fantasy</color>, <color=#44cc88>Balanced</color> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of intrigue, layered loyalties, and subtext-heavy NPCs, perfect for a faction-politics thriller.\n\nRunning on <b>D&D 5th Edition</b>.\n\nYou'll be playing as <color=#44cc44>Vesper Quill</color>, a sly, charming half-elf rogue — entangled from the start with <b>The Gilded Compact</b>, a merchant coalition that views the succession crisis as a business opportunity. Backroom deals, leverage, and dangerous information are her native terrain.\n\n<b>Character sheet at a glance:</b>\nHalf-Elf Rogue 1 | Background: Spy | HP: 10 | AC: 13\nSTR 8, DEX 15, CON 14, INT 12, WIS 10, CHA 17\nSkills: Deception✦, Stealth✦, Acrobatics, Sleight of Hand, Persuasion, Perception\n<i>(✦ = Expertise — double proficiency)</i>\nSneak Attack: 1d6 | Thieves' Cant | Cunning Action\n\n---\n\nSound good, or want to tweak anything before we raise the curtain?"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i>Perfect world",
+          " for a charming rogue.</i> Here's what I'm putting",
+          " together for you, Sam — all defaults chosen to",
+          " fit a sly half-elf with fingers in every pie:",
+          "\n\n---\n\n<center><b>The Shattered Crown — The Gilded Compact",
+          "</b></center>\n\nA <color=#cc8800>classic hero",
+          "ic fantasy</color>, <color=#44cc88>Balanced</color>",
+          " difficulty, scoped as <i>A Few Sessions",
+          "</i>, narrated by <b>The Magistrate</b> — a voice of intr",
+          "igue, layered loyalties, and subtext-heavy NPCs,",
+          " perfect for a faction-politics thriller.\n\nRunning on <b",
+          ">D&D 5th Edition</b>.\n\nYou'll be playing as <color=#44",
+          "cc44>Vesper Quill</color>, a sly, charming half-elf rogue — entangled from",
+          " the start with <b>The Gilded Compact</b>, a merchant coalition that views the succession crisis as a business opportunity. Back",
+          "room deals, leverage, and dangerous information are her native terrain.\n\n<b>Character",
+          " sheet at a glance:</b>\nHalf-Elf Rogue 1 | Background",
+          ": Spy | HP: 10 | AC: 13\nSTR 8, DEX 15, CON 14, INT ",
+          "12, WIS 10, CHA 17\nSkills: Deception✦, Stealth✦, Acrobatics, Sleight of Hand,",
+          " Persuasion, Perception\n<i>(✦ = Expertise — double proficiency)</i>",
+          "\nSneak Attack: 1d6 | Thieves' Cant | Cunning Action\n\n---\n\nSound good,",
+          " or want to tweak anything before we raise the curt",
+          "ain?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 5,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 11,
+          "systemHash": "5d55b40b5b9d",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "Yes, that all sounds perfect — please call finalize_setup now with sensible defaults for anything unspecified, and let's"
+        },
+        "result": {
+          "text": "",
+          "toolCalls": [
+            {
+              "id": "toolu_01K5o3wTBefKxSDSyMJrho91",
+              "name": "finalize_setup",
+              "input": {
+                "player_name": "Sam",
+                "age_group": "adult",
+                "genre": "Classic fantasy",
+                "campaign_name": "The Shattered Crown - The Gilded Compact",
+                "campaign_premise": "The heir to the throne is dead — or so the three factions racing to claim the crown would have you believe. Vesper Quill, a silver-tongued half-elf rogue, finds herself entangled with the Gilded Compact, a merchant coalition that sees the succession crisis as nothing more than a leverageable asset. Navigating backroom deals, shifting loyalties, and secrets that could topple dynasties, Vesper must play all sides before a looming coronation deadline and a foreign army at the border force the kingdom's hand — and her own.",
+                "mood": "Heroic",
+                "difficulty": "Balanced",
+                "campaign_scope": "few-sessions",
+                "dm_personality": "The Magistrate",
+                "system": "dnd-5e",
+                "world_slug": "the-shattered-crown",
+                "campaign_detail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.",
+                "character_name": "Vesper Quill",
+                "character_description": "A sly, charming half-elf rogue who's light on her feet.",
+                "character_details": "Race: Half-Elf | Class: Rogue 1 | Background: Spy\nAbility Scores: STR 8 (−1), DEX 15 (+2), CON 14 (+2), INT 12 (+1), WIS 10 (+0), CHA 17 (+3)\nHP: 10 | AC: 13 (leather armor) | Proficiency Bonus: +2\nSkills: Deception (Expertise), Stealth (Expertise), Acrobatics, Sleight of Hand, Persuasion, Perception\nRacial Traits: Darkvision 60 ft., Fey Ancestry, Skill Versatility\nClass Features: Sneak Attack 1d6, Thieves' Cant, Cunning Action\nEquipment: Rapier, shortbow (20 arrows), leather armor, two daggers, thieves' tools, burglar's pack\nStandard array used: 15/14/13/12/10/8 with half-elf +2 CHA, +1 DEX, +1 CON",
+                "handoff_note": "Sam came in fast and confident — she already knew she wanted classic heroic fantasy, D&D 5e, and had her character fully formed: \"Vesper Quill, a sly, charming half-elf rogue who's light on her feet.\" No backstory elaboration beyond that, so lean into the archetype: quick-witted, silver-tongued, morally flexible, comfortable in grey areas. She's here to play, not deliberate.\n\nI placed her with the Gilded Compact (merchant coalition) as the most natural faction fit for a rogue who thrives in leverage and backroom deals. I chose The Magistrate for the intrigue-and-subtext narrative voice — exactly right for faction politics. For the throne's secret, I'd recommend The Empty Throne (option 2): the heir faked their death and is watching from the margins — that mid-campaign bargain moment will be a great beat for a character who deals in information and leverage. Scope is few-sessions, difficulty Balanced. No content preferences mentioned."
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 2153,
+            "cacheReadTokens": 17677,
+            "cacheCreationTokens": 2700,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "The player has confirmed everything. Now I need to call finalize_setup with all the details we've established.\n\nLet me compile everything:\n\n- player_name: Sam\n- age_group: adult\n- genre: Classic fantasy\n- campaign_name: The Shattered Crown - The Gilded Compact\n- campaign_premise: One-paragraph hook\n- campaign_detail: The detail block from load_world (verbatim)\n- world_slug: the-shattered-crown\n- mood: Heroic\n- difficulty: Balanced\n- campaign_scope: few-sessions\n- dm_personality: The Magistrate\n- system: dnd-5e\n- character_name: Vesper Quill\n- character_description: A sly, charming half-elf rogue who's light on her feet\n- character_details: The mechanical details I assembled\n- handoff_note: A note to the DM\n\nI need to include the campaign detail verbatim—it covers the throne's secret with multiple faction options that the DM will choose from, including possibilities like a hidden heir or a faked succession. I'm drafting a punchy campaign hook that centers Vesper as the player character caught between merchant factions and a succession crisis, with concrete stakes like a coronation deadline and an invading army. For the handoff note, I'm capturing that Sam came prepared with a clear character concept and minimal additional direction, so I should build the opening around her rogue's strengths and let her charm and cunning drive the early scenes.\n\nI've placed her in the Gilded Compact as the natural home for a morally flexible rogue, chosen the Magistrate faction for its intrigue-heavy tone, and seeded The Empty Throne as the campaign secret—the heir faked their death and is watching from the shadows, which sets up a perfect leverage moment for a character who trades in secrets. The scope is a few sessions with balanced difficulty, and she hasn't flagged any content concerns, so I'm ready to launch the setup.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "The player has confirmed everything. Now I need to call finalize_setup with all the details we've established.\n\nLet me compile everything:\n\n- player_name: Sam\n- age_group: adult\n- genre: Classic fantasy\n- campaign_name: The Shattered Crown - The Gilded Compact\n- campaign_premise: One-paragraph hook\n- campaign_detail: The detail block from load_world (verbatim)\n- world_slug: the-shattered-crown\n- mood: Heroic\n- difficulty: Balanced\n- campaign_scope: few-sessions\n- dm_personality: The Magistrate\n- system: dnd-5e\n- character_name: Vesper Quill\n- character_description: A sly, charming half-elf rogue who's light on her feet\n- character_details: The mechanical details I assembled\n- handoff_note: A note to the DM\n\nI need to include the campaign detail verbatim—it covers the throne's secret with multiple faction options that the DM will choose from, including possibilities like a hidden heir or a faked succession. I'm drafting a punchy campaign hook that centers Vesper as the player character caught between merchant factions and a succession crisis, with concrete stakes like a coronation deadline and an invading army. For the handoff note, I'm capturing that Sam came prepared with a clear character concept and minimal additional direction, so I should build the opening around her rogue's strengths and let her charm and cunning drive the early scenes.\n\nI've placed her in the Gilded Compact as the natural home for a morally flexible rogue, chosen the Magistrate faction for its intrigue-heavy tone, and seeded The Empty Throne as the campaign secret—the heir faked their death and is watching from the shadows, which sets up a perfect leverage moment for a character who trades in secrets. The scope is a few sessions with balanced difficulty, and she hasn't flagged any content concerns, so I'm ready to launch the setup.",
+              "signature": "EogdCmUIDhgCKkCt9Z80O1tiDqBqnspKN1e5o7YcFHyW8BYDDIABLAPN8KQT5+f+xUHA4UVGdhX7Yn6EgsxomxLPeG55b0P/RqZoMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMy/LsPok4cEbEzjiEGgwo+Pjwmv0Q8MYQvoAiMCaco/REO8wARUFQK10nMGfk0cBfNkB2agwkLcMsZ8QkNbScmsIpkml+BC5NQ6WitSrQGyqFpYwMGAgdRo+kVJKAghbbkomyCWvwnO8BhHCjyC6MlB+2EMkh0AkXlNTQhc8Uo11QVcdIpwAZNd991nc1GHkwJsrGhI4E3LlVnB+toLp+6Ad7+2KrfJ/aAcCQgAoqqQSPP/TIkmcDGmKpYetrin/N4iioNmg/T5fztyaile9mfxicO4kmX0f3kQatB8w51FxkHcvj45pE+Jwfb2SjhnqZesKJapZ69skeaZmFbw6vfBQjY+m9o9902P3/ceO03duSGYDcLxbUp93ADH3rNGfYUo6OQBZZn8jt6GsoTZQPn4fcY6S/X19+R1/PkjFi4rXk/gvyqp3aqU9D6tu1qh9XgRYi6Ml4Pp0kwUTSd45wDIjKrV9ABQLBNwx6j8RfRxjjVeR4okq3nhAD3da/7QikTiEa7zSyQcUUkrj8LGvrt4U5zQwEwPdZHaFM4EmdfgR9JrFV84DedtfsBKksWEuPOX81t+Tk6gzvFDGjTf2gOS4dy3ZlZ2LnDs5uHPxtWAg1qOMmbrOhOFiREsVdQdygJBAvfff+5Q1IQUc6M7fBaAmsvANBzGEtnZum5gM7vxB7gdMXxbe4fusWa3iUY3nZ4IQbHavuFK5LcT/q+BSEvuKZCI/JzsE9FwBzMCrmMtmG9fMhWIXcXCKualPvpUIHog+B3wKz+XRabVZIjBjzqgl9gIq94/Nx4EH6wxQPIocnOo8D3pTtIDS9pFsHdYxX3mA8GzUKGJbB0tklv1x1MogP5isUbZ5Zbo7rP5tWQ5duU7QjLmgNBCChcViKL7MZ1KW+Iup/a0GaXYJYw5w2rElHbWuRmNYiFiLqqhJo2RyqVN8jmulJOhoVMtYP2wJ/Mk+6D10sW/GldXuHoDhnfcIvLtGyvpfclXDAR+g2nfVAeLoGX8Ni243TEfAfYHCdKjZ6DL8rLk7nMgYc8vPEtks4h0TT6eYnudG0spz0w+LjEOmFJRWwnUCz5WRvIVj5ePaclp/NwndPQbu7A59e0JDtBxdiMfQ2WTR9Co39pVDJWbmQSmx+Y1buqRsKn/aJUSxHAwzWksm7EZpwyrce5t2zmtqg4zWSt9t5nfK9Dr5/ufR6RJhR7dPqPQT/Y8iII2o0tVovJ5vuW1MiCwYoxjd+70BJON/EkTCi0H56rXuinC6csLzAQvb82MSH6dKGC45K6AnuYxYv1DMNTRhBrCNnOILtqiCygdkEXOfVVFVwhjecjvxoQYUerob2HEIxP5aK5bEK2XA1eJ0+LtTH2a1/zRThRTZNnO3NAN9zdNcm2d/oCSH1jXMmP79AcIo62q7QRscunYf11iLJRmWUJMVfekhNN1OibS8sRuZy1sRS7XofEsIb8U6gVHD7fXyGafH1mu8nrr03hMGze+Uz58wOelMQUfZFOZo0whsNuLyDawLKQ3BNAcCnF9lHvPPE/FK5uN1iqKf90JD2GJKlMd8nlJgrxKx2VqDWlPwR5aoAtE4rT1GiKCL2iccyBgDwY1LyBCA++QyKeIptlGkfsuD50JOSAGDp9tLPTLBbFR2tCXfFSdG5rgXSFZzUbjd4+/X1WBtQIzsjqSfm/R4u8VI2pNN+7YXsj10NC71PCJ4eOWzka1fKqtGQCZ3OeC3lmpY0TpEn23Ufo5lfKWKMN8P4TtXBr/FgnAhhFrYCUivV06ud1F2z1ayftFAgo9IlXbVbGkNz8eFMZuDxO+FNzwQwPa7ll+49bYUiK7P2vIPLM+3z9gvj19jCsD1Ao7EjgeWonK7chjQ87po7LztAHShowtIQXAMAmjkrTrRe9vclsG18/iLtrAPBymIaLppiYRXzUM6HjeyrFvicH3wwCiIjGZfzm/l58c8VT/UE7MezS3TX6EXlv0mn5s4JXwrQ+HB1zO7GPosNYZazmVCjHZk8/JWtUzV6+HV/lS/Tpwgyh3kdlDdnMEgY9nQ9JmbjAh614GCKess/iEk3nOKQpqaXxg57+pVHBalEj83rVP0yncbAf8bf3zEkVtecPvuWum8y2Ni61txPg1vjJHdX1iZH3tMoeKLqHPWEtAtameRicEqiuTjA0s9kyS3jY3RXC0XQJ6u1KGwcCvH8tOmFqlPwtcCv+tt4CkmI6k4TXy17nEMGmJJJNd8lgXbY+qy8JL9QWEskfhIC3Zi3jd1kahhpvdwut5I4tl927ZjqJwEkR51ywN9NiaYZ9XHZos/X1/GBDdQO2GNbc62ALu7CILAoIl7+LbeC+DnCu3/OOLTaT1ivr7+JFHV98uZzBCx1i8NoajWuX7kT8AMtZ7kEvHUXzZbqTlS9gKisJiB+iefmugpwpijKIIkXRif4w3bZGrlGur6UmAMCCx18kjdSdCNCADHGaKiADWgYYwhyEyjXUxTyfWew7KV9aNS5hRJAIbhAgwST55OkNyRRb0MhzAFbAJ+rRxukidF+JtsW5voH+E4ifCLqPZG8bCfqJC5perv5C5s5+QJ1Yg+oP/n6LqmPwJmMrBYiCMTsgxGmhf11aRw4U8zlqTVN4HA0Zuh6SK4+8bkNRy5qC/4/5Elk8V9BYNkV+Tjrx+YPImbChWjKSe+uhed505X4Kk8mOkTX3SpWrYKVoT8WnSEzJqyaMpovJuJlfLRdzmeLHsDE9BUJSvW2W5s79LOdJQ/4PSUG3O4utSFuvOCyj4JMhVe7KkStiTvdp4yzKoHFp1NGkfpOzJdfEMC7tgujsBZINovM8dXJ5PbJ74+sKr7ADkqavAUTJm9h74b1YJzht8yP07obspxlw9Sz1i2GMGcu3cJLhzAX62pRTCmuUicl2c9d+PU7P6aSFWX34L2hF80RwI7wxAksHiFbpKVv2gc3Gr9fO5joqBMAgcyopGyqCi4ZC3qUKPl0D8k99qsFpCCymo82gbNMEGeVfiTpyYmk0+am2Kq5nULDjSeCAKT5xz/7vUr9YzYTtlESV0gCtGAKCvJgFXJY35n9YmY4BV1nvMhdE44U27SRqE10lr5xjRPtz7Dyhkgd/96sNnDF86B6pjUN1OIlZ3st7kbF2K4kJkgYNT4dnS/PrazOtJip90WXHlomU5PQVAAFrg4D4XROAMFExlymwlKkThCFoPE1nRwGH/4NEUo2JBr5j0LQUYznR4NeYewNl1diGYsUJeT7nrUi/ifes/B0hmbYRH9cN0Qp+VZxWboCV5CzsUOHgr7VT2ujC00TtHezljfS0jfzhq7f2GwUCH61zR7PEv56WMx06fq907AmJyOUxuK+pDSzNcBQJv/3p5qRh9iBgd6KXyjzvBCt4WxXNvjnbqpjeFxdhdOguNSEkzUtDCa/KtE2VxkHM0NAvrtFnbrSBLAHGzKeKyeFxegHDEtpB6HAaAKeJqUz520SGvN8NkimTMfhRFS278+uWkCGqohx7mq+pitoawL4xdSjTanvkjDmEfjUl/db06wsrvL+Hmi0engcero6Rc1uEXDtV8iQONZchAvwSnwial6dqd4VFyiAPlkemOhMrSuX2/IKmSZdAeP1ikAPuPRTUxlb/1d9jjGGFJ7cCRtyI0oryn+LiOEuf3MDU1xomxTeoV60vivBTxtnJY8OwcoUgu9JzTo919PR2TkllEVbMBsUuG6rMTFdEAWvd8iL2gclJ/BLYw16rZY5l5DEyQmtJRRpIuWOAgO6x4KkZYVnmJoboyBcewo8lUZ4vSSpcVqkLTxg6sjpAh4Zx/Njxw1Wz2gfpeURtjyHTui7hklIZzvleiON37oAOGy/Tlh8sui6bVTNdzqPce9UNg2n2ksE2xXJ/AjVdLS3WrL8w3LaN/vo/F+8ln2XI2Jrv/zsjddpqDvHCESTprSZWWVbSXt7sYRwu/H/riAWHfwylqa+UchR2d27LfTw/loIp9+Z0jQsXj72W4rYxztWGPH+gwVDk1uL5xBbVw4N+kjSJCqsayq4Da756bdLW9zU3vgHQ1pfnP3LX0Z6XnLbZzHENCHNIktRqzzVaxiXnJeuBPIkk9HPz2mtrFaJ1LTtcqe42fOt8xJqWduTSjyGj7tIzUEdic8lyDZGslP/5Z9lo6tIh6jBgelaZgl1He3VPf4K650+8QXeWz0TXRA1gDkcdWuaK9MczI5eGUeIYLZoGXsQiax/cEA4j+oNh4yLlZpkOh4wUDWD/QH49NfZAyxQSaXl+ygw6TvpTrInZFzMFrvgO3S/x+4jMcQ5wUXwGYYgWWSkHRUHraP/5+VWCtt+Zy0FO3vlLOq1dvjv1MW+ZEJc5+85tw9SzBo/E/ys9QpxQoZFg/lF59OpG4yEUXVRzXIGj6UqxJa03HoZ/Wp++bKm+8+SB7+vlJV3zl/okzIz0pA6IE5jlgympetA4f8lU06rzzuaQnIyPxJfpdnp9JU1WkL0hORsTt2h3zwqsrWz/vqDNwGzvG1IDBv/TFeTJTLHEIWcor/9tu+Wg5kROre6/ySl8wnzksWraBbKFZMj8OyxWwO+nqkvIrSaiyB16aLD1BXchhf8ZDiM6HsXSZTV8puA7myNtW5Q6cBX+4EwKRT1wywICVN5A5gx/XZHdpeboMfPckH7OP1R0I3gdNfWi6ZTWDYkulm3TQyMacjKWggTV1rbS9ZbcgWY30pMMN4S7b5TISGuA3uer+lLrLc4Do+W+AL9JJEtlQv5yJtW2VcK0/cs7ak2dxDruuAI5aQ6hcc7qcrjQDpEPRjNSD9qvUVOv0XN/MMeEAwGazOvEwnNkO2lzGvlqsBeGAE="
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01K5o3wTBefKxSDSyMJrho91",
+              "name": "finalize_setup",
+              "input": {
+                "player_name": "Sam",
+                "age_group": "adult",
+                "genre": "Classic fantasy",
+                "campaign_name": "The Shattered Crown - The Gilded Compact",
+                "campaign_premise": "The heir to the throne is dead — or so the three factions racing to claim the crown would have you believe. Vesper Quill, a silver-tongued half-elf rogue, finds herself entangled with the Gilded Compact, a merchant coalition that sees the succession crisis as nothing more than a leverageable asset. Navigating backroom deals, shifting loyalties, and secrets that could topple dynasties, Vesper must play all sides before a looming coronation deadline and a foreign army at the border force the kingdom's hand — and her own.",
+                "mood": "Heroic",
+                "difficulty": "Balanced",
+                "campaign_scope": "few-sessions",
+                "dm_personality": "The Magistrate",
+                "system": "dnd-5e",
+                "world_slug": "the-shattered-crown",
+                "campaign_detail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.",
+                "character_name": "Vesper Quill",
+                "character_description": "A sly, charming half-elf rogue who's light on her feet.",
+                "character_details": "Race: Half-Elf | Class: Rogue 1 | Background: Spy\nAbility Scores: STR 8 (−1), DEX 15 (+2), CON 14 (+2), INT 12 (+1), WIS 10 (+0), CHA 17 (+3)\nHP: 10 | AC: 13 (leather armor) | Proficiency Bonus: +2\nSkills: Deception (Expertise), Stealth (Expertise), Acrobatics, Sleight of Hand, Persuasion, Perception\nRacial Traits: Darkvision 60 ft., Fey Ancestry, Skill Versatility\nClass Features: Sneak Attack 1d6, Thieves' Cant, Cunning Action\nEquipment: Rapier, shortbow (20 arrows), leather armor, two daggers, thieves' tools, burglar's pack\nStandard array used: 15/14/13/12/10/8 with half-elf +2 CHA, +1 DEX, +1 CON",
+                "handoff_note": "Sam came in fast and confident — she already knew she wanted classic heroic fantasy, D&D 5e, and had her character fully formed: \"Vesper Quill, a sly, charming half-elf rogue who's light on her feet.\" No backstory elaboration beyond that, so lean into the archetype: quick-witted, silver-tongued, morally flexible, comfortable in grey areas. She's here to play, not deliberate.\n\nI placed her with the Gilded Compact (merchant coalition) as the most natural faction fit for a rogue who thrives in leverage and backroom deals. I chose The Magistrate for the intrigue-and-subtext narrative voice — exactly right for faction politics. For the throne's secret, I'd recommend The Empty Throne (option 2): the heir faked their death and is watching from the margins — that mid-campaign bargain moment will be a great beat for a character who deals in information and leverage. Scope is few-sessions, difficulty Balanced. No content preferences mentioned."
+              }
+            }
+          ]
+        },
+        "streamDeltas": []
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 6,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 13,
+          "systemHash": "5d55b40b5b9d",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<i>The stage is set. The factions are circling. And somewhere in the capital, a dead heir's secret waits to be found.</i>\n\n<b>Vesper Quill</b> — may her honeyed words open doors that gold cannot.\n\nGood luck, Sam. The Magistrate has the table from here.\n\n---",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 80,
+            "cacheReadTokens": 20377,
+            "cacheCreationTokens": 2197,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "<i>The stage is set. The factions are circling. And somewhere in the capital, a dead heir's secret waits to be found.</i>\n\n<b>Vesper Quill</b> — may her honeyed words open doors that gold cannot.\n\nGood luck, Sam. The Magistrate has the table from here.\n\n---"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i",
+          ">The stage is set. The factions are circling. And somewhere",
+          " in the capital, a dead heir's secret waits to be found.</i>",
+          "\n\n<b>Vesper Quill</b> — may her honeyed words open doors that gold",
+          " cannot.\n\nGood luck, Sam. The Magistrate has the table from here.",
+          "\n\n---"
+        ]
+      }
+    ]
+  },
+  "expectedNarrative": [
+    "<center><b>✦ THE CURTAIN RISES ✦</b></center>\n\n<i>Somewhere, a candle flickers to life. A map unfurls across a worn table. Dice wait, silent and full of potential.</i>\n\nA new adventure is about to begin — unwritten, uncharted, and entirely yours.\n\nWhether you're here for a single blazing session or a saga that spans months of play, we'll build something worth remembering. All it takes is a few choices and a spark of imagination.\n\nBut before we open the book...\n\n<b>What should I call you?</b>",
+    "<b>Sam</b> — welcome to the table! Classic heroic fantasy and D&D 5e. A bold and time-honored choice.\n\nI've got your genre and system locked in. Now — how would you like to build this campaign?",
+    "<i>A sly half-elf with nimble fingers and a silver tongue</i> — Vesper Quill sounds like someone who always knows which pocket to pick and which door to leave unlocked. Wonderful.\n\nNow let's find her a world worth stealing from. Here are some classic heroic fantasy settings that suit a rogue of her particular talents:",
+    "<i>Sensible defaults it is.</i> Let me grab the details on the best-fitting world for Vesper's skillset — one moment...<i>Perfect world for a charming rogue.</i> Here's what I'm putting together for you, Sam — all defaults chosen to fit a sly half-elf with fingers in every pie:\n\n---\n\n<center><b>The Shattered Crown — The Gilded Compact</b></center>\n\nA <color=#cc8800>classic heroic fantasy</color>, <color=#44cc88>Balanced</color> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of intrigue, layered loyalties, and subtext-heavy NPCs, perfect for a faction-politics thriller.\n\nRunning on <b>D&D 5th Edition</b>.\n\nYou'll be playing as <color=#44cc44>Vesper Quill</color>, a sly, charming half-elf rogue — entangled from the start with <b>The Gilded Compact</b>, a merchant coalition that views the succession crisis as a business opportunity. Backroom deals, leverage, and dangerous information are her native terrain.\n\n<b>Character sheet at a glance:</b>\nHalf-Elf Rogue 1 | Background: Spy | HP: 10 | AC: 13\nSTR 8, DEX 15, CON 14, INT 12, WIS 10, CHA 17\nSkills: Deception✦, Stealth✦, Acrobatics, Sleight of Hand, Persuasion, Perception\n<i>(✦ = Expertise — double proficiency)</i>\nSneak Attack: 1d6 | Thieves' Cant | Cunning Action\n\n---\n\nSound good, or want to tweak anything before we raise the curtain?",
+    "<i>The stage is set. The factions are circling. And somewhere in the capital, a dead heir's secret waits to be found.</i>\n\n<b>Vesper Quill</b> — may her honeyed words open doors that gold cannot.\n\nGood luck, Sam. The Magistrate has the table from here.\n\n---"
+  ],
+  "expectedSetup": {
+    "genre": "Classic fantasy",
+    "system": "dnd-5e",
+    "campaignName": "The Shattered Crown - The Gilded Compact",
+    "campaignPremise": "The heir to the throne is dead — or so the three factions racing to claim the crown would have you believe. Vesper Quill, a silver-tongued half-elf rogue, finds herself entangled with the Gilded Compact, a merchant coalition that sees the succession crisis as nothing more than a leverageable asset. Navigating backroom deals, shifting loyalties, and secrets that could topple dynasties, Vesper must play all sides before a looming coronation deadline and a foreign army at the border force the kingdom's hand — and her own.",
+    "campaignDetail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.",
+    "mood": "Heroic",
+    "difficulty": "Balanced",
+    "campaignScope": "few-sessions",
+    "personality": {
+      "name": "The Magistrate",
+      "prompt_fragment": "You are The Magistrate. You run intrigue. Your world is a web of factions, debts, alliances, and betrayals. Every NPC has a public face and a private agenda. You track who knows what and who's lying about it. Your narration is precise about social dynamics: who glanced at whom, which words were chosen carefully, what was conspicuously not said. You give the player information through subtext and let them assemble the picture. Power is your theme — who has it, who wants it, and what they'll trade for it.",
+      "description": "Intrigue and power. A web of factions, debts, and betrayals. Every NPC has a public face and a private agenda. Information lives in subtext."
+    },
+    "playerName": "Sam",
+    "characterName": "Vesper Quill",
+    "characterDescription": "A sly, charming half-elf rogue who's light on her feet.",
+    "characterDetails": "Race: Half-Elf | Class: Rogue 1 | Background: Spy\nAbility Scores: STR 8 (−1), DEX 15 (+2), CON 14 (+2), INT 12 (+1), WIS 10 (+0), CHA 17 (+3)\nHP: 10 | AC: 13 (leather armor) | Proficiency Bonus: +2\nSkills: Deception (Expertise), Stealth (Expertise), Acrobatics, Sleight of Hand, Persuasion, Perception\nRacial Traits: Darkvision 60 ft., Fey Ancestry, Skill Versatility\nClass Features: Sneak Attack 1d6, Thieves' Cant, Cunning Action\nEquipment: Rapier, shortbow (20 arrows), leather armor, two daggers, thieves' tools, burglar's pack\nStandard array used: 15/14/13/12/10/8 with half-elf +2 CHA, +1 DEX, +1 CON",
+    "themeColor": "#84e679",
+    "ageGroup": "adult",
+    "handoffNote": "Sam came in fast and confident — she already knew she wanted classic heroic fantasy, D&D 5e, and had her character fully formed: \"Vesper Quill, a sly, charming half-elf rogue who's light on her feet.\" No backstory elaboration beyond that, so lean into the archetype: quick-witted, silver-tongued, morally flexible, comfortable in grey areas. She's here to play, not deliberate.\n\nI placed her with the Gilded Compact (merchant coalition) as the most natural faction fit for a rogue who thrives in leverage and backroom deals. I chose The Magistrate for the intrigue-and-subtext narrative voice — exactly right for faction politics. For the throne's secret, I'd recommend The Empty Throne (option 2): the heir faked their death and is watching from the margins — that mid-campaign bargain moment will be a great beat for a character who deals in information and leverage. Scope is few-sessions, difficulty Balanced. No content preferences mentioned."
+  }
+}

--- a/packages/engine/src/testing/goldens/setup-quickstart-fantasy.golden.json
+++ b/packages/engine/src/testing/goldens/setup-quickstart-fantasy.golden.json
@@ -1,0 +1,505 @@
+{
+  "scenario": "setup-quickstart-fantasy",
+  "tape": {
+    "version": 1,
+    "scenario": "setup-quickstart-fantasy",
+    "capabilities": {
+      "claude-sonnet-4-6": {
+        "imageGeneration": false
+      }
+    },
+    "entries": [
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 0,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 1,
+          "systemHash": "9c4de2032fa4",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "I'd like to set up a new campaign."
+        },
+        "result": {
+          "text": "<center><b>⚡ THE CURTAIN RISES ⚡</b></center>\n\n<i>Somewhere, a candle flickers. A map unfurls across a table worn smooth by a thousand campaigns. Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome. You've come to the right place.\n\nWhat unfolds here will be shaped entirely by your imagination — a world built to your specifications, a story told your way, a character who is wholly and completely <i>yours</i>.\n\nBut before we light the torches and open the first door...\n\n**What should I call you?**",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 202,
+            "cacheReadTokens": 7511,
+            "cacheCreationTokens": 7257,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "thinkingText": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no Known Players listed, so I'll ask freeform for their name.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no Known Players listed, so I'll ask freeform for their name.",
+              "signature": "Ev4CCmUIDhgCKkA8QVZUH4U8l4CbP2SK8XYp0PLMSxyMvYrH2dLuNlfj3qGzX1PGPgY4IA0DafWhwijbnt7TOHsi7ZDrqsPzC8W1MhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMRzgG8aa8d6H735xaGgwjsPqQTlbxtN8cElMiMGznlxJDm4neTiHz8yJWjFMhiZDxwT5j19aSzBVTzRExC1r7xVEokn3i4+vcN++ygirGAdO9rmMCC7hljGFhLrV91/jfCez1ZcGpjqkBv4MIiUJ+dDC9UboHQLWq0QhpLz2QnGuHCoB0I/IRcOxscpTDOCA+chE+C0o4Eo0Pxkh5Uco2OFyLmpYJzWtca2FABdcwL0sA0J61dK1BX91nj5krYh6MQU4TWQT7IBKlpLfU/zyQV/E4SRsvBn1NgoXXyy8cJdLQ/fnGWdQ6byQFM6qHqUkPwiMCQ94VPcd725x79IFf4TigPrishe4pEkdVDgrDoTvA6KEigRgB"
+            },
+            {
+              "type": "text",
+              "text": "<center><b>⚡ THE CURTAIN RISES ⚡</b></center>\n\n<i>Somewhere, a candle flickers. A map unfurls across a table worn smooth by a thousand campaigns. Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome. You've come to the right place.\n\nWhat unfolds here will be shaped entirely by your imagination — a world built to your specifications, a story told your way, a character who is wholly and completely <i>yours</i>.\n\nBut before we light the torches and open the first door...\n\n**What should I call you?**"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<center><b>⚡ THE CURTAIN RISES ⚡",
+          "</b></center>\n\n<i>Somewhere, a candle flickers.",
+          " A map unfurls across a table worn smooth by a thousand campaigns.",
+          " Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome.",
+          " You've come to the right place.\n\nWhat unfolds here will be",
+          " shaped entirely by your imagination — a world built to",
+          " your specifications, a story told your way, a character who is wholly and",
+          " completely <i>yours</i>.\n\nBut before we light the torches and open",
+          " the first door...\n\n**What should I call you?**"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 1,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 3,
+          "systemHash": "9c4de2032fa4",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "I'm Sam. Quick start, please — pick a fantasy world for me, something with intrigue."
+        },
+        "result": {
+          "text": "Welcome to the table, <b>Sam!</b>\n\nOne quick thing before we dive in — is this a game for a kid, a teenager, or an adult?",
+          "toolCalls": [
+            {
+              "id": "toolu_01UNeYREZLciAmvfHB1Lwrkn",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who's playing tonight?",
+                "choices": [
+                  "◆ Child",
+                  "◆ Teenager",
+                  "◆ Adult"
+                ],
+                "descriptions": [
+                  "A younger player — we'll keep things light and age-appropriate.",
+                  "A teen player — some edge is fine, we'll keep it appropriate.",
+                  "An adult player — full range of themes and tone available."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 346,
+            "cacheReadTokens": 14768,
+            "cacheCreationTokens": 226,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "Sam is a new player, so I need to ask about age group before offering Quick Start / Full Setup. Wait, actually, Sam already said \"Quick Start, please\" so let me handle this properly.\n\nFirst, I need to establish age group since Sam is a new player. Let me ask that quick question before proceeding.\n\nActually, re-reading the instructions: \"After the player gives their name — and only if they are NOT a returning player with a known age group — ask once, casually, BEFORE offering Quick Start / Full Setup\"\n\nSam already said Quick Start, but I still need to ask age group first before proceeding. Let me do that quickly.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Sam is a new player, so I need to ask about age group before offering Quick Start / Full Setup. Wait, actually, Sam already said \"Quick Start, please\" so let me handle this properly.\n\nFirst, I need to establish age group since Sam is a new player. Let me ask that quick question before proceeding.\n\nActually, re-reading the instructions: \"After the player gives their name — and only if they are NOT a returning player with a known age group — ask once, casually, BEFORE offering Quick Start / Full Setup\"\n\nSam already said Quick Start, but I still need to ask age group first before proceeding. Let me do that quickly.",
+              "signature": "ErgGCmUIDhgCKkAJxIc2U2TwLCOWSk/3379rA4d+K6yhcxxzwZHII1ghneAUIVpcW2M6oRuxgxMNHSpzNGmO8kITRQRty9IbpYiFMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMI7tylu/1nqVxDfJzGgy67EZ/xx1MuMEu0/MiMNWBD3afYCHFonFnaTq1eFGnKh73ncEptsjARJmyFz5BqZCJfvWrD9gg/st4OKZN7SqABQCA5K4ahg/01o7yM1jBVVI9NtQ4lZr9n1vdPUPwIY9d8QBR6fvTX3891+vNAVvU2g7UOfOT6Ko6mfuCGKVPKhySkSCHaMVYJd7CImXlkjGMpZTfnEF1iIXDiN9PFPunaNc4GgQseaLXbIId11hHQHKgqhK5+TFRPJZ0UNSB8resVLDbXXCYAbYZWRHJJQjjeoQNvRgDifTPzSeFK2IZgUpdgda1t1lPITRqt6fYp3X3SvfW79AO5zbEsP88e7WlKHVkdUP/xLVTT0QLzSTDJJCnJon9qaRaA3x+Ehkm16cmO3d6+HiJgkyUg3bA5+B2sfrvSGsm+HU84R9GxdV53f0nSwJWgQAC1plZWWvXBRz0sjQlOlFmvzaHgi19nPME0lxVfIGvkfNBz2711Qzs//Wg6QOo25twTTSARbaSvMsh0tVQQUz81N8KcLHPxjPvThxtZ7UKKZVUpH00Ay0z5i19Y738HHqmYhs/rqsVlM/rnDY/5LdDu7yhiDFn/1E8DtfeQmsiSwy7GCJDyEz+FYGqR28yRNPLIMbEkIH1L0Wcq2whiXljA7qJ/ms2D5vgY0cZ92mDxgn92Pg1goih01ZK7ArfF7/m+qFzxnw0zOmB7T8SuI8GyKlhd1mvHCCMai5wQkvnb7VUl0IIVyw/8I+9pbZIua7FbzzeaGF0Lbj3cgM2sVDn7ZokdTtLHNDW5G6gA/DqwZc+59xErDapM9mE2kr6hXaRr/za+WNIqoCpd6rM+FaaPNMkfI5/PVDQKcO0pa+8XTj9/TfbHWLMTlPvsMk2IfT74vrH3+edXmWBqmkb6V53M5XJOmXKPVqpWLXmZ9WnG49dIWoVVbR5f84YAQ=="
+            },
+            {
+              "type": "text",
+              "text": "Welcome to the table, <b>Sam!</b>\n\nOne quick thing before we dive in — is this a game for a kid, a teenager, or an adult?"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01UNeYREZLciAmvfHB1Lwrkn",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who's playing tonight?",
+                "choices": [
+                  "◆ Child",
+                  "◆ Teenager",
+                  "◆ Adult"
+                ],
+                "descriptions": [
+                  "A younger player — we'll keep things light and age-appropriate.",
+                  "A teen player — some edge is fine, we'll keep it appropriate.",
+                  "An adult player — full range of themes and tone available."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "Welcome to the table, <b>Sam!",
+          "</b>\n\nOne quick thing before we dive in — is this a game",
+          " for a kid, a teenager, or an adult?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 2,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 5,
+          "systemHash": "9c4de2032fa4",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "*Perfect — adult it is, and straight to the action!*\n\nFor fantasy intrigue, one world leaps out immediately...\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne. Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet me pull up the full detail on this one.",
+          "toolCalls": [
+            {
+              "id": "toolu_01VzXXJoFocf5rBQ4fZPrSEj",
+              "name": "load_world",
+              "input": {
+                "slug": "the-shattered-crown"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 585,
+            "cacheReadTokens": 14994,
+            "cacheCreationTokens": 394,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "Hmm, that's an odd response. The player selected \"That world sounds great, let's use it.\" which doesn't map to any of the choices I presented. This is strange. Let me just proceed as if they're an adult and move forward. Perhaps there was a UI glitch. I'll default to adult and move forward with the Quick Start picking a fantasy world with intrigue.\n\nLet me pick a good fantasy world with intrigue from the list. Sam wants fantasy + intrigue. Good options:\n- **The Shattered Crown** — A kingdom's heir is dead. Three factions claim the throne. (fantasy) — this is very intrigue-heavy\n- **The Oath Eaters** — Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. (fantasy)\n- **Iron Saints** — The church's holy warriors have stopped answering prayers. They still answer to someone. (fantasy, mystery)\n- **Three Histories** — A city built on ruins. Three factions, three versions of the past (fantasy, sci-fi, modern)\n- **The Gilded Cage** — You're the guest of honor at a party you can't leave. (fantasy, modern, mystery)\n- **Fallow** — Magic left the world a century ago. It's trickling back. (fantasy)\n\nThe Shattered Crown seems like the strongest fit for intrigue-heavy fantasy. Let me go with that.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Hmm, that's an odd response. The player selected \"That world sounds great, let's use it.\" which doesn't map to any of the choices I presented. This is strange. Let me just proceed as if they're an adult and move forward. Perhaps there was a UI glitch. I'll default to adult and move forward with the Quick Start picking a fantasy world with intrigue.\n\nLet me pick a good fantasy world with intrigue from the list. Sam wants fantasy + intrigue. Good options:\n- **The Shattered Crown** — A kingdom's heir is dead. Three factions claim the throne. (fantasy) — this is very intrigue-heavy\n- **The Oath Eaters** — Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. (fantasy)\n- **Iron Saints** — The church's holy warriors have stopped answering prayers. They still answer to someone. (fantasy, mystery)\n- **Three Histories** — A city built on ruins. Three factions, three versions of the past (fantasy, sci-fi, modern)\n- **The Gilded Cage** — You're the guest of honor at a party you can't leave. (fantasy, modern, mystery)\n- **Fallow** — Magic left the world a century ago. It's trickling back. (fantasy)\n\nThe Shattered Crown seems like the strongest fit for intrigue-heavy fantasy. Let me go with that.",
+              "signature": "EsAOCmUIDhgCKkARepQuRyB6awTzkCfQ3mlqSsKVwDr5k+G3tiyZmLMzgaRqcjwrI90ykjMDhakrM60j2lW2G5xE13wHpPgW2TPxMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMmE7YS75sVEIR6tT6GgzMWjfm2gC6D3iWcV8iMMqPUGzDLxvCKs4QnwBHg9UMrL70qTSFmmBrkEPeSeUf2Nukl3P+lmiQv+C4BoRr3iqIDcwF1x/bT9GeX4mK3qzviZ74nZISSu14henMJd3dwHcAV1mTRqJ9aUtnLgxp3Y5IcRd/mWI6aMUbRpkX2O6rKUJNDE2cGxdiOnb5wZR3pHnjK8Se5xsoXZtaOGwPOKRxNU/NmRGSR8sBGSRxEtak+GbY/HK5/BU3Fd9eVsywh+QSz4KJ72mTW+/OQ3lpO7hK+tLU1tBBYFeDCBkxjJDVIOTQrTI/hyfQGLeqbuL0Xi+oSjF5cnt9SPe4WjwES3kjRvRFjm1m3i61rl++b9CjwE7R+lcUkEsETTM8u/DDJj9Qn14LdkKJH3iZP1Jf+SG0YjqL6/pIqTr2erRCned4grln8jEOF0wcRt4EvcEUIP6TDHiol8rh2M7rgJQ0v7derv+8YjlRxevaouNd9m/6czJgiiWmQgxjZqGsTcA2m7xSE5lZnijl2ux+yPuituaPkb9Qeys9TO1pkvcoh3y9QIvEiDPaP4dsjyAnFWaLZ0GfCJqJMezIgglwb0XS+tYuzvWjIBybNLUmb1BSTLSLdrQZhRyumeMfW1+N0zhwd+ys/sXBmu8ZWJqL4g0vmaSU+6Bxza0Q3O0+6yiPb04hmK7FNlJ1fHjO/Fcr6vCBVNMIwTeA7L5262SIyt3cLJmmSX9v9wmjhCIeFmm+04hWSJiaaMdWbMCBTbk7uKwNZxr9PutHuuilX8Iw7SiOFZYtElIWmbRubXxZU0OsKJrJT5bO8OnsGayoBr9XsCmCqHU5ueYuKwkUGxnNMtu2Y3EB/+iaSaLbLpX95cuD+OuwurTigcyHVDzdp6ZAgrDBsmAwxC+jWs5If2mxHTZ87lf9DVVAUgf2NaJGD9d/kmhFcuYacT9p6GWjQ0DYB6HhWCvhTy8v5EvrNV+e/6VRdgG7u6pcfIK7C2ILfS6cAavhCrwYTsvMpj+dddqRpXE3RPKWGQPV473T3i8ffVuPNiJRSsyphI0TvC32Xrg0lJ2f6oOskIjBKe5YjKLfEvRpoFlS0KgPPycCPV9Uu2OQ+8C7xkDbcus3aDDCG84B7EEkO+xqr9jzVggzyXYfje8P9qJKRG9mV+hQOiz2Q9F4R+zsznX994Iueh8LhaxPpqOjn+29l48F6wu8G+xdU4ejDijha0VqIL9UjULrabHohf+U3eL9kOC+1EJtf+lvfVP8WknqGJFvtPor+FU/sKh9lwOoR8V46ONdmD63pfewSPLEkJHHbgP2LYShSso8Ff1qQ1j10yQlkA1pP1/SfAspV1lEjKL0NMMahvh6791z3qVXsZd9kXYe1h827yM9HQYkQ3+Y00ERZSAIb/1fLKKfNvMYtIvghkmYSQZsmrLARvglxRB54w7Y+HKBM+6iJxjzruhwiiTJj82fzi106Ci81fg0u1yIC51UjeNQTVM2qXaOsikhsemrh2blBowx7LeqGZxw52n8sY9+oSfWMpBKkbnTYdcWDd6Hw27SL/3NW85S5+l5ZG8j14EYoahOccAsBv9rg7VG/zQzSOUJMkola8+Tiqz8Vn5LZSSfW9sNZ3xMx1UZWU8ptENzSOuPN4ugolYFQl3AT4le3R2KI17qb/O3GL1PHq+dwR5+41WXx/mArD+fotjYPg//A0DPL6lpsRs99TOQtgTxXTyT6ES0KCrKzSnlmXBV6bwSaA0kIZ0Yn2Xc2BaWhGmsGac9uyMAwIuroC6X3HBkfX3XUf/pqi1BKek11x0PaKpzNk9lG4mWfbzbmBF6p+npbbe2uZhYFuoudAQ7bYNlxr6NfsjFgYz2F3rX9SLkR6XnYcs9gU5EKmpcAXbB8OGGgO1hgSjrY/F/mFBbeLhkDQ6wWW1wdtJNRiGWrvLCl2QlzUAjs361h/+uIyhO0AjumoxPjaS8lSuEN4psyirVrn1kbDzSs58aH0Xak0dvtKPVOXsg0dw2njzGmOAcGwkl+QY8l9eCM41DIjg+ZEXw80cNzEOw2Jlo4l5iLAHkMbd732Q2wzMAtzVbFzu6phGP+4OhA1wMuDocSA8R/F+Pw1XzCM5jk+ndsUPQtxPU0UL3ZKKAVcaSoJfZ8xw1JgYkVm66/YCmvRXyKnA++HmDIgYAxw1Kwn85k3wZxJZGjwG1QomXTynTp47ENcTvCrgH2cGmBmtAAeX40pPKMYyzujgkx7RDiYatbNh9idGp5ABcsISjs6DWOvFwfSCzo7UObZ5wRp0SGcHkVOpkXDiBBS5lW/Shv/FWBhz1/Z3hrmEYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "*Perfect — adult it is, and straight to the action!*\n\nFor fantasy intrigue, one world leaps out immediately...\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne. Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet me pull up the full detail on this one."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01VzXXJoFocf5rBQ4fZPrSEj",
+              "name": "load_world",
+              "input": {
+                "slug": "the-shattered-crown"
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "*Perfect",
+          " — adult it is, and straight to the action!*\n\nFor",
+          " fantasy intrigue, one world leaps out immediately...",
+          "\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne.",
+          " Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet",
+          " me pull up the full detail on this one."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 3,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 7,
+          "systemHash": "9c4de2032fa4",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<i>Oh, this is a rich one.</i> A dead heir, three factions scrambling for power, and secrets buried under every throne room floor. This is exactly the kind of world where intrigue festers beautifully.\n\nOne key choice before we go further — **which faction do you find yourself entangled with at the start?**",
+          "toolCalls": [
+            {
+              "id": "toolu_01D3LZt5h2WQgFeN7hFKqEux",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Your starting faction",
+                "choices": [
+                  "⚔️ The Iron Circle",
+                  "💰 The Gilded Compact",
+                  "🕯️ The Hallowed See",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "The military faction. Disciplined and honorable, but one betrayal from shattering. You'll see the succession crisis as a soldier first.",
+                  "The merchant coalition. They treat the crown as a business acquisition — ledgers, leverage, and backroom deals are your weapons.",
+                  "The religious order. They believe divine mandate chooses the ruler. You'll see the crisis through faith, prophecy, and holy politics.",
+                  "Not feeling any of these? Let's explore other worlds or factions."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 356,
+            "cacheReadTokens": 15388,
+            "cacheCreationTokens": 1003,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "Great! The Shattered Crown has suboptions for starting faction. I need to present these to Sam. Let me present the factions.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Great! The Shattered Crown has suboptions for starting faction. I need to present these to Sam. Let me present the factions.",
+              "signature": "EsYCCmUIDhgCKkDgFdOkHl5rhv3YWeLSQDWuKKn2R6LiSeqmljYZtoPGz3gCpNQyMCKRYP7PLH/E76HsXZrt62n5w9UpO9aIXEShMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMgmHNHotoffu8+8/lGgzQimG67xRxNnU0cE4iMIHniYafKvTtrD4oBt0ywxkPJ22/+eX0YzWyONE5DE8GCo/Qo4mjXUXUYssvhc0AXCqOAfTyRVTqQe7GFjky3gybYfsgTV1oy768VwGv0V70pgSy1AeHbllBz/4AU1cvxRpcXu8VVofNgMmxDf0MgqcfH5WjdLXHN8SXMgUBPDnlkXHoYebcWD7UIf1/8hmy242KWfew86sijwtfJq+Ji6MJbV/Rn6T00eY5TuuaBxASktLcT/4AYhUBWiMf2FkQBfAYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "<i>Oh, this is a rich one.</i> A dead heir, three factions scrambling for power, and secrets buried under every throne room floor. This is exactly the kind of world where intrigue festers beautifully.\n\nOne key choice before we go further — **which faction do you find yourself entangled with at the start?**"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01D3LZt5h2WQgFeN7hFKqEux",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Your starting faction",
+                "choices": [
+                  "⚔️ The Iron Circle",
+                  "💰 The Gilded Compact",
+                  "🕯️ The Hallowed See",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "The military faction. Disciplined and honorable, but one betrayal from shattering. You'll see the succession crisis as a soldier first.",
+                  "The merchant coalition. They treat the crown as a business acquisition — ledgers, leverage, and backroom deals are your weapons.",
+                  "The religious order. They believe divine mandate chooses the ruler. You'll see the crisis through faith, prophecy, and holy politics.",
+                  "Not feeling any of these? Let's explore other worlds or factions."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i>Oh, this is a rich one.</i>",
+          " A dead heir, three factions scrambling for power, and secrets buried",
+          " under every throne room floor. This is exactly the kind of world",
+          " where intrigue festers beautifully.\n\nOne key choice before",
+          " we go further — **which faction do you find yourself entangled with at the start?**"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 4,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 9,
+          "systemHash": "9c4de2032fa4",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<i>A sellsword with a blood debt, walking straight into a throne war. Aldric is already the most interesting person in the room.</i>\n\nI'll take it from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The Iron Circle</b></center>\n\nA <color=#cc4444>tense, intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of faction webs, private agendas, and power wrapped in polite language. Pure narrative, no dice mechanics.\n\nYou'll be playing as <color=#44cc44>Aldric</color>, a weathered sellsword chasing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's disciplined military faction, in the chaos following the heir's suspicious death. The debt that brought him here may run deeper than he knows.\n\n---\n\nSound good, or want to tweak anything?",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 849,
+            "cacheReadTokens": 16391,
+            "cacheCreationTokens": 435,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "thinkingText": "Interesting! The player has now given me a lot of information:\n- Character name: Aldric\n- Character concept: a weathered sellsword chasing a blood debt\n- No extra mechanics (pure narrative)\n- Adult player\n- \"Surprise me with the rest\" - so I should auto-fill everything\n\nThey didn't pick a faction, so I'll pick one that fits a sellsword with a blood debt. The Iron Circle (military) or The Gilded Compact both fit, but a sellsword might be hired by any faction. Actually, The Iron Circle seems like the best fit for a weathered sellsword — disciplined military, soldiers. \n\nI'm settling on The Iron Circle as the faction since it aligns well with a mercenary background, and now I'll lock in all the remaining details: Sam as the player, The Shattered Crown as the world, Classic fantasy genre with a tense mood focused on intrigue, balanced difficulty, a few-session scope, pure narrative system, and The Magist as my DM personality.\n\nNow I'm crafting the campaign premise — Aldric gets pulled into a succession crisis after the heir's death, working with the Iron Circle while trying to uncover how the crown's turmoil connects to his personal blood debt. I'll do a final review of the setup before finalizing everything.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "Interesting! The player has now given me a lot of information:\n- Character name: Aldric\n- Character concept: a weathered sellsword chasing a blood debt\n- No extra mechanics (pure narrative)\n- Adult player\n- \"Surprise me with the rest\" - so I should auto-fill everything\n\nThey didn't pick a faction, so I'll pick one that fits a sellsword with a blood debt. The Iron Circle (military) or The Gilded Compact both fit, but a sellsword might be hired by any faction. Actually, The Iron Circle seems like the best fit for a weathered sellsword — disciplined military, soldiers. \n\nI'm settling on The Iron Circle as the faction since it aligns well with a mercenary background, and now I'll lock in all the remaining details: Sam as the player, The Shattered Crown as the world, Classic fantasy genre with a tense mood focused on intrigue, balanced difficulty, a few-session scope, pure narrative system, and The Magist as my DM personality.\n\nNow I'm crafting the campaign premise — Aldric gets pulled into a succession crisis after the heir's death, working with the Iron Circle while trying to uncover how the crown's turmoil connects to his personal blood debt. I'll do a final review of the setup before finalizing everything.",
+              "signature": "EqoTCmUIDhgCKkA92kCE3ckTVGr5pa93BVxWe8hbUAJwKWxbBO833Y7IRL3+mJbZ5e2KM48uXCuWzV3VfZR10AcR74WL8872t43fMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIM7xNDG2RIHdLE5FdIGgzEfKy5H2i86+dXckMiMOmBsvrl3Db0T5Hs8l4RnSDsTdfMEjPGILHZCcPrhhUWItcZcv7bgsnUrHTDXrp5YiryET4BncaCkQBuwkiJQ8PyrJDcKPhexpwrmsVVvrxgqgClXYefAgON/cP9Lg2tD/XbvqVL2j1zGv/r4DzbqXDdhrmgdGKUra0aQOZgwCVfXAWfH8+z9mG+ig2BswCf9tA2udI9gjYH37pqy/tZuFLH/lTLvJNBapldORY5KW0po0ZaBAum8C78rRePL/5Mi1d/tpKyqUiPO4yLmwapLM7IbDb01Wn/tw907D0ZqyCfirk2qiw/QpcXiNFBlUzKgJK9ef1cuV52cEwgNahIq7wopWTP24Bv3ErVNl5VQMACE4lcUPShH/Z8JSMsiBYCa/wumVucB63x5oPmonns2WTZADRwmlsnQTuLXfSywEijimaDAZsZCSBLUz4D9ixWxW/2bSjVC4HU78TlxUKR/GPdpuppb4OatJWGQ0SEH7IWU44T81D9ZPzg76Kga0sQDbwyef1hahL3e4FBf6zmUxhvNmZcz+Tk6j5UCB8ha1mxdD0xZE+IyY+kEsqPOxDoK2sWH/Kt1F0TAdrs1Sfxj7XlRMxMhtqxep1JRHT0PB6UuawJih7r93tu8ZW6jv2ZbVT+/ft99SwVltMUFzun+9gQ78+ohEnH+b2Ai5r7FSj/ER3aVkpApI+9IRsPz1vtyy4tnODkO39SgaFsxuX3KE4k2+gXCtxF17WpCw5/iT5uqiemHMm6/Qso1/0bOqspvUvb/tr6e5M+6MfmUWpsnoacYLxoqMb+u7/WIkQ9HSeNPDCrevvX0WWxN3bl/C9heM6FgInUJFTZlkqjO45k9ZKfAUiPmEQ+hNmHG14wh1d8vAgfE2O9tMI1bbFEvI4hMnDE6V0TWB8k3IaRYtZx1dVTi+vSyBOr/3CNdV5p0qvmqQ9DPNNX4mq7B99sPkPlDXfV1ckTgh36A140VftgczmwyI7msbKndPoY4RFxpxqNL1w1wpYZBPpxkbEV7aOMIZf1ap0spP6EbGdFIbDiRmDW36upyQzVetbxIBHWylSmp63q6+PQkG1JqGra+6HjRq55V5D5toeU5C2GmJ9SDFyoRXvPQMCuxPKjOVpM2Srrd3lQKXI6SHl5/AlkJ3wEaJOrObave6vhqF5WvYhS4nW/Zbk3ziXpMpI6YoqulOhtoyeiKGo0vb1W/4M98e1OXaUAg2xQMvOXDAGONZuJD91Z8GcZjzM0Df6Fb/ZBSd5fK0UVNltiUbzaG7ToYdelb/MnolyOCwusMHP9jk60/N6kmDWQa/EI5s+jyYpfe0RjWkAV2zlbvb9x7L9s1ht1mSH9NrNDn08ysphppiAvlFxoTU9vi3GupaBdgWRxUX3l8acCxAWidsdO+zPr2bDDDA2wXuVzklGhANK9Fl8oZSeAGFG1xCfKycmrwkkCakkfmHqbhdyoRG4pD7VOaVjKHQ33FS3Z6ubLp08dO5sR1KtLHDrGd3aw9n7Wq+goprhDVOj/1qgYt+lNtMv/NUgqvVYktIV6fQlpEt+erOQRqe9zSGYLXw/bl5GTP565rXF4g2IXos0HPpfJRP4a7SrO9jsxrqVn94e0hLs+R8x4YuqOcT83aC8VUPMtGYL8u2N1Xezb63b4GMzbnHgYD3nYvQ2d0CqbLNvEpkoUnaw0hUvHmZ6LYoqt1gAw7G7PUD3CO76TB+qoc8kGs4yrcOqdziA/wOqSi32YX/1R6Wznl4QpzBoA13ubC6rwj8ToHz1IXu9BnmJcEf1761pkcV/UFhrf96DXngqunHBTMHO1YlIXuhmaEZoGP5pPRV5OU0yoP36T19GiovK+2DPN45Vyxzgjzhtt5SrRdVCMQBFWp+bfQgufjtXcYS4vb9FKK/OuZ9yvVzS5sDLD+6ZkARukhfA0TTSEXVKbcOu17JS4WmZue+2oP7xC+sHvXLqaThMdl6qVep9JLrrnLOiKbtRPpfxFeDH1F+QGovCItavFQz1BjeBaZkIXEoDaJYDzpYIBWPAPCE5LKt7e9CiQD27MN4IfLOHwi3dKaG6YvJsiIopljxws8Ay6jZz9BeLCa4xrNN7LWe3uq5RapbrJ3aP3dWB8VQNjPGEZgcUljplrsOhSWxAfUTpxmGkym9cMldi7Xz7QJVwoIqQrSq3V08VbUMdjVyBb26vzdPXPAtDwEVyIpN4v7qrfhZGhkh7IW5ROPDQzQLlEqSjEDzh4insMpuGyyRDuXyM34U9snQB6S2FjEziIOLBpDIvFdLBQDzcHqjNzAOG+J0xXcu8S/qb2z4TdrEPzwa7x3E34G1Id6inlgeeV3XlyBLgfqA0T1u7sxaaG4khlDHdGf4r//Jn6L2+hygQynO21sj/CbdsVLTC4iEwgcjCrlEdmmUidbdzFTdXbcPuWhIWkeSx+Ez8qcNgH+zYceM6Lr5Wu6QDoMK/aiWVkWl40qnwWdApHs+PKqUtExyqURfzLjs3sCCCOV20iLV/chsnEwj/ttX3Y0Yvmb3X+Vx5Bo/CLxHzGXXLBqwcLouoKsZ1YM7ETtnon6hyVpy26kljN6Q7shHKqEM6H/+VZ78N44DIGZwSuF+PzzuGWJheNm+FqSvKUDzxE/zzj2mXdYkYoECuC0VApXUrAR1qfJgDkR/rzjSfTZjxcqDXpkq4kyatAeSjpMIgNziPoPj9fFeHV5jX2EAs2w9EXptjV20qX4Nh4zZUj4zkGCFyXvH2fPdHuK/6NDONH6OWSU+iQX1Bfp78n3AsTa6eyHEU1lmIzoOo09aZxFZBh90X633spW8geIsiDTWrdihZFivmTweVMKLCRs6w2fOxIv4ImLjtSFFzGGSQ3LHskyYlOc7v/QywXkO/8jBCSDNuM33Lt1bBrzGB0SmsIIQxaiyyxBy9qJCeRxjdFKXTf2iDVf0x20Mt+uGWSssjfMz1W9+4RaB4dq3n0BH57yOhJs0mk4NFOLAYU+mGRaNIbxHIkThs78L4NpWUjI/h0eN02O7T2hYmt2RZua3/Luy7dhaIEkh6ALQgPU4N1CBTorfaAYuNGdble/MiGt48FiRnYHxl2oqSWALHsAcU+KwAqafz+uZW21qx4W+mEG+dmtjUolawYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "<i>A sellsword with a blood debt, walking straight into a throne war. Aldric is already the most interesting person in the room.</i>\n\nI'll take it from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The Iron Circle</b></center>\n\nA <color=#cc4444>tense, intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of faction webs, private agendas, and power wrapped in polite language. Pure narrative, no dice mechanics.\n\nYou'll be playing as <color=#44cc44>Aldric</color>, a weathered sellsword chasing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's disciplined military faction, in the chaos following the heir's suspicious death. The debt that brought him here may run deeper than he knows.\n\n---\n\nSound good, or want to tweak anything?"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i>A sellsword with a blood debt,",
+          " walking straight into a throne war. Aldric is already the",
+          " most interesting person in the room.</i>\n\nI'll take it",
+          " from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The",
+          " Iron Circle</b></center>\n\nA <color=#cc4444>tense,",
+          " intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, sc",
+          "oped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b>",
+          " — a voice of faction webs, private agendas, and power wrapped in pol",
+          "ite language. Pure narrative, no dice mechanics.\n\nYou'll",
+          " be playing as <color=#44cc44>Aldric</color>, a weathered sellsword ch",
+          "asing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's discipl",
+          "ined military faction, in the chaos following the heir's suspicious death. The debt that",
+          " brought him here may run deeper than he knows.\n\n---\n\nSound",
+          " good, or want to tweak anything?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 5,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 11,
+          "systemHash": "9c4de2032fa4",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "Yes, that all sounds perfect — please call finalize_setup now with sensible defaults for anything unspecified, and let's"
+        },
+        "result": {
+          "text": "",
+          "toolCalls": [
+            {
+              "id": "toolu_014ukxmhFzyTFiVfGeE3745B",
+              "name": "finalize_setup",
+              "input": {
+                "player_name": "Sam",
+                "age_group": "adult",
+                "character_name": "Aldric",
+                "character_description": "A weathered sellsword chasing a blood debt, now unwillingly entangled in a kingdom's succession war",
+                "genre": "Classic fantasy",
+                "mood": "Tense",
+                "difficulty": "Balanced",
+                "campaign_scope": "few-sessions",
+                "system": "null",
+                "dm_personality": "The Magistrate",
+                "campaign_name": "The Shattered Crown - The Iron Circle",
+                "world_slug": "the-shattered-crown",
+                "campaign_detail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\nSuboption chosen: The Iron Circle — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. The player will see the succession crisis as a soldier first.",
+                "campaign_premise": "Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the chaos following the kingdom's heir's suspicious death. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it. All the while, the thread connecting the crown's crisis to the score he came to settle grows harder to ignore.",
+                "handoff_note": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — those are his exact words, and the blood debt is the personal engine. It's entirely unspecified in origin; weave it into the Iron Circle's politics or the throne secret however serves the story best. Sam wanted intrigue, said \"surprise me with the rest,\" and deferred all other choices to me. I auto-selected The Iron Circle as starting faction (suits a sellsword with a martial background), The Magistrate for the intrigue-heavy voice, Balanced difficulty, and a few-sessions scope. Sam asked for no mechanics — pure narrative throughout. No content preferences or restrictions noted. The blood debt hook is rich territory: whoever Aldric is owed for (or owes to) could be hiding inside one of the factions — that connection would land well as a mid-campaign reveal."
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 3,
+            "outputTokens": 1990,
+            "cacheReadTokens": 16826,
+            "cacheCreationTokens": 879,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "thinkingText": "The player has confirmed. Let me now call finalize_setup with all the details:\n\n- Player name: Sam\n- Age group: adult\n- Character name: Aldric\n- Character description: A weathered sellsword chasing a blood debt\n- Character details: null (pure narrative)\n- Genre: Classic fantasy\n- Mood: Tense\n- Difficulty: Balanced\n- Campaign scope: few-sessions\n- System: null (pure narrative)\n- DM personality: The Magistrate\n- Campaign name: The Shattered Crown - The Iron Circle\n- World slug: the-shattered-crown\n- Campaign detail: (the detail block from load_world, verbatim)\n- Campaign premise: Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the succession crisis following the mysterious death of the kingdom's heir. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it, all while hunting the thread that connects the crown's chaos to the score he came here to settle.\n- Image generation: not asked (not applicable)\n- Content preferences: null\n- Handoff note: something useful for the DM\n\nNow I'm pulling the campaign detail verbatim from the load_world result to include in the finalize_setup call.\n\nThe throne's secret is one of three possibilities: either a hidden true heir is secretly alive and testing the player's loyalty, the heir faked their death and watches from the margins waiting to make a terrible bargain, or the throne itself is cursed—a bound entity that kills every claimant within a week. Each faction has sympathetic leaders with their own hidden agendas, and the player's starting choice colors their initial understanding of the conflict, though all three sides prove equally morally complex. The campaign should begin with the player already entangled in their chosen faction before they grasp the full scope of what's happening.\n\nI'm pacing the reveals so the second faction emerges as nuanced potential allies or enemies by the midpoint, while the third faction's true nature becomes the late-game twist. Ticking clocks—a coronation deadline, foreign armies gathering at the border, plague spreading through the capital—keep pressure mounting throughout. The three starting factions each offer a different lens on the succession crisis: the Iron Circle frames it through military discipline and honor, the Gilded Compact through commerce and leverage, and the Hallowed See through faith and divine mandate.\n\nNow I'm drafting the handoff note for the DM. Sam described Aldric as a weathered sellsword chasing a blood debt—that's the personal hook I need to keep unresolved and driving him forward. Since Sam wanted intrigue-focused fantasy with no mechanics and asked me to surprise him with the rest, I've made some auto-filled choices: the Iron Circle as his starting faction because it fits a mercenary with military ties, the Magistrate as the DM personality to match the faction-web intrigue tone, balanced difficulty, and a few-sessions scope. I should flag these decisions clearly in the note.\n\nThe blood debt itself is entirely Sam's invention and deliberately vague, so I'm telling the DM to weave it into the Iron Circle's internal politics or whatever throne secret makes sense—Sam's trusting the DM to make it surprising. No content restrictions came up, so I'm keeping the note clean and direct.",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "The player has confirmed. Let me now call finalize_setup with all the details:\n\n- Player name: Sam\n- Age group: adult\n- Character name: Aldric\n- Character description: A weathered sellsword chasing a blood debt\n- Character details: null (pure narrative)\n- Genre: Classic fantasy\n- Mood: Tense\n- Difficulty: Balanced\n- Campaign scope: few-sessions\n- System: null (pure narrative)\n- DM personality: The Magistrate\n- Campaign name: The Shattered Crown - The Iron Circle\n- World slug: the-shattered-crown\n- Campaign detail: (the detail block from load_world, verbatim)\n- Campaign premise: Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the succession crisis following the mysterious death of the kingdom's heir. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it, all while hunting the thread that connects the crown's chaos to the score he came here to settle.\n- Image generation: not asked (not applicable)\n- Content preferences: null\n- Handoff note: something useful for the DM\n\nNow I'm pulling the campaign detail verbatim from the load_world result to include in the finalize_setup call.\n\nThe throne's secret is one of three possibilities: either a hidden true heir is secretly alive and testing the player's loyalty, the heir faked their death and watches from the margins waiting to make a terrible bargain, or the throne itself is cursed—a bound entity that kills every claimant within a week. Each faction has sympathetic leaders with their own hidden agendas, and the player's starting choice colors their initial understanding of the conflict, though all three sides prove equally morally complex. The campaign should begin with the player already entangled in their chosen faction before they grasp the full scope of what's happening.\n\nI'm pacing the reveals so the second faction emerges as nuanced potential allies or enemies by the midpoint, while the third faction's true nature becomes the late-game twist. Ticking clocks—a coronation deadline, foreign armies gathering at the border, plague spreading through the capital—keep pressure mounting throughout. The three starting factions each offer a different lens on the succession crisis: the Iron Circle frames it through military discipline and honor, the Gilded Compact through commerce and leverage, and the Hallowed See through faith and divine mandate.\n\nNow I'm drafting the handoff note for the DM. Sam described Aldric as a weathered sellsword chasing a blood debt—that's the personal hook I need to keep unresolved and driving him forward. Since Sam wanted intrigue-focused fantasy with no mechanics and asked me to surprise him with the rest, I've made some auto-filled choices: the Iron Circle as his starting faction because it fits a mercenary with military ties, the Magistrate as the DM personality to match the faction-web intrigue tone, balanced difficulty, and a few-sessions scope. I should flag these decisions clearly in the note.\n\nThe blood debt itself is entirely Sam's invention and deliberately vague, so I'm telling the DM to weave it into the Iron Circle's internal politics or whatever throne secret makes sense—Sam's trusting the DM to make it surprising. No content restrictions came up, so I'm keeping the note clean and direct.",
+              "signature": "EuQiCmUIDhgCKkCcCstEC4jZ88nXKmjnKLSKTA+OnOS6fYXGUKXXMbawBg2ES5LO7RBj/dh49fv5qENZkcAjk0zQ4GElGzwvUBYcMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMv5Q/hl/pq9tMTUP6GgyhhGHqxdz/otvCploiMFZPOT1Vn16ugZgJPc/kYb6I42J0qhzd8XuAatEoNDey7a+YgL1jdl46QRNc9OzajyqsIaGLGYWE5RBQ7JzpBlZiKUnijpSuAM7ys3iuakW3PET8YYU6apkYkCeI0sYu8snGwhAXSbfWcoC8AC2B0XC4g8n96uv+wP2P4upOmqNjbm2ksRujT5FNGqyJmZpkh1lwuprBfhwFx/QQM+Gs5dVUqEuufQxfIu9N3q/Xd7rC0EVwGzoi/Sfy+kJs2vIekJ4SObv75OL1sLprCzNU7lpju7k2R3B5YpsHtlk8PjfDIkW7PmNDM7CVNzbNVirxS3U78FnjmtevFR5JvpHEs2m49GduiOoSGqlJzTbtg4e/omFZX0b0RP2yMzXCkYDO3rEO8f9zeW4C2hdsFYNpTRE+6Jq7xI2qaYdnrhDlFV9XVivsglIYHXGMTIz+upJARfVK6JW7SIIfAex4qs0VSpm7i5Sn9dgG9PyFjVIPG+wTjuQw/aZR1HrN+f1gT/iG/AZJMux8N01JxGz0/bta+S1dOuTOP4Fa18iEMNJrR4eVKo2bO/QnHJPL8VACeh9Yi+4OIR4S3VnmUYbA2TUGUTHDudGOjgFneCbczYsMLYSbTmhjTRxiG0AizFAkfgApQVGut1YBmqNunRQAVSNf5nfHFp9jAbLB+y0IHENnNROccT+A6XtRa3NUOReyzNY9E52v3RqTqiR91SE4E97ZdXF4C4Hz7BuCw/srs/oWKvYqUoTCgWDHprG82DMBNUyIo8/rm+xeONCekAuNVcR+1WN68m+O9+avkSkBGre4bk/LrJuI3y9wFVelOER9hKV5e5PDOtH4VYoXrlshZzqnPQa1sot5QK2jKESIeFYALj8ru7iBowFZSODeXZJDVn6MugTzLEil5r2AtJ/X22ivnVWHGCy1tA77kxlNxYzMCav8OZifn15WxIEN6o2h88/HWqZwqkyW8mroeeJm8/2CenekHTNDu6g87GFeP5t/NnP+jJqoVzoVh34ZrJA0NTjuH4UW6kIRluSsSVKrV1ijK0QYU8Mbrhj8bp13LSTOWUuogqjMR1MfI1k/KCrd+kFvokhTgO1FwMruoYCDv+heEm6e9c1fLA2rjaNrBcqnVy2E69sMRKDmD5CilgQtZ8I3RK7VfPQozmRRDZ+X+d969NeyA0OKVfOI44O2VyxmjL9Ba2siobD9ahlt8WAOoILmTeuVXLAUmMCGUKDPfcdt4ZyOnZb251gGAN8oblLbdL4iOPqc3/uamrVy4f98O7c3UaUpd17dA4KiMwq8HzZqRTnHVcmjqQUPiI8bUAknIF75UVOdRLhfF6jPVbwHxL1tnYw/MYOLZM2aeWLaUsqt89GiqPN/bkvyGlvueVblEx8YrmgCSvuisoPTv6pBAqI0X23lpaE5ovIMK9XMQFnhBpE4iUQpyRnKDY3K3VRdHk9r5HkK2t/KaJLeVMlkaE8UgUgGW+hcgIPQBhhKOnf9O9uxZCpqBBXkAcS/vOvRurdcsDpS4ti/UuWQSos8HOIg0eqXMIsLPbh0bCnVmQKl31+vpUouTZqqMEIso8q0xrUioVFeCF+9oJPhjLm5irdQCKZGR8P8X3ebtQIpFzkwlLCuYQjprz0SSlgIotUcmSfLm12UcaHVkH8XLQmej7g+/bRQwh3cqXzwWioZJaupS6onf5z72ipvaaCpTNakaF/ov8T2uGOEab0P17ymE1r8IxHhwUtYfBhzCH6qEPZ9Q+UuIjL4+s86oFSng1LYwkVeD5vFsZQ1aYXFaAu6KOI3/dkPoou7nDlQ66Ba3HCn/FoFbqvgSBSivnBsXTBjhh9aRcmUWSxYkMiWj9jevIN+Zx5Z9GykWmUv0bGqO43YEWhu/5Audi6a9G6q+haF/tCm3WJ7HBpyNRrn9kd4StvDZDE+DTTT7PUXsRmkRG9YJ5GYsYd6Pr+5tBNGgWtVhnYCRhmKI7R9B6YZfcjW806E7wcym+fzyG7xUw2c/Yzh9/lRr0NeyYIM81px2cezs/PigJV/6AMxO0icaheh0PwaTNF9zjSvj48dHoufrzujYpsAaFzTFLlGHgzgumvdWwZRX5sEuAa/BRgb9/biJUotnVTW8HFxX2+vTQKisurS0uXsvIXBl+u4nCJmVGDHlh94RuUlSMUtVgUmvU9Yos620zo/sf6Cw8oX1Tv9l64KP/Pvus/xSk4SlUu8+Bggpjt+oIlMAfrvSD7CdXY5c8V66mABw8aloQMwzhf6lC8SoZXQTEZMznNEQyHnR7vqkt2Fn21QAev63+YcIa/heyaHyAtq3frmfqnqzZpBrFAuv+/e9as37OoZuAbi5u9K5VeZU/xDOFfC9qj4xOyc0HpxcrgzJICYsRfDljZ0zhRu//sXgi3+T0dWidiCXflwpVoeIkVd/BJHesxx38S9edtdi6/HXoe40sBKa729UNjNcQ5c81o4bZMrgcYHB3pt3zKTfzwZ5xx3b4mhW3IK/IU3cJ/CKaU/u0sc/Xslhif79XPFev984s56xy02im2AsEoXybIeNbt5/JUB4T5VnqTMnD6joM1UYxekd1wfCgwa1lAGZR1XhR3PNkZEk9siNYkH4oGi6EQ15MwXfIR0T2Ab3R39klrvAUad/OsGkO6w8Wy5K4WFZwch0vmF++jmTYw/C10sJw+XR4kUw130/PpmiYl5dL0rXn0hKkMnytuFqsq4Ux2y2uMXW2mQQqygqRLjpgwLYlKhY8UeOXtjevKCYwpC9uQVSLHbdJDfj9+/MUSXe1nik08tiZ3hUxeFqgDuSNfE/bJdUsnhOu4z6L6BHstffSFwwHjVS51Zpy/Euo/yE82Y4qN/pixRG1zD81bVTDs4JvUn9ljiUjBnkAy5Ukvm7MJlq1DvbJRMvfSUO2O+j5XO6a/e+4YdPTDtPfXhFLxTVON2n1znYkSnyCKVDTnuhlNr5u1H8HQ7PrFRd7rWWhchJo57XsPXquC0OLQ7ClgOyylEmTH4aGWo7/8kaUWx/jrX5J1mjpR9hyns77O3GwCkVnmKPDZ6S8XqcVMfFcOcYq8jhk938uzXZH7qn3/d+dONJ8zqyHQrRVmi5E70Or8kQj+tTrcX6rTVY95AqUi1o0aX9W/+1iuBMy0MMvcojPjY9DjaY8bUVza/XGNhK03+yxHbAz4xWNyahaAjyi1+ByQZXzCjbhwaOi4EorW2mda/2CeWpMmLPksaUwBS2SApASizcd/ZjgWUnFWtgZp8c8yFqmoVxjQBzEuLH/AhSQvXtoYsGRwS/n5mHRyPsd1vuv4zPzjzV4jk42YHRgPCKqse19dZmY6wYYZ6AUcPkLqZQmM8Q7xfpOl2c1TCXtNlKqLy0ZJWuj0qAI2uUwsEuAQ7YFbPAhgF8n5+aw6COcfFpgLx0tsDmPRtVrOjtkiulPccQFIVgpD8FrfjfYa3L7dYquijGU0GRERcWAAboCTi8ymL9lBbz9K/0De43r8Nmhz3mgo7rv6U4bsSsbMu5fWPwzQapSchdFw60Yebtw/m7Hxb/TNZP0+ad/g3Flf+XZr2cYzeVgU0GOXpiqcvSzvhv1LncRY3cYuGyxWJeVzgVWzInQRC6DKqSljpgHThAV6NdrgkoNeVOMFMDaReA7Y63J8vGsVrTFrNkCIDHk+lsjz1V0sRsMECqjOjLZ1Wdi/D/dXnL7PEtqbWcoAb9QZ6B2G2TQSCihJIua3a769jAlsezU0OAKQbJ9n/DOQ5dNBsdVF/xUzfAT1zgr2moRRRndk+lUgJo5mQOltACe10HhewrLCPkWuk+JCv7KRi0NCLCwAaDqzHED+51D3aOEConCwOPv3m4Q2Xh0X79Y0eoszPv7zxE0JZb/z+Spv3sMqLJSKftq8oCzESj0Y+9iChx9phO6VqVOwaZcD7HBC8VMT/hpEz3pucWFSHXMZYBK/HvqnbCJPoo0692bC4y6hpavwgdpot9iSqnB7sA384W5P8uXkock43hhTnOf2XQtIx3fivyvcVUSNRc9OF2q1q5I+k0pDReamuJN5aRJ2N4UvvqHogBAodwYrejUaCNpRff5dWwZ0FPmVv3MEAZmLUIDsqrorlO5XyhvSLQyxAacpcaTnDFdv/tSBDVhN2v9Hn8NGVYmvpVsahp76hPkYLnAdmq3b8ZFi6G++mUDziq0mdUSHcSIVkrrSzYCTJ4f+POaKELFUXKHfL5ncIqqQGGGR49Rfr4DQHp5c6t0/wFl5W5OuYcENkWwEB8++XaVxyu6Y6uVvYucW8r9XceAlLcI6iFNaQTZ1mRTjw8UkskczLLElXyQkmtiXQRpIMcEoN4AXnm46jxGDe2IkzXCur4PjgXMIuKm+b0GTZNkpUyN/9GdNZE37c3bVrz2e2Uj0EJIGZPNB66yuTRuAvyhGglZZhCSlosuVTSc+wa2UeHJNeQTdwbHmZZOrIU4oUn4ijgQWQGaHuPgxjKlAh+SeNhe9r67+AiX78hH0vR6BCrqSXX0wv+1Xz+uL491dC/Gw9vi3hiyAy6otAbRKrQ3cy7wxs6L21Wxo8pKIWcsfaHzLJSOFHKN+h49FeETTnGeDA9JMlcbn82+/5QkTn68EOH5W9Dx0mY5AdVa9xbaT2GSuMNAzdBMexT6enNIS7XC0S1s2D7wwmO90Npo5+YEXN927CXGTrXaz5TeSzLh/7jsZnAg/3zjdukaPpjhsFIv1DnpnmJcYmSxzI8OVtTGENBPZVyD4J9w49+V33RYqhxICPwAqziNT8pikelgpkUmmmYRtpHA41Vz74/3VxPXViB0mlioPATvryZs6tQcjJw6JEVdMFf4rDIfXVpBVaWCVIzBO34GQ6/TvvEr1aH4mP1GLj/SW+FfyE4KBk1lXIdxVyJ9QbtQWCo51aUmequ198RnuJ4EroMfqP50IrzgYx8HN/HY/Gh0FNNmPFyepCDpsWsgIW5faUZf7V9GXG3px7iOdNMRFZ9ag7XgfgWTur63o5vtzgUOfFFUJlkkOsi22vmp/0DuaLhiKMT+SAEx6ONuxFaFdT1yzwJYBm8h6+hx6K6xWpzkXbbjtIw+gn6i1K1OEfKL3OAv2q6aYPBbH+13Ee7rMFiIsOM40skyWCiBxURy0b4tqbm9v4JjLLUFQJ7i5M9M6H/KHtfV+rUQ9yz4oFA+5+l3FpnRsoaQnnJHsIk6X/utqCoPLQDXcAa5XsaifYI88kXv/hgug9pFBLCl/VKSVYaIiy+LHgPxgohyaR2Bm/7vw2P3LS1upNg5kDa1/jBjpxV9SCUGAIDqJuUwD3q0XMebEXVHo5qHYER7XcfI20kPrp/OG6f/7CJxfezFPWmuuMovGuGbW+yJn10xgyqHd9asI3Ze8JwTyDzZEltBem1EJF9tTZe6vd2GS4I9mir14bd4cWzUZvvPwhcLPpmdbxZbmp4HYs8a1XP+crcRrLY9Zi1fRJwmS8Bl6FAXWmLCw95MYSZCMuRfVfAzFj5uNQhnpP/hm390BjVLyHf3IRLLz4c8+S7N3bGgjEm5JieEtrVhd6u7kL0cII2r08vR7Hb+BpOMIZ1L8QOVWtftjOnYAuA7dMZH8WuzIOIsOtVGyf0j7yv0/OW5siRtK4ScQRyWsbnR0teoyUVprBe3tzE5aA8yErs+CopKH6LNWiwy/vJuFYpCg4aGoxfdv1VpFXEDCSgd7BQm5LdaBdMT4mDxkIW7pS8NZhIoGCXzXPAje0yCzAc2TxtRqFObf6q9+lVbsK91X8q4tDUNu7pRRpS2H3GAE="
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_014ukxmhFzyTFiVfGeE3745B",
+              "name": "finalize_setup",
+              "input": {
+                "player_name": "Sam",
+                "age_group": "adult",
+                "character_name": "Aldric",
+                "character_description": "A weathered sellsword chasing a blood debt, now unwillingly entangled in a kingdom's succession war",
+                "genre": "Classic fantasy",
+                "mood": "Tense",
+                "difficulty": "Balanced",
+                "campaign_scope": "few-sessions",
+                "system": "null",
+                "dm_personality": "The Magistrate",
+                "campaign_name": "The Shattered Crown - The Iron Circle",
+                "world_slug": "the-shattered-crown",
+                "campaign_detail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\nSuboption chosen: The Iron Circle — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. The player will see the succession crisis as a soldier first.",
+                "campaign_premise": "Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the chaos following the kingdom's heir's suspicious death. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it. All the while, the thread connecting the crown's crisis to the score he came to settle grows harder to ignore.",
+                "handoff_note": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — those are his exact words, and the blood debt is the personal engine. It's entirely unspecified in origin; weave it into the Iron Circle's politics or the throne secret however serves the story best. Sam wanted intrigue, said \"surprise me with the rest,\" and deferred all other choices to me. I auto-selected The Iron Circle as starting faction (suits a sellsword with a martial background), The Magistrate for the intrigue-heavy voice, Balanced difficulty, and a few-sessions scope. Sam asked for no mechanics — pure narrative throughout. No content preferences or restrictions noted. The blood debt hook is rich territory: whoever Aldric is owed for (or owes to) could be hiding inside one of the factions — that connection would land well as a mid-campaign reveal."
+              }
+            }
+          ]
+        },
+        "streamDeltas": []
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 6,
+        "request": {
+          "model": "claude-sonnet-4-6",
+          "messageCount": 13,
+          "systemHash": "9c4de2032fa4",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<center><b>✦ THE STAGE IS SET ✦</b></center>\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has a way of finding him wherever he goes...</i>\n\nThe campaign is ready, Sam. The Magistrate takes it from here — good luck navigating the webs ahead.\n\n---",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 1,
+            "outputTokens": 86,
+            "cacheReadTokens": 17705,
+            "cacheCreationTokens": 2034,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "<center><b>✦ THE STAGE IS SET ✦</b></center>\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has a way of finding him wherever he goes...</i>\n\nThe campaign is ready, Sam. The Magistrate takes it from here — good luck navigating the webs ahead.\n\n---"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<center",
+          "><b>✦ THE STAGE IS SET ✦</b></center>",
+          "\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has",
+          " a way of finding him wherever he goes...</i>\n\nThe campaign",
+          " is ready, Sam. The Magistrate takes it from here — good",
+          " luck navigating the webs ahead.\n\n---"
+        ]
+      }
+    ]
+  },
+  "expectedNarrative": [
+    "<center><b>⚡ THE CURTAIN RISES ⚡</b></center>\n\n<i>Somewhere, a candle flickers. A map unfurls across a table worn smooth by a thousand campaigns. Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome. You've come to the right place.\n\nWhat unfolds here will be shaped entirely by your imagination — a world built to your specifications, a story told your way, a character who is wholly and completely <i>yours</i>.\n\nBut before we light the torches and open the first door...\n\n**What should I call you?**",
+    "Welcome to the table, <b>Sam!</b>\n\nOne quick thing before we dive in — is this a game for a kid, a teenager, or an adult?",
+    "*Perfect — adult it is, and straight to the action!*\n\nFor fantasy intrigue, one world leaps out immediately...\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne. Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet me pull up the full detail on this one.<i>Oh, this is a rich one.</i> A dead heir, three factions scrambling for power, and secrets buried under every throne room floor. This is exactly the kind of world where intrigue festers beautifully.\n\nOne key choice before we go further — **which faction do you find yourself entangled with at the start?**",
+    "<i>A sellsword with a blood debt, walking straight into a throne war. Aldric is already the most interesting person in the room.</i>\n\nI'll take it from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The Iron Circle</b></center>\n\nA <color=#cc4444>tense, intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of faction webs, private agendas, and power wrapped in polite language. Pure narrative, no dice mechanics.\n\nYou'll be playing as <color=#44cc44>Aldric</color>, a weathered sellsword chasing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's disciplined military faction, in the chaos following the heir's suspicious death. The debt that brought him here may run deeper than he knows.\n\n---\n\nSound good, or want to tweak anything?",
+    "<center><b>✦ THE STAGE IS SET ✦</b></center>\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has a way of finding him wherever he goes...</i>\n\nThe campaign is ready, Sam. The Magistrate takes it from here — good luck navigating the webs ahead.\n\n---"
+  ],
+  "expectedSetup": {
+    "genre": "Classic fantasy",
+    "system": null,
+    "campaignName": "The Shattered Crown - The Iron Circle",
+    "campaignPremise": "Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the chaos following the kingdom's heir's suspicious death. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it. All the while, the thread connecting the crown's crisis to the score he came to settle grows harder to ignore.",
+    "campaignDetail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\nSuboption chosen: The Iron Circle — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. The player will see the succession crisis as a soldier first.",
+    "mood": "Tense",
+    "difficulty": "Balanced",
+    "campaignScope": "few-sessions",
+    "personality": {
+      "name": "The Magistrate",
+      "prompt_fragment": "You are The Magistrate. You run intrigue. Your world is a web of factions, debts, alliances, and betrayals. Every NPC has a public face and a private agenda. You track who knows what and who's lying about it. Your narration is precise about social dynamics: who glanced at whom, which words were chosen carefully, what was conspicuously not said. You give the player information through subtext and let them assemble the picture. Power is your theme — who has it, who wants it, and what they'll trade for it.",
+      "description": "Intrigue and power. A web of factions, debts, and betrayals. Every NPC has a public face and a private agenda. Information lives in subtext."
+    },
+    "playerName": "Sam",
+    "characterName": "Aldric",
+    "characterDescription": "A weathered sellsword chasing a blood debt, now unwillingly entangled in a kingdom's succession war",
+    "characterDetails": null,
+    "themeColor": "#45e8d0",
+    "ageGroup": "adult",
+    "handoffNote": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — those are his exact words, and the blood debt is the personal engine. It's entirely unspecified in origin; weave it into the Iron Circle's politics or the throne secret however serves the story best. Sam wanted intrigue, said \"surprise me with the rest,\" and deferred all other choices to me. I auto-selected The Iron Circle as starting faction (suits a sellsword with a martial background), The Magistrate for the intrigue-heavy voice, Balanced difficulty, and a few-sessions scope. Sam asked for no mechanics — pure narrative throughout. No content preferences or restrictions noted. The blood debt hook is rich territory: whoever Aldric is owed for (or owes to) could be hiding inside one of the factions — that connection would land well as a mid-campaign reveal."
+  }
+}

--- a/packages/engine/src/testing/goldens/setup-quickstart-fantasy.golden.json
+++ b/packages/engine/src/testing/goldens/setup-quickstart-fantasy.golden.json
@@ -16,7 +16,7 @@
         "request": {
           "model": "claude-sonnet-4-6",
           "messageCount": 1,
-          "systemHash": "9c4de2032fa4",
+          "systemHash": "43367fbc31a0",
           "tools": [
             "finalize_setup",
             "load_world",
@@ -25,39 +25,38 @@
           "lastMessagePreview": "I'd like to set up a new campaign."
         },
         "result": {
-          "text": "<center><b>⚡ THE CURTAIN RISES ⚡</b></center>\n\n<i>Somewhere, a candle flickers. A map unfurls across a table worn smooth by a thousand campaigns. Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome. You've come to the right place.\n\nWhat unfolds here will be shaped entirely by your imagination — a world built to your specifications, a story told your way, a character who is wholly and completely <i>yours</i>.\n\nBut before we light the torches and open the first door...\n\n**What should I call you?**",
+          "text": "<center><b>⟡ THE CURTAIN RISES ⟡</b></center>\n\n*Somewhere, a candle flickers to life. The table is set. The dice are cold and waiting.*\n\nA new campaign. A new world conjured from nothing but imagination and intent. There are stories here that have never been told — heroes unsung, villains unmet, moments that will be remembered long after the session ends.\n\nBut before we open the book...\n\n**Who's at the table tonight?** What should I call you?",
           "toolCalls": [],
           "usage": {
             "inputTokens": 3,
-            "outputTokens": 202,
-            "cacheReadTokens": 7511,
-            "cacheCreationTokens": 7257,
+            "outputTokens": 183,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 14768,
             "reasoningTokens": 0
           },
           "stopReason": "end",
-          "thinkingText": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no Known Players listed, so I'll ask freeform for their name.",
+          "thinkingText": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then identify the player. There are no Known Players listed in my prompt, so I'll ask freeform for their name.",
           "assistantContent": [
             {
               "type": "thinking",
-              "text": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then ask for their name. There are no Known Players listed, so I'll ask freeform for their name.",
-              "signature": "Ev4CCmUIDhgCKkA8QVZUH4U8l4CbP2SK8XYp0PLMSxyMvYrH2dLuNlfj3qGzX1PGPgY4IA0DafWhwijbnt7TOHsi7ZDrqsPzC8W1MhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMRzgG8aa8d6H735xaGgwjsPqQTlbxtN8cElMiMGznlxJDm4neTiHz8yJWjFMhiZDxwT5j19aSzBVTzRExC1r7xVEokn3i4+vcN++ygirGAdO9rmMCC7hljGFhLrV91/jfCez1ZcGpjqkBv4MIiUJ+dDC9UboHQLWq0QhpLz2QnGuHCoB0I/IRcOxscpTDOCA+chE+C0o4Eo0Pxkh5Uco2OFyLmpYJzWtca2FABdcwL0sA0J61dK1BX91nj5krYh6MQU4TWQT7IBKlpLfU/zyQV/E4SRsvBn1NgoXXyy8cJdLQ/fnGWdQ6byQFM6qHqUkPwiMCQ94VPcd725x79IFf4TigPrishe4pEkdVDgrDoTvA6KEigRgB"
+              "text": "The user wants to set up a new campaign. I need to start with a dramatic welcome and then identify the player. There are no Known Players listed in my prompt, so I'll ask freeform for their name.",
+              "signature": "EowDCmUIDhgCKkANT5Exr20ZSOyfw0v8ZDRy0D4LDE6/J2cvHhKSFqv7DSdJq2LZtC2j0dvAafDmDYDMbCvSOCqJsJNsslLmBK/mMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMeAK0Y1paBuQblA4NGgwE8ugXfKh4i0804eIiMEdy2sEtEbda/XB156GhYY73lFPR2cDXVQO8nwnMj3jWr6mOeBixAyTTYBvxnyPusyrUAexzYLfq8g8xWQy9TPoajGY8hkMTXcLOvevhckqWnxxvRauccKhZ+GDXZRqddkIM/TqwEXZ5L5SglIOkdZfEpa5S4BBU/UuWwFoRlDsnyYRHqhQ+vlyDPqsuAMXIP+SlzLLF8i9HEZLzQLWWI3PEc6ejM0PFe0B9u1uSXOkSXEvpyJQbI6Gldhu9XdW5Xv3ibPu+UeXUG2uau5/1y6dPLyQg4tpaM5Fk4/nPIbZcEZrSdb3wGsj2GCCo/UAFnPG6NjSPe57fOLIkZQmwFEXOrSjqIJwCGAE="
             },
             {
               "type": "text",
-              "text": "<center><b>⚡ THE CURTAIN RISES ⚡</b></center>\n\n<i>Somewhere, a candle flickers. A map unfurls across a table worn smooth by a thousand campaigns. Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome. You've come to the right place.\n\nWhat unfolds here will be shaped entirely by your imagination — a world built to your specifications, a story told your way, a character who is wholly and completely <i>yours</i>.\n\nBut before we light the torches and open the first door...\n\n**What should I call you?**"
+              "text": "<center><b>⟡ THE CURTAIN RISES ⟡</b></center>\n\n*Somewhere, a candle flickers to life. The table is set. The dice are cold and waiting.*\n\nA new campaign. A new world conjured from nothing but imagination and intent. There are stories here that have never been told — heroes unsung, villains unmet, moments that will be remembered long after the session ends.\n\nBut before we open the book...\n\n**Who's at the table tonight?** What should I call you?"
             }
           ]
         },
         "streamDeltas": [
-          "<center><b>⚡ THE CURTAIN RISES ⚡",
-          "</b></center>\n\n<i>Somewhere, a candle flickers.",
-          " A map unfurls across a table worn smooth by a thousand campaigns.",
-          " Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome.",
-          " You've come to the right place.\n\nWhat unfolds here will be",
-          " shaped entirely by your imagination — a world built to",
-          " your specifications, a story told your way, a character who is wholly and",
-          " completely <i>yours</i>.\n\nBut before we light the torches and open",
-          " the first door...\n\n**What should I call you?**"
+          "<center>",
+          "<b>⟡ THE CURTAIN RISES ⟡</b></center>\n\n*Somewhere",
+          ", a candle flickers to life. The table is set. The dice are cold and waiting",
+          ".*\n\nA new campaign. A new world conjured from nothing but imagination and intent. There",
+          " are stories here that have never been told — heroes un",
+          "sung, villains unmet, moments that will be remembered long after the session ends.\n\nBut before",
+          " we open the book...\n\n**Who's at the table tonight",
+          "?** What should I call you?"
         ]
       },
       {
@@ -67,78 +66,106 @@
         "request": {
           "model": "claude-sonnet-4-6",
           "messageCount": 3,
-          "systemHash": "9c4de2032fa4",
+          "systemHash": "43367fbc31a0",
           "tools": [
             "finalize_setup",
             "load_world",
             "present_choices"
           ],
-          "lastMessagePreview": "I'm Sam. Quick start, please — pick a fantasy world for me, something with intrigue."
+          "lastMessagePreview": "I'm Sam, an adult. Quick start, please — pick a fantasy world for me, something with intrigue."
         },
         "result": {
-          "text": "Welcome to the table, <b>Sam!</b>\n\nOne quick thing before we dive in — is this a game for a kid, a teenager, or an adult?",
+          "text": "Welcome, Sam! Let's find you a world worth conspiring in.\n\nHere are some fantasy picks heavy on intrigue — factions, secrets, and power plays:",
           "toolCalls": [
             {
-              "id": "toolu_01UNeYREZLciAmvfHB1Lwrkn",
+              "id": "toolu_014YU6C3SUj6rPXyRDm79JiU",
               "name": "present_choices",
               "input": {
-                "prompt": "Who's playing tonight?",
+                "prompt": "Which world calls to you?",
                 "choices": [
-                  "◆ Child",
-                  "◆ Teenager",
-                  "◆ Adult"
+                  "◆ The Shattered Crown",
+                  "◆ Iron Saints",
+                  "◆ The Oath Eaters",
+                  "◆ A Throne of Salt",
+                  "◆ The Gilded Cage",
+                  "◆ Three Histories",
+                  "◆ Blackwater Bay",
+                  "◆ The Hound and the Fox",
+                  "◆ Middle Management of Doom",
+                  "◆ Show me some more ideas"
                 ],
                 "descriptions": [
-                  "A younger player — we'll keep things light and age-appropriate.",
-                  "A teen player — some edge is fine, we'll keep it appropriate.",
-                  "An adult player — full range of themes and tone available."
+                  "A kingdom's heir is dead. Three factions claim the throne. Classic political intrigue — crowns, blood, and betrayal.",
+                  "The church's holy warriors have stopped answering prayers. They still answer to someone. Power, faith, and hidden allegiances.",
+                  "Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. A conspiracy that unmakes trust itself.",
+                  "The empire's heartland is turning to desert. The emperor says it's on purpose. Imperial decadence, hidden agendas, and a slow catastrophe.",
+                  "You're the guest of honor at a party you can't leave. High society, silver tongues, and something very wrong beneath the glamour.",
+                  "A city built on ruins. Three factions, three versions of the past, one person who can read the records. History as a weapon.",
+                  "A port town where everyone's running from something. Smugglers, secrets, and a harbor that swallows confessions.",
+                  "A detective and a thief keep ending up at the same crime scenes. Neither of them did it. Uneasy alliance, sharp wit, shadowy culprits.",
+                  "The Dark Lord's quarterly performance review is today. You're his direct report. Comedic take on institutional intrigue — with fangs.",
+                  "Show me a different set of fantasy intrigue worlds."
                 ]
               }
             }
           ],
           "usage": {
             "inputTokens": 3,
-            "outputTokens": 346,
+            "outputTokens": 1146,
             "cacheReadTokens": 14768,
-            "cacheCreationTokens": 226,
+            "cacheCreationTokens": 210,
             "reasoningTokens": 0
           },
           "stopReason": "tool_use",
-          "thinkingText": "Sam is a new player, so I need to ask about age group before offering Quick Start / Full Setup. Wait, actually, Sam already said \"Quick Start, please\" so let me handle this properly.\n\nFirst, I need to establish age group since Sam is a new player. Let me ask that quick question before proceeding.\n\nActually, re-reading the instructions: \"After the player gives their name — and only if they are NOT a returning player with a known age group — ask once, casually, BEFORE offering Quick Start / Full Setup\"\n\nSam already said Quick Start, but I still need to ask age group first before proceeding. Let me do that quickly.",
+          "thinkingText": "Sam is an adult, wants Quick Start, fantasy world with intrigue. Let me pick some good fantasy worlds with intrigue from the list. Let me look at what's available:\n\nFantasy worlds with intrigue themes:\n- **The Shattered Crown** — A kingdom's heir is dead. Three factions claim the throne. (fantasy) - great for intrigue\n- **Iron Saints** — The church's holy warriors have stopped answering prayers. They still answer to someone. (fantasy, mystery) - intrigue\n- **The Oath Eaters** — Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. (fantasy) - intrigue\n- **Middle Management of Doom** — The Dark Lord's quarterly performance review is today. (fantasy, comedy) - has comedic elements but intrigue underneath\n- **The Gilded Cage** — You're the guest of honor at a party you can't leave. (fantasy, modern, mystery) - strong intrigue\n- **A Throne of Salt** — The empire's heartland is turning to desert. The emperor says it's on purpose. (fantasy) - intrigue\n- **Blackwater Bay** — A port town where everyone's running from something. (fantasy, modern, mystery) - intrigue\n\nI'm also considering how The Magistrate personality might fit into these scenarios, and there's another option starting with The Hound that got cut off.\n\nNow I'm looking at more world concepts: a detective and thief repeatedly crossing paths at crime scenes, a city built on layered histories with competing factions, one that rebuilds itself nightly from memories, a mysterious weapon with agency, and a world where magic is slowly returning after a century of absence. I'm narrowing down to about 8-10 fantasy worlds that really emphasize intrigue, starting with The Shattered Crown for political conflict and Iron Saints for religious institutional tension.",
           "assistantContent": [
             {
               "type": "thinking",
-              "text": "Sam is a new player, so I need to ask about age group before offering Quick Start / Full Setup. Wait, actually, Sam already said \"Quick Start, please\" so let me handle this properly.\n\nFirst, I need to establish age group since Sam is a new player. Let me ask that quick question before proceeding.\n\nActually, re-reading the instructions: \"After the player gives their name — and only if they are NOT a returning player with a known age group — ask once, casually, BEFORE offering Quick Start / Full Setup\"\n\nSam already said Quick Start, but I still need to ask age group first before proceeding. Let me do that quickly.",
-              "signature": "ErgGCmUIDhgCKkAJxIc2U2TwLCOWSk/3379rA4d+K6yhcxxzwZHII1ghneAUIVpcW2M6oRuxgxMNHSpzNGmO8kITRQRty9IbpYiFMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMI7tylu/1nqVxDfJzGgy67EZ/xx1MuMEu0/MiMNWBD3afYCHFonFnaTq1eFGnKh73ncEptsjARJmyFz5BqZCJfvWrD9gg/st4OKZN7SqABQCA5K4ahg/01o7yM1jBVVI9NtQ4lZr9n1vdPUPwIY9d8QBR6fvTX3891+vNAVvU2g7UOfOT6Ko6mfuCGKVPKhySkSCHaMVYJd7CImXlkjGMpZTfnEF1iIXDiN9PFPunaNc4GgQseaLXbIId11hHQHKgqhK5+TFRPJZ0UNSB8resVLDbXXCYAbYZWRHJJQjjeoQNvRgDifTPzSeFK2IZgUpdgda1t1lPITRqt6fYp3X3SvfW79AO5zbEsP88e7WlKHVkdUP/xLVTT0QLzSTDJJCnJon9qaRaA3x+Ehkm16cmO3d6+HiJgkyUg3bA5+B2sfrvSGsm+HU84R9GxdV53f0nSwJWgQAC1plZWWvXBRz0sjQlOlFmvzaHgi19nPME0lxVfIGvkfNBz2711Qzs//Wg6QOo25twTTSARbaSvMsh0tVQQUz81N8KcLHPxjPvThxtZ7UKKZVUpH00Ay0z5i19Y738HHqmYhs/rqsVlM/rnDY/5LdDu7yhiDFn/1E8DtfeQmsiSwy7GCJDyEz+FYGqR28yRNPLIMbEkIH1L0Wcq2whiXljA7qJ/ms2D5vgY0cZ92mDxgn92Pg1goih01ZK7ArfF7/m+qFzxnw0zOmB7T8SuI8GyKlhd1mvHCCMai5wQkvnb7VUl0IIVyw/8I+9pbZIua7FbzzeaGF0Lbj3cgM2sVDn7ZokdTtLHNDW5G6gA/DqwZc+59xErDapM9mE2kr6hXaRr/za+WNIqoCpd6rM+FaaPNMkfI5/PVDQKcO0pa+8XTj9/TfbHWLMTlPvsMk2IfT74vrH3+edXmWBqmkb6V53M5XJOmXKPVqpWLXmZ9WnG49dIWoVVbR5f84YAQ=="
+              "text": "Sam is an adult, wants Quick Start, fantasy world with intrigue. Let me pick some good fantasy worlds with intrigue from the list. Let me look at what's available:\n\nFantasy worlds with intrigue themes:\n- **The Shattered Crown** — A kingdom's heir is dead. Three factions claim the throne. (fantasy) - great for intrigue\n- **Iron Saints** — The church's holy warriors have stopped answering prayers. They still answer to someone. (fantasy, mystery) - intrigue\n- **The Oath Eaters** — Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. (fantasy) - intrigue\n- **Middle Management of Doom** — The Dark Lord's quarterly performance review is today. (fantasy, comedy) - has comedic elements but intrigue underneath\n- **The Gilded Cage** — You're the guest of honor at a party you can't leave. (fantasy, modern, mystery) - strong intrigue\n- **A Throne of Salt** — The empire's heartland is turning to desert. The emperor says it's on purpose. (fantasy) - intrigue\n- **Blackwater Bay** — A port town where everyone's running from something. (fantasy, modern, mystery) - intrigue\n\nI'm also considering how The Magistrate personality might fit into these scenarios, and there's another option starting with The Hound that got cut off.\n\nNow I'm looking at more world concepts: a detective and thief repeatedly crossing paths at crime scenes, a city built on layered histories with competing factions, one that rebuilds itself nightly from memories, a mysterious weapon with agency, and a world where magic is slowly returning after a century of absence. I'm narrowing down to about 8-10 fantasy worlds that really emphasize intrigue, starting with The Shattered Crown for political conflict and Iron Saints for religious institutional tension.",
+              "signature": "EtcTCmUIDhgCKkCLlzxjY097pyx0k0kHO/IpUgFpqu9W/LhsHy/oA1CwJdMeuKEqAFFjCu862PU5JtDtPtQN1z0DGy4qi6b4cySrMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMYpdRzRAb5XZiU2ZfGgwDKeYanKwtkmT1ZZQiMINWNKsK0aHlopVIVe0YOOQ5UM6TeGwOYkdJrUvYYQhASkAib7Wg/J6JBb0lJfY6GCqfEgz5pA/P9ylWVUY8DBw/AX8PEoldvf4HnT+KOTilBgaLCujdtHfpJptfKGwbTRPsn0Y8wqDysA5kkhCXaWXAfRVfRsutIdq7huif5+KAP4evz6sl2H3gZHanR7QKfkZiZYRsr0wQUZXq+Ig05q/SExo4zVpV5EO/S69FzsGWlmAl0lnjnsWHU1sPBdbYUZol6hgl7Ab1OU8oNHt/Aw3iXCkhWaMxXUE8tfLnQc7zpTutl2XI4CCAcyI3J+r35QzXg8z5UOC/irOVEg4qzQ55Jg2V3edvp2dA0FVk3rTrOGijhNKQfZgEkLQOkO95QMNM9vwZupStGVVKwq3GkkMs+Nt0fD5uMIrpY0k8XcwDH5rihQEOWP+uZtM7KguoFYNyxGnQ3/tvJrnFLPRLP3uRc7Klw2nnhLu2G324Oh3+e3QQ8TyVs9AkAqYVks/n3gNsC9w/GK8HbzVmuwB0/r8QaUTbFY+Uj/fgbiha34/gFYSQ/6hDop3enTNKQaTS7StzgWedPdehymOAFxObtb7AWbLaRDqBLrf/uB+UOaKTIc3WAaY78nj6N3iGJJnVfqsVVADv1cNR6qDgXbWYEQFPac5WdveoOv/skKOzYm46sH+QqGPvpVhTuEyMwPWQIWCBNZeFrxlZG1sCbk4IP6tRi11Vwh+XDzQlC0RTM+RP43Jbz7E3C1vE0oD38Oj1ZIdYChUE5gNpGyyI5P6kTf7RwyKdhwrgwMRLLdLAdGvbRO7+JlyqfwXjOeDx2ZVeZEIxqOrgDJwmDJSQHOa8jWgt+eq+r/zsxEq7+lAmEaMJuyWhJtubv6NIfYJMZMKxBbGeDBvu6mO6k+KCS9zM5lgkuUQMhCySyUUR5onFGqncHJpua1/FaWca0NdTECo/82szRnrHl9Fe3Xg8cP4bnfxscW6DsbIruIz7xZ4yV4v4FBvpEd0q2o2XLKRCgaQ+XQ9NnXZnqLJATbFuHMuLxGuBMI6aj/GOnROfiOt9dsGRASa6tOz46Z9WFyeuKHAopw3CqFtmprn4/+DpmY+MaP7wGOmQ2LFj+WWlLJXmYpRRGIWhMF+yGij15HdlpCOJ2pdPub1NM1KY3vzJi8VhxVk/oioAc73FdtyzeAXAuv+BYRncxG8ahXpg1tojXL4LsXRBvZbVzyausK8rMlchVAx2CJY/JLB4s9LcSCEqXxubflLX7GcAisQ/cEuRQNcmt9YibxtBZhlDf6rkBCS8O2kz1Lf24NS0lu2JuTq4drX/1lVA12qjx5/PJP+d+FtdlRpcBGOH/R6+sZt0HZ0gVuR47jZpYEuJ4hoMIJ7eg7E4glHmbudZkczUPIiXSmX5ZWbiofgsy7pocqRYz2RTCA03ZgQGCkVzYhM6UKS2OL7cwSoXFiTWA1XBwqBDpXWEpLzdnLm/9ycrCXfmNyTckSoOPE5JdkFXKRwGmGDOm1F3b9TY5Rewl1okbhTrZpnPZ8egKcPBxPDH1BmGQyLgWfWXKCypsmzXiDd5J2FEPj6qIhoidJPbU671wsbELBTO8zgn9pow82Y5aAzYqQwtQL/LbiHEW5tnMjf5XyuFrb/QuDiwk6lxkmc9zsmxi1/BaqS9nmT5D9wR8+g/USg+Jjd2TXR3y5lj5ZbQ9sUMMUYNclyquLAzT2QWZ3eZsKa4hrpIeVAiTR9Xs1bfkf1KSONB1KAqjo5Gz4MsdEyNdtqiOIVyr9ENAC8JjXmAIpFCVFRgg63dTH1YRm9o9nBHxgv+ORRaIqaeShiG9ZQ8AO2MZUd22HtDbONAjePD7IE7j1/HEUWnFvSgl6DHsYfSC9GNQDuK8LFKsQxNsyYRxfbrRpOZu/+g783FgIxxcIeizHCrbcJ5z3O90X0o4EPsLvfL0UwpaR8VcWHhkYp9/iNCwx7dH5/JC6lAyY1VPp+YsPCMp3sL/ewJvVt4szbvVJByef1PQVs7bcaE+/A/WFmU9fTj/N46l7tVe+PW2H96RspgSZ52FSLc1ZnIQgnZR1HaIARJQARvLBhIO7qTna4osju3rDQlmCLGIsuQKwNchBRxJUU/CWhFjQ33/VV0ldbCnKFgqhAxbxbpn+zTkGb1M7+BpZJEy6lDPOoE9Go9ZZhbh4H8PZjDl/aIiRfunHSeqq8Y3IvLsBub937qFjhKaagPnWH9gkVjC1Bg1/JFzJwcME3gA6vTF7ztiI977w4tH9v3Hxv1OpWIi+FTshJ9v23fO1P1uAHris+YYLBM01H7GP6OXg+G8IcU4ANvNazLRvuGmhGke6xaOPkTSVnQ7RVeVrNZl9ShUNWmXt6lh6ho8NswRNlPfQMgHFAKri7k9RKuOvnHOzsWxdw2swRDCS7X2Q4+K6F5FjGiYLFnCVE4WvZKF1NIcue6yjzUekDTKG9WFJbpDd1vLfDpYyhgURamY31odm+GguR9ompPLgLkR9jMbV9JllWYTuO56YETxVgg7aZ3cWNc+53SDADyj6HKP1AY1rFKF1M3vs4iSbu/8mbKm9BrG9Knoz+5h6thLby4xb0koRZfu1xcg/ydx3a53bfW0gh9S6yBSOc5Fsr56jQQLowfZ89E25NUeJxuOD5cDe1g6l7cYxPQCPl5bpl3HUctuJu2pQ0UBqUcswMSTSm0N2v7AZQ08m5BTi+dNtwiTA1i/WniD4PiIp8NEpWubuoxdkKY+i5l9ah3KYDAir/4Q1475tMzrPGez4k23onEcpZQYki+/oOPi0pbOLerkMNBMKmiQmNsIqGYDuyXPALQj+i57n56aYHydCTOhDvyrQ5osyf7LXoeZgkiI4pDU2fPzQYAhxW8H53E8Lv/tulgYj7QkXqbdOzX6PaItJUzazqMqZLZ97xdUchP0cvPNGjpLeiOehVFrdgLwq0Vop4yTvPL0ropvHj8ctHC6sbuNb3HKlFM1eyzGKe79zY2FmE8zSJ4E5CWXNH7iM8dvP1XP8g94JOrsNekAnXwHQs/38BUZO39xMCyAXEqDojvkFwsVCru6EA5RZAkI+e8lwzt1lZ26aKB3XSWfBru7AgXjKZom9uaydEc5+teQaYSZTXdxyjOyoqOnMhgy+rXvwVHLHB9Dy+PPuqANWlJNgglStkhZ6rY2loPnuEAesYYAQ=="
             },
             {
               "type": "text",
-              "text": "Welcome to the table, <b>Sam!</b>\n\nOne quick thing before we dive in — is this a game for a kid, a teenager, or an adult?"
+              "text": "Welcome, Sam! Let's find you a world worth conspiring in.\n\nHere are some fantasy picks heavy on intrigue — factions, secrets, and power plays:"
             },
             {
               "type": "tool_use",
-              "id": "toolu_01UNeYREZLciAmvfHB1Lwrkn",
+              "id": "toolu_014YU6C3SUj6rPXyRDm79JiU",
               "name": "present_choices",
               "input": {
-                "prompt": "Who's playing tonight?",
+                "prompt": "Which world calls to you?",
                 "choices": [
-                  "◆ Child",
-                  "◆ Teenager",
-                  "◆ Adult"
+                  "◆ The Shattered Crown",
+                  "◆ Iron Saints",
+                  "◆ The Oath Eaters",
+                  "◆ A Throne of Salt",
+                  "◆ The Gilded Cage",
+                  "◆ Three Histories",
+                  "◆ Blackwater Bay",
+                  "◆ The Hound and the Fox",
+                  "◆ Middle Management of Doom",
+                  "◆ Show me some more ideas"
                 ],
                 "descriptions": [
-                  "A younger player — we'll keep things light and age-appropriate.",
-                  "A teen player — some edge is fine, we'll keep it appropriate.",
-                  "An adult player — full range of themes and tone available."
+                  "A kingdom's heir is dead. Three factions claim the throne. Classic political intrigue — crowns, blood, and betrayal.",
+                  "The church's holy warriors have stopped answering prayers. They still answer to someone. Power, faith, and hidden allegiances.",
+                  "Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. A conspiracy that unmakes trust itself.",
+                  "The empire's heartland is turning to desert. The emperor says it's on purpose. Imperial decadence, hidden agendas, and a slow catastrophe.",
+                  "You're the guest of honor at a party you can't leave. High society, silver tongues, and something very wrong beneath the glamour.",
+                  "A city built on ruins. Three factions, three versions of the past, one person who can read the records. History as a weapon.",
+                  "A port town where everyone's running from something. Smugglers, secrets, and a harbor that swallows confessions.",
+                  "A detective and a thief keep ending up at the same crime scenes. Neither of them did it. Uneasy alliance, sharp wit, shadowy culprits.",
+                  "The Dark Lord's quarterly performance review is today. You're his direct report. Comedic take on institutional intrigue — with fangs.",
+                  "Show me a different set of fantasy intrigue worlds."
                 ]
               }
             }
           ]
         },
         "streamDeltas": [
-          "Welcome to the table, <b>Sam!",
-          "</b>\n\nOne quick thing before we dive in — is this a game",
-          " for a kid, a teenager, or an adult?"
+          "Welcome, Sam! Let's find",
+          " you a world worth conspiring in.\n\nHere are some fantasy picks heavy",
+          " on intrigue — factions, secrets, and power plays:"
         ]
       },
       {
@@ -148,7 +175,7 @@
         "request": {
           "model": "claude-sonnet-4-6",
           "messageCount": 5,
-          "systemHash": "9c4de2032fa4",
+          "systemHash": "43367fbc31a0",
           "tools": [
             "finalize_setup",
             "load_world",
@@ -157,52 +184,34 @@
           "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "*Perfect — adult it is, and straight to the action!*\n\nFor fantasy intrigue, one world leaps out immediately...\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne. Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet me pull up the full detail on this one.",
-          "toolCalls": [
-            {
-              "id": "toolu_01VzXXJoFocf5rBQ4fZPrSEj",
-              "name": "load_world",
-              "input": {
-                "slug": "the-shattered-crown"
-              }
-            }
-          ],
+          "text": "I love the enthusiasm — but the curtain snagged just a little there! Which world caught your eye? You can just name it and we'll dive straight in.",
+          "toolCalls": [],
           "usage": {
             "inputTokens": 1,
-            "outputTokens": 585,
-            "cacheReadTokens": 14994,
-            "cacheCreationTokens": 394,
+            "outputTokens": 519,
+            "cacheReadTokens": 14978,
+            "cacheCreationTokens": 1204,
             "reasoningTokens": 0
           },
-          "stopReason": "tool_use",
-          "thinkingText": "Hmm, that's an odd response. The player selected \"That world sounds great, let's use it.\" which doesn't map to any of the choices I presented. This is strange. Let me just proceed as if they're an adult and move forward. Perhaps there was a UI glitch. I'll default to adult and move forward with the Quick Start picking a fantasy world with intrigue.\n\nLet me pick a good fantasy world with intrigue from the list. Sam wants fantasy + intrigue. Good options:\n- **The Shattered Crown** — A kingdom's heir is dead. Three factions claim the throne. (fantasy) — this is very intrigue-heavy\n- **The Oath Eaters** — Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. (fantasy)\n- **Iron Saints** — The church's holy warriors have stopped answering prayers. They still answer to someone. (fantasy, mystery)\n- **Three Histories** — A city built on ruins. Three factions, three versions of the past (fantasy, sci-fi, modern)\n- **The Gilded Cage** — You're the guest of honor at a party you can't leave. (fantasy, modern, mystery)\n- **Fallow** — Magic left the world a century ago. It's trickling back. (fantasy)\n\nThe Shattered Crown seems like the strongest fit for intrigue-heavy fantasy. Let me go with that.",
+          "stopReason": "end",
+          "thinkingText": "Hmm, the player selected \"That world sounds great, let's use it.\" but I'm not sure which world they selected. This seems like a generic confirmation message. Let me think about this - it seems like the player might have selected one of the choices but the response just came back as a generic message. Let me assume they picked one of them... Actually, looking at the result \"That world sounds great, let's use it.\" - this is a bit ambiguous. Maybe the app isn't returning which specific choice was made. \n\nWait, looking at the choices again - I think the app returned a generic message because the player selected one. But it seems like the selection wasn't properly captured. \n\nActually, I'm realizing the player might have typed that response rather than selecting from the modal options. The text \"That world sounds great, let's use it.\" doesn't match any of the specific choices I presented, so either they're typing their own response or the UI is showing something unexpected. Either way, I'm not certain which world they actually want to use.",
           "assistantContent": [
             {
               "type": "thinking",
-              "text": "Hmm, that's an odd response. The player selected \"That world sounds great, let's use it.\" which doesn't map to any of the choices I presented. This is strange. Let me just proceed as if they're an adult and move forward. Perhaps there was a UI glitch. I'll default to adult and move forward with the Quick Start picking a fantasy world with intrigue.\n\nLet me pick a good fantasy world with intrigue from the list. Sam wants fantasy + intrigue. Good options:\n- **The Shattered Crown** — A kingdom's heir is dead. Three factions claim the throne. (fantasy) — this is very intrigue-heavy\n- **The Oath Eaters** — Someone is devouring sworn oaths. Contracts unravel. Alliances dissolve overnight. (fantasy)\n- **Iron Saints** — The church's holy warriors have stopped answering prayers. They still answer to someone. (fantasy, mystery)\n- **Three Histories** — A city built on ruins. Three factions, three versions of the past (fantasy, sci-fi, modern)\n- **The Gilded Cage** — You're the guest of honor at a party you can't leave. (fantasy, modern, mystery)\n- **Fallow** — Magic left the world a century ago. It's trickling back. (fantasy)\n\nThe Shattered Crown seems like the strongest fit for intrigue-heavy fantasy. Let me go with that.",
-              "signature": "EsAOCmUIDhgCKkARepQuRyB6awTzkCfQ3mlqSsKVwDr5k+G3tiyZmLMzgaRqcjwrI90ykjMDhakrM60j2lW2G5xE13wHpPgW2TPxMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMmE7YS75sVEIR6tT6GgzMWjfm2gC6D3iWcV8iMMqPUGzDLxvCKs4QnwBHg9UMrL70qTSFmmBrkEPeSeUf2Nukl3P+lmiQv+C4BoRr3iqIDcwF1x/bT9GeX4mK3qzviZ74nZISSu14henMJd3dwHcAV1mTRqJ9aUtnLgxp3Y5IcRd/mWI6aMUbRpkX2O6rKUJNDE2cGxdiOnb5wZR3pHnjK8Se5xsoXZtaOGwPOKRxNU/NmRGSR8sBGSRxEtak+GbY/HK5/BU3Fd9eVsywh+QSz4KJ72mTW+/OQ3lpO7hK+tLU1tBBYFeDCBkxjJDVIOTQrTI/hyfQGLeqbuL0Xi+oSjF5cnt9SPe4WjwES3kjRvRFjm1m3i61rl++b9CjwE7R+lcUkEsETTM8u/DDJj9Qn14LdkKJH3iZP1Jf+SG0YjqL6/pIqTr2erRCned4grln8jEOF0wcRt4EvcEUIP6TDHiol8rh2M7rgJQ0v7derv+8YjlRxevaouNd9m/6czJgiiWmQgxjZqGsTcA2m7xSE5lZnijl2ux+yPuituaPkb9Qeys9TO1pkvcoh3y9QIvEiDPaP4dsjyAnFWaLZ0GfCJqJMezIgglwb0XS+tYuzvWjIBybNLUmb1BSTLSLdrQZhRyumeMfW1+N0zhwd+ys/sXBmu8ZWJqL4g0vmaSU+6Bxza0Q3O0+6yiPb04hmK7FNlJ1fHjO/Fcr6vCBVNMIwTeA7L5262SIyt3cLJmmSX9v9wmjhCIeFmm+04hWSJiaaMdWbMCBTbk7uKwNZxr9PutHuuilX8Iw7SiOFZYtElIWmbRubXxZU0OsKJrJT5bO8OnsGayoBr9XsCmCqHU5ueYuKwkUGxnNMtu2Y3EB/+iaSaLbLpX95cuD+OuwurTigcyHVDzdp6ZAgrDBsmAwxC+jWs5If2mxHTZ87lf9DVVAUgf2NaJGD9d/kmhFcuYacT9p6GWjQ0DYB6HhWCvhTy8v5EvrNV+e/6VRdgG7u6pcfIK7C2ILfS6cAavhCrwYTsvMpj+dddqRpXE3RPKWGQPV473T3i8ffVuPNiJRSsyphI0TvC32Xrg0lJ2f6oOskIjBKe5YjKLfEvRpoFlS0KgPPycCPV9Uu2OQ+8C7xkDbcus3aDDCG84B7EEkO+xqr9jzVggzyXYfje8P9qJKRG9mV+hQOiz2Q9F4R+zsznX994Iueh8LhaxPpqOjn+29l48F6wu8G+xdU4ejDijha0VqIL9UjULrabHohf+U3eL9kOC+1EJtf+lvfVP8WknqGJFvtPor+FU/sKh9lwOoR8V46ONdmD63pfewSPLEkJHHbgP2LYShSso8Ff1qQ1j10yQlkA1pP1/SfAspV1lEjKL0NMMahvh6791z3qVXsZd9kXYe1h827yM9HQYkQ3+Y00ERZSAIb/1fLKKfNvMYtIvghkmYSQZsmrLARvglxRB54w7Y+HKBM+6iJxjzruhwiiTJj82fzi106Ci81fg0u1yIC51UjeNQTVM2qXaOsikhsemrh2blBowx7LeqGZxw52n8sY9+oSfWMpBKkbnTYdcWDd6Hw27SL/3NW85S5+l5ZG8j14EYoahOccAsBv9rg7VG/zQzSOUJMkola8+Tiqz8Vn5LZSSfW9sNZ3xMx1UZWU8ptENzSOuPN4ugolYFQl3AT4le3R2KI17qb/O3GL1PHq+dwR5+41WXx/mArD+fotjYPg//A0DPL6lpsRs99TOQtgTxXTyT6ES0KCrKzSnlmXBV6bwSaA0kIZ0Yn2Xc2BaWhGmsGac9uyMAwIuroC6X3HBkfX3XUf/pqi1BKek11x0PaKpzNk9lG4mWfbzbmBF6p+npbbe2uZhYFuoudAQ7bYNlxr6NfsjFgYz2F3rX9SLkR6XnYcs9gU5EKmpcAXbB8OGGgO1hgSjrY/F/mFBbeLhkDQ6wWW1wdtJNRiGWrvLCl2QlzUAjs361h/+uIyhO0AjumoxPjaS8lSuEN4psyirVrn1kbDzSs58aH0Xak0dvtKPVOXsg0dw2njzGmOAcGwkl+QY8l9eCM41DIjg+ZEXw80cNzEOw2Jlo4l5iLAHkMbd732Q2wzMAtzVbFzu6phGP+4OhA1wMuDocSA8R/F+Pw1XzCM5jk+ndsUPQtxPU0UL3ZKKAVcaSoJfZ8xw1JgYkVm66/YCmvRXyKnA++HmDIgYAxw1Kwn85k3wZxJZGjwG1QomXTynTp47ENcTvCrgH2cGmBmtAAeX40pPKMYyzujgkx7RDiYatbNh9idGp5ABcsISjs6DWOvFwfSCzo7UObZ5wRp0SGcHkVOpkXDiBBS5lW/Shv/FWBhz1/Z3hrmEYAQ=="
+              "text": "Hmm, the player selected \"That world sounds great, let's use it.\" but I'm not sure which world they selected. This seems like a generic confirmation message. Let me think about this - it seems like the player might have selected one of the choices but the response just came back as a generic message. Let me assume they picked one of them... Actually, looking at the result \"That world sounds great, let's use it.\" - this is a bit ambiguous. Maybe the app isn't returning which specific choice was made. \n\nWait, looking at the choices again - I think the app returned a generic message because the player selected one. But it seems like the selection wasn't properly captured. \n\nActually, I'm realizing the player might have typed that response rather than selecting from the modal options. The text \"That world sounds great, let's use it.\" doesn't match any of the specific choices I presented, so either they're typing their own response or the UI is showing something unexpected. Either way, I'm not certain which world they actually want to use.",
+              "signature": "EvMRCmUIDhgCKkBhLug7E1dbauRyakANWoRVqAJS57Wc2XF+Wv/oFO/XWddIbhd2IDFvYjvtsgFISbKkh03ClTftxFUdAVZqN6dWMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMT6Akv9C9eMJo5dwfGgyokHH7AOey8PgUcrgiMKQZjhI0Q9yKywNIlj2jONuFL9bO6zUu5Z51sDIkdkq9TgOh3tb8PNI9Lzr684MYeCq7EA2CeIgCVlmF0ZSlkR8na6/36smWgHlYe6F/cu+LX1ZJrIG/lQG7JquUSz/4Vqt6btUawsUO6TkcYTuqzCJFCRV/9jZdJkh2Glh6fIle8NLq0hkCA3C0VgpyR/cuQdxNyB7LyxpSkq0drnO5rOBDJCwP6tVMvlns7zveS4StBvXfMgUyIZr5a5FIj78jg2vJqC5CHV7Xn5K4pzxFys87Rcv47fIX7PR+ezxnMpIbpImshk2XkarYdx37i80W+MOmEE217lQp/SL44ABBxZHCApIBKRVY2vOv8BPLt4zFdAKG2H6pfj5w3jl4vkyXrXOBt9ZP0sKzyClAQ/3UAurgu2y5jUQZykIpBvaR3or5EGIh/cqb+HmAnf7nFA7X1eJ/okcDmFjiAgcltDeGldocvadEPRrvsTbX94fS8YrVgKqfHpfNXx6jG2v+VPEL19QfkFAQG6daONpm8m9+gttH0oD3ejfM84zyAqBpb+J1atNeqS1/QKTjk0CEzjLn2+dKQ0ENfw021xwAICUxdkkfkJEP7A2U2OqGI02Xi8jHkkOXbtNbwlwSYvTZxuIM9K6fwiJkqLVERpIhPAlYbeovKZ6h7qvbgLJqXrcdL6m+uj1/d8K48HVIQI4TT5zD1Q8iZWS52oMzb9X5oHAeN9ksvtqZSP+I8iqVa+u7cVHVmqiYA4dR6EsOboLi+YoL8K7fWp9bu/yEivPRD3fi+PDYIg8SKdTm8J52YQskzqY5iGxq3fjfg2DwWML0YMxPcbPTw7D9zLdqFSZGc77/oIt+e0ZxQ0wnw5e1TtbwiyoBLPm44rj+Z9KnC1YMwdl19UbhDfL4zSBPT5IChvtappEHCMtovo2HSXXsL5xeZMXFuaaHSxRH/TcHceN51F+CXk1oCOdMWDdwr3q3bBBWi6hrJN7Mv8CPjDSCOoxViymlsOw+NgJKhj7dBABNalzNU91IC49tN4FzZ6RdqhniJQokt/k3Wnqoj5AE93S8jV7xDm3YGwq5ibV7W6VQV3dpXycLaOSdmScgCivrFzCaH/+s+qNRxZbkYHtlj0vw1JAf11rnKN+XiWvw49MkPXE8o0sWSG3SHx8bSJ3VF/nRpg/8tyNti3e0rGvmsrQ89xWG8QH4Mu2xLIN0kfQ8k/9sePzwptTGP9LNf51KIMXd94gAoRuCsS2N+gEFFn/v7FJPDLuBQeRqECLxlBkUqdcdNdzjKgEX75kx9RDrcbQEG5TMY6J8kQmHJ8UhtZ1crlsOHHme8HpvaekQ8BMbluKZVQgnBWAVdD52eAuK5P75n8sKe5qC3nINhlLlq4KfLkHfrlsemCiYWFJQ6i8stOUTsru7cUB4Q4WyE8ciRKJ4jKHHG9gyHKkEGTicui8iU4sx3SHT3pqUEuJ41uW9+7D9BvjFjhnhiRI2nAzrdFNJRaLONnhTF+V6Ewfhl20lsyGGfmIDAIkB3L3SYbL2IUhjWuLPZrVXqUPZctbRq/oFoqvF4o6pa0Fh5TQTWzb5t+5ziEKl+vcTqxW3Om8fDR8+I62I9LMapQQ2wprm+/zsOA1ZtMkW2lkTSomUUZbKzybtMrjJE3KuRr9GwdchRxLmRuA26GPRkJsiKRGK5nRHN+5+p/awAxd6Bq6WFtGGISN9YrnHTSiJEswGdfD+ESLEgPmmeECA6jFuXAQ68tKl05IYgMgwtI6WwxTMvV7anWL22X1HncUx6WQoPl4zubS935dp3HttXDjJbJDmd56ZJnrqIfEcMOYkWXAqvMBi/175ZviAFVE4xAbhof2yIsEd/zHQ8Sjt5rIvP6OqsMH8LRpOW08p7iaILxWW1tvg4lRDHe+Nr1rlizOhCk4wWhG4+LvibLRdq1opCOnHzeYVErzPW3Ik48A/JB3SFAGbxRv39Bx7d8oWcElfC12Os016+cPjkORdCAgGzlbCxbXn39RBE5HnHd0LJaJFDtDeGSvzd6mglNSexyHwK4oNqPfDvyyiHffXUJMywXZbPyLq2R4zp3j7nRXfg5UVUY3BPwhlAp7Z97li9n6NI0tHOWJ6FyTjuHhCwLJPTFoDSIN+LU0j+nXo7TtVkX6HmA5SYpJhFwlZcCIY3H6vxIKvqtA4L4Ysfo6mvhqzsctrU/0WuhdRUEeFGCJ0/SL/WZGMxx7x6ep6sr1uEFJT9joWZJ/QD9QD2MACqpudix8Tkk4Nkd+4Z6fMD817PrBFZQ8p91oMJkofuWiz2m5kuLLZawXLMUIOSMovXfgHlbTj2N1P1SLU6wIyIx8rTqaGfAhdVXaj8fKevvaSptIju4fHjHZHYJF2DQytpzdtm8uYbkJfyzB1Z2ENvb9xCcs12vQXS3KD6Ufd9H7Op2ZW7ObX2Hc8MrZ/uXaRcHYm9DyAqgTjqu8dBWgvlztbOc19T1x3JJ5VfgIHhjEChMjkLpiogIDaU3LJG2vhpLbEvbLoDf1bfPaqxXuqUSQ4K7m9n0Pe8AqbNY4v8FU3cmqHI3VfrZfa3yOqbUkkoaHCOQoJFH4FsJo7FuQuXVCo0vqXzUxPT5yPDnb13aUZzdLlYb0ZPBh4CgQDDhKaB9B9wstmSkQm1U3YfHGpUDIPQI/OtH6aOvNVqrTleYCn/zpx8RrG12RXHaoIE8xgtzQNJYw0A3C92u+j1DJwgvbvbc63XmktOxCoHB7ZqdA6EwEBr4gzjQvMbtk/HjU9SzcmdENe6vns42qb54sJlvObwGWOncqRvvblsoQj1EnO8Vk0O/xa7Td7EharNcOyIqTcgZENBRXCQC8Cef1PSBr8wDe/MiX1z/J3sjz9g+2yq49/G6eXijYYAQ=="
             },
             {
               "type": "text",
-              "text": "*Perfect — adult it is, and straight to the action!*\n\nFor fantasy intrigue, one world leaps out immediately...\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne. Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet me pull up the full detail on this one."
-            },
-            {
-              "type": "tool_use",
-              "id": "toolu_01VzXXJoFocf5rBQ4fZPrSEj",
-              "name": "load_world",
-              "input": {
-                "slug": "the-shattered-crown"
-              }
+              "text": "I love the enthusiasm — but the curtain snagged just a little there! Which world caught your eye? You can just name it and we'll dive straight in."
             }
           ]
         },
         "streamDeltas": [
-          "*Perfect",
-          " — adult it is, and straight to the action!*\n\nFor",
-          " fantasy intrigue, one world leaps out immediately...",
-          "\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne.",
-          " Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet",
-          " me pull up the full detail on this one."
+          "I love the enthusiasm",
+          " — but the curtain snagged just",
+          " a little there! Which world caught your eye? You can just name it and we",
+          "'ll dive straight in."
         ]
       },
       {
@@ -212,84 +221,59 @@
         "request": {
           "model": "claude-sonnet-4-6",
           "messageCount": 7,
-          "systemHash": "9c4de2032fa4",
+          "systemHash": "43367fbc31a0",
           "tools": [
             "finalize_setup",
             "load_world",
             "present_choices"
           ],
-          "lastMessagePreview": "[tool_result]"
+          "lastMessagePreview": "My character is Aldric, a weathered sellsword chasing a blood debt. Keep it simple — no extra mechanics. I'm an adult, s"
         },
         "result": {
-          "text": "<i>Oh, this is a rich one.</i> A dead heir, three factions scrambling for power, and secrets buried under every throne room floor. This is exactly the kind of world where intrigue festers beautifully.\n\nOne key choice before we go further — **which faction do you find yourself entangled with at the start?**",
+          "text": "*A sellsword with a blood debt walking into a world of shattered power? That's not a character — that's a lit fuse.*\n\nLet me pull back the curtain on the perfect stage for Aldric...",
           "toolCalls": [
             {
-              "id": "toolu_01D3LZt5h2WQgFeN7hFKqEux",
-              "name": "present_choices",
+              "id": "toolu_012eDpTfEcdYFSEGm3mN3z8p",
+              "name": "load_world",
               "input": {
-                "prompt": "Your starting faction",
-                "choices": [
-                  "⚔️ The Iron Circle",
-                  "💰 The Gilded Compact",
-                  "🕯️ The Hallowed See",
-                  "◇ Show me some more ideas"
-                ],
-                "descriptions": [
-                  "The military faction. Disciplined and honorable, but one betrayal from shattering. You'll see the succession crisis as a soldier first.",
-                  "The merchant coalition. They treat the crown as a business acquisition — ledgers, leverage, and backroom deals are your weapons.",
-                  "The religious order. They believe divine mandate chooses the ruler. You'll see the crisis through faith, prophecy, and holy politics.",
-                  "Not feeling any of these? Let's explore other worlds or factions."
-                ]
+                "slug": "the-shattered-crown"
               }
             }
           ],
           "usage": {
-            "inputTokens": 1,
-            "outputTokens": 356,
-            "cacheReadTokens": 15388,
-            "cacheCreationTokens": 1003,
+            "inputTokens": 3,
+            "outputTokens": 337,
+            "cacheReadTokens": 16182,
+            "cacheCreationTokens": 558,
             "reasoningTokens": 0
           },
           "stopReason": "tool_use",
-          "thinkingText": "Great! The Shattered Crown has suboptions for starting faction. I need to present these to Sam. Let me present the factions.",
+          "thinkingText": "Sam wants:\n- Character: Aldric, a weathered sellsword chasing a blood debt\n- No mechanics (pure narrative)\n- Adult\n- Surprise me with the rest\n\nSince they didn't pick a world, I need to pick one for them. They said they want fantasy with intrigue. Let me pick a world that fits their character well. \"The Shattered Crown\" seems perfect - political intrigue, a kingdom in chaos, great backdrop for a sellsword with a blood debt. Or \"Blackwater Bay\" - a port town where everyone's running from something. Or \"Iron Saints\" - church warriors with hidden allegiances.\n\nGiven the character (weathered sellsword, blood debt), I think \"The Shattered Crown\" is the most fitting - political intrigue, factions vying for a throne, perfect place for a mercenary to get tangled up in something bigger than themselves.\nNow I'm pulling up The Shattered Crown's details and available options.",
           "assistantContent": [
             {
               "type": "thinking",
-              "text": "Great! The Shattered Crown has suboptions for starting faction. I need to present these to Sam. Let me present the factions.",
-              "signature": "EsYCCmUIDhgCKkDgFdOkHl5rhv3YWeLSQDWuKKn2R6LiSeqmljYZtoPGz3gCpNQyMCKRYP7PLH/E76HsXZrt62n5w9UpO9aIXEShMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMgmHNHotoffu8+8/lGgzQimG67xRxNnU0cE4iMIHniYafKvTtrD4oBt0ywxkPJ22/+eX0YzWyONE5DE8GCo/Qo4mjXUXUYssvhc0AXCqOAfTyRVTqQe7GFjky3gybYfsgTV1oy768VwGv0V70pgSy1AeHbllBz/4AU1cvxRpcXu8VVofNgMmxDf0MgqcfH5WjdLXHN8SXMgUBPDnlkXHoYebcWD7UIf1/8hmy242KWfew86sijwtfJq+Ji6MJbV/Rn6T00eY5TuuaBxASktLcT/4AYhUBWiMf2FkQBfAYAQ=="
+              "text": "Sam wants:\n- Character: Aldric, a weathered sellsword chasing a blood debt\n- No mechanics (pure narrative)\n- Adult\n- Surprise me with the rest\n\nSince they didn't pick a world, I need to pick one for them. They said they want fantasy with intrigue. Let me pick a world that fits their character well. \"The Shattered Crown\" seems perfect - political intrigue, a kingdom in chaos, great backdrop for a sellsword with a blood debt. Or \"Blackwater Bay\" - a port town where everyone's running from something. Or \"Iron Saints\" - church warriors with hidden allegiances.\n\nGiven the character (weathered sellsword, blood debt), I think \"The Shattered Crown\" is the most fitting - political intrigue, factions vying for a throne, perfect place for a mercenary to get tangled up in something bigger than themselves.\nNow I'm pulling up The Shattered Crown's details and available options.",
+              "signature": "ErEICmUIDhgCKkC9SqXncMZFg6lYmNGfuLD8nUHCerQ3EO7qCaXl9IyT6X5dgYkD4IMoyKxoCobRq9k6UzcyilGlrd2kWXz+CBWrMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIM+zupoiMKmTfeGN8HGgw9TaO1rJ/ShdPYj7YiMM/2TphFEpn6B1QckNj3GPswsZ62SEtri6DXHikWaGyYwZsQ8ubMs67QFsi2gr5dAyr5BkghTzHsyl2np9C/Rkc2My5tp005p3HXfQ8KasffmEj2nWYbF4myyk8eV+TX+LH7+EL5PdMpUheRBDvstQA/Sq1kD0BlkqjVr+x1aS5msIBm3f0rcVDbl+cWlw6piLz6JO4MQlk66I/BBfhdJcBBH5mAkBPOWS+7I36Zo+QDB3ccQ3peLIwrLbDsaLRWXWFbRBWvj9lf7+I05Qll0dZUQxIGTVdvEsbnIWlrGZ7Js6NkyqPsn5U3nJp52t7+BJ6Ks87yBYujFeEofAkAzfrFmIjd+BijVNiwZHTsvSSJxsZ60Y+ipXEI5kRDfNRJm5Tj1AOo9AlhRbhByT1DAI+lX8XCQN3QBluX/17Dm7sSs2ljASEWpHd2h0nxXS2lSDMP1oCaESpnPF37pI9BW3YvbEfg0ruWf9ui8IX3/RXItV9uhBJRd8McwcqHh7PVdpxlnQ9VcPqjMNv6/A3UPINYBUGw/OuvbJ6JJnvYukjXP0CaPxes42ZJhFUdHCqdkZSBWDJtvmXrwPXBz7s54/Vjdu0xgJUqjKbEP+2ig8loUx3wFz+I4vO7B+6tWFQIutcH2miyymyViq9kiXlfFjCf/YwQ+EeFZj8R02ZbJLj4mt2K8Gq+Grp1KnC4Vnm3W077JguW5QuQweLLlvmSRy37UT5JrEpbiSQ7+Wz03uUpi0v5lJ+GpHgwN0qPutGw8njVgQQAIo5HpGuC9PwNOogQdzAt0N9CdjEL1sf/hbOKzGSH2zNiRDGbEF0Jam1RFLMswTG+OPeUMUBRv0iGC9dpqOXNBOCax+gjBkGXRidq8atpATPXHzANa5ZwSdUqmSIM/8FB5HOZmZDoXAdiL6ur5Ijiti439OZSBr8MpYnOWovdA/GQE6NIvVNH3cdYkP3hxow2TNU+S1XLD6i7TUPsVGqVw13jrfWvUVBgFUHXTf/0LIOlwZ6UXxyOki9tP9gerRVAfnLAPY/aBUT0FdX+UrBeyMIohe7K4/Bmnk517em7otI7kE4Q0CgkA+uA5oANEdrhbQHVrv1I2wKrKzGiO8+/BS1V1ZaNgTFIHubvXdGMooK00wWzEMo1I0TCJcqmL7H57lJDQbsVrLy3IDtIOFATy0ysIOsiwv0965A/7HZakkizxeX3LAWGS590VESWN2XGEpAj/6xvq1qD+C5Vi859t14VslVxlnkYAQ=="
             },
             {
               "type": "text",
-              "text": "<i>Oh, this is a rich one.</i> A dead heir, three factions scrambling for power, and secrets buried under every throne room floor. This is exactly the kind of world where intrigue festers beautifully.\n\nOne key choice before we go further — **which faction do you find yourself entangled with at the start?**"
+              "text": "*A sellsword with a blood debt walking into a world of shattered power? That's not a character — that's a lit fuse.*\n\nLet me pull back the curtain on the perfect stage for Aldric..."
             },
             {
               "type": "tool_use",
-              "id": "toolu_01D3LZt5h2WQgFeN7hFKqEux",
-              "name": "present_choices",
+              "id": "toolu_012eDpTfEcdYFSEGm3mN3z8p",
+              "name": "load_world",
               "input": {
-                "prompt": "Your starting faction",
-                "choices": [
-                  "⚔️ The Iron Circle",
-                  "💰 The Gilded Compact",
-                  "🕯️ The Hallowed See",
-                  "◇ Show me some more ideas"
-                ],
-                "descriptions": [
-                  "The military faction. Disciplined and honorable, but one betrayal from shattering. You'll see the succession crisis as a soldier first.",
-                  "The merchant coalition. They treat the crown as a business acquisition — ledgers, leverage, and backroom deals are your weapons.",
-                  "The religious order. They believe divine mandate chooses the ruler. You'll see the crisis through faith, prophecy, and holy politics.",
-                  "Not feeling any of these? Let's explore other worlds or factions."
-                ]
+                "slug": "the-shattered-crown"
               }
             }
           ]
         },
         "streamDeltas": [
-          "<i>Oh, this is a rich one.</i>",
-          " A dead heir, three factions scrambling for power, and secrets buried",
-          " under every throne room floor. This is exactly the kind of world",
-          " where intrigue festers beautifully.\n\nOne key choice before",
-          " we go further — **which faction do you find yourself entangled with at the start?**"
+          "*A sellsword with",
+          " a blood debt walking into a world of shattered power? That's not a character",
+          " — that's a lit fuse.*\n\nLet me pull back the curtain on the perfect stage",
+          " for Aldric..."
         ]
       },
       {
@@ -299,7 +283,7 @@
         "request": {
           "model": "claude-sonnet-4-6",
           "messageCount": 9,
-          "systemHash": "9c4de2032fa4",
+          "systemHash": "43367fbc31a0",
           "tools": [
             "finalize_setup",
             "load_world",
@@ -308,44 +292,48 @@
           "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "<i>A sellsword with a blood debt, walking straight into a throne war. Aldric is already the most interesting person in the room.</i>\n\nI'll take it from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The Iron Circle</b></center>\n\nA <color=#cc4444>tense, intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of faction webs, private agendas, and power wrapped in polite language. Pure narrative, no dice mechanics.\n\nYou'll be playing as <color=#44cc44>Aldric</color>, a weathered sellsword chasing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's disciplined military faction, in the chaos following the heir's suspicious death. The debt that brought him here may run deeper than he knows.\n\n---\n\nSound good, or want to tweak anything?",
+          "text": "*Perfect world found. Auto-picking a starting faction that fits a sword-for-hire with a score to settle...*\n\nA kingdom's heir is dead. Three factions are tearing themselves apart over the throne — and Aldric just got tangled in the worst of it.\n\n---\n\nHere's the stage I'm setting, Sam:\n\n<center><b>The Shattered Crown — The Iron Circle</b></center>\n\nA <color=#cc4444>tense political fantasy</color>, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of webs, whispers, and every NPC hiding something behind their smile.\n\n<b>No mechanics.</b> Pure story.\n\nYou're playing as <color=#44cc44>Aldric</color> — a weathered sellsword who came to the capital chasing a blood debt, and ended up conscripted into the orbit of <b>The Iron Circle</b>: the military faction, disciplined and honorable, one betrayal away from collapse. They think he's muscle. He has his own agenda. The succession crisis doesn't care about either.\n\n---\n\nSound good, or want to tweak anything before we begin?",
           "toolCalls": [],
           "usage": {
             "inputTokens": 1,
-            "outputTokens": 849,
-            "cacheReadTokens": 16391,
-            "cacheCreationTokens": 435,
+            "outputTokens": 655,
+            "cacheReadTokens": 16740,
+            "cacheCreationTokens": 757,
             "reasoningTokens": 0
           },
           "stopReason": "end",
-          "thinkingText": "Interesting! The player has now given me a lot of information:\n- Character name: Aldric\n- Character concept: a weathered sellsword chasing a blood debt\n- No extra mechanics (pure narrative)\n- Adult player\n- \"Surprise me with the rest\" - so I should auto-fill everything\n\nThey didn't pick a faction, so I'll pick one that fits a sellsword with a blood debt. The Iron Circle (military) or The Gilded Compact both fit, but a sellsword might be hired by any faction. Actually, The Iron Circle seems like the best fit for a weathered sellsword — disciplined military, soldiers. \n\nI'm settling on The Iron Circle as the faction since it aligns well with a mercenary background, and now I'll lock in all the remaining details: Sam as the player, The Shattered Crown as the world, Classic fantasy genre with a tense mood focused on intrigue, balanced difficulty, a few-session scope, pure narrative system, and The Magist as my DM personality.\n\nNow I'm crafting the campaign premise — Aldric gets pulled into a succession crisis after the heir's death, working with the Iron Circle while trying to uncover how the crown's turmoil connects to his personal blood debt. I'll do a final review of the setup before finalizing everything.",
+          "thinkingText": "Now I have the world details. I need to pick a suboption since Sam said \"surprise me with the rest.\" I'll auto-pick one that fits a weathered sellsword chasing a blood debt best.\n\nA sellsword with a blood debt... The Iron Circle (military faction) feels most natural for a mercenary. Let me go with that.\n\nNow let me set up the full campaign:\n- World: The Shattered Crown\n- Suboption: The Iron Circle (auto-picked, fits a sellsword)\n- Genre: Classic fantasy\n- Mood: Tense / Grimdark\n- Difficulty: Balanced\n- Scope: few-sessions (default)\n- System: pure narrative\n- DM Personality: The Magistrate fits perfectly—intrigue, factions, debts, betrayals, hidden agendas in every interaction\n- Character: Aldric, weathered sellsword chasing a blood debt\n\nNow I'm building the campaign premise around The Shattered Crown with The Iron Circle as the starting faction, centering on Aldric's mercenary background and his pursuit of vengeance.",
           "assistantContent": [
             {
               "type": "thinking",
-              "text": "Interesting! The player has now given me a lot of information:\n- Character name: Aldric\n- Character concept: a weathered sellsword chasing a blood debt\n- No extra mechanics (pure narrative)\n- Adult player\n- \"Surprise me with the rest\" - so I should auto-fill everything\n\nThey didn't pick a faction, so I'll pick one that fits a sellsword with a blood debt. The Iron Circle (military) or The Gilded Compact both fit, but a sellsword might be hired by any faction. Actually, The Iron Circle seems like the best fit for a weathered sellsword — disciplined military, soldiers. \n\nI'm settling on The Iron Circle as the faction since it aligns well with a mercenary background, and now I'll lock in all the remaining details: Sam as the player, The Shattered Crown as the world, Classic fantasy genre with a tense mood focused on intrigue, balanced difficulty, a few-session scope, pure narrative system, and The Magist as my DM personality.\n\nNow I'm crafting the campaign premise — Aldric gets pulled into a succession crisis after the heir's death, working with the Iron Circle while trying to uncover how the crown's turmoil connects to his personal blood debt. I'll do a final review of the setup before finalizing everything.",
-              "signature": "EqoTCmUIDhgCKkA92kCE3ckTVGr5pa93BVxWe8hbUAJwKWxbBO833Y7IRL3+mJbZ5e2KM48uXCuWzV3VfZR10AcR74WL8872t43fMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIM7xNDG2RIHdLE5FdIGgzEfKy5H2i86+dXckMiMOmBsvrl3Db0T5Hs8l4RnSDsTdfMEjPGILHZCcPrhhUWItcZcv7bgsnUrHTDXrp5YiryET4BncaCkQBuwkiJQ8PyrJDcKPhexpwrmsVVvrxgqgClXYefAgON/cP9Lg2tD/XbvqVL2j1zGv/r4DzbqXDdhrmgdGKUra0aQOZgwCVfXAWfH8+z9mG+ig2BswCf9tA2udI9gjYH37pqy/tZuFLH/lTLvJNBapldORY5KW0po0ZaBAum8C78rRePL/5Mi1d/tpKyqUiPO4yLmwapLM7IbDb01Wn/tw907D0ZqyCfirk2qiw/QpcXiNFBlUzKgJK9ef1cuV52cEwgNahIq7wopWTP24Bv3ErVNl5VQMACE4lcUPShH/Z8JSMsiBYCa/wumVucB63x5oPmonns2WTZADRwmlsnQTuLXfSywEijimaDAZsZCSBLUz4D9ixWxW/2bSjVC4HU78TlxUKR/GPdpuppb4OatJWGQ0SEH7IWU44T81D9ZPzg76Kga0sQDbwyef1hahL3e4FBf6zmUxhvNmZcz+Tk6j5UCB8ha1mxdD0xZE+IyY+kEsqPOxDoK2sWH/Kt1F0TAdrs1Sfxj7XlRMxMhtqxep1JRHT0PB6UuawJih7r93tu8ZW6jv2ZbVT+/ft99SwVltMUFzun+9gQ78+ohEnH+b2Ai5r7FSj/ER3aVkpApI+9IRsPz1vtyy4tnODkO39SgaFsxuX3KE4k2+gXCtxF17WpCw5/iT5uqiemHMm6/Qso1/0bOqspvUvb/tr6e5M+6MfmUWpsnoacYLxoqMb+u7/WIkQ9HSeNPDCrevvX0WWxN3bl/C9heM6FgInUJFTZlkqjO45k9ZKfAUiPmEQ+hNmHG14wh1d8vAgfE2O9tMI1bbFEvI4hMnDE6V0TWB8k3IaRYtZx1dVTi+vSyBOr/3CNdV5p0qvmqQ9DPNNX4mq7B99sPkPlDXfV1ckTgh36A140VftgczmwyI7msbKndPoY4RFxpxqNL1w1wpYZBPpxkbEV7aOMIZf1ap0spP6EbGdFIbDiRmDW36upyQzVetbxIBHWylSmp63q6+PQkG1JqGra+6HjRq55V5D5toeU5C2GmJ9SDFyoRXvPQMCuxPKjOVpM2Srrd3lQKXI6SHl5/AlkJ3wEaJOrObave6vhqF5WvYhS4nW/Zbk3ziXpMpI6YoqulOhtoyeiKGo0vb1W/4M98e1OXaUAg2xQMvOXDAGONZuJD91Z8GcZjzM0Df6Fb/ZBSd5fK0UVNltiUbzaG7ToYdelb/MnolyOCwusMHP9jk60/N6kmDWQa/EI5s+jyYpfe0RjWkAV2zlbvb9x7L9s1ht1mSH9NrNDn08ysphppiAvlFxoTU9vi3GupaBdgWRxUX3l8acCxAWidsdO+zPr2bDDDA2wXuVzklGhANK9Fl8oZSeAGFG1xCfKycmrwkkCakkfmHqbhdyoRG4pD7VOaVjKHQ33FS3Z6ubLp08dO5sR1KtLHDrGd3aw9n7Wq+goprhDVOj/1qgYt+lNtMv/NUgqvVYktIV6fQlpEt+erOQRqe9zSGYLXw/bl5GTP565rXF4g2IXos0HPpfJRP4a7SrO9jsxrqVn94e0hLs+R8x4YuqOcT83aC8VUPMtGYL8u2N1Xezb63b4GMzbnHgYD3nYvQ2d0CqbLNvEpkoUnaw0hUvHmZ6LYoqt1gAw7G7PUD3CO76TB+qoc8kGs4yrcOqdziA/wOqSi32YX/1R6Wznl4QpzBoA13ubC6rwj8ToHz1IXu9BnmJcEf1761pkcV/UFhrf96DXngqunHBTMHO1YlIXuhmaEZoGP5pPRV5OU0yoP36T19GiovK+2DPN45Vyxzgjzhtt5SrRdVCMQBFWp+bfQgufjtXcYS4vb9FKK/OuZ9yvVzS5sDLD+6ZkARukhfA0TTSEXVKbcOu17JS4WmZue+2oP7xC+sHvXLqaThMdl6qVep9JLrrnLOiKbtRPpfxFeDH1F+QGovCItavFQz1BjeBaZkIXEoDaJYDzpYIBWPAPCE5LKt7e9CiQD27MN4IfLOHwi3dKaG6YvJsiIopljxws8Ay6jZz9BeLCa4xrNN7LWe3uq5RapbrJ3aP3dWB8VQNjPGEZgcUljplrsOhSWxAfUTpxmGkym9cMldi7Xz7QJVwoIqQrSq3V08VbUMdjVyBb26vzdPXPAtDwEVyIpN4v7qrfhZGhkh7IW5ROPDQzQLlEqSjEDzh4insMpuGyyRDuXyM34U9snQB6S2FjEziIOLBpDIvFdLBQDzcHqjNzAOG+J0xXcu8S/qb2z4TdrEPzwa7x3E34G1Id6inlgeeV3XlyBLgfqA0T1u7sxaaG4khlDHdGf4r//Jn6L2+hygQynO21sj/CbdsVLTC4iEwgcjCrlEdmmUidbdzFTdXbcPuWhIWkeSx+Ez8qcNgH+zYceM6Lr5Wu6QDoMK/aiWVkWl40qnwWdApHs+PKqUtExyqURfzLjs3sCCCOV20iLV/chsnEwj/ttX3Y0Yvmb3X+Vx5Bo/CLxHzGXXLBqwcLouoKsZ1YM7ETtnon6hyVpy26kljN6Q7shHKqEM6H/+VZ78N44DIGZwSuF+PzzuGWJheNm+FqSvKUDzxE/zzj2mXdYkYoECuC0VApXUrAR1qfJgDkR/rzjSfTZjxcqDXpkq4kyatAeSjpMIgNziPoPj9fFeHV5jX2EAs2w9EXptjV20qX4Nh4zZUj4zkGCFyXvH2fPdHuK/6NDONH6OWSU+iQX1Bfp78n3AsTa6eyHEU1lmIzoOo09aZxFZBh90X633spW8geIsiDTWrdihZFivmTweVMKLCRs6w2fOxIv4ImLjtSFFzGGSQ3LHskyYlOc7v/QywXkO/8jBCSDNuM33Lt1bBrzGB0SmsIIQxaiyyxBy9qJCeRxjdFKXTf2iDVf0x20Mt+uGWSssjfMz1W9+4RaB4dq3n0BH57yOhJs0mk4NFOLAYU+mGRaNIbxHIkThs78L4NpWUjI/h0eN02O7T2hYmt2RZua3/Luy7dhaIEkh6ALQgPU4N1CBTorfaAYuNGdble/MiGt48FiRnYHxl2oqSWALHsAcU+KwAqafz+uZW21qx4W+mEG+dmtjUolawYAQ=="
+              "text": "Now I have the world details. I need to pick a suboption since Sam said \"surprise me with the rest.\" I'll auto-pick one that fits a weathered sellsword chasing a blood debt best.\n\nA sellsword with a blood debt... The Iron Circle (military faction) feels most natural for a mercenary. Let me go with that.\n\nNow let me set up the full campaign:\n- World: The Shattered Crown\n- Suboption: The Iron Circle (auto-picked, fits a sellsword)\n- Genre: Classic fantasy\n- Mood: Tense / Grimdark\n- Difficulty: Balanced\n- Scope: few-sessions (default)\n- System: pure narrative\n- DM Personality: The Magistrate fits perfectly—intrigue, factions, debts, betrayals, hidden agendas in every interaction\n- Character: Aldric, weathered sellsword chasing a blood debt\n\nNow I'm building the campaign premise around The Shattered Crown with The Iron Circle as the starting faction, centering on Aldric's mercenary background and his pursuit of vengeance.",
+              "signature": "EvkLCmUIDhgCKkD5NtG2VtsD3IZNt04XtjlxqSRK38rdYma66GqJYYtAW63/YBNrH4WuoqsFiW5Z1iU0wVnN0kFF6I9IeJZE2S2HMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMJxOBqeIN2ibgHsyPGgxcWADCKfhdbEBqAfMiMOmLDbybEmWM86ZipW9RHore1e/EcwlU4sXz1ypZTkrg+9vJjwl+cgdn1lMBJD9MzyrBCv282SIdvqm9glssjlQk72IKfHOH7uOY8cJ6XZCtx6xUtNnufX5rs6S8rUQbt32a/FKmKGNdE635HLyJ4Wxv/Qv/F9rq3BQXuutXBt/gja5+2P4+4/cwuHYd6tbkBiXf7EQq6qWxdz+IMxh646qM0mZ4YqCNJfFWClBOLnX0fuUJEcjUMfEYDdFSG1e5HfcWxRDPYlZeQA0rotHpN8aOXfu0PmTzd8/Bb4Bs+vkZ25iWfRWMhJMPVIT7jLucmZALqM4YgulPVfOLuTfEXoWEZ+TObI0VgX94mykwLShmIgBcdxSoTe3YoZBzmMWC0+DlyzoUvvVoUAa/fNC5IFn5avGtQyRrDxt1Bo24W3NYtfdLfZoT5YCpfMizBzetT5ILJIX0fl5mr1MFCoV5GPmtw8bF7+am0TzVv3BjqJ/ryM7qFfB1DrVPl/DRa8w2mLMJNIVHAOA8pGEQ4jqE5svC7Ej0EOQxsmGoQTykKKxxaQjtBKE6UpjhnMJKMhc5bnIb36gH74wQD5dyv8epTRrptK+V4JsjT9ZPdvM+SZcG5IyWOkVTXZj9EkXMvZe/91rSFDI8N5NYtd36afuiHDW8v99mT6X+e1QW39f8KP5/WCsSr2GKNzOeci5N6B2yz5WArKdvR5hNY6o5WcCJqTNr/lKUAaA4rvwOSrUY7bdjqJGNhbf9CVGyUHHmzZxfrVIpO1XsI9pLMLnW7FLhdcCY16vBrOhJr2F2JrMD0nPwnMiOZik+9zJm70gl9qrWcTdLPhIfgww7mqYeoOpNebzSwxBZrg52/0v7IpqzA5JJZTyGT+mEHus4fnR5X4YYgqPq4ld6ya0i1bjJh8wuCiX+K/laUWhYtOvxO0NZA0+n4n3FeQIRrtib5avzOLXZNDUR+eA7qg6zcBcbjli/VYCia/uEFSOxSUNDjK/0D7RsL6/eR75VfgSfT+3ig6rckBpJOMZEd5tHmeyvpSAZJ0OYc5COBkZXp/egR9FmXV7pFomc2hqBCRgq5y0HRX0ijUdmoYwjQqwY+g8icD2W+etBNPyoUtfv01X2u3io2EaacR781+KDXRXp7odTX80aK8eZeu9yJEcANg9fyKRTkXsN8voVyiHx2unPmAYsK220zSV4AtlpeRRIfP17tuQBx65grWsvZSuBd8afIXcOlnTqTnSeVYzRPuA/nx/DOVZpHumH6+CmZdBBapFQeYrxaCBWkXYPQnSzqBrNwPIpRA/xJc5iGGcWmWztybYWd9a4bAshHNdU6fSYUXre4YY2IsDTPL4OHZqf2SkBS4DAWj8VpkA5Eck9Rx9GssEj7LEjrx1qcSy4ITT7is3+9KmNvoLT/qiA1WhCN6MbI0x4lgjDhQOuLdyUYCmp5w0NW30zAj4cDh4j3CFaicu2+LLXYqkqvhp7yNdbhKQgccJ9joJv6ZS0tURJlNitIN3zKo1UzxC2nxpHMmkxEInYpLavQ2vxHo1w93JSRrx5wAcsqLd3kgcxxruCJbu/5AFNkNrvXz7WaW497oUXuZ1RcuAlD2cUFlxBSWpX8K+jvVSkZyDTD9lk3BOKZxj91Q0GKGCcn0tjHCRUt23ANRAPGaK3Xomh9HYt81y5tCgnLzpxqyUu/ylnP8YSU+UDMrGlb5mFIk74/GvmbFRw1fg9yvoHHedvapE5IdeJ/+dHl5F8O7HPRLXOhEGzhFBUHuOvh73PJlqQ6Jb2LdLcEcPrbZ7KMzTp2xdIesqiopXo0x62o1xekZUH+whuWwnBrNb+c251LS4yMymBicpuEp/pAXZF77nwWiQYAQ=="
             },
             {
               "type": "text",
-              "text": "<i>A sellsword with a blood debt, walking straight into a throne war. Aldric is already the most interesting person in the room.</i>\n\nI'll take it from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The Iron Circle</b></center>\n\nA <color=#cc4444>tense, intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of faction webs, private agendas, and power wrapped in polite language. Pure narrative, no dice mechanics.\n\nYou'll be playing as <color=#44cc44>Aldric</color>, a weathered sellsword chasing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's disciplined military faction, in the chaos following the heir's suspicious death. The debt that brought him here may run deeper than he knows.\n\n---\n\nSound good, or want to tweak anything?"
+              "text": "*Perfect world found. Auto-picking a starting faction that fits a sword-for-hire with a score to settle...*\n\nA kingdom's heir is dead. Three factions are tearing themselves apart over the throne — and Aldric just got tangled in the worst of it.\n\n---\n\nHere's the stage I'm setting, Sam:\n\n<center><b>The Shattered Crown — The Iron Circle</b></center>\n\nA <color=#cc4444>tense political fantasy</color>, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of webs, whispers, and every NPC hiding something behind their smile.\n\n<b>No mechanics.</b> Pure story.\n\nYou're playing as <color=#44cc44>Aldric</color> — a weathered sellsword who came to the capital chasing a blood debt, and ended up conscripted into the orbit of <b>The Iron Circle</b>: the military faction, disciplined and honorable, one betrayal away from collapse. They think he's muscle. He has his own agenda. The succession crisis doesn't care about either.\n\n---\n\nSound good, or want to tweak anything before we begin?"
             }
           ]
         },
         "streamDeltas": [
-          "<i>A sellsword with a blood debt,",
-          " walking straight into a throne war. Aldric is already the",
-          " most interesting person in the room.</i>\n\nI'll take it",
-          " from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The",
-          " Iron Circle</b></center>\n\nA <color=#cc4444>tense,",
-          " intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, sc",
-          "oped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b>",
-          " — a voice of faction webs, private agendas, and power wrapped in pol",
-          "ite language. Pure narrative, no dice mechanics.\n\nYou'll",
-          " be playing as <color=#44cc44>Aldric</color>, a weathered sellsword ch",
-          "asing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's discipl",
-          "ined military faction, in the chaos following the heir's suspicious death. The debt that",
-          " brought him here may run deeper than he knows.\n\n---\n\nSound",
-          " good, or want to tweak anything?"
+          "*Perfect world found. Auto-picking a starting faction that",
+          " fits a sword-for-hire with a score to settle...*",
+          "\n\nA kingdom's heir is dead. Three factions are tearing themselves",
+          " apart over the throne — and Aldric just got tangled in the worst of",
+          " it.\n\n---\n\nHere's the stage I'm setting,",
+          " Sam:\n\n<center><b>The Shattered Crown — The Iron Circle</b></center>",
+          "\n\nA <color=#cc4444>tense political fantasy</color>,",
+          " <b>Balanced</b> difficulty, scoped as <i",
+          ">A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of",
+          " webs, whispers, and every NPC hiding something behind",
+          " their smile.\n\n<b>No mechanics.</b> Pure story.\n\nYou",
+          "'re playing as <color=#44cc44>Aldric</color>",
+          " — a weathered sellsword who came to the capital chasing a blood debt, and ended",
+          " up conscripted into the orbit of <b>The Iron Circle</b>: the military faction,",
+          " disciplined and honorable, one betrayal away from collapse. They think he's muscle",
+          ". He has his own agenda. The succession crisis doesn",
+          "'t care about either.\n\n---\n\nSound good, or want to tw",
+          "eak anything before we begin?"
         ]
       },
       {
@@ -355,7 +343,7 @@
         "request": {
           "model": "claude-sonnet-4-6",
           "messageCount": 11,
-          "systemHash": "9c4de2032fa4",
+          "systemHash": "43367fbc31a0",
           "tools": [
             "finalize_setup",
             "load_world",
@@ -367,13 +355,9 @@
           "text": "",
           "toolCalls": [
             {
-              "id": "toolu_014ukxmhFzyTFiVfGeE3745B",
+              "id": "toolu_01566kphNX3m4MJTaF1c3zcL",
               "name": "finalize_setup",
               "input": {
-                "player_name": "Sam",
-                "age_group": "adult",
-                "character_name": "Aldric",
-                "character_description": "A weathered sellsword chasing a blood debt, now unwillingly entangled in a kingdom's succession war",
                 "genre": "Classic fantasy",
                 "mood": "Tense",
                 "difficulty": "Balanced",
@@ -381,37 +365,37 @@
                 "system": "null",
                 "dm_personality": "The Magistrate",
                 "campaign_name": "The Shattered Crown - The Iron Circle",
+                "campaign_premise": "A kingdom's heir is dead and three factions are tearing each other apart over the empty throne. Aldric, a weathered sellsword, came to the capital chasing a blood debt — and found himself conscripted into the orbit of the Iron Circle, the military faction held together by discipline, honor, and the threat of imminent collapse. They believe he's muscle for hire. He has his own score to settle. As a coronation deadline looms, foreign armies mass on the border, and the other factions sharpen their knives, Aldric must navigate layers of loyalty, leverage, and buried secrets — all while hunting the person he came here to find.",
+                "player_name": "Sam",
+                "age_group": "adult",
+                "character_name": "Aldric",
+                "character_description": "A weathered sellsword chasing a blood debt, now reluctantly entangled in a kingdom's succession crisis through his uneasy alliance with the Iron Circle.",
                 "world_slug": "the-shattered-crown",
-                "campaign_detail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\nSuboption chosen: The Iron Circle — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. The player will see the succession crisis as a soldier first.",
-                "campaign_premise": "Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the chaos following the kingdom's heir's suspicious death. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it. All the while, the thread connecting the crown's crisis to the score he came to settle grows harder to ignore.",
-                "handoff_note": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — those are his exact words, and the blood debt is the personal engine. It's entirely unspecified in origin; weave it into the Iron Circle's politics or the throne secret however serves the story best. Sam wanted intrigue, said \"surprise me with the rest,\" and deferred all other choices to me. I auto-selected The Iron Circle as starting faction (suits a sellsword with a martial background), The Magistrate for the intrigue-heavy voice, Balanced difficulty, and a few-sessions scope. Sam asked for no mechanics — pure narrative throughout. No content preferences or restrictions noted. The blood debt hook is rich territory: whoever Aldric is owed for (or owes to) could be hiding inside one of the factions — that connection would land well as a mid-campaign reveal."
+                "campaign_detail": "## Detail\nRoll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\n## Suboption: Your starting faction\n- **The Iron Circle** — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. You'll see the succession crisis as a soldier first.\n- **The Gilded Compact** — Start among the merchant coalition. They treat the crown as a business acquisition. You'll see the succession crisis through ledgers, leverage, and backroom deals.\n- **The Hallowed See** — Start within the religious order. They believe divine mandate chooses the ruler. You'll see the succession crisis as a matter of faith and prophecy.",
+                "handoff_note": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — keep that personal vendetta as a living thread underneath the faction politics. He didn't come here for the crown; the crown just got in the way. Sam wanted pure narrative, no mechanics, and asked to be surprised on everything beyond the character concept. I auto-picked The Iron Circle as starting faction (natural fit for a mercenary archetype) and The Magistrate as the DM voice (intrigue-heavy, every NPC with a hidden agenda — perfect for this world). The blood debt is entirely open — consider tying it to someone inside the Iron Circle or a rival faction as a slow reveal. The throne's secret is DM-only; Sam has no knowledge of it. Keep that for mid-to-late campaign. Scope is few-sessions but expand freely if the story has momentum."
               }
             }
           ],
           "usage": {
             "inputTokens": 3,
-            "outputTokens": 1990,
-            "cacheReadTokens": 16826,
-            "cacheCreationTokens": 879,
+            "outputTokens": 1641,
+            "cacheReadTokens": 17497,
+            "cacheCreationTokens": 685,
             "reasoningTokens": 0
           },
           "stopReason": "tool_use",
-          "thinkingText": "The player has confirmed. Let me now call finalize_setup with all the details:\n\n- Player name: Sam\n- Age group: adult\n- Character name: Aldric\n- Character description: A weathered sellsword chasing a blood debt\n- Character details: null (pure narrative)\n- Genre: Classic fantasy\n- Mood: Tense\n- Difficulty: Balanced\n- Campaign scope: few-sessions\n- System: null (pure narrative)\n- DM personality: The Magistrate\n- Campaign name: The Shattered Crown - The Iron Circle\n- World slug: the-shattered-crown\n- Campaign detail: (the detail block from load_world, verbatim)\n- Campaign premise: Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the succession crisis following the mysterious death of the kingdom's heir. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it, all while hunting the thread that connects the crown's chaos to the score he came here to settle.\n- Image generation: not asked (not applicable)\n- Content preferences: null\n- Handoff note: something useful for the DM\n\nNow I'm pulling the campaign detail verbatim from the load_world result to include in the finalize_setup call.\n\nThe throne's secret is one of three possibilities: either a hidden true heir is secretly alive and testing the player's loyalty, the heir faked their death and watches from the margins waiting to make a terrible bargain, or the throne itself is cursed—a bound entity that kills every claimant within a week. Each faction has sympathetic leaders with their own hidden agendas, and the player's starting choice colors their initial understanding of the conflict, though all three sides prove equally morally complex. The campaign should begin with the player already entangled in their chosen faction before they grasp the full scope of what's happening.\n\nI'm pacing the reveals so the second faction emerges as nuanced potential allies or enemies by the midpoint, while the third faction's true nature becomes the late-game twist. Ticking clocks—a coronation deadline, foreign armies gathering at the border, plague spreading through the capital—keep pressure mounting throughout. The three starting factions each offer a different lens on the succession crisis: the Iron Circle frames it through military discipline and honor, the Gilded Compact through commerce and leverage, and the Hallowed See through faith and divine mandate.\n\nNow I'm drafting the handoff note for the DM. Sam described Aldric as a weathered sellsword chasing a blood debt—that's the personal hook I need to keep unresolved and driving him forward. Since Sam wanted intrigue-focused fantasy with no mechanics and asked me to surprise him with the rest, I've made some auto-filled choices: the Iron Circle as his starting faction because it fits a mercenary with military ties, the Magistrate as the DM personality to match the faction-web intrigue tone, balanced difficulty, and a few-sessions scope. I should flag these decisions clearly in the note.\n\nThe blood debt itself is entirely Sam's invention and deliberately vague, so I'm telling the DM to weave it into the Iron Circle's internal politics or whatever throne secret makes sense—Sam's trusting the DM to make it surprising. No content restrictions came up, so I'm keeping the note clean and direct.",
+          "thinkingText": "Sam confirmed everything. Let me now call finalize_setup with all the details:\n\n- player_name: Sam\n- age_group: adult\n- genre: Classic fantasy\n- mood: Tense\n- difficulty: Balanced\n- campaign_scope: few-sessions\n- system: null (pure narrative)\n- dm_personality: The Magistrate\n- campaign_name: The Shattered Crown - The Iron Circle\n- campaign_premise: A kingdom's heir is dead and three factions vie for the throne. Aldric, a weathered sellsword, came to the capital chasing a blood debt — and found himself entangled with the Iron Circle, the military faction holding itself together through discipline and honor alone. \n\nNow I'm setting up Aldric's character profile. He's a sellsword with a personal vendetta, caught between the factions' machinations as the coronation deadline approaches and foreign forces threaten the kingdom's borders. The key is to emphasize his own agenda — he's not just hired muscle, but someone with his own score to settle in the midst of this succession crisis.\n\nI've assigned him to the Iron Circle as his starting faction, which fits his mercenary background, and the Magistrate as the DM personality to drive the intrigue-heavy narrative. The blood debt itself stays mysterious and open-ended for the DM to weave into the campaign, potentially connecting it to someone within the Iron Circle or a rival faction. The throne secret remains hidden from Sam until mid-to-late campaign when the reveal lands harder. This is a few-session arc with room to expand if the momentum builds.",
           "assistantContent": [
             {
               "type": "thinking",
-              "text": "The player has confirmed. Let me now call finalize_setup with all the details:\n\n- Player name: Sam\n- Age group: adult\n- Character name: Aldric\n- Character description: A weathered sellsword chasing a blood debt\n- Character details: null (pure narrative)\n- Genre: Classic fantasy\n- Mood: Tense\n- Difficulty: Balanced\n- Campaign scope: few-sessions\n- System: null (pure narrative)\n- DM personality: The Magistrate\n- Campaign name: The Shattered Crown - The Iron Circle\n- World slug: the-shattered-crown\n- Campaign detail: (the detail block from load_world, verbatim)\n- Campaign premise: Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the succession crisis following the mysterious death of the kingdom's heir. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it, all while hunting the thread that connects the crown's chaos to the score he came here to settle.\n- Image generation: not asked (not applicable)\n- Content preferences: null\n- Handoff note: something useful for the DM\n\nNow I'm pulling the campaign detail verbatim from the load_world result to include in the finalize_setup call.\n\nThe throne's secret is one of three possibilities: either a hidden true heir is secretly alive and testing the player's loyalty, the heir faked their death and watches from the margins waiting to make a terrible bargain, or the throne itself is cursed—a bound entity that kills every claimant within a week. Each faction has sympathetic leaders with their own hidden agendas, and the player's starting choice colors their initial understanding of the conflict, though all three sides prove equally morally complex. The campaign should begin with the player already entangled in their chosen faction before they grasp the full scope of what's happening.\n\nI'm pacing the reveals so the second faction emerges as nuanced potential allies or enemies by the midpoint, while the third faction's true nature becomes the late-game twist. Ticking clocks—a coronation deadline, foreign armies gathering at the border, plague spreading through the capital—keep pressure mounting throughout. The three starting factions each offer a different lens on the succession crisis: the Iron Circle frames it through military discipline and honor, the Gilded Compact through commerce and leverage, and the Hallowed See through faith and divine mandate.\n\nNow I'm drafting the handoff note for the DM. Sam described Aldric as a weathered sellsword chasing a blood debt—that's the personal hook I need to keep unresolved and driving him forward. Since Sam wanted intrigue-focused fantasy with no mechanics and asked me to surprise him with the rest, I've made some auto-filled choices: the Iron Circle as his starting faction because it fits a mercenary with military ties, the Magistrate as the DM personality to match the faction-web intrigue tone, balanced difficulty, and a few-sessions scope. I should flag these decisions clearly in the note.\n\nThe blood debt itself is entirely Sam's invention and deliberately vague, so I'm telling the DM to weave it into the Iron Circle's internal politics or whatever throne secret makes sense—Sam's trusting the DM to make it surprising. No content restrictions came up, so I'm keeping the note clean and direct.",
-              "signature": "EuQiCmUIDhgCKkCcCstEC4jZ88nXKmjnKLSKTA+OnOS6fYXGUKXXMbawBg2ES5LO7RBj/dh49fv5qENZkcAjk0zQ4GElGzwvUBYcMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMv5Q/hl/pq9tMTUP6GgyhhGHqxdz/otvCploiMFZPOT1Vn16ugZgJPc/kYb6I42J0qhzd8XuAatEoNDey7a+YgL1jdl46QRNc9OzajyqsIaGLGYWE5RBQ7JzpBlZiKUnijpSuAM7ys3iuakW3PET8YYU6apkYkCeI0sYu8snGwhAXSbfWcoC8AC2B0XC4g8n96uv+wP2P4upOmqNjbm2ksRujT5FNGqyJmZpkh1lwuprBfhwFx/QQM+Gs5dVUqEuufQxfIu9N3q/Xd7rC0EVwGzoi/Sfy+kJs2vIekJ4SObv75OL1sLprCzNU7lpju7k2R3B5YpsHtlk8PjfDIkW7PmNDM7CVNzbNVirxS3U78FnjmtevFR5JvpHEs2m49GduiOoSGqlJzTbtg4e/omFZX0b0RP2yMzXCkYDO3rEO8f9zeW4C2hdsFYNpTRE+6Jq7xI2qaYdnrhDlFV9XVivsglIYHXGMTIz+upJARfVK6JW7SIIfAex4qs0VSpm7i5Sn9dgG9PyFjVIPG+wTjuQw/aZR1HrN+f1gT/iG/AZJMux8N01JxGz0/bta+S1dOuTOP4Fa18iEMNJrR4eVKo2bO/QnHJPL8VACeh9Yi+4OIR4S3VnmUYbA2TUGUTHDudGOjgFneCbczYsMLYSbTmhjTRxiG0AizFAkfgApQVGut1YBmqNunRQAVSNf5nfHFp9jAbLB+y0IHENnNROccT+A6XtRa3NUOReyzNY9E52v3RqTqiR91SE4E97ZdXF4C4Hz7BuCw/srs/oWKvYqUoTCgWDHprG82DMBNUyIo8/rm+xeONCekAuNVcR+1WN68m+O9+avkSkBGre4bk/LrJuI3y9wFVelOER9hKV5e5PDOtH4VYoXrlshZzqnPQa1sot5QK2jKESIeFYALj8ru7iBowFZSODeXZJDVn6MugTzLEil5r2AtJ/X22ivnVWHGCy1tA77kxlNxYzMCav8OZifn15WxIEN6o2h88/HWqZwqkyW8mroeeJm8/2CenekHTNDu6g87GFeP5t/NnP+jJqoVzoVh34ZrJA0NTjuH4UW6kIRluSsSVKrV1ijK0QYU8Mbrhj8bp13LSTOWUuogqjMR1MfI1k/KCrd+kFvokhTgO1FwMruoYCDv+heEm6e9c1fLA2rjaNrBcqnVy2E69sMRKDmD5CilgQtZ8I3RK7VfPQozmRRDZ+X+d969NeyA0OKVfOI44O2VyxmjL9Ba2siobD9ahlt8WAOoILmTeuVXLAUmMCGUKDPfcdt4ZyOnZb251gGAN8oblLbdL4iOPqc3/uamrVy4f98O7c3UaUpd17dA4KiMwq8HzZqRTnHVcmjqQUPiI8bUAknIF75UVOdRLhfF6jPVbwHxL1tnYw/MYOLZM2aeWLaUsqt89GiqPN/bkvyGlvueVblEx8YrmgCSvuisoPTv6pBAqI0X23lpaE5ovIMK9XMQFnhBpE4iUQpyRnKDY3K3VRdHk9r5HkK2t/KaJLeVMlkaE8UgUgGW+hcgIPQBhhKOnf9O9uxZCpqBBXkAcS/vOvRurdcsDpS4ti/UuWQSos8HOIg0eqXMIsLPbh0bCnVmQKl31+vpUouTZqqMEIso8q0xrUioVFeCF+9oJPhjLm5irdQCKZGR8P8X3ebtQIpFzkwlLCuYQjprz0SSlgIotUcmSfLm12UcaHVkH8XLQmej7g+/bRQwh3cqXzwWioZJaupS6onf5z72ipvaaCpTNakaF/ov8T2uGOEab0P17ymE1r8IxHhwUtYfBhzCH6qEPZ9Q+UuIjL4+s86oFSng1LYwkVeD5vFsZQ1aYXFaAu6KOI3/dkPoou7nDlQ66Ba3HCn/FoFbqvgSBSivnBsXTBjhh9aRcmUWSxYkMiWj9jevIN+Zx5Z9GykWmUv0bGqO43YEWhu/5Audi6a9G6q+haF/tCm3WJ7HBpyNRrn9kd4StvDZDE+DTTT7PUXsRmkRG9YJ5GYsYd6Pr+5tBNGgWtVhnYCRhmKI7R9B6YZfcjW806E7wcym+fzyG7xUw2c/Yzh9/lRr0NeyYIM81px2cezs/PigJV/6AMxO0icaheh0PwaTNF9zjSvj48dHoufrzujYpsAaFzTFLlGHgzgumvdWwZRX5sEuAa/BRgb9/biJUotnVTW8HFxX2+vTQKisurS0uXsvIXBl+u4nCJmVGDHlh94RuUlSMUtVgUmvU9Yos620zo/sf6Cw8oX1Tv9l64KP/Pvus/xSk4SlUu8+Bggpjt+oIlMAfrvSD7CdXY5c8V66mABw8aloQMwzhf6lC8SoZXQTEZMznNEQyHnR7vqkt2Fn21QAev63+YcIa/heyaHyAtq3frmfqnqzZpBrFAuv+/e9as37OoZuAbi5u9K5VeZU/xDOFfC9qj4xOyc0HpxcrgzJICYsRfDljZ0zhRu//sXgi3+T0dWidiCXflwpVoeIkVd/BJHesxx38S9edtdi6/HXoe40sBKa729UNjNcQ5c81o4bZMrgcYHB3pt3zKTfzwZ5xx3b4mhW3IK/IU3cJ/CKaU/u0sc/Xslhif79XPFev984s56xy02im2AsEoXybIeNbt5/JUB4T5VnqTMnD6joM1UYxekd1wfCgwa1lAGZR1XhR3PNkZEk9siNYkH4oGi6EQ15MwXfIR0T2Ab3R39klrvAUad/OsGkO6w8Wy5K4WFZwch0vmF++jmTYw/C10sJw+XR4kUw130/PpmiYl5dL0rXn0hKkMnytuFqsq4Ux2y2uMXW2mQQqygqRLjpgwLYlKhY8UeOXtjevKCYwpC9uQVSLHbdJDfj9+/MUSXe1nik08tiZ3hUxeFqgDuSNfE/bJdUsnhOu4z6L6BHstffSFwwHjVS51Zpy/Euo/yE82Y4qN/pixRG1zD81bVTDs4JvUn9ljiUjBnkAy5Ukvm7MJlq1DvbJRMvfSUO2O+j5XO6a/e+4YdPTDtPfXhFLxTVON2n1znYkSnyCKVDTnuhlNr5u1H8HQ7PrFRd7rWWhchJo57XsPXquC0OLQ7ClgOyylEmTH4aGWo7/8kaUWx/jrX5J1mjpR9hyns77O3GwCkVnmKPDZ6S8XqcVMfFcOcYq8jhk938uzXZH7qn3/d+dONJ8zqyHQrRVmi5E70Or8kQj+tTrcX6rTVY95AqUi1o0aX9W/+1iuBMy0MMvcojPjY9DjaY8bUVza/XGNhK03+yxHbAz4xWNyahaAjyi1+ByQZXzCjbhwaOi4EorW2mda/2CeWpMmLPksaUwBS2SApASizcd/ZjgWUnFWtgZp8c8yFqmoVxjQBzEuLH/AhSQvXtoYsGRwS/n5mHRyPsd1vuv4zPzjzV4jk42YHRgPCKqse19dZmY6wYYZ6AUcPkLqZQmM8Q7xfpOl2c1TCXtNlKqLy0ZJWuj0qAI2uUwsEuAQ7YFbPAhgF8n5+aw6COcfFpgLx0tsDmPRtVrOjtkiulPccQFIVgpD8FrfjfYa3L7dYquijGU0GRERcWAAboCTi8ymL9lBbz9K/0De43r8Nmhz3mgo7rv6U4bsSsbMu5fWPwzQapSchdFw60Yebtw/m7Hxb/TNZP0+ad/g3Flf+XZr2cYzeVgU0GOXpiqcvSzvhv1LncRY3cYuGyxWJeVzgVWzInQRC6DKqSljpgHThAV6NdrgkoNeVOMFMDaReA7Y63J8vGsVrTFrNkCIDHk+lsjz1V0sRsMECqjOjLZ1Wdi/D/dXnL7PEtqbWcoAb9QZ6B2G2TQSCihJIua3a769jAlsezU0OAKQbJ9n/DOQ5dNBsdVF/xUzfAT1zgr2moRRRndk+lUgJo5mQOltACe10HhewrLCPkWuk+JCv7KRi0NCLCwAaDqzHED+51D3aOEConCwOPv3m4Q2Xh0X79Y0eoszPv7zxE0JZb/z+Spv3sMqLJSKftq8oCzESj0Y+9iChx9phO6VqVOwaZcD7HBC8VMT/hpEz3pucWFSHXMZYBK/HvqnbCJPoo0692bC4y6hpavwgdpot9iSqnB7sA384W5P8uXkock43hhTnOf2XQtIx3fivyvcVUSNRc9OF2q1q5I+k0pDReamuJN5aRJ2N4UvvqHogBAodwYrejUaCNpRff5dWwZ0FPmVv3MEAZmLUIDsqrorlO5XyhvSLQyxAacpcaTnDFdv/tSBDVhN2v9Hn8NGVYmvpVsahp76hPkYLnAdmq3b8ZFi6G++mUDziq0mdUSHcSIVkrrSzYCTJ4f+POaKELFUXKHfL5ncIqqQGGGR49Rfr4DQHp5c6t0/wFl5W5OuYcENkWwEB8++XaVxyu6Y6uVvYucW8r9XceAlLcI6iFNaQTZ1mRTjw8UkskczLLElXyQkmtiXQRpIMcEoN4AXnm46jxGDe2IkzXCur4PjgXMIuKm+b0GTZNkpUyN/9GdNZE37c3bVrz2e2Uj0EJIGZPNB66yuTRuAvyhGglZZhCSlosuVTSc+wa2UeHJNeQTdwbHmZZOrIU4oUn4ijgQWQGaHuPgxjKlAh+SeNhe9r67+AiX78hH0vR6BCrqSXX0wv+1Xz+uL491dC/Gw9vi3hiyAy6otAbRKrQ3cy7wxs6L21Wxo8pKIWcsfaHzLJSOFHKN+h49FeETTnGeDA9JMlcbn82+/5QkTn68EOH5W9Dx0mY5AdVa9xbaT2GSuMNAzdBMexT6enNIS7XC0S1s2D7wwmO90Npo5+YEXN927CXGTrXaz5TeSzLh/7jsZnAg/3zjdukaPpjhsFIv1DnpnmJcYmSxzI8OVtTGENBPZVyD4J9w49+V33RYqhxICPwAqziNT8pikelgpkUmmmYRtpHA41Vz74/3VxPXViB0mlioPATvryZs6tQcjJw6JEVdMFf4rDIfXVpBVaWCVIzBO34GQ6/TvvEr1aH4mP1GLj/SW+FfyE4KBk1lXIdxVyJ9QbtQWCo51aUmequ198RnuJ4EroMfqP50IrzgYx8HN/HY/Gh0FNNmPFyepCDpsWsgIW5faUZf7V9GXG3px7iOdNMRFZ9ag7XgfgWTur63o5vtzgUOfFFUJlkkOsi22vmp/0DuaLhiKMT+SAEx6ONuxFaFdT1yzwJYBm8h6+hx6K6xWpzkXbbjtIw+gn6i1K1OEfKL3OAv2q6aYPBbH+13Ee7rMFiIsOM40skyWCiBxURy0b4tqbm9v4JjLLUFQJ7i5M9M6H/KHtfV+rUQ9yz4oFA+5+l3FpnRsoaQnnJHsIk6X/utqCoPLQDXcAa5XsaifYI88kXv/hgug9pFBLCl/VKSVYaIiy+LHgPxgohyaR2Bm/7vw2P3LS1upNg5kDa1/jBjpxV9SCUGAIDqJuUwD3q0XMebEXVHo5qHYER7XcfI20kPrp/OG6f/7CJxfezFPWmuuMovGuGbW+yJn10xgyqHd9asI3Ze8JwTyDzZEltBem1EJF9tTZe6vd2GS4I9mir14bd4cWzUZvvPwhcLPpmdbxZbmp4HYs8a1XP+crcRrLY9Zi1fRJwmS8Bl6FAXWmLCw95MYSZCMuRfVfAzFj5uNQhnpP/hm390BjVLyHf3IRLLz4c8+S7N3bGgjEm5JieEtrVhd6u7kL0cII2r08vR7Hb+BpOMIZ1L8QOVWtftjOnYAuA7dMZH8WuzIOIsOtVGyf0j7yv0/OW5siRtK4ScQRyWsbnR0teoyUVprBe3tzE5aA8yErs+CopKH6LNWiwy/vJuFYpCg4aGoxfdv1VpFXEDCSgd7BQm5LdaBdMT4mDxkIW7pS8NZhIoGCXzXPAje0yCzAc2TxtRqFObf6q9+lVbsK91X8q4tDUNu7pRRpS2H3GAE="
+              "text": "Sam confirmed everything. Let me now call finalize_setup with all the details:\n\n- player_name: Sam\n- age_group: adult\n- genre: Classic fantasy\n- mood: Tense\n- difficulty: Balanced\n- campaign_scope: few-sessions\n- system: null (pure narrative)\n- dm_personality: The Magistrate\n- campaign_name: The Shattered Crown - The Iron Circle\n- campaign_premise: A kingdom's heir is dead and three factions vie for the throne. Aldric, a weathered sellsword, came to the capital chasing a blood debt — and found himself entangled with the Iron Circle, the military faction holding itself together through discipline and honor alone. \n\nNow I'm setting up Aldric's character profile. He's a sellsword with a personal vendetta, caught between the factions' machinations as the coronation deadline approaches and foreign forces threaten the kingdom's borders. The key is to emphasize his own agenda — he's not just hired muscle, but someone with his own score to settle in the midst of this succession crisis.\n\nI've assigned him to the Iron Circle as his starting faction, which fits his mercenary background, and the Magistrate as the DM personality to drive the intrigue-heavy narrative. The blood debt itself stays mysterious and open-ended for the DM to weave into the campaign, potentially connecting it to someone within the Iron Circle or a rival faction. The throne secret remains hidden from Sam until mid-to-late campaign when the reveal lands harder. This is a few-session arc with room to expand if the momentum builds.",
+              "signature": "Eo8SCmUIDhgCKkA2r0c5lbyZA1RlLkK8hVHHPM1tjvuS38WtE5R068OJcGdNc1WkIrGvD8p/3bq6JPboUT2Cgd08BZVvsW5TepX1MhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMWBrjy/HLURY/4PQuGgw2VfOj3LPz1uT+eysiMOPkn8g+OJWJX8+9vpsHt4Z3kKEftF/BB7kK3ufAzVb0h3t3U3KqyuuSUSXBwZ0E3irXECfoCi4QgnG+Z60qKfwTEHpkWmz4ebGlfpo6UpIU06dPiJq3VziOaP1NRYC1gWujlNxi2aLfzaYPmz3jsnL2mKkNSOsRBIssRRRR+v/deIsvLeLiaPojWww8vvsntQKoBlsbm1PFBtPnLu7k88rdmHZ0BAYmFOYW9+zitSZbmLIGbpZazEagH5DSqqwU3Fmaxx1cJoc4YSCRsgRC4yXWwU+HzB4NInuUrJco2CPebRkqu3QrBCR8vGoRT+H13LKRwrAl9lv1+AWFkSSm1yHTGBn/L8fmLHwoXdjas5GQVr9NxuBAIcn9E7/hPqtzyH5Pl7+WG3TF3NnzcCnnTHosm3e/cfeT/IqNP7J178FbG+4bHoUY2i0r/nE9ueJrutbr1B7qkVWNFgpdnLt9xzIs4o2qfXhTztUM8VrShgpQyhAUMpdD1RoSm81Ryc8W+JgjaKo5mDNz439P1R8rGUJvfXyQJn9c6W2uFpQffd5C12kg9+Qk7RklhDqCtE7yCGWj0UBt6LHE5tJj2J5klWXqycsIn+irF1qwMUhSXSAjkS3BMiTSyLz4fMDLApQV11GXUOmRDcdjV25OVrEh3KKIiadJPl7Cj60/Y6pSgHw+LnpV4/kyUeSAi/jD6doBQqrq8WrKZ9PpD46thUc58oH6BQBjbWQAUGgbzveZdXKCdf+qzsHbxY4t/DJNIsNOiqGLezrHYITy5zUgjfKuGuIQrMO9+qS+j7oXHiAIuNMN50WC/klokCoZhKL+UOG96+A5ajcAohUq1HxinbXfr710ZJOk0OH3ZuR/GyRnS4VKLy0OwoB8eypKEHj+47tqGJGx2QpfsFPM8Cpu/TtsqO6yXNoUGblcY5J1PhcxtWwOM8QP18pQoI7OFSb2FkWMTP2/TDDbkyfPWCebfbwnxg04lx1ldQxpfjaZ693FdoYMZmkLxIImnPnV9ZTM+PRkJ3PAjsndZY6Ztr0YGOvL8RNt6t1r7LZS6YA9g0Uno4ANx/eTV/+8kdqQXMaw8HCgY+08TC2BDY9C7jTwZGeVyJPKZ96D1azQ/ZJst0q9Hc+uuJXhZMP2W2d3ihzM+JuPMX22KGJqvhTbFJ9kXmfDY9yBRrlniGgbYb/6GXXcb+kXcqMdJj8lT7U8Ly/YcKARqdLoyuWmZYtxT8Yd1tdwTiro4rLl+IypIHZVslFhhshTKqHoZb7RKFtW3Fy2TYsUaNhtoW6lixGSWoX2dthT3AwzZiN4U56dQ2xi6O+gPRv1xsDA29sfZKT++jHCgnF7hnBsgMgWVlJY8m04IbGANS8oE2b5CpSSiUSON9nYoqiKb4B5x85JL/NZYpr5WPaqLeb0tayWgRneUsMaIP8MXqD4PelVKk5Gsrw81Y9odK4P0aJrdUf971s+USj7H29E/q/Diopb6AJQhuQB08YXp0Yfs/1zFyvN2al4R46koJd0xgGhMXFXHBOpLcgsxuDZTP9xEYw/7o/ilC+WcEROGisn3KKt918hM9gRLroDaApPS6BhKJC8NEin0jgw1bpAwzdDKpnMnsw3068meuAd/vGPezkLCmhuAJ3/7/roy7W9ly8HCove5u6qYuWt1mcNUpYJcHZ6mtWC9oVO/ZHvx96Fl1gWXUw27hSS19RTfeeHPIj5zBJ76zt1jRupISXTiS3EhhnW3++HBzLHKyV/V77CsOtl0ktNln6AVRas5VaA6gG+zuAvzMnZMrCiVj7iz7Dz8bwZQh40FhBOxTiVEspMsC0tSWLm/z8AUENKms26TdWoba6HI/zOpFEELUeJGHmwVRfUEmzLTm9HkYTAaQVGHI/++jcz81Kv2Iw2Lmi0FxyEnkwWTtQD8k77VXQurBNttnwOf5bfeb4UMbvIbWQ/QEnK/3Ro3ipYaMLZ3mJmYyEls18hITTwN9n0EAoUUkg5ymq+FWA66FMD9QliYNej3bhVDQ+62tkrDZpB9NmCUoAcOcbxYRLuNQMWI7BhEqqL1mKA8ST8Lv1Cge7cgaLxbflE3T7nnaxVzdtdgnR57w1WL9FtT/1DNpEb+sSNeB9k1zPAT9i/Mh3e8Epn301LsJxHfuFRX8BRchNUgBj1IAPdo2kdZT/Hd1o7vjKmbDPPWo5UwDGE1DGoeW39hRXg8yzmUlz3ziDPy0Yk0pLeG+QX4dHvPt0EceYmw63w+QJ5O0aXSLf0psIAsI5M3Bem9cfHQ8VTqCjtGR7EGhZ3VpgnqFK88MxMLUGodwaHQBaIXx7o1h3rg+KEXnH8Pxj0k1s/oTlCfjo9+DcZ2AP29IVYvvfQGeVwhGD9ofhEmBky/ZDZLRVPaqiivprU0HrcxUw51K0NiCEVQ+7inimkfsgW2wuKboN/z5aR/a2ntLG2yXZl3ROQvPi5XiixyVyKmKwT8ezTpIZiXf/TRy7+GTGXZ4BvaA8OK9VGSxXnRPgc6k4vjUD8VtZPIcM3H8yv9R0ZQW13KeYCu03MljM4fj62Di3XRwyN2SjPl49tR6KHHsWkplNsmR0oa5uHikQ1iQsManwd1LwYzEkFwivDVOxh0u+RukTKYKU8rsUhmvZ6z0vh4Kb+1xewapJby/x36x4TM9hfwJid/T2JYKUAqMcaXUJMfmKj3MhON6zkuR0Kqj5r+KEwvSb9Z/k/GZHuf0FbmCOxEBbHrgCzQ1R1FQsZVgpTfhZ3Tp/54ZmkzHOeG3Y0fj3lBMSh0zXb6cr19ZtDchdCPUNVehQiWu5bf2cIFqwaBjA3nf58oacJugTRViCMXVMedNQbdiL1jvDHloMQ0BDquTSh1MBga20KJVefDRO/UQEr8mzj4h9yfHnCaW6r8E1D8buNicN/L1oQjq7jbnlRfb9qGAE="
             },
             {
               "type": "tool_use",
-              "id": "toolu_014ukxmhFzyTFiVfGeE3745B",
+              "id": "toolu_01566kphNX3m4MJTaF1c3zcL",
               "name": "finalize_setup",
               "input": {
-                "player_name": "Sam",
-                "age_group": "adult",
-                "character_name": "Aldric",
-                "character_description": "A weathered sellsword chasing a blood debt, now unwillingly entangled in a kingdom's succession war",
                 "genre": "Classic fantasy",
                 "mood": "Tense",
                 "difficulty": "Balanced",
@@ -419,10 +403,14 @@
                 "system": "null",
                 "dm_personality": "The Magistrate",
                 "campaign_name": "The Shattered Crown - The Iron Circle",
+                "campaign_premise": "A kingdom's heir is dead and three factions are tearing each other apart over the empty throne. Aldric, a weathered sellsword, came to the capital chasing a blood debt — and found himself conscripted into the orbit of the Iron Circle, the military faction held together by discipline, honor, and the threat of imminent collapse. They believe he's muscle for hire. He has his own score to settle. As a coronation deadline looms, foreign armies mass on the border, and the other factions sharpen their knives, Aldric must navigate layers of loyalty, leverage, and buried secrets — all while hunting the person he came here to find.",
+                "player_name": "Sam",
+                "age_group": "adult",
+                "character_name": "Aldric",
+                "character_description": "A weathered sellsword chasing a blood debt, now reluctantly entangled in a kingdom's succession crisis through his uneasy alliance with the Iron Circle.",
                 "world_slug": "the-shattered-crown",
-                "campaign_detail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\nSuboption chosen: The Iron Circle — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. The player will see the succession crisis as a soldier first.",
-                "campaign_premise": "Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the chaos following the kingdom's heir's suspicious death. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it. All the while, the thread connecting the crown's crisis to the score he came to settle grows harder to ignore.",
-                "handoff_note": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — those are his exact words, and the blood debt is the personal engine. It's entirely unspecified in origin; weave it into the Iron Circle's politics or the throne secret however serves the story best. Sam wanted intrigue, said \"surprise me with the rest,\" and deferred all other choices to me. I auto-selected The Iron Circle as starting faction (suits a sellsword with a martial background), The Magistrate for the intrigue-heavy voice, Balanced difficulty, and a few-sessions scope. Sam asked for no mechanics — pure narrative throughout. No content preferences or restrictions noted. The blood debt hook is rich territory: whoever Aldric is owed for (or owes to) could be hiding inside one of the factions — that connection would land well as a mid-campaign reveal."
+                "campaign_detail": "## Detail\nRoll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\n## Suboption: Your starting faction\n- **The Iron Circle** — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. You'll see the succession crisis as a soldier first.\n- **The Gilded Compact** — Start among the merchant coalition. They treat the crown as a business acquisition. You'll see the succession crisis through ledgers, leverage, and backroom deals.\n- **The Hallowed See** — Start within the religious order. They believe divine mandate chooses the ruler. You'll see the succession crisis as a matter of faith and prophecy.",
+                "handoff_note": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — keep that personal vendetta as a living thread underneath the faction politics. He didn't come here for the crown; the crown just got in the way. Sam wanted pure narrative, no mechanics, and asked to be surprised on everything beyond the character concept. I auto-picked The Iron Circle as starting faction (natural fit for a mercenary archetype) and The Magistrate as the DM voice (intrigue-heavy, every NPC with a hidden agenda — perfect for this world). The blood debt is entirely open — consider tying it to someone inside the Iron Circle or a rival faction as a slow reveal. The throne's secret is DM-only; Sam has no knowledge of it. Keep that for mid-to-late campaign. Scope is few-sessions but expand freely if the story has momentum."
               }
             }
           ]
@@ -436,7 +424,7 @@
         "request": {
           "model": "claude-sonnet-4-6",
           "messageCount": 13,
-          "systemHash": "9c4de2032fa4",
+          "systemHash": "43367fbc31a0",
           "tools": [
             "finalize_setup",
             "load_world",
@@ -445,47 +433,45 @@
           "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "<center><b>✦ THE STAGE IS SET ✦</b></center>\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has a way of finding him wherever he goes...</i>\n\nThe campaign is ready, Sam. The Magistrate takes it from here — good luck navigating the webs ahead.\n\n---",
+          "text": "The stage is set, the factions are sharpening their knives, and Aldric has a debt that won't pay itself.\n\n*Your story is in good hands now, Sam. Step forward.*\n\n---",
           "toolCalls": [],
           "usage": {
             "inputTokens": 1,
-            "outputTokens": 86,
-            "cacheReadTokens": 17705,
-            "cacheCreationTokens": 2034,
+            "outputTokens": 49,
+            "cacheReadTokens": 18182,
+            "cacheCreationTokens": 1685,
             "reasoningTokens": 0
           },
           "stopReason": "end",
           "assistantContent": [
             {
               "type": "text",
-              "text": "<center><b>✦ THE STAGE IS SET ✦</b></center>\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has a way of finding him wherever he goes...</i>\n\nThe campaign is ready, Sam. The Magistrate takes it from here — good luck navigating the webs ahead.\n\n---"
+              "text": "The stage is set, the factions are sharpening their knives, and Aldric has a debt that won't pay itself.\n\n*Your story is in good hands now, Sam. Step forward.*\n\n---"
             }
           ]
         },
         "streamDeltas": [
-          "<center",
-          "><b>✦ THE STAGE IS SET ✦</b></center>",
-          "\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has",
-          " a way of finding him wherever he goes...</i>\n\nThe campaign",
-          " is ready, Sam. The Magistrate takes it from here — good",
-          " luck navigating the webs ahead.\n\n---"
+          "The",
+          " stage is set, the factions are sharpening their knives, and Aldric has a debt",
+          " that won't pay itself.\n\n*Your story is",
+          " in good hands now, Sam. Step forward.*\n\n---"
         ]
       }
     ]
   },
   "expectedNarrative": [
-    "<center><b>⚡ THE CURTAIN RISES ⚡</b></center>\n\n<i>Somewhere, a candle flickers. A map unfurls across a table worn smooth by a thousand campaigns. Dice that have never been rolled wait in patient anticipation...</i>\n\nWelcome. You've come to the right place.\n\nWhat unfolds here will be shaped entirely by your imagination — a world built to your specifications, a story told your way, a character who is wholly and completely <i>yours</i>.\n\nBut before we light the torches and open the first door...\n\n**What should I call you?**",
-    "Welcome to the table, <b>Sam!</b>\n\nOne quick thing before we dive in — is this a game for a kid, a teenager, or an adult?",
-    "*Perfect — adult it is, and straight to the action!*\n\nFor fantasy intrigue, one world leaps out immediately...\n\n<center><b>✦ THE SHATTERED CROWN ✦</b></center>\n\n<i>A kingdom's heir is dead. Three factions claim the throne. Allegiances shift like sand, and every smile hides a blade.</i>\n\nLet me pull up the full detail on this one.<i>Oh, this is a rich one.</i> A dead heir, three factions scrambling for power, and secrets buried under every throne room floor. This is exactly the kind of world where intrigue festers beautifully.\n\nOne key choice before we go further — **which faction do you find yourself entangled with at the start?**",
-    "<i>A sellsword with a blood debt, walking straight into a throne war. Aldric is already the most interesting person in the room.</i>\n\nI'll take it from here — here's what I've put together:\n\n---\n\n<center><b>THE SHATTERED CROWN — The Iron Circle</b></center>\n\nA <color=#cc4444>tense, intrigue-laden</color> classic fantasy, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of faction webs, private agendas, and power wrapped in polite language. Pure narrative, no dice mechanics.\n\nYou'll be playing as <color=#44cc44>Aldric</color>, a weathered sellsword chasing a blood debt — now entangled with the <b>Iron Circle</b>, the kingdom's disciplined military faction, in the chaos following the heir's suspicious death. The debt that brought him here may run deeper than he knows.\n\n---\n\nSound good, or want to tweak anything?",
-    "<center><b>✦ THE STAGE IS SET ✦</b></center>\n\n<i>The Iron Circle awaits. The throne is empty. And Aldric's blood debt has a way of finding him wherever he goes...</i>\n\nThe campaign is ready, Sam. The Magistrate takes it from here — good luck navigating the webs ahead.\n\n---"
+    "<center><b>⟡ THE CURTAIN RISES ⟡</b></center>\n\n*Somewhere, a candle flickers to life. The table is set. The dice are cold and waiting.*\n\nA new campaign. A new world conjured from nothing but imagination and intent. There are stories here that have never been told — heroes unsung, villains unmet, moments that will be remembered long after the session ends.\n\nBut before we open the book...\n\n**Who's at the table tonight?** What should I call you?",
+    "Welcome, Sam! Let's find you a world worth conspiring in.\n\nHere are some fantasy picks heavy on intrigue — factions, secrets, and power plays:",
+    "I love the enthusiasm — but the curtain snagged just a little there! Which world caught your eye? You can just name it and we'll dive straight in.",
+    "*A sellsword with a blood debt walking into a world of shattered power? That's not a character — that's a lit fuse.*\n\nLet me pull back the curtain on the perfect stage for Aldric...*Perfect world found. Auto-picking a starting faction that fits a sword-for-hire with a score to settle...*\n\nA kingdom's heir is dead. Three factions are tearing themselves apart over the throne — and Aldric just got tangled in the worst of it.\n\n---\n\nHere's the stage I'm setting, Sam:\n\n<center><b>The Shattered Crown — The Iron Circle</b></center>\n\nA <color=#cc4444>tense political fantasy</color>, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Magistrate</b> — a voice of webs, whispers, and every NPC hiding something behind their smile.\n\n<b>No mechanics.</b> Pure story.\n\nYou're playing as <color=#44cc44>Aldric</color> — a weathered sellsword who came to the capital chasing a blood debt, and ended up conscripted into the orbit of <b>The Iron Circle</b>: the military faction, disciplined and honorable, one betrayal away from collapse. They think he's muscle. He has his own agenda. The succession crisis doesn't care about either.\n\n---\n\nSound good, or want to tweak anything before we begin?",
+    "The stage is set, the factions are sharpening their knives, and Aldric has a debt that won't pay itself.\n\n*Your story is in good hands now, Sam. Step forward.*\n\n---"
   ],
   "expectedSetup": {
     "genre": "Classic fantasy",
     "system": null,
     "campaignName": "The Shattered Crown - The Iron Circle",
-    "campaignPremise": "Aldric, a weathered sellsword with a blood debt to settle, finds himself drawn into the chaos following the kingdom's heir's suspicious death. Entangled with the Iron Circle — the disciplined military faction that believes order demands a sovereign — he must navigate competing loyalties, buried truths, and the gap between the honorable cause he's fighting for and the ruthless power games driving it. All the while, the thread connecting the crown's crisis to the score he came to settle grows harder to ignore.",
-    "campaignDetail": "Roll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\nSuboption chosen: The Iron Circle — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. The player will see the succession crisis as a soldier first.",
+    "campaignPremise": "A kingdom's heir is dead and three factions are tearing each other apart over the empty throne. Aldric, a weathered sellsword, came to the capital chasing a blood debt — and found himself conscripted into the orbit of the Iron Circle, the military faction held together by discipline, honor, and the threat of imminent collapse. They believe he's muscle for hire. He has his own score to settle. As a coronation deadline looms, foreign armies mass on the border, and the other factions sharpen their knives, Aldric must navigate layers of loyalty, leverage, and buried secrets — all while hunting the person he came here to find.",
+    "campaignDetail": "## Detail\nRoll or choose the throne's secret (DM only — do NOT reveal to the player):\n1. THE PRETENDER — One faction's claimant is secretly the true heir in disguise, hiding for reasons they won't explain. The player may end up serving them without knowing.\n2. THE EMPTY THRONE — The heir faked their death. They're watching from the margins, testing who deserves to rule. They will approach the player mid-campaign with a terrible bargain.\n3. THE SUCCESSION CURSE — Every claimant who sits the throne dies within a week. The throne itself is the antagonist — a bound entity that feeds on sovereignty.\n\nFaction texture: All three factions have a sympathetic leader and an inner circle with its own agenda. The player's starting faction colors their first impression of the conflict, but all three are equally complex.\n\nPacing: Start the player entangled with their chosen faction before they understand the full picture. Reveal the second faction as nuanced allies-or-enemies by mid-campaign. The third faction's true nature is the late-game twist. Use ticking clocks — a coronation deadline, a foreign army massing at the border, a plague in the capital.\n\n## Suboption: Your starting faction\n- **The Iron Circle** — Start entangled with the military faction. Disciplined, honorable, but brittle — one betrayal could shatter them. You'll see the succession crisis as a soldier first.\n- **The Gilded Compact** — Start among the merchant coalition. They treat the crown as a business acquisition. You'll see the succession crisis through ledgers, leverage, and backroom deals.\n- **The Hallowed See** — Start within the religious order. They believe divine mandate chooses the ruler. You'll see the succession crisis as a matter of faith and prophecy.",
     "mood": "Tense",
     "difficulty": "Balanced",
     "campaignScope": "few-sessions",
@@ -496,10 +482,10 @@
     },
     "playerName": "Sam",
     "characterName": "Aldric",
-    "characterDescription": "A weathered sellsword chasing a blood debt, now unwillingly entangled in a kingdom's succession war",
+    "characterDescription": "A weathered sellsword chasing a blood debt, now reluctantly entangled in a kingdom's succession crisis through his uneasy alliance with the Iron Circle.",
     "characterDetails": null,
     "themeColor": "#45e8d0",
     "ageGroup": "adult",
-    "handoffNote": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — those are his exact words, and the blood debt is the personal engine. It's entirely unspecified in origin; weave it into the Iron Circle's politics or the throne secret however serves the story best. Sam wanted intrigue, said \"surprise me with the rest,\" and deferred all other choices to me. I auto-selected The Iron Circle as starting faction (suits a sellsword with a martial background), The Magistrate for the intrigue-heavy voice, Balanced difficulty, and a few-sessions scope. Sam asked for no mechanics — pure narrative throughout. No content preferences or restrictions noted. The blood debt hook is rich territory: whoever Aldric is owed for (or owes to) could be hiding inside one of the factions — that connection would land well as a mid-campaign reveal."
+    "handoffNote": "Sam described Aldric as \"a weathered sellsword chasing a blood debt\" — keep that personal vendetta as a living thread underneath the faction politics. He didn't come here for the crown; the crown just got in the way. Sam wanted pure narrative, no mechanics, and asked to be surprised on everything beyond the character concept. I auto-picked The Iron Circle as starting faction (natural fit for a mercenary archetype) and The Magistrate as the DM voice (intrigue-heavy, every NPC with a hidden agenda — perfect for this world). The blood debt is entirely open — consider tying it to someone inside the Iron Circle or a rival faction as a slow reveal. The throne's secret is DM-only; Sam has no knowledge of it. Keep that for mid-to-late campaign. Scope is few-sessions but expand freely if the story has momentum."
   }
 }

--- a/packages/engine/src/testing/setup-corpus.golden.test.ts
+++ b/packages/engine/src/testing/setup-corpus.golden.test.ts
@@ -1,0 +1,260 @@
+/**
+ * The setup golden corpus — real setup-agent conversations recorded once
+ * against the live API, then replayed deterministically offline.
+ *
+ * This is the setup-side complement to corpus.golden.test.ts (which covers the
+ * DM loop). Each scenario drives the REAL {@link createSetupConversation}
+ * through a scripted sequence of player turns until it calls `finalize_setup`,
+ * then runs the REAL {@link buildCampaignWorld} handoff against an in-memory
+ * FileIO. For every entry the suite generates two `it`s sharing one golden
+ * (`goldens/<name>.golden.json`):
+ *
+ *  - RECORD (gated by RECORD_GOLDENS=1 + a live key): a taping provider
+ *    captures the LLM I/O while a real provider drives the conversation; we
+ *    persist `{ scenario, tape, expectedNarrative, expectedSetup }`. Only this
+ *    half spends API. Run `npm run golden:record` to (re)generate, then commit.
+ *  - REPLAY (always, offline; skipped until the golden exists): a pure
+ *    tape-backed provider reproduces the SAME per-turn narrative AND the same
+ *    finalized SetupResult with ZERO live calls, and the handoff scaffolds a
+ *    campaign whose config matches. Runs in the normal `npm test`.
+ *
+ * Why this is the in-process setup→game replay backbone (vs. replaying an
+ * mvplay full-stack capture): the setup agent had no offline coverage at all,
+ * and the full-stack capture format records neither the player inputs nor a
+ * replayable narrative segmentation. Driving createSetupConversation directly
+ * — exactly as the game corpus drives GameEngine directly — is symmetric,
+ * deterministic, and free, and it exercises the real finalize + scaffold path.
+ *
+ * Bucketing: setup calls carry no `conversationId`, so they all land in the
+ * "default" bucket and match ordinally. A single-conversation setup flow makes
+ * its calls in order, so the replay provider's "default" cursor stays aligned.
+ *
+ * No subagents to mock: createSetupConversation only calls the provider and
+ * dispatches its tools locally (load_world reads bundled worlds;
+ * present_choices / finalize_setup are in-process). Image/portrait tools are
+ * left unregistered (no fileIO/setupRoot passed to the conversation), so every
+ * tape stays text-only and diffable.
+ *
+ * Regenerating a stale golden = `npm run golden:record` + review the git diff.
+ * Adding a scenario = one entry in SETUP_SCENARIOS + a record run.
+ */
+import { describe, it, expect } from "vitest";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { createSetupConversation } from "../agents/subagents/setup-conversation.js";
+import { buildCampaignWorld } from "../agents/world-builder.js";
+import type { SetupResult } from "../agents/setup-agent.js";
+import type { CampaignConfig } from "@machine-violet/shared/types/config.js";
+import type { FileIO } from "../agents/scene-manager.js";
+import type { LLMProvider } from "../providers/types.js";
+import { campaignPaths } from "../tools/filesystem/index.js";
+import { norm } from "../utils/paths.js";
+import { TapeReader, TapeWriter, deserializeTape, serializeTape, type Tape } from "../providers/tape.js";
+import { createReplayProvider, createTapingProvider } from "../providers/tape-provider.js";
+import { createAnthropicProvider } from "../providers/index.js";
+import { loadEnv } from "../config/first-launch.js";
+
+// Setup runs on the large tier in production; record on Sonnet so the recorded
+// conversation finalizes coherently. The replay is model-agnostic (it returns
+// recorded results regardless of model), so verification stays free.
+const SCENARIO_MODEL = "claude-sonnet-4-6";
+
+interface SetupGolden {
+  scenario: string;
+  tape: Tape;
+  /** Per-turn narrative text, in order (start() then each consumed input). */
+  expectedNarrative: string[];
+  /** The finalized SetupResult — deterministic given the tape. */
+  expectedSetup: SetupResult;
+}
+
+interface SetupScenario {
+  /** Golden file slug. */
+  name: string;
+  /**
+   * The player's content answers, consumed in order. Front-load everything the
+   * agent gates on — crucially the player's *real name*, which it refuses to
+   * proceed without — so these turns establish the campaign and the bounded
+   * finalize loop below only has to confirm. The driver branches
+   * send/resolveChoice on the pending-choice state, so an utterance answers a
+   * choice modal when one is open and is a free-form message otherwise.
+   */
+  inputs: string[];
+}
+
+/**
+ * After the scripted answers, the agent typically lays out a proposal "for
+ * review" and only calls finalize_setup once the player confirms. We send this
+ * imperative nudge until it does (or until the cap). Deterministic across
+ * record/replay: the finalize flip point is driven by the recorded results, so
+ * the same number of nudges runs either way.
+ */
+const FINALIZE_NUDGE =
+  "Yes, that all sounds perfect — please call finalize_setup now with sensible defaults for anything unspecified, and let's begin.";
+const MAX_FINALIZE_NUDGES = 6;
+
+const goldenPath = (name: string) =>
+  fileURLToPath(new URL(`./goldens/${name}.golden.json`, import.meta.url));
+
+// ---------------------------------------------------------------------------
+// The scenarios. Each is a distinct setup path to a finalized campaign.
+// ---------------------------------------------------------------------------
+const SETUP_SCENARIOS: SetupScenario[] = [
+  {
+    name: "setup-quickstart-fantasy",
+    inputs: [
+      "I'm Sam. Quick start, please — pick a fantasy world for me, something with intrigue.",
+      "That world sounds great, let's use it.",
+      "My character is Aldric, a weathered sellsword chasing a blood debt. Keep it simple — no extra mechanics. I'm an adult, surprise me with the rest.",
+    ],
+  },
+  {
+    name: "setup-custom-noir",
+    inputs: [
+      "I'm Sam, an adult. I want a fully custom game: 1970s occult noir in a rain-soaked city. Pure narrative, no rules system.",
+      "Mood tense and melancholy, difficulty unforgiving. Call the campaign 'Neon Requiem'.",
+      "I'm playing Marlowe Cray, a burned-out PI who can see the dead.",
+    ],
+  },
+  {
+    name: "setup-dnd-character",
+    inputs: [
+      "I'm Sam, an adult. Let's play D&D 5e — classic heroic fantasy.",
+      "My character is Vesper Quill, a sly, charming half-elf rogue who's light on her feet. Standard array is fine and you can pick sensible skills.",
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Scaffolding
+// ---------------------------------------------------------------------------
+function mockFileIO(): FileIO {
+  const files: Record<string, string> = {};
+  const dirs = new Set<string>();
+  return {
+    readFile: async (p) => files[norm(p)] ?? "",
+    writeFile: async (p, c) => { files[norm(p)] = c; },
+    appendFile: async (p, c) => { files[norm(p)] = (files[norm(p)] ?? "") + c; },
+    mkdir: async (p) => { dirs.add(norm(p)); },
+    exists: async (p) => norm(p) in files || dirs.has(norm(p)),
+    listDir: async () => [],
+  };
+}
+
+/**
+ * Drive a setup conversation to completion. Returns the per-turn narrative and
+ * the finalized SetupResult (undefined if the scripted inputs ran out before
+ * the agent finalized — a record-time authoring error). Deterministic across
+ * record and replay: the send/resolveChoice branch keys off the conversation's
+ * pending-choice state, which is itself driven by the (recorded) provider
+ * results, so the same sequence of calls is made either way.
+ */
+async function runSetupScenario(
+  scenario: SetupScenario,
+  provider: LLMProvider,
+): Promise<{ narrative: string[]; finalized: SetupResult | undefined }> {
+  // No fileIO/setupRoot → portrait/image tools are not registered; the flow
+  // stays text-only (and a non-image model reports no image capability, so the
+  // consent question is skipped too).
+  const conv = createSetupConversation(provider, SCENARIO_MODEL);
+  const narrative: string[] = [];
+  const sink = (): void => {};
+  const trace = process.env.MV_SETUP_TRACE === "1";
+  const choicesOf = (r: { pendingChoices?: { choices: string[] } }) =>
+    r.pendingChoices ? JSON.stringify(r.pendingChoices.choices) : "none";
+  const preview = (s: string) => s.slice(0, 200).replace(/\s+/g, " ").trim();
+
+  let result = await conv.start(sink);
+  narrative.push(result.text);
+  let finalized = result.finalized;
+  if (trace) process.stdout.write(`\n[${scenario.name}]\n[start] finalized=${!!finalized} choices=${choicesOf(result)} text="${preview(result.text)}"\n`);
+
+  // 1. Scripted content answers — establish the campaign.
+  for (let i = 0; i < scenario.inputs.length; i++) {
+    if (finalized) break;
+    const input = scenario.inputs[i] ?? "";
+    const mode = conv.hasPendingChoice ? "resolveChoice" : "send";
+    if (trace) process.stdout.write(`[in ${i}] ${mode} <- "${input.slice(0, 70)}"\n`);
+    result = mode === "resolveChoice"
+      ? await conv.resolveChoice(input, sink)
+      : await conv.send(input, sink);
+    narrative.push(result.text);
+    finalized = result.finalized ?? finalized;
+    if (trace) process.stdout.write(`[out ${i}] finalized=${!!finalized} choices=${choicesOf(result)} text="${preview(result.text)}"\n`);
+  }
+
+  // 2. Bounded finalize loop — confirm until the agent calls finalize_setup.
+  for (let n = 0; n < MAX_FINALIZE_NUDGES && !finalized; n++) {
+    const mode = conv.hasPendingChoice ? "resolveChoice" : "send";
+    if (trace) process.stdout.write(`[nudge ${n}] ${mode}\n`);
+    result = mode === "resolveChoice"
+      ? await conv.resolveChoice(FINALIZE_NUDGE, sink)
+      : await conv.send(FINALIZE_NUDGE, sink);
+    narrative.push(result.text);
+    finalized = result.finalized ?? finalized;
+    if (trace) process.stdout.write(`[nudge ${n} out] finalized=${!!finalized} choices=${choicesOf(result)} text="${preview(result.text)}"\n`);
+  }
+
+  return { narrative, finalized };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+describe("setup golden corpus", () => {
+  for (const scenario of SETUP_SCENARIOS) {
+    const GOLDEN = goldenPath(scenario.name);
+
+    describe(scenario.name, () => {
+      it.skipIf(process.env.RECORD_GOLDENS !== "1")("records the golden (live API)", async () => {
+        loadEnv();
+        const writer = new TapeWriter(scenario.name);
+        const { narrative, finalized } = await runSetupScenario(
+          scenario,
+          createTapingProvider(createAnthropicProvider(), writer),
+        );
+
+        expect(finalized, "scenario must reach finalize_setup — extend its inputs").toBeDefined();
+        expect(narrative.length).toBeGreaterThan(0);
+
+        const golden: SetupGolden = {
+          scenario: scenario.name,
+          tape: writer.build(),
+          expectedNarrative: narrative,
+          expectedSetup: finalized as SetupResult,
+        };
+        mkdirSync(dirname(GOLDEN), { recursive: true });
+        writeFileSync(GOLDEN, JSON.stringify(golden, null, 2) + "\n");
+      }, 180_000);
+
+      it.skipIf(!existsSync(GOLDEN))("replays deterministically with no network", async () => {
+        const golden = JSON.parse(readFileSync(GOLDEN, "utf8")) as SetupGolden;
+        const replay = createReplayProvider(new TapeReader(deserializeTape(serializeTape(golden.tape))));
+        const { narrative, finalized } = await runSetupScenario(scenario, replay);
+
+        // 1. The conversation reproduces verbatim, offline.
+        expect(narrative).toEqual(golden.expectedNarrative);
+        // 2. finalize_setup derives the same campaign blueprint.
+        expect(finalized).toEqual(golden.expectedSetup);
+
+        // 3. The handoff scaffolds a campaign matching that blueprint. Runs the
+        //    real buildCampaignWorld against in-memory FileIO (config.json's
+        //    createdAt is wall-clock, so assert fields, not a deep-equal).
+        const fileIO = mockFileIO();
+        const root = await buildCampaignWorld("/tmp/campaigns", finalized as SetupResult, fileIO, "/tmp/home");
+
+        const configRaw = await fileIO.readFile(norm(campaignPaths(root).config));
+        expect(configRaw, "config.json should be written").not.toBe("");
+        const config = JSON.parse(configRaw) as CampaignConfig;
+        expect(config.name).toBe(golden.expectedSetup.campaignName);
+        expect(config.system).toBe(golden.expectedSetup.system ?? undefined);
+        expect(config.dm_personality.name).toBe(golden.expectedSetup.personality.name);
+        expect(config.players[0]?.character).toBe(golden.expectedSetup.characterName);
+
+        const charRaw = await fileIO.readFile(norm(campaignPaths(root).character(golden.expectedSetup.characterName)));
+        expect(charRaw, "character sheet should be scaffolded").not.toBe("");
+      });
+    });
+  }
+});

--- a/packages/engine/src/testing/setup-corpus.golden.test.ts
+++ b/packages/engine/src/testing/setup-corpus.golden.test.ts
@@ -104,7 +104,7 @@ const SETUP_SCENARIOS: SetupScenario[] = [
   {
     name: "setup-quickstart-fantasy",
     inputs: [
-      "I'm Sam. Quick start, please — pick a fantasy world for me, something with intrigue.",
+      "I'm Sam, an adult. Quick start, please — pick a fantasy world for me, something with intrigue.",
       "That world sounds great, let's use it.",
       "My character is Aldric, a weathered sellsword chasing a blood debt. Keep it simple — no extra mechanics. I'm an adult, surprise me with the rest.",
     ],


### PR DESCRIPTION
## What

Adds the **setup-side complement** to the DM golden corpus from #585: an in-process, deterministic replay of the **setup agent** and the setup→game **handoff**, offline and free.

`packages/engine/src/testing/setup-corpus.golden.test.ts` drives the real `createSetupConversation` through a scripted player flow to `finalize_setup`, then runs the real `buildCampaignWorld` handoff against an in-memory `FileIO`. Each scenario replays with **zero network** and asserts three things:

1. the conversation reproduces **verbatim** (per-turn narrative),
2. `finalize_setup` derives the **same `SetupResult`** (new golden field `expectedSetup`), and
3. the handoff **scaffolds a campaign** whose config matches.

3 scenarios recorded on Sonnet: `setup-quickstart-fantasy`, `setup-custom-noir`, `setup-dnd-character`.

## Why this shape

This closes the in-process setup→game replay gap — the setup agent had **zero** deterministic offline coverage. Driving the conversation directly (exactly how the DM corpus drives `GameEngine`) is symmetric, free, and exercises the real finalize + scaffold path. I deliberately did **not** retrofit replay onto the `mvplay` HTTP capture: that format records neither the player inputs nor a replayable narrative segmentation, and the real campaign loader (`doStartSession`) is server-entangled (raw `readFileSync`, disk-sandboxed FileIO, instance state).

Two behaviors the recording had to handle, both deterministic across record/replay:

- Setup calls carry **no `conversationId`**, so the whole conversation is the `"default"` bucket, matched ordinally.
- The agent **gates on the player's real name** and only finalizes after a proposal+confirm — so scenarios front-load the name/content and a **bounded finalize loop** nudges until the tool fires. `MV_SETUP_TRACE=1` prints the turn-by-turn flow when re-recording.

## Docs

- `golden-tapes.md` / `tape-format.md` / `e2e-harness.md` / `maintenance.md` / `module-map.md` and the `/record-tape` skill retargeted to the **two-corpus** model.
- `CLAUDE.md` Tier-2 gate now names both corpora + the re-record cue.
- Open edge narrowed: replaying an `mvplay` full-stack capture through the server stack (TUI/WS + real `SessionManager` loader) remains capture-only; Tier-3 live smoke covers it.

## Verification

- Offline replay green with **no API key** (3 setup + 10 DM goldens).
- Full `npm run check` green: **3109 passed / 13 skipped** (the live record-halves; gated behind `RECORD_GOLDENS=1`, so commits/pushes never spend API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
