### PR TITLE
feat(tui): "The DM is creating an image..." activity indicator + tool glyph

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -98,10 +98,13 @@ The activity line shows what the engine is doing, mapped automatically from in-f
 | `scene_transition` cascade | `Scene transition...` | `⟳` |
 | Waiting for DM API response | `The DM is thinking...` | `◆` |
 | Tool call in flight (`tool_running`) | `The DM is working...` | `◆` |
+| Image render in flight (`generating_image`) | `The DM is creating an image...` | `🎨` |
 | Setup→game handoff in flight | `Preparing your campaign...` | `◆` |
 | Player's turn (idle) | *(hidden)* | *(hidden)* |
 
 The `tool_running` row matters because subagent-backed tools (e.g. `style_scene` → theme-styler) routinely take 20-60s. ActivityLine also renders any accumulated tool glyphs even when the engine state itself has no mapped label, so a transient or unmapped state can never silently wipe the row.
+
+`generating_image` is its own state (not just `tool_running`) because image rendering is the slowest tool by far — minutes — and deserves a clear "creating an image" message with tier escalation. Crucially, image gen runs *concurrently* with faster sibling tools (a scene-snapshot fires alongside `scene_transition` + `style_scene`), so the engine counts in-flight renders and holds `generating_image` until the **last** one finishes — a quick sibling completing first must not drop the indicator back to `dm_thinking`. Its accumulating tool glyph is `❖` (magenta).
 
 The modeline glyph column is used when the activity line has been dropped due to viewport size (see [Responsive Design](#responsive-design)). The glyph appears at the start of the modeline.
 

--- a/packages/client-ink/src/tui/activity.test.ts
+++ b/packages/client-ink/src/tui/activity.test.ts
@@ -37,6 +37,13 @@ describe("activity indicators", () => {
     expect(ACTIVITY_MAP.scene_transition).toBeDefined();
     expect(ACTIVITY_MAP.dm_thinking).toBeDefined();
     expect(ACTIVITY_MAP.starting_session).toBeDefined();
+    expect(ACTIVITY_MAP.generating_image).toBeDefined();
+  });
+
+  it("returns the image-generation indicator", () => {
+    const indicator = getActivity("generating_image");
+    expect(indicator).toBeDefined();
+    expect(indicator!.label).toBe("The DM is creating an image...");
   });
 
   it("returns starting_session indicator for setup→game handoff", () => {
@@ -77,6 +84,13 @@ describe("getActivityLabel", () => {
     expect(getActivityLabel("tool_running", 45)).toBe("Still working...");
   });
 
+  it("escalates generating_image over a multi-minute render", () => {
+    expect(getActivityLabel("generating_image", 0)).toBe("The DM is creating an image...");
+    expect(getActivityLabel("generating_image", 44)).toBe("The DM is creating an image...");
+    expect(getActivityLabel("generating_image", 45)).toBe("Still rendering the image...");
+    expect(getActivityLabel("generating_image", 120)).toBe("The image is taking a little while...");
+  });
+
   it("returns undefined for null or unknown state", () => {
     expect(getActivityLabel(null, 0)).toBeUndefined();
     expect(getActivityLabel("nope", 0)).toBeUndefined();
@@ -89,6 +103,7 @@ describe("hasElapsedAwareLabel", () => {
     expect(hasElapsedAwareLabel("dm_thinking")).toBe(true);
     expect(hasElapsedAwareLabel("tool_running")).toBe(true);
     expect(hasElapsedAwareLabel("starting_session")).toBe(true);
+    expect(hasElapsedAwareLabel("generating_image")).toBe(true);
     // Mapped but tier-less — fast states should NOT trigger ticker/suffix
     expect(hasElapsedAwareLabel("roll_dice")).toBe(false);
     expect(hasElapsedAwareLabel("rule_lookup")).toBe(false);
@@ -159,6 +174,15 @@ describe("getToolGlyph", () => {
   it("returns glyph for entity/scribe tools", () => {
     expect(getToolGlyph("scribe")!.glyph).toBe("✎");
     expect(getToolGlyph("dm_notes")!.glyph).toBe("✎");
+  });
+
+  it("returns a single-width glyph for image generation", () => {
+    const img = getToolGlyph("generate_image");
+    expect(img).toBeDefined();
+    expect(img!.glyph).toBe("❖");
+    expect(img!.color).toBe("magenta");
+    // Single code point so it aligns in the concatenated glyph row.
+    expect([...img!.glyph]).toHaveLength(1);
   });
 
   it("returns undefined for unknown tool names", () => {

--- a/packages/client-ink/src/tui/activity.ts
+++ b/packages/client-ink/src/tui/activity.ts
@@ -25,6 +25,18 @@ export const ACTIVITY_MAP: Record<string, IndicatorWithTiers> = {
       { atSec: 75, label: "The DM is still working..." },
     ],
   },
+  // Set while one or more image renders are in flight. Image gen is the
+  // slowest tool by far (minutes), so it gets its own indicator instead of the
+  // generic "working" one, with tiers so a multi-minute render reads as
+  // progress. The engine holds this state across faster sibling tools.
+  generating_image: {
+    label: "The DM is creating an image...",
+    glyph: "🎨",
+    tiers: [
+      { atSec: 45, label: "Still rendering the image..." },
+      { atSec: 120, label: "The image is taking a little while..." },
+    ],
+  },
   // Engine emits this for the duration of any in-flight tool call.
   // Most tools finish in milliseconds, but subagent-backed tools (style_scene
   // → theme-styler, scribe, etc.) routinely run 20-60s. Without an entry
@@ -78,6 +90,9 @@ const TOOL_GLYPH_MAP: Record<string, ToolGlyph> = {
   // Entity / worldbuilding
   scribe:             { glyph: "✎", color: "green" },
   dm_notes:           { glyph: "✎", color: "green" },
+  // Image generation (single-width symbol so it aligns in the glyph row;
+  // the long-form "creating an image" label lives in ACTIVITY_MAP)
+  generate_image:     { glyph: "❖", color: "magenta" },
   // TUI / presentation
   update_modeline:    { glyph: "◆", color: "magenta" },
   style_scene:        { glyph: "◆", color: "magenta" },

--- a/packages/engine/src/agents/game-engine.test.ts
+++ b/packages/engine/src/agents/game-engine.test.ts
@@ -308,6 +308,64 @@ describe("GameEngine", () => {
     expect(log.toolEnds).toContain("style_scene");
   });
 
+  it("holds 'generating_image' across a faster sibling tool finishing mid-render", async () => {
+    // generate_image runs for minutes alongside fast tools batched in the same
+    // turn. The activity indicator must stay on "generating_image" for the whole
+    // render — a sibling's completion must NOT flip it back to dm_thinking.
+    const engineRef: { current?: { getState(): string } } = {};
+    let stateWhileRendering: string | undefined;
+    const imageBatch: ChatResult = {
+      text: "",
+      toolCalls: [
+        { id: "t1", name: "generate_image", input: { prompt: "a sword", effort: "standard", aspect: "square" } },
+        { id: "t2", name: "roll_dice", input: { expression: "1d20" } },
+      ],
+      usage: mockUsage(),
+      stopReason: "tool_use",
+      assistantContent: [
+        { type: "tool_use", id: "t1", name: "generate_image", input: { prompt: "a sword", effort: "standard", aspect: "square" } },
+        { type: "tool_use", id: "t2", name: "roll_dice", input: { expression: "1d20" } },
+      ],
+    };
+    const responses = [imageBatch, textMessage("Here it is.")];
+    let idx = 0;
+    const provider = {
+      providerId: "mock",
+      chat: vi.fn(async () => responses[idx++]),
+      stream: vi.fn(async () => responses[idx++]),
+      healthCheck: vi.fn(async () => ({ ok: true })),
+      getCapabilities: () => ({ imageGeneration: true, thinking: false, tools: true, streaming: true, caching: false }),
+      generateImage: vi.fn(async () => {
+        // Yield so the concurrently-dispatched roll_dice finishes first, then
+        // snapshot the engine state mid-render.
+        await new Promise((r) => setTimeout(r, 5));
+        stateWhileRendering = engineRef.current!.getState();
+        return { base64: "AAA=", mimeType: "image/png", effortUsed: "standard", aspectUsed: "square" };
+      }),
+    } as unknown as LLMProvider;
+    const { callbacks, log } = mockCallbacks();
+
+    const engine = makeEngine({
+      provider,
+      gameState: mockState(),
+      scene: mockScene(),
+      sessionState: mockSessionState(),
+      fileIO: { ...mockFileIO(), writeBinaryFile: vi.fn(async () => {}) },
+      callbacks,
+      model: "claude-haiku-4-5-20251001",
+    });
+    engineRef.current = engine;
+
+    await engine.processInput("Aldric", "Show me the sword.");
+
+    // The render emitted the dedicated state...
+    expect(log.states).toContain("generating_image");
+    // ...and roll_dice ending did not clobber it back to dm_thinking.
+    expect(stateWhileRendering).toBe("generating_image");
+    // Turn still ends cleanly.
+    expect(engine.getState()).toBe("waiting_input");
+  });
+
   it("tracks session usage", async () => {
     const provider = mockProvider([textMessage("Hello.")]);
     const { callbacks, log } = mockCallbacks();

--- a/packages/engine/src/agents/game-engine.ts
+++ b/packages/engine/src/agents/game-engine.ts
@@ -5,6 +5,7 @@ import { DM_TURN_LENGTH_PCT_DEFAULT } from "@machine-violet/shared/types/config.
 import { agentLoopStreaming } from "./agent-loop.js";
 import type { AgentLoopConfig, TuiCommand, UsageStats } from "./agent-loop.js";
 import type { LLMProvider, NormalizedMessage, ContentPart, TierProvider } from "../providers/types.js";
+import { GENERATE_IMAGE_TOOL_NAME } from "../providers/types.js";
 import { ConversationManager } from "../context/conversation.js";
 import type { DroppedExchange } from "../context/conversation.js";
 import { narrativeLinesToMarkdown } from "../context/display-log.js";
@@ -86,6 +87,12 @@ export class GameEngine {
   private sceneManager: SceneManager;
   private callbacks: EngineCallbacks;
   private engineState: EngineState = "idle";
+  /** Count of in-flight `generate_image` tool calls. Image renders take minutes
+   *  and run concurrently with faster sibling tools (scene_transition,
+   *  style_scene); this keeps the "generating_image" activity state up for the
+   *  whole render instead of letting a sibling's completion flip it to thinking.
+   *  Reset to 0 at each turn start in case a render was abandoned mid-flight. */
+  private imageGenInFlight = 0;
   private sessionUsage: UsageStats = {
     inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0,
   };
@@ -519,6 +526,7 @@ export class GameEngine {
     };
     this.callbacks.onTurnStart(dmTurn);
 
+    this.imageGenInFlight = 0;
     this.setState("dm_thinking");
     const turnStartTime = Date.now();
     this.dmProvidedChoicesThisTurn = false;
@@ -1494,6 +1502,7 @@ export class GameEngine {
     const active = getActivePlayer(this.gameState);
     const characterName = active.characterName;
 
+    this.imageGenInFlight = 0;
     this.setState("dm_thinking");
 
     // Load character sheet (best-effort)
@@ -1608,11 +1617,17 @@ export class GameEngine {
       asyncToolHandler: (name, input) => this.handleAsyncToolInternal(name, input),
       onTextDelta: (delta) => this.callbacks.onNarrativeDelta(delta),
       onToolStart: (name) => {
-        this.setState("tool_running");
+        if (name === GENERATE_IMAGE_TOOL_NAME) this.imageGenInFlight++;
+        // An in-flight image render owns the indicator (it's the slow, notable
+        // one); otherwise it's a generic tool.
+        this.setState(this.imageGenInFlight > 0 ? "generating_image" : "tool_running");
         this.callbacks.onToolStart(name);
       },
       onToolEnd: (name, result) => {
-        this.setState("dm_thinking");
+        if (name === GENERATE_IMAGE_TOOL_NAME && this.imageGenInFlight > 0) this.imageGenInFlight--;
+        // Stay on "generating_image" while any render is still going — a faster
+        // sibling tool finishing first must not drop the image indicator.
+        this.setState(this.imageGenInFlight > 0 ? "generating_image" : "dm_thinking");
         this.callbacks.onToolEnd(name, result);
       },
       onTuiCommand: (cmd) => {

--- a/packages/shared/src/types/engine.ts
+++ b/packages/shared/src/types/engine.ts
@@ -65,6 +65,11 @@ export type EngineState =
   | "waiting_input"
   | "dm_thinking"
   | "tool_running"
+  // Set while one or more image renders are in flight. Distinct from
+  // tool_running because image gen is slow (minutes) and worth its own
+  // "creating an image" indicator; the engine holds this state until the
+  // last in-flight render finishes, even as faster sibling tools come and go.
+  | "generating_image"
   | "scene_transition"
   | "session_ending";
 


### PR DESCRIPTION
## What

Image generation runs for **minutes** — far longer than any other tool — but it showed the generic `The DM is working...` (`tool_running`). This gives it a dedicated activity-line indicator and an accumulating tool glyph, so a long render reads as intentional progress instead of a frozen UI.

- **Label:** `The DM is creating an image...`, with elapsed-time tiers (45s → "Still rendering the image...", 120s → "The image is taking a little while...") and the `(Ns)` counter, since renders run for minutes.
- **Glyph:** `❖` (magenta), accumulating on the activity line alongside the other tool glyphs.

## The interesting part: surviving concurrency

Image gen fires in the **same parallel tool batch** as `scene_transition` + `style_scene` (a scene snapshot), and those siblings finish in seconds while the render runs for minutes. A naive new state would get clobbered back to `dm_thinking` the instant the first sibling completed.

So the engine counts in-flight `generate_image` calls and holds `generating_image` until the **last** render finishes — `onToolEnd` for a fast sibling keeps the image indicator up as long as any render is still going. The counter resets at each turn start as a defensive guard against an abandoned render.

## Changes

- `packages/shared/src/types/engine.ts` — add `EngineState` `"generating_image"`.
- `packages/engine/src/agents/game-engine.ts` — in-flight counter + state selection in `onToolStart`/`onToolEnd`; reset at turn start.
- `packages/client-ink/src/tui/activity.ts` — `ACTIVITY_MAP` entry (label + tiers) and `TOOL_GLYPH_MAP` entry (`generate_image` → `❖`).

## Tests / docs

- `activity.test.ts` — label, tier escalation, `hasElapsedAwareLabel`, single-width glyph.
- `game-engine.test.ts` — a deterministic test proving the state **survives a faster sibling tool finishing mid-render** (snapshots engine state inside a deferred `generateImage` after `roll_dice` has completed).
- `docs/tui-design.md` — activity-indicator table row + the concurrency note.
- Full suite green (3379 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)