### PR TITLE
fix(image): clear the render-timeout timer when the turn settles

### DIFF
--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -388,6 +388,12 @@ export class OpenAIChatGptProvider implements LLMProvider {
       },
     );
 
+    // The render-timeout backstop. Held out here so the `finally` can clear it
+    // the instant the race settles — otherwise the timer survives a *successful*
+    // render and fires ~10min later, logging a bogus image_gen:timeout and
+    // rejecting an already-settled promise. In long-lived gameplay every
+    // successful render would leak one, making the timeout signal untrustworthy.
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
       // Reference images (PC portraits, opt-in per call) ride as `image`
       // input items ahead of the text, so the model sees them as visual
@@ -413,8 +419,8 @@ export class OpenAIChatGptProvider implements LLMProvider {
 
       const completed = await Promise.race([
         completion,
-        new Promise<never>((_, reject) =>
-          setTimeout(
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
             () => {
               // Dump whatever arrived before the stall so a timeout is
               // diagnosable too — e.g. an imageGeneration item that started
@@ -434,8 +440,9 @@ export class OpenAIChatGptProvider implements LLMProvider {
               ));
             },
             OpenAIChatGptProvider.IMAGE_RENDER_TIMEOUT_MS,
-          ).unref(),
-        ),
+          );
+          timeoutHandle.unref();
+        }),
       ]);
 
       // Any terminal status other than "completed" (failed, interrupted, or
@@ -520,6 +527,7 @@ export class OpenAIChatGptProvider implements LLMProvider {
         aspectUsed: aspect,
       };
     } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
       unsubItem();
       unsubCompleted();
     }

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -420,7 +420,7 @@ export class OpenAIChatGptProvider implements LLMProvider {
       const completed = await Promise.race([
         completion,
         new Promise<never>((_, reject) => {
-          timeoutHandle = setTimeout(
+          const handle = setTimeout(
             () => {
               // Dump whatever arrived before the stall so a timeout is
               // diagnosable too — e.g. an imageGeneration item that started
@@ -441,7 +441,8 @@ export class OpenAIChatGptProvider implements LLMProvider {
             },
             OpenAIChatGptProvider.IMAGE_RENDER_TIMEOUT_MS,
           );
-          timeoutHandle.unref();
+          handle.unref();
+          timeoutHandle = handle;
         }),
       ]);
 


### PR DESCRIPTION
## Problem

The 10-min image-render backstop (added in #593) was a bare `setTimeout` inside a `Promise.race` that was **never cleared**. When a render succeeds, the `completion` promise wins the race but the timer keeps running and fires ~10 min later — logging a **phantom `image_gen:timeout`** and rejecting an already-settled promise.

In long-lived gameplay (the provider subprocess outlives every render by far more than 10 min), **every successful render leaks one timer**, so the `image_gen:timeout` diagnostic this branch just added would fire constantly and falsely — undermining the very signal it was meant to provide.

## Fix

Hold the timer handle in a variable outside the `try` and `clearTimeout` it in the `finally`, so it dies the instant the race settles — success, no-data, or turn-failed alike. `.unref()` is preserved.

## How it surfaced

While validating reference-image conditioning, a slow two-attempt render completed fine but logged **two** phantom `image_gen:timeout` events (one stray timer per attempt). That's what flagged the leak.

## Tests

Provider suite green (106 pass). No behavior change beyond not leaking the timer; nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)