### PR TITLE
fix(tui): keep Tab quick-view reachable while a choice overlay is up (#541)

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -584,6 +584,7 @@ The character pane is a right-side overlay (Tab toggle) that shows the active ch
 
 **Behavior:**
 - Toggled with Tab (or via key hints indicator in the Player Pane top-right)
+- Tab stays available while a choice overlay is on screen — the quick view opens over the narrative and the overlay keeps arrow/Enter for selection, so the two don't conflict (the Tab toggle is handled ahead of the choices input guard)
 - 35-column fixed-width panel, right-aligned over the narrative area
 - Lazy-fetches the character sheet on first open via `GET /session/character/:name` (returns `{ name, content }`)
 - Caches content across toggles; cache invalidates when the active player changes

--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -415,13 +415,16 @@ export function PlayingPhase() {
       return;
     }
 
-    if (activeChoices) return;
-
-    // Tab: toggle character pane
+    // Tab: toggle the quick-view character pane. Handled before the choices
+    // guard below so the quick view stays reachable while a choice overlay is
+    // on screen — the overlay keeps arrow/Enter for selection, so the two
+    // don't conflict (see #541).
     if (key.tab) {
       setCharacterPaneOpen((prev) => !prev);
       return;
     }
+
+    if (activeChoices) return;
 
     // In OOC/Dev mode: ESC exits
     if (mode === "ooc" || mode === "dev") {


### PR DESCRIPTION
@-