### PR TITLE
fix(fileio): forward readBinaryFile through sandboxFileIO

### DIFF
--- a/packages/engine/src/tools/filesystem/sandbox.test.ts
+++ b/packages/engine/src/tools/filesystem/sandbox.test.ts
@@ -13,6 +13,7 @@ function mockFileIO(): FileIO {
     listDir: vi.fn(async () => ["a.md", "b.md"]),
     deleteFile: vi.fn(async () => {}),
     writeBinaryFile: vi.fn(async () => {}),
+    readBinaryFile: vi.fn(async () => new Uint8Array([1, 2, 3])),
   };
 }
 
@@ -166,6 +167,39 @@ describe("sandboxFileIO", () => {
       resolve(ROOT, "images", "portrait.png"),
       bytes,
     );
+  });
+
+  it("guards readBinaryFile", async () => {
+    const sandboxed = sandboxFileIO(mockFileIO(), [ROOT]);
+
+    await expect(
+      sandboxed.readBinaryFile!(resolve("/tmp/evil.png")),
+    ).rejects.toThrow("Path outside sandbox");
+  });
+
+  it("propagates readBinaryFile only when inner supports it", () => {
+    const inner = mockFileIO();
+    delete inner.readBinaryFile;
+    const sandboxed = sandboxFileIO(inner, [ROOT]);
+
+    expect(sandboxed.readBinaryFile).toBeUndefined();
+  });
+
+  it("forwards readBinaryFile to inner with guarded path", async () => {
+    // Regression: sandboxFileIO forwarded writeBinaryFile but NOT
+    // readBinaryFile, so the production sandbox-wrapped FileIO had
+    // `readBinaryFile: undefined`. loadDmPortraitMessage gates on that method
+    // and silently returned null, so PC portraits never reached the DM
+    // context — generated characters drifted off-model. Keep the read/write
+    // binary forwards symmetric.
+    const inner = mockFileIO();
+    const sandboxed = sandboxFileIO(inner, [ROOT]);
+
+    const out = await sandboxed.readBinaryFile!(ROOT + sep + "characters" + sep + "x-portrait.png");
+    expect(inner.readBinaryFile).toHaveBeenCalledWith(
+      resolve(ROOT, "characters", "x-portrait.png"),
+    );
+    expect(out).toEqual(new Uint8Array([1, 2, 3]));
   });
 
   it("prevents root prefix spoofing", async () => {

--- a/packages/engine/src/tools/filesystem/sandbox.ts
+++ b/packages/engine/src/tools/filesystem/sandbox.ts
@@ -39,5 +39,13 @@ export function sandboxFileIO(inner: FileIO, allowedRoots: string[]): FileIO {
     ...(inner.deleteFile ? { deleteFile: async (p: string) => inner.deleteFile!(guard(p)) } : {}),
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by ternary
     ...(inner.writeBinaryFile ? { writeBinaryFile: async (p: string, b: Uint8Array) => inner.writeBinaryFile!(guard(p), b) } : {}),
+    // readBinaryFile MUST be forwarded symmetrically with writeBinaryFile.
+    // Dropping it silently breaks the DM PC-portrait inject: loadDmPortraitMessage
+    // gates on `fileIO.readBinaryFile` and returns null when it's missing, so the
+    // portrait never reaches the DM context (it just falls back to text). The
+    // omission is invisible — images still persist (writeBinaryFile is here) — so
+    // it surfaced only as generated characters drifting off-model.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by ternary
+    ...(inner.readBinaryFile ? { readBinaryFile: async (p: string) => inner.readBinaryFile!(guard(p)) } : {}),
   };
 }


### PR DESCRIPTION
## The bug

PC portraits were **never reaching the DM's context**. Found while investigating why a generated scene's characters drifted off-model from the player's portrait (a clone NPC who should wear an identical outfit didn't match).

`sandboxFileIO` forwards `writeBinaryFile` but silently **dropped `readBinaryFile`** — so the production sandbox-wrapped FileIO had `readBinaryFile: undefined`. `loadDmPortraitMessage` gates on exactly that method (`if (!fileIO.readBinaryFile) return null`), so it bailed every turn and the portrait was never injected. The DM authored character appearance from the **text** sheet alone.

The omission was invisible because:
- it fails silently — `loadDmPortraitMessage` tolerates missing portraits by design (the declined-consent case), and
- image **persistence** still worked (`writeBinaryFile` *was* forwarded), so disk writes gave no hint.

## Evidence

Confirmed against a real campaign (`ghosts-of-station-proxima-the-cenotaph`) via codex session rollouts: **zero `input_image` / zero "Party portraits" prefix across an entire session**, despite the portrait file existing on disk *before* the first DM turn. A probe reproduced it exactly — `loadDmPortraitMessage` returns a full message with the base FileIO, but `null` with the sandbox-wrapped one (`readBinaryFile: undefined`).

## Fix

Forward `readBinaryFile` symmetrically with `writeBinaryFile`. Adds three regression tests mirroring the existing `writeBinaryFile` suite (guard, conditional propagation, guarded-path forward) — that suite exists because this *same class* of omission bit `writeBinaryFile` once before. Keeps the read/write binary forwards symmetric so a future refactor can't silently drop one again.

## Scope note

This gets the portrait into the DM's **context** (it can now see and faithfully describe the PC every turn). The image **renderer** still receives only the DM's text prompt — true pixel-level consistency (reference-image / image-to-image conditioning) is a separate, larger change being scoped next.

## Testing
- `tsc -b` clean, `eslint` clean
- sandbox + dm-portraits suites green (26 tests); pre-push full `npm run check` green
- Live probe: portrait now loads through the sandboxed FileIO

🤖 Generated with [Claude Code](https://claude.com/claude-code)