### PR TITLE
Re-platform the DM formatting pipeline: width-safe, leak-free, + <br>/<code>/<quote>/lists

### DIFF
--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -24,6 +24,30 @@ the real model. (The setup *agent conversation* itself now has deterministic
 offline coverage via the Tier-2 setup corpus.) It is **not** the everyday gate;
 that's Tier 2.
 
+### Formatting invariant harness (Tier 1, property-based)
+
+The DM narrative formatting/render pipeline has its own deterministic, LLM-free
+harness at
+[`packages/client-ink/src/tui/narrative/harness/`](../packages/client-ink/src/tui/narrative/harness/).
+It runs the **real** pipeline (`processNarrativeLines`) and asserts the formatting
+contract — no markup leaks, every physical row fits the terminal's *display* width,
+content is preserved, the AST is well-formed, aligned rows pad correctly, and
+output is deterministic + cache-transparent — over three input sources at every
+width: hand-authored fixtures (one per construct + every known-hard combo), a
+**seeded generator** of legal documents (`generator.ts`, reproducible by seed),
+and the **committed campaign corpus** under `harness/corpus/`. A curated subset is
+re-checked through the real Ink renderer (`harness.render.test.tsx`) to confirm
+Ink's layout agrees with the width oracle.
+
+```bash
+npx vitest run packages/client-ink/src/tui/narrative/      # default: fast gate
+MV_FORMAT_SOAK=1 npx vitest run .../harness/harness.test.ts # 6000 seeds × all widths
+MV_LIVE_CORPUS=<campaigns-dir> npx vitest run .../harness/   # replay real on-disk campaigns
+```
+
+Touching the formatting pipeline or its vocabulary → see
+[maintenance.md](maintenance.md) and keep this harness green.
+
 ## Two ways to use the live harness: scripted probes vs. interactive play
 
 Built on the same launcher + sidecar:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -39,6 +39,13 @@ This project maintains a closed loop between code and documentation. When you ch
 2. If it's a new modal type, add to [tui-design.md](tui-design.md)
 3. Add to the tui section of [docs/module-map.md](module-map.md)
 
+### Changing the DM formatting pipeline / vocabulary
+
+1. Add/alter the tag in the `FormattingTag` union in `packages/shared/src/types/tui.ts` (the single source of truth) and handle it in both renderers — `render-nodes.tsx` (Ink) and `commands/transcript.ts` (HTML) — plus the node-walkers in `formatting.ts`
+2. Map any dialect/synonym for it in `packages/client-ink/src/tui/narrative/normalize.ts`
+3. Teach it in the `<formatting>` block of `packages/engine/src/prompts/dm-directives.md` and update the tag list + pipeline stages in [tui-design.md](tui-design.md)
+4. Extend the invariant harness (`packages/client-ink/src/tui/narrative/harness/`): add a fixture and, if it's a new construct, a generator production. Run `npx vitest run packages/client-ink/src/tui/narrative/` and the soak (`MV_FORMAT_SOAK=1`, and `MV_LIVE_CORPUS=<dir>` against real campaigns) — zero violations is the gate
+
 ### Changing the scene transition cascade
 
 1. Update step list in [state-atlas.md](state-atlas.md) (section 6)

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -148,25 +148,30 @@ The DM can use a small set of inline tags in narration for dramatic effect. Thes
 
 Available tags:
 - `<b>`, `<i>`, `<u>` — bold, italic, underline
+- `<code>` — inline monospace (rendered dim), for diegetic system text / identifiers
 - `<sub>`, `<sup>` — subscript, superscript (rendered via Unicode substitution in `render-nodes.tsx`; chars without a Unicode equivalent pass through unchanged)
-- `<center>`, `<right>` — text justification (default is left)
+- `<center>`, `<right>` — text justification (default is left); the content **wraps** to terminal width
+- `<br>` — a hard line break, a contentless `linebreak` leaf; inside an alignment block it splits a multi-line sign into independently-padded rows
 - `<color=#hex>` — hex color (e.g., `<color=#cc0000>The King has died.</color>`)
 
-The DM prompt includes one line: *"You can use `<b>`, `<i>`, `<u>`, `<sub>`, `<sup>`, `<center>`, `<right>`, and `<color=#hex>` tags in your narration for dramatic effect. Use sparingly."*
+The DM contract (`packages/engine/src/prompts/dm-directives.md`, `<formatting>` block) teaches this set. The tag vocabulary is defined once by the `FormattingTag` union in `packages/shared/src/types/tui.ts`.
 
-Unrecognized tags are stripped. Malformed tags render as plain text. This is cosmetic — no tag changes game state.
+Anything tag-shaped but outside the vocabulary is **stripped to its content** — it never renders as literal markup (the no-leak guarantee). Dialect synonyms (`<strong>`→`<b>`, `<em>`→`<i>`, `<h1-6>`→bold, attribute variants, a little inline Markdown) are mapped onto the canonical set first, by `narrative/normalize.ts`. A bare `<` that isn't a tag (`3 < 5`, `<3`) stays literal. None of this changes game state.
 
 ### Formatting Pipeline
 
 All DM text processing flows through `processNarrativeLines(lines, width, quoteColor?) → ProcessedLine[]`:
 
-1. **Heal** cross-line tags on raw strings (all formatting tags persist across source lines; only real paragraph boundaries — blank DM lines from `\n\n` — reset the tag stack; visual spacers from single `\n` don't reset)
-2. **Parse** healed text into `FormattingNode[]` AST via `parseFormatting`
-3. **Wrap** each AST at terminal width via `wrapNodes` (tags never break across lines)
-4. **Pad** alignment lines (`<center>`, `<right>`) with blank lines for breathing room
-5. **Quote highlight** with paragraph-scoped reset (blank DM lines reset quote state)
+1. **Normalize** each DM line's dialect into the canonical vocabulary (`narrative/normalize.ts`) before anything else
+2. **Heal** cross-line tags on raw strings (all formatting tags persist across source lines; only real paragraph boundaries — blank DM lines from `\n\n` — reset the tag stack; visual spacers from single `\n` don't reset; `<br>` is a leaf and does **not** reset the stack)
+3. **Parse** healed text into `FormattingNode[]` AST via `parseFormatting`
+4. **Layout** each line into width-safe physical rows by DISPLAY width via `narrative/layout.ts` (`layoutRuns`): wraps by terminal columns using the real `string-width`, hard-breaks an overlong token, splits a run on `<br>`, and wraps + pads aligned blocks. Tags never break across rows. (The legacy `wrapNodes` measures code units and is retained only for the modals.)
+5. **Pad** alignment groups (`<center>`, `<right>`) with blank lines for breathing room (consecutive aligned rows of one sign are not split)
+6. **Quote highlight** with paragraph-scoped reset (blank DM lines reset quote state)
 
 Non-DM lines (player, dev, system) pass through without entering the formatting pipeline.
+
+The contract is pinned by an invariant harness (`narrative/harness/`) that runs the real pipeline over synthetic fixtures, a seeded generator of legal documents, and the committed/live campaign corpus, asserting no-leak, width-safety (real display width), content preservation, well-formedness, alignment, and cache-transparent determinism at every width. See [e2e-harness.md](e2e-harness.md).
 
 ### Quote Highlighting
 

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -151,22 +151,25 @@ Available tags:
 - `<code>` — inline monospace (rendered dim), for diegetic system text / identifiers
 - `<sub>`, `<sup>` — subscript, superscript (rendered via Unicode substitution in `render-nodes.tsx`; chars without a Unicode equivalent pass through unchanged)
 - `<center>`, `<right>` — text justification (default is left); the content **wraps** to terminal width
-- `<br>` — a hard line break, a contentless `linebreak` leaf; inside an alignment block it splits a multi-line sign into independently-padded rows
+- `<quote>` — a block-level set-apart passage (letter, inscription, readout): split onto its own line and rendered as an indented block with a left rule (`▏`), content wrapped to width minus the rule. Multi-line via `<br>`. Deliberately **not** Markdown `>` (which collides with the player display-log marker).
+- `<br>` — a hard line break, a contentless `linebreak` leaf; inside an alignment or quote block it splits a multi-line sign into independent rows
 - `<color=#hex>` — hex color (e.g., `<color=#cc0000>The King has died.</color>`)
 
 The DM contract (`packages/engine/src/prompts/dm-directives.md`, `<formatting>` block) teaches this set. The tag vocabulary is defined once by the `FormattingTag` union in `packages/shared/src/types/tui.ts`.
 
-Anything tag-shaped but outside the vocabulary is **stripped to its content** — it never renders as literal markup (the no-leak guarantee). Dialect synonyms (`<strong>`→`<b>`, `<em>`→`<i>`, `<h1-6>`→bold, attribute variants, a little inline Markdown) are mapped onto the canonical set first, by `narrative/normalize.ts`. A bare `<` that isn't a tag (`3 < 5`, `<3`) stays literal. None of this changes game state.
+**Markdown lists** are a tolerated block construct (not a tag): a line beginning `- `/`* ` or `N.`/`N)` becomes a `kind: "list"` row with a resolved marker (`•` or the literal number) and a hanging indent, content wrapped to width minus the indent. Consecutive items render tight (the `appendDelta` spacer between them is collapsed); nesting is intentionally flattened. Markers/indent are renderer-side decoration carried on `ProcessedLine.listMarker`/`listIndent`.
+
+Anything tag-shaped but outside the vocabulary is **stripped to its content** — it never renders as literal markup (the no-leak guarantee). Dialect synonyms (`<strong>`→`<b>`, `<em>`→`<i>`, `<h1-6>`→bold, `<blockquote>`→`<quote>`, attribute variants, a little inline Markdown) are mapped onto the canonical set first, by `narrative/normalize.ts`. A bare `<` that isn't a tag (`3 < 5`, `<3`) stays literal. None of this changes game state.
 
 ### Formatting Pipeline
 
 All DM text processing flows through `processNarrativeLines(lines, width, quoteColor?) → ProcessedLine[]`:
 
-1. **Normalize** each DM line's dialect into the canonical vocabulary (`narrative/normalize.ts`) before anything else
-2. **Heal** cross-line tags on raw strings (all formatting tags persist across source lines; only real paragraph boundaries — blank DM lines from `\n\n` — reset the tag stack; visual spacers from single `\n` don't reset; `<br>` is a leaf and does **not** reset the stack)
+1. **Normalize** each DM line's dialect into the canonical vocabulary (`narrative/normalize.ts`) before anything else, then **tighten lists** (drop the `appendDelta` spacer between adjacent list items)
+2. **Heal** cross-line tags on raw strings (all formatting tags persist across source lines; only real paragraph boundaries — blank DM lines from `\n\n` — reset the tag stack; visual spacers from single `\n` don't reset; `<br>` is a leaf and does **not** reset the stack). List items are detected here, healed self-contained (marker lifted to metadata), and reset the heal stack.
 3. **Parse** healed text into `FormattingNode[]` AST via `parseFormatting`
-4. **Layout** each line into width-safe physical rows by DISPLAY width via `narrative/layout.ts` (`layoutRuns`): wraps by terminal columns using the real `string-width`, hard-breaks an overlong token, splits a run on `<br>`, and wraps + pads aligned blocks. Tags never break across rows. (The legacy `wrapNodes` measures code units and is retained only for the modals.)
-5. **Pad** alignment groups (`<center>`, `<right>`) with blank lines for breathing room (consecutive aligned rows of one sign are not split)
+4. **Layout** each line into width-safe physical rows by DISPLAY width via `narrative/layout.ts` (`layoutRuns`): wraps by terminal columns using the real `string-width`, hard-breaks an overlong token, splits a run on `<br>`, and wraps aligned/quote blocks (each to width minus its rule/indent) and list items (to width minus the hanging indent). Tags never break across rows. (The legacy `wrapNodes` measures code units and is retained only for the modals.)
+5. **Frame** block groups (`<center>`, `<right>`, `<quote>`) with blank lines for breathing room (consecutive rows of one block are not split)
 6. **Quote highlight** with paragraph-scoped reset (blank DM lines reset quote state)
 
 Non-DM lines (player, dev, system) pass through without entering the formatting pipeline.

--- a/packages/client-ink/package.json
+++ b/packages/client-ink/package.json
@@ -19,7 +19,8 @@
     "ink-scroll-view": "^0.3.6",
     "react": "^19.2.0",
     "sharp": "^0.34.5",
-    "sixel": "^0.16.0"
+    "sixel": "^0.16.0",
+    "string-width": "^8.2.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.0",

--- a/packages/client-ink/src/commands/transcript.test.ts
+++ b/packages/client-ink/src/commands/transcript.test.ts
@@ -96,6 +96,42 @@ describe("buildTranscriptHtml", () => {
     expect(html).not.toContain("debug info");
   });
 
+  it("renders a <quote> block as a styled blockquote", () => {
+    const lines: NarrativeLine[] = [
+      { kind: "dm", text: "<quote>Here lies the <i>last honest broker</i>.</quote>" },
+    ];
+    const html = buildTranscriptHtml(buildOpts(lines));
+    expect(html).toContain('class="dm-quote"');
+    expect(html).toContain("<blockquote");
+    expect(html).toContain("<i>last honest broker</i>");
+    // The literal tag must not leak.
+    expect(html).not.toContain("&lt;quote&gt;");
+  });
+
+  it("renders an ordered list with markers and hanging indent", () => {
+    const lines: NarrativeLine[] = [
+      { kind: "dm", text: "1. Bread primary." },
+      { kind: "dm", text: "2. Crackers forbidden." },
+    ];
+    const html = buildTranscriptHtml(buildOpts(lines));
+    expect(html).toContain('class="list-item"');
+    expect(html).toContain("text-indent:-3ch");
+    expect(html).toContain("1. ");
+    expect(html).toContain("Bread primary.");
+  });
+
+  it("renders an unordered list with bullet glyphs", () => {
+    const lines: NarrativeLine[] = [
+      { kind: "dm", text: "- A coil of rope" },
+      { kind: "dm", text: "- A spare lantern" },
+    ];
+    const html = buildTranscriptHtml(buildOpts(lines));
+    expect(html).toContain('class="list-item"');
+    expect(html).toContain("•");
+    // The raw dash marker is replaced by the bullet glyph.
+    expect(html).toContain("A coil of rope");
+  });
+
   it("escapes HTML entities in text", () => {
     const lines: NarrativeLine[] = [
       { kind: "dm", text: "A < B & C > D" },

--- a/packages/client-ink/src/commands/transcript.ts
+++ b/packages/client-ink/src/commands/transcript.ts
@@ -34,6 +34,7 @@ function nodeToHtml(node: FormattingNode): string {
 }
 
 function tagToHtml(tag: FormattingTag): string {
+  if (tag.type === "linebreak") return "<br>";
   const inner = tag.content.map(nodeToHtml).join("");
   switch (tag.type) {
     case "bold":
@@ -42,6 +43,8 @@ function tagToHtml(tag: FormattingTag): string {
       return `<i>${inner}</i>`;
     case "underline":
       return `<u>${inner}</u>`;
+    case "code":
+      return `<code>${inner}</code>`;
     case "subscript":
       return `<sub>${inner}</sub>`;
     case "superscript":
@@ -124,7 +127,7 @@ function lineToHtml(
       if (line.alignment) {
         const align = line.alignment === "center" ? "center" : "right";
         const inner =
-          line.nodes.length === 1 && typeof line.nodes[0] !== "string"
+          line.nodes.length === 1 && typeof line.nodes[0] !== "string" && "content" in line.nodes[0]
             ? line.nodes[0].content
             : line.nodes;
         return `<div class="dm" style="text-align:${align}">${nodesToHtml(inner)}</div>`;

--- a/packages/client-ink/src/commands/transcript.ts
+++ b/packages/client-ink/src/commands/transcript.ts
@@ -57,7 +57,8 @@ function tagToHtml(tag: FormattingTag): string {
       return inner;
     case "center":
     case "right":
-      // Alignment handled at line level; if nested, just render inline
+    case "quote":
+      // Block tags handled at line level; if nested, just render inline
       return inner;
   }
 }
@@ -122,8 +123,23 @@ function lineToHtml(
       return `<div class="player" style="color:${esc(opts.playerColor)}">${esc(text)}</div>`;
     }
 
+    case "list": {
+      // Each ProcessedLine is one physical row. The first row carries the marker
+      // and a hanging indent (negative text-indent); continuation rows just pad.
+      const indent = line.listIndent ?? 0;
+      if (line.listMarker !== undefined) {
+        return `<div class="list-item" style="padding-left:${indent}ch;text-indent:-${indent}ch">${esc(line.listMarker)} ${nodesToHtml(line.nodes)}</div>`;
+      }
+      return `<div class="list-item" style="padding-left:${indent}ch">${nodesToHtml(line.nodes)}</div>`;
+    }
+
     case "dm": {
       if (isEmpty) return `<div class="dm">&nbsp;</div>`;
+      // Blockquote row: a bordered, indented passage.
+      const sole = line.nodes.length === 1 && typeof line.nodes[0] !== "string" ? line.nodes[0] : undefined;
+      if (sole && sole.type === "quote") {
+        return `<blockquote class="dm-quote">${nodesToHtml(sole.content)}</blockquote>`;
+      }
       if (line.alignment) {
         const align = line.alignment === "center" ? "center" : "right";
         const inner =
@@ -241,6 +257,17 @@ div {
 b { font-weight: bold; }
 i { font-style: italic; }
 u { text-decoration: underline; }
+.dm-quote {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  border-left: 2px solid #666;
+  margin: 0;
+  padding-left: 1ch;
+  opacity: 0.9;
+  font-style: italic;
+  min-height: 1.4em;
+}
+.list-item { white-space: pre-wrap; word-wrap: break-word; }
 /* Image shadowbox: clicking a narrative image fills the viewport on black. */
 #shadowbox {
   display: none;

--- a/packages/client-ink/src/tui/components/NarrativeArea.tsx
+++ b/packages/client-ink/src/tui/components/NarrativeArea.tsx
@@ -5,6 +5,7 @@ import type { ScrollViewRef } from "ink-scroll-view";
 import { InlineImage } from "../image/InlineImage.js";
 import type { NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
 import { processNarrativeLines } from "../formatting.js";
+import { QUOTE_RULE } from "../narrative/layout.js";
 import { renderNodes } from "../render-nodes.js";
 import { useScrollHandle } from "../hooks/useScrollHandle.js";
 import type { ScrollHandle } from "../hooks/useScrollHandle.js";
@@ -419,7 +420,34 @@ const NarrativeLineComponent = React.memo(function NarrativeLineComponent({
       return <Text wrap="truncate" color="#FFBF00">{text}</Text>;
     }
 
+    case "list": {
+      // Layout already wrapped the content to width − indent, so marker + content
+      // (first row) and indent + content (continuation rows) each fit `width`.
+      const indent = line.listIndent ?? 0;
+      if (line.listMarker !== undefined) {
+        return (
+          <Text wrap="truncate">
+            <Text>{line.listMarker} </Text>
+            {renderNodes(line.nodes)}
+          </Text>
+        );
+      }
+      return <Text wrap="truncate">{" ".repeat(indent)}{renderNodes(line.nodes)}</Text>;
+    }
+
     case "dm": {
+      // Blockquote row: a left rule + the wrapped inner content. Layout reserved
+      // the rule's columns, so rule + content fits `width`.
+      const sole = line.nodes.length === 1 && typeof line.nodes[0] !== "string" ? line.nodes[0] : undefined;
+      if (sole && sole.type === "quote") {
+        return (
+          <Text wrap="truncate">
+            <Text dimColor>{QUOTE_RULE} </Text>
+            {renderNodes(sole.content)}
+          </Text>
+        );
+      }
+
       // Alignment lines get Box layout
       if (width && line.alignment) {
         const justify = line.alignment === "center" ? "center" : "flex-end";

--- a/packages/client-ink/src/tui/components/NarrativeArea.tsx
+++ b/packages/client-ink/src/tui/components/NarrativeArea.tsx
@@ -424,7 +424,7 @@ const NarrativeLineComponent = React.memo(function NarrativeLineComponent({
       if (width && line.alignment) {
         const justify = line.alignment === "center" ? "center" : "flex-end";
         // Unwrap the outer alignment tag to get inner content
-        const inner = line.nodes.length === 1 && typeof line.nodes[0] !== "string"
+        const inner = line.nodes.length === 1 && typeof line.nodes[0] !== "string" && "content" in line.nodes[0]
           ? line.nodes[0].content
           : line.nodes;
         return (

--- a/packages/client-ink/src/tui/formatting.test.ts
+++ b/packages/client-ink/src/tui/formatting.test.ts
@@ -77,10 +77,11 @@ describe("parseFormatting", () => {
     expect(result).toEqual(["before <b>unclosed"]);
   });
 
-  it("treats unrecognized tags as plain text", () => {
+  it("strips unrecognized tags to their content (INV-NO-LEAK)", () => {
+    // An unknown tag-shaped run never renders as literal markup; the delimiters
+    // are stripped and the content is kept.
     const result = parseFormatting("<blink>flashing</blink>");
-    // <blink> isn't recognized, so < is treated as text
-    expect(toPlainText(result)).toBe("<blink>flashing</blink>");
+    expect(toPlainText(result)).toBe("flashing");
   });
 
   it("strips orphan close tags silently (issue #454)", () => {
@@ -91,11 +92,51 @@ describe("parseFormatting", () => {
     expect(parseFormatting("a</color>b")).toEqual(["ab"]);
   });
 
-  it("does not strip unrecognized close tags", () => {
-    // Only known tag names are stripped; arbitrary </blink> stays literal
-    // so e.g. code samples and quoted HTML still render.
+  it("strips unrecognized close tags too (INV-NO-LEAK)", () => {
+    // Any tag-shaped close — known or not — is stripped rather than leaked.
     const result = parseFormatting("text</blink>more");
-    expect(toPlainText(result)).toBe("text</blink>more");
+    expect(toPlainText(result)).toBe("textmore");
+  });
+
+  it("keeps a bare '<' that isn't tag-shaped literal", () => {
+    // Strip-to-content only fires on tag-shaped runs (a letter right after '<').
+    expect(toPlainText(parseFormatting("if x < y then"))).toBe("if x < y then");
+    expect(toPlainText(parseFormatting("a <3 emoticon"))).toBe("a <3 emoticon");
+    expect(toPlainText(parseFormatting("i<j and j>k"))).toBe("i<j and j>k");
+  });
+
+  it("parses <br> as a contentless linebreak leaf", () => {
+    const result = parseFormatting("line one<br>line two");
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe("line one");
+    expect((result[1] as FormattingTag).type).toBe("linebreak");
+    expect(result[2]).toBe("line two");
+    // A linebreak contributes no plain text (it's structural).
+    expect(toPlainText(result)).toBe("line oneline two");
+  });
+
+  it("tolerates <br/> and <br /> void forms", () => {
+    expect((parseFormatting("a<br/>b")[1] as FormattingTag).type).toBe("linebreak");
+    expect((parseFormatting("a<br />b")[1] as FormattingTag).type).toBe("linebreak");
+  });
+
+  it("parses <code> as inline code", () => {
+    const result = parseFormatting("run <code>npm test</code> now");
+    expect((result[1] as FormattingTag).type).toBe("code");
+    expect((result[1] as FormattingTag).content).toEqual(["npm test"]);
+  });
+
+  it("nests <br> inside an alignment + color span (the diegetic-sign case)", () => {
+    const result = parseFormatting(
+      "<center><color=#20b2aa>A</color><br><color=#20b2aa>B</color></center>",
+    );
+    const center = result[0] as FormattingTag;
+    expect(center.type).toBe("center");
+    // content: color(A), linebreak, color(B)
+    expect(center.type === "center" && center.content).toHaveLength(3);
+    if (center.type === "center") {
+      expect((center.content[1] as FormattingTag).type).toBe("linebreak");
+    }
   });
 
   it("handles empty content between tags", () => {
@@ -1448,13 +1489,9 @@ describe("wikilink tag", () => {
     );
   });
 
-  it("rejects malformed wikilink (no slug attribute)", () => {
-    // Unparseable open tag — `<wikilink>` without slug=. The `<wikilink>`
-    // open emits as literal text (no matching close for an unparseable open).
-    // The trailing `</wikilink>` is a known close tag with no matching open
-    // in scope, so it's stripped as an orphan (issue #454 behavior).
-    const result = parseFormatting("<wikilink>Foo</wikilink>");
-    expect(stripFormatting("<wikilink>Foo</wikilink>")).toBe("<wikilink>Foo");
-    expect(result.length).toBeGreaterThan(0);
+  it("strips a malformed wikilink (no slug attribute) to its content", () => {
+    // `<wikilink>` without slug= is not a valid open tag; both it and its close
+    // are tag-shaped and stripped to content rather than leaked (INV-NO-LEAK).
+    expect(stripFormatting("<wikilink>Foo</wikilink>")).toBe("Foo");
   });
 });

--- a/packages/client-ink/src/tui/formatting.test.ts
+++ b/packages/client-ink/src/tui/formatting.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { parseFormatting, toPlainText, stripFormatting, stripLeadingBullet, highlightQuotesWithState, markdownToTags, nodeVisibleLength, wrapNodes, processNarrativeLines, isHorizontalRule, splitTrailingHorizontalRule } from "./formatting.js";
-import type { FormattingTag, FormattingNode, NarrativeLine } from "@machine-violet/shared/types/tui.js";
+import { parseFormatting, toPlainText, stripFormatting, stripLeadingBullet, highlightQuotesWithState, markdownToTags, matchListItem, nodeVisibleLength, wrapNodes, processNarrativeLines, isHorizontalRule, splitTrailingHorizontalRule } from "./formatting.js";
+import type { FormattingTag, FormattingNode, NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
 
 describe("parseFormatting", () => {
   it("returns plain text as-is", () => {
@@ -1493,5 +1493,99 @@ describe("wikilink tag", () => {
     // `<wikilink>` without slug= is not a valid open tag; both it and its close
     // are tag-shaped and stripped to content rather than leaked (INV-NO-LEAK).
     expect(stripFormatting("<wikilink>Foo</wikilink>")).toBe("Foo");
+  });
+});
+
+describe("matchListItem", () => {
+  it("recognizes unordered markers and lifts the bullet glyph", () => {
+    expect(matchListItem("- a coil of rope")).toEqual({ marker: "•", indent: 2, ordered: false, content: "a coil of rope" });
+    expect(matchListItem("* a coil")).toMatchObject({ marker: "•", ordered: false, content: "a coil" });
+  });
+
+  it("recognizes ordered markers and preserves the number (normalizing N) → N.)", () => {
+    expect(matchListItem("1. Bread primary.")).toEqual({ marker: "1.", indent: 3, ordered: true, content: "Bread primary." });
+    expect(matchListItem("12) wait")).toMatchObject({ marker: "12.", indent: 4, ordered: true, content: "wait" });
+  });
+
+  it("rejects horizontal rules, marker-without-space, and plain prose", () => {
+    expect(matchListItem("---")).toBeNull();
+    expect(matchListItem("* * *")).toBeNull();
+    expect(matchListItem("-nospace")).toBeNull();
+    expect(matchListItem("just prose")).toBeNull();
+    expect(matchListItem("-")).toBeNull(); // marker with no content
+  });
+});
+
+describe("processNarrativeLines — blockquote", () => {
+  const isQuoteRow = (l: ProcessedLine): boolean =>
+    l.kind === "dm" && l.nodes.length === 1 && typeof l.nodes[0] !== "string"
+    && (l.nodes[0] as FormattingTag).type === "quote";
+  const quoteText = (l: ProcessedLine): string => toPlainText(l.nodes);
+
+  it("emits a single quote node per row, wraps wide content within width − rule, and never leaks", () => {
+    const out = processNarrativeLines(
+      [{ kind: "dm", text: "<quote>The inscription read the last honest broker rests here beneath cold stone tonight forever</quote>" }],
+      40,
+      "#ffffff",
+    );
+    const rows = out.filter(isQuoteRow);
+    expect(rows.length).toBeGreaterThan(1); // it wrapped
+    for (const r of rows) expect(quoteText(r).length).toBeLessThanOrEqual(38); // 40 − rule prefix
+    expect(out.map((l) => toPlainText(l.nodes)).join(" ")).not.toContain("<quote>");
+  });
+
+  it("splits a <br> blockquote into independent ruled rows", () => {
+    const out = processNarrativeLines(
+      [{ kind: "dm", text: "<quote>ALERT<br>breach<br>evacuate</quote>" }],
+      40,
+      "#ffffff",
+    );
+    expect(out.filter(isQuoteRow).map(quoteText)).toEqual(["ALERT", "breach", "evacuate"]);
+  });
+});
+
+describe("processNarrativeLines — lists", () => {
+  it("renders an ordered list tight, with markers + hanging-indent continuation rows", () => {
+    const input: NarrativeLine[] = [
+      { kind: "dm", text: "1. alpha" },
+      { kind: "spacer", text: "" },
+      { kind: "dm", text: "2. a very long second item that will certainly wrap across to a continuation row at forty cols" },
+    ];
+    const out = processNarrativeLines(input, 40, "#ffffff");
+    const lists = out.filter((l) => l.kind === "list");
+    // Both items keep their (normalized) markers on the first row.
+    expect(lists.find((l) => l.listMarker === "1.")).toBeTruthy();
+    expect(lists.find((l) => l.listMarker === "2.")).toBeTruthy();
+    // Tight: the inter-item spacer was collapsed away.
+    expect(out.some((l) => l.kind === "spacer")).toBe(false);
+    // The long item wrapped: continuation rows carry the indent but no marker.
+    const cont = lists.filter((l) => l.listMarker === undefined);
+    expect(cont.length).toBeGreaterThan(0);
+    for (const c of cont) expect(c.listIndent).toBe(3);
+    // Every list row fits width − indent.
+    for (const l of lists) expect(toPlainText(l.nodes).length).toBeLessThanOrEqual(37);
+  });
+
+  it("uses bullet glyphs for unordered markers", () => {
+    const out = processNarrativeLines(
+      [{ kind: "dm", text: "- rope" }, { kind: "spacer", text: "" }, { kind: "dm", text: "* lantern" }],
+      40,
+      "#ffffff",
+    );
+    expect(out.filter((l) => l.kind === "list" && l.listMarker !== undefined).map((l) => l.listMarker)).toEqual(["•", "•"]);
+  });
+
+  it("keeps the lead-in blank but tightens the list (intro line then items)", () => {
+    const input: NarrativeLine[] = [
+      { kind: "dm", text: "Pack list:" },
+      { kind: "spacer", text: "" },
+      { kind: "dm", text: "- rope" },
+      { kind: "spacer", text: "" },
+      { kind: "dm", text: "- lantern" },
+    ];
+    const out = processNarrativeLines(input, 40, "#ffffff");
+    // The intro keeps its spacer (prev is not a list item); the inter-item one is gone.
+    expect(out.filter((l) => l.kind === "spacer").length).toBe(1);
+    expect(out.filter((l) => l.kind === "list").length).toBe(2);
   });
 });

--- a/packages/client-ink/src/tui/formatting.ts
+++ b/packages/client-ink/src/tui/formatting.ts
@@ -1,15 +1,22 @@
 import type { FormattingNode, FormattingTag, NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
+import { stringWidth } from "./frames/string-width.js";
+import { normalizeDialect } from "./narrative/normalize.js";
+import { layoutRuns } from "./narrative/layout.js";
 
 /**
  * Parse DM text with inline formatting tags into a tree of FormattingNodes.
  *
- * Supported tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>, <color=#hex>,
- * <wikilink slug=foo>...</wikilink> (render-only — emitted by the colorizer, not LLMs)
- * Unrecognized tags are stripped. Malformed tags render as plain text.
- * Orphan close tags (e.g. `</i>` with no matching open in scope) are stripped
- * silently — they're nearly always a leak from healing across paragraph
- * boundaries, never something the user intended to display literally.
- * Tags can be nested: <b><i>bold italic</i></b>
+ * Supported tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>, <code>,
+ * <color=#hex>, <br> (a contentless line-break leaf), and the render-only
+ * <wikilink slug=foo>...</wikilink> (emitted by the colorizer, not LLMs).
+ * Tags can nest: <b><i>bold italic</i></b>.
+ *
+ * Anything tag-SHAPED but outside this vocabulary — unknown tags (<strong>,
+ * <table>), attribute-laden variants (<b class="x">), or an orphan close left
+ * by healing across a paragraph boundary (#454) — is STRIPPED to its content;
+ * it never renders as literal markup (the INV-NO-LEAK guarantee). A bare '<'
+ * that isn't tag-shaped (math `3 < 5`, an emoticon `<3`) stays literal.
+ * Dialect synonyms and markdown are mapped upstream in `narrative/normalize.ts`.
  */
 export function parseFormatting(input: string): FormattingNode[] {
   const result: FormattingNode[] = [];
@@ -33,18 +40,25 @@ export function parseFormatting(input: string): FormattingNode[] {
     // Try to parse an opening tag
     const parsed = parseOpenTag(input, tagStart);
     if (!parsed) {
-      // Orphan close tag (e.g. `</i>` with no matching open in this scope):
-      // strip it silently. Healing leaves these behind when an open tag is
-      // reset by a paragraph boundary before its close arrives — without this,
-      // the close would render as literal `</tagname>` text (issue #454).
-      const orphanClose = input.slice(tagStart).match(KNOWN_CLOSE_TAG_RE);
-      if (orphanClose) {
-        i = tagStart + orphanClose[0].length;
+      // Tag-shaped but outside our vocabulary (unknown tag like <strong>, an
+      // attribute-laden <b class="x">, or an orphan </i> left by healing across
+      // a paragraph boundary, #454): strip the delimiter and keep any inner
+      // content. Unknown markup never renders literally (INV-NO-LEAK).
+      const generic = input.slice(tagStart).match(GENERIC_TAG_RE);
+      if (generic) {
+        i = tagStart + generic[0].length;
         continue;
       }
-      // Not a recognized tag at all — treat the < as plain text
+      // A bare '<' that isn't tag-shaped (math `3 < 5`, emoticon `<3`) is literal.
       pushText(result, "<");
       i = tagStart + 1;
+      continue;
+    }
+
+    // Void tags (<br>) are contentless leaves — emit and move on (no close tag).
+    if (parsed.void) {
+      result.push({ type: "linebreak" });
+      i = parsed.end;
       continue;
     }
 
@@ -84,6 +98,8 @@ export function toPlainText(nodes: FormattingNode[]): string {
   return nodes
     .map((node) => {
       if (typeof node === "string") return node;
+      // A linebreak is structural (handled at layout) and carries no text.
+      if (node.type === "linebreak") return "";
       return toPlainText(node.content);
     })
     .join("");
@@ -100,10 +116,21 @@ export function stripLeadingBullet(input: string): string {
 }
 
 /**
- * Compute the visible length of a FormattingNode array (strip all tags).
+ * Visible LENGTH of a FormattingNode array in code units (strip all tags).
+ * Legacy measure retained for the modal `wrapNodes` callers. For terminal
+ * layout prefer {@link nodeDisplayWidth} — code units overflow on wide glyphs.
  */
 export function nodeVisibleLength(nodes: FormattingNode[]): number {
   return toPlainText(nodes).length;
+}
+
+/**
+ * Visible DISPLAY WIDTH of a FormattingNode array in terminal columns, via the
+ * real `string-width` oracle (CJK/wide = 2, combining/zero-width = 0, emoji by
+ * rendered width). This is the measure the narrative layout engine wraps by.
+ */
+export function nodeDisplayWidth(nodes: FormattingNode[]): number {
+  return stringWidth(toPlainText(nodes));
 }
 
 /**
@@ -168,8 +195,12 @@ export function wrapNodes(nodes: FormattingNode[], width: number): FormattingNod
  * Flatten a FormattingNode[] into word tokens, splitting text at spaces.
  * Each word token carries structurally well-formed node fragments.
  * Returns true if the last text ended with a space (trailing word break).
+ *
+ * Exported for the narrative layout engine (`narrative/layout.ts`), which reuses
+ * this proven tokenizer (spacing + wikilink atomicity) but re-measures each word
+ * by display width and adds overlong-token breaking.
  */
-function flattenToWords(
+export function flattenToWords(
   nodes: FormattingNode[],
   words: { nodes: FormattingNode[]; visible: number }[],
 ): boolean {
@@ -217,6 +248,12 @@ function flattenToWords(
         words.push({ nodes: [node], visible });
       }
       wordBreak = false;
+    } else if (node.type === "linebreak") {
+      // wrapNodes is the legacy single-line wrapper (modal callers); hard breaks
+      // don't occur on that path. If one ever appears, treat it as a word
+      // boundary so adjacent text doesn't fuse. The narrative path handles
+      // linebreaks structurally in the layout engine, not here.
+      wordBreak = true;
     } else {
       // Tag node — recurse into children, wrapping fragments in the same tag type
       const childWords: { nodes: FormattingNode[]; visible: number }[] = [];
@@ -288,8 +325,15 @@ export function processNarrativeLines(
   // (e.g. on session resume, the disk's "---" markers are streamed as DM
   // chunks AND the client injects a separator before the first DM chunk
   // after a player line).
+  // Pre-pass: rewrite each DM line's dialect (semantic HTML, attribute variants,
+  // inline markdown) into the canonical vocabulary before healing/parsing, so the
+  // heal and parse stages only ever see the closed tag set.
+  const normLines: NarrativeLine[] = lines.map((l) =>
+    l.kind === "dm" && l.text !== "" ? { ...l, text: normalizeDialect(l.text) } : l,
+  );
+
   const expandedLines: NarrativeLine[] = [];
-  for (const srcLine of lines) {
+  for (const srcLine of normLines) {
     if (srcLine.kind === "dm" && srcLine.text.trim() !== "") {
       if (isHorizontalRule(srcLine.text)) {
         pushSeparator(expandedLines);
@@ -372,19 +416,31 @@ export function processNarrativeLines(
     parsed.push({ kind: "dm", nodes, isSourceBoundary: true });
   }
 
-  // Phase 2: Wrap each line
+  // Phase 2: Lay out each line into physical rows by DISPLAY width. Aligned
+  // blocks wrap their inner content and split on <br> into independent rows, each
+  // emitted as its own single-tag aligned line; every row fits `width` (INV-WIDTH).
   const wrapped: { kind: NarrativeLine["kind"]; nodes: FormattingNode[]; isSourceBoundary: boolean; intent?: Extract<NarrativeLine, { kind: "image" }>["intent"] }[] = [];
   for (const line of parsed) {
-    if (line.kind === "dm" || line.kind === "player") {
-      const wLines = wrapNodes(line.nodes, width);
-      for (let j = 0; j < wLines.length; j++) {
-        if (line.kind === "player") {
-          // Player nodes are always plain strings — re-join after wrapping
-          // so the renderer can still read nodes[0] as the full line text.
-          wrapped.push({ kind: "player", nodes: [toPlainText(wLines[j])], isSourceBoundary: j === 0 });
-        } else {
-          wrapped.push({ kind: "dm", nodes: wLines[j], isSourceBoundary: j === 0 });
-        }
+    const first = line.nodes[0];
+    if (line.kind === "dm" && line.nodes.length === 1 && typeof first !== "string"
+        && (first.type === "center" || first.type === "right")) {
+      // Aligned block: wrap + split-on-<br> the inner content; re-wrap each row
+      // in the alignment tag so it stays a single-node aligned line.
+      const rows = layoutRuns(first.content, width);
+      for (let j = 0; j < rows.length; j++) {
+        wrapped.push({ kind: "dm", nodes: [{ ...first, content: rows[j] }], isSourceBoundary: j === 0 });
+      }
+    } else if (line.kind === "dm") {
+      const rows = layoutRuns(line.nodes, width);
+      for (let j = 0; j < rows.length; j++) {
+        wrapped.push({ kind: "dm", nodes: rows[j], isSourceBoundary: j === 0 });
+      }
+    } else if (line.kind === "player") {
+      // Player nodes are always plain strings — re-join after wrapping so the
+      // renderer can still read nodes[0] as the full line text.
+      const rows = layoutRuns(line.nodes, width);
+      for (let j = 0; j < rows.length; j++) {
+        wrapped.push({ kind: "player", nodes: [toPlainText(rows[j])], isSourceBoundary: j === 0 });
       }
     } else {
       wrapped.push(line);
@@ -398,15 +454,19 @@ export function processNarrativeLines(
     const isAlign = line.kind === "dm" && isAlignmentNode(line.nodes);
 
     if (isAlign) {
-      // Blank line before if previous is non-empty
+      // Blank line before the aligned GROUP if the previous line is non-empty
+      // and not itself aligned (consecutive aligned rows — e.g. a multi-line
+      // <br> sign — must not get blanks between them).
       const prev = padded[padded.length - 1];
-      if (prev !== undefined && !isEmptyNodes(prev.nodes)) {
+      const prevAlign = prev !== undefined && prev.kind === "dm" && isAlignmentNode(prev.nodes);
+      if (prev !== undefined && !isEmptyNodes(prev.nodes) && !prevAlign) {
         padded.push({ kind: "dm", nodes: [], isSourceBoundary: false });
       }
       padded.push(line);
-      // Blank line after if next is non-empty
+      // Blank line after if the next line is non-empty and not aligned.
       const next = wrapped[i + 1];
-      if (next !== undefined && !isEmptyNodes(next.nodes)) {
+      const nextAlign = next !== undefined && next.kind === "dm" && isAlignmentNode(next.nodes);
+      if (next !== undefined && !isEmptyNodes(next.nodes) && !nextAlign) {
         padded.push({ kind: "dm", nodes: [], isSourceBoundary: false });
       }
     } else {
@@ -442,7 +502,7 @@ export function processNarrativeLines(
         alignment = line.nodes[0].type;
       }
 
-      result.push({ kind: "dm", nodes, alignment });
+      result.push({ kind: "dm", nodes, alignment, ...(alignment ? { padWidth: width } : {}) });
     } else {
       result.push({
         kind: line.kind,
@@ -556,6 +616,8 @@ export function highlightQuotesWithState(
       result.push(...expanded);
       // Update state: count quotes in this text
       for (const ch of node) if (ch === '"') inQuote = !inQuote;
+    } else if (node.type === "linebreak") {
+      result.push(node); // contentless leaf — no quote state to thread
     } else {
       const newContent = highlightQuotesWithState(node.content, color, inQuote);
       result.push({ ...node, content: newContent } as FormattingTag);
@@ -588,7 +650,7 @@ function scanTagChanges(line: string): TagChange[] {
     if (tagStart === -1) break;
 
     // Try close tag first: </tagname>
-    const closeMatch = line.slice(tagStart).match(/^<\/(b|i|u|sub|sup|center|right|color|wikilink)>/);
+    const closeMatch = line.slice(tagStart).match(/^<\/(b|i|u|sub|sup|center|right|color|wikilink|code)>/);
     if (closeMatch) {
       changes.push({ kind: "close", name: closeMatch[1], raw: closeMatch[0] });
       i = tagStart + closeMatch[0].length;
@@ -598,6 +660,13 @@ function scanTagChanges(line: string): TagChange[] {
     // Try open tag via parseOpenTag (reuses existing logic)
     const parsed = parseOpenTag(line, tagStart);
     if (parsed) {
+      // Void tags (<br>) are self-contained — they never open a span, so they
+      // must not push onto the heal stack (else healing would emit a bogus
+      // </br> closer).
+      if (parsed.void) {
+        i = parsed.end;
+        continue;
+      }
       changes.push({ kind: "open", name: parsed.tagName, raw: line.slice(tagStart, parsed.end) });
       i = parsed.end;
       continue;
@@ -663,10 +732,17 @@ interface ParsedTag {
   type: string;
   color?: string;
   target?: string;
+  void?: boolean; // self-contained leaf (e.g. <br>) — no closing tag
   end: number; // index after the closing >
 }
 
-const KNOWN_CLOSE_TAG_RE = /^<\/(?:b|i|u|sub|sup|center|right|color|wikilink)>/;
+// A tag-shaped run to strip: `<name>`, `</name>`, `<name/>`, or an attributed
+// `<name key="v" …>` (an attribute section is required to contain `=`). Matches
+// unknown opens (<strong>, <h2>, <b class="x">, <span style="…">) and any close
+// (</foo>). Deliberately does NOT match prose that merely contains angle
+// brackets — `3 < 5` (space after `<`), `<3` (digit), or `i<j and j>k`
+// (bareword "attributes" with no `=`) all stay literal.
+const GENERIC_TAG_RE = /^<\/?[a-zA-Z][a-zA-Z0-9]*\s*(?:\/?>|[^<>]*=[^<>]*>)/;
 
 const SIMPLE_TAGS: Record<string, string> = {
   b: "bold",
@@ -676,14 +752,15 @@ const SIMPLE_TAGS: Record<string, string> = {
   sup: "superscript",
   center: "center",
   right: "right",
+  code: "code",
 };
 
 function parseOpenTag(input: string, start: number): ParsedTag | null {
   // Match <tagname> or <color=#hex>
   const remaining = input.slice(start);
 
-  // Simple tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>
-  const simpleMatch = remaining.match(/^<(b|i|u|sub|sup|center|right)>/);
+  // Simple paired tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>, <code>
+  const simpleMatch = remaining.match(/^<(b|i|u|sub|sup|center|right|code)>/);
   if (simpleMatch) {
     const tagName = simpleMatch[1];
     return {
@@ -691,6 +768,12 @@ function parseOpenTag(input: string, start: number): ParsedTag | null {
       type: SIMPLE_TAGS[tagName],
       end: start + simpleMatch[0].length,
     };
+  }
+
+  // Void tag: <br> / <br/> / <br /> → a hard line-break leaf.
+  const brMatch = remaining.match(/^<br\s*\/?>/);
+  if (brMatch) {
+    return { tagName: "br", type: "linebreak", void: true, end: start + brMatch[0].length };
   }
 
   // Color tag: <color=#hex>
@@ -735,6 +818,16 @@ function findClosingTag(input: string, startAfter: number, tagName: string): num
     while (searchPos < nextClose) {
       const nextOpen = input.indexOf(openTag, searchPos);
       if (nextOpen === -1 || nextOpen >= nextClose) break;
+      // The match is a real nested open of THIS tag only if the char after the
+      // name is a tag terminator. Without this, counting `<b>` would treat the
+      // unrelated `<br>` as a nested open (the "<b" prefix matches) and never
+      // balance — leaking the `<b>` as literal text.
+      const after = input[nextOpen + openTag.length];
+      const isRealOpen = after === ">" || after === " " || after === "/" || after === "=";
+      if (!isRealOpen) {
+        searchPos = nextOpen + openTag.length;
+        continue;
+      }
       // Verify it's a complete open tag (ends with >)
       const afterOpen = input.indexOf(">", nextOpen);
       if (afterOpen !== -1 && afterOpen < nextClose) {
@@ -766,6 +859,8 @@ function buildNode(
       return { type: "italic", content: children };
     case "underline":
       return { type: "underline", content: children };
+    case "code":
+      return { type: "code", content: children };
     case "subscript":
       return { type: "subscript", content: children };
     case "superscript":

--- a/packages/client-ink/src/tui/formatting.ts
+++ b/packages/client-ink/src/tui/formatting.ts
@@ -1,14 +1,14 @@
-import type { FormattingNode, FormattingTag, NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
+import type { FormattingNode, FormattingTag, ImageIntent, NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
 import { stringWidth } from "./frames/string-width.js";
 import { normalizeDialect } from "./narrative/normalize.js";
-import { layoutRuns } from "./narrative/layout.js";
+import { layoutRuns, QUOTE_PREFIX_COLS } from "./narrative/layout.js";
 
 /**
  * Parse DM text with inline formatting tags into a tree of FormattingNodes.
  *
  * Supported tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>, <code>,
- * <color=#hex>, <br> (a contentless line-break leaf), and the render-only
- * <wikilink slug=foo>...</wikilink> (emitted by the colorizer, not LLMs).
+ * <quote>, <color=#hex>, <br> (a contentless line-break leaf), and the
+ * render-only <wikilink slug=foo>...</wikilink> (emitted by the colorizer, not LLMs).
  * Tags can nest: <b><i>bold italic</i></b>.
  *
  * Anything tag-SHAPED but outside this vocabulary — unknown tags (<strong>,
@@ -307,6 +307,85 @@ export function splitTrailingHorizontalRule(text: string): string | null {
 }
 
 /**
+ * Recognize a Markdown list item: a line whose first non-space content is an
+ * unordered marker (`-`/`*`) or an ordered marker (`N.`/`N)`) followed by at
+ * least one space and non-empty content. Horizontal rules (`---`, `* * *`) are
+ * rejected explicitly so they stay separators, not bullets. Returns the resolved
+ * display marker, the hanging-indent width (marker + one space, in display
+ * columns), whether it's ordered, and the remaining content text.
+ *
+ * Nesting is deliberately flattened — leading indent is ignored (no sub-lists),
+ * matching what real DM narration emits (notebooks, itineraries, sign readouts).
+ */
+export function matchListItem(
+  text: string,
+): { marker: string; indent: number; ordered: boolean; content: string } | null {
+  if (isHorizontalRule(text)) return null;
+  const m = text.match(/^\s*([-*]|\d{1,9}[.)])\s+(\S.*)$/);
+  if (!m) return null;
+  const raw = m[1];
+  const ordered = /\d/.test(raw);
+  // Unordered → a single bullet glyph; ordered → the literal number normalized to
+  // `N.` form (we preserve the DM's number rather than renumbering).
+  const marker = ordered ? `${raw.replace(/[.)]$/, "")}.` : "•";
+  const indent = stringWidth(marker) + 1; // marker + one space
+  return { marker, indent, ordered, content: m[2] };
+}
+
+/**
+ * Close any tags left open within a single self-contained line (a list item's
+ * content), so an unclosed `<b>` closes at the item end instead of leaking. No
+ * prefix — nothing is open before a standalone unit. Reuses {@link scanTagChanges}.
+ */
+function healStandalone(text: string): string {
+  const stack: string[] = [];
+  for (const c of scanTagChanges(text)) {
+    if (c.kind === "open") {
+      stack.push(c.name);
+    } else {
+      for (let j = stack.length - 1; j >= 0; j--) {
+        if (stack[j] === c.name) { stack.splice(j, 1); break; }
+      }
+    }
+  }
+  const suffix = stack.reverse().map((n) => `</${n}>`).join("");
+  return text + suffix;
+}
+
+/**
+ * Drop the visual `spacer` that `appendDelta` inserts between two consecutive
+ * list items, so a list renders tight (bulleted) rather than double-spaced. Only
+ * a spacer flanked by two list items is removed; the spacers framing the list as
+ * a whole are left in place. A list run never contains a blank DM line, so it
+ * never straddles the incremental cache's frozen-prefix split — this stays
+ * transparent to INV-DETERMINISM.
+ */
+function collapseListSpacers(lines: NarrativeLine[]): NarrativeLine[] {
+  const isItem = (l: NarrativeLine | undefined): boolean =>
+    l !== undefined && l.kind === "dm" && matchListItem(l.text) !== null;
+  const out: NarrativeLine[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const l = lines[i];
+    if (l.kind === "spacer" && isItem(out[out.length - 1]) && isItem(lines[i + 1])) {
+      continue;
+    }
+    out.push(l);
+  }
+  return out;
+}
+
+/** One line threaded through the processing pipeline. Carries the parsed AST plus
+ *  the block decoration (image intent, list marker/indent) accumulated per phase. */
+interface PipelineLine {
+  kind: ProcessedLine["kind"];
+  nodes: FormattingNode[];
+  isSourceBoundary: boolean;
+  intent?: ImageIntent;
+  listMarker?: string;
+  listIndent?: number;
+}
+
+/**
  * Unified processing pipeline for NarrativeLines.
  * Heal → parse → wrap → pad alignment → quote highlight.
  * Returns ProcessedLine[] ready for direct rendering.
@@ -332,8 +411,12 @@ export function processNarrativeLines(
     l.kind === "dm" && l.text !== "" ? { ...l, text: normalizeDialect(l.text) } : l,
   );
 
+  // Tighten lists: drop the appendDelta spacer between adjacent list items so a
+  // list renders bulleted/contiguous rather than double-spaced.
+  const tightLines = collapseListSpacers(normLines);
+
   const expandedLines: NarrativeLine[] = [];
-  for (const srcLine of normLines) {
+  for (const srcLine of tightLines) {
     if (srcLine.kind === "dm" && srcLine.text.trim() !== "") {
       if (isHorizontalRule(srcLine.text)) {
         pushSeparator(expandedLines);
@@ -358,7 +441,7 @@ export function processNarrativeLines(
   // Phase 1: Heal cross-line tags on raw strings, then parse into AST.
   // Healing must happen before parsing because parseFormatting treats
   // unclosed tags as plain text.
-  const parsed: { kind: NarrativeLine["kind"]; nodes: FormattingNode[]; isSourceBoundary: boolean; intent?: Extract<NarrativeLine, { kind: "image" }>["intent"] }[] = [];
+  const parsed: PipelineLine[] = [];
 
   // Track open tags across DM source lines for cross-line healing
   const openStack: { raw: string; name: string }[] = [];
@@ -371,6 +454,24 @@ export function processNarrativeLines(
         isSourceBoundary: true,
         // Carry image framing intent through the pipeline (only image lines have it).
         ...(srcLine.kind === "image" ? { intent: srcLine.intent } : {}),
+      });
+      continue;
+    }
+
+    // List item? Lift the marker to metadata and treat the item as a
+    // self-contained, paragraph-like unit: the content is healed on its own (so
+    // an unclosed tag closes at the item end), and the cross-line heal stack is
+    // reset so prior formatting doesn't bleed into the marker or the item.
+    const item = srcLine.text.trim() === "" ? null : matchListItem(srcLine.text);
+    if (item) {
+      openStack.length = 0;
+      const nodes = parseFormatting(healStandalone(item.content));
+      parsed.push({
+        kind: "list",
+        nodes,
+        isSourceBoundary: true,
+        listMarker: item.marker,
+        listIndent: item.indent,
       });
       continue;
     }
@@ -419,7 +520,7 @@ export function processNarrativeLines(
   // Phase 2: Lay out each line into physical rows by DISPLAY width. Aligned
   // blocks wrap their inner content and split on <br> into independent rows, each
   // emitted as its own single-tag aligned line; every row fits `width` (INV-WIDTH).
-  const wrapped: { kind: NarrativeLine["kind"]; nodes: FormattingNode[]; isSourceBoundary: boolean; intent?: Extract<NarrativeLine, { kind: "image" }>["intent"] }[] = [];
+  const wrapped: PipelineLine[] = [];
   for (const line of parsed) {
     const first = line.nodes[0];
     if (line.kind === "dm" && line.nodes.length === 1 && typeof first !== "string"
@@ -427,6 +528,16 @@ export function processNarrativeLines(
       // Aligned block: wrap + split-on-<br> the inner content; re-wrap each row
       // in the alignment tag so it stays a single-node aligned line.
       const rows = layoutRuns(first.content, width);
+      for (let j = 0; j < rows.length; j++) {
+        wrapped.push({ kind: "dm", nodes: [{ ...first, content: rows[j] }], isSourceBoundary: j === 0 });
+      }
+    } else if (line.kind === "dm" && line.nodes.length === 1 && typeof first !== "string"
+        && first.type === "quote") {
+      // Blockquote: reserve columns for the renderer's left rule, then wrap +
+      // split-on-<br>; each row stays a single quote tag so the rule prefix plus
+      // the wrapped content fits `width` (INV-WIDTH, proven at render level).
+      const inner = width > 0 ? Math.max(1, width - QUOTE_PREFIX_COLS) : width;
+      const rows = layoutRuns(first.content, inner);
       for (let j = 0; j < rows.length; j++) {
         wrapped.push({ kind: "dm", nodes: [{ ...first, content: rows[j] }], isSourceBoundary: j === 0 });
       }
@@ -442,31 +553,48 @@ export function processNarrativeLines(
       for (let j = 0; j < rows.length; j++) {
         wrapped.push({ kind: "player", nodes: [toPlainText(rows[j])], isSourceBoundary: j === 0 });
       }
+    } else if (line.kind === "list") {
+      // List item: wrap the content to the column budget left after the marker /
+      // hanging indent, so marker + content fits `width`. The marker rides only
+      // on the first physical row; continuation rows carry the indent alone.
+      const indent = line.listIndent ?? 0;
+      const inner = width > 0 ? Math.max(1, width - indent) : width;
+      const rows = layoutRuns(line.nodes, inner);
+      for (let j = 0; j < rows.length; j++) {
+        wrapped.push({
+          kind: "list",
+          nodes: rows[j],
+          isSourceBoundary: j === 0,
+          listIndent: indent,
+          ...(j === 0 ? { listMarker: line.listMarker } : {}),
+        });
+      }
     } else {
       wrapped.push(line);
     }
   }
 
-  // Phase 3: Pad alignment lines
-  const padded: { kind: NarrativeLine["kind"]; nodes: FormattingNode[]; isSourceBoundary: boolean; intent?: Extract<NarrativeLine, { kind: "image" }>["intent"] }[] = [];
+  // Phase 3: Frame block rows (alignment + blockquote) with a blank line before
+  // and after the GROUP, but keep the rows within a group tight.
+  const padded: PipelineLine[] = [];
   for (let i = 0; i < wrapped.length; i++) {
     const line = wrapped[i];
-    const isAlign = line.kind === "dm" && isAlignmentNode(line.nodes);
+    const isBlock = line.kind === "dm" && isBlockTagNode(line.nodes);
 
-    if (isAlign) {
-      // Blank line before the aligned GROUP if the previous line is non-empty
-      // and not itself aligned (consecutive aligned rows — e.g. a multi-line
-      // <br> sign — must not get blanks between them).
+    if (isBlock) {
+      // Blank line before the GROUP if the previous line is non-empty and not
+      // itself a block row (consecutive block rows — e.g. a multi-line <br> sign
+      // or a wrapped blockquote — must not get blanks between them).
       const prev = padded[padded.length - 1];
-      const prevAlign = prev !== undefined && prev.kind === "dm" && isAlignmentNode(prev.nodes);
-      if (prev !== undefined && !isEmptyNodes(prev.nodes) && !prevAlign) {
+      const prevBlock = prev !== undefined && prev.kind === "dm" && isBlockTagNode(prev.nodes);
+      if (prev !== undefined && !isEmptyNodes(prev.nodes) && !prevBlock) {
         padded.push({ kind: "dm", nodes: [], isSourceBoundary: false });
       }
       padded.push(line);
-      // Blank line after if the next line is non-empty and not aligned.
+      // Blank line after if the next line is non-empty and not a block row.
       const next = wrapped[i + 1];
-      const nextAlign = next !== undefined && next.kind === "dm" && isAlignmentNode(next.nodes);
-      if (next !== undefined && !isEmptyNodes(next.nodes) && !nextAlign) {
+      const nextBlock = next !== undefined && next.kind === "dm" && isBlockTagNode(next.nodes);
+      if (next !== undefined && !isEmptyNodes(next.nodes) && !nextBlock) {
         padded.push({ kind: "dm", nodes: [], isSourceBoundary: false });
       }
     } else {
@@ -508,6 +636,8 @@ export function processNarrativeLines(
         kind: line.kind,
         nodes: line.nodes,
         ...(line.intent ? { intent: line.intent } : {}),
+        ...(line.listMarker !== undefined ? { listMarker: line.listMarker } : {}),
+        ...(line.listIndent !== undefined ? { listIndent: line.listIndent } : {}),
       });
     }
   }
@@ -516,12 +646,12 @@ export function processNarrativeLines(
 }
 
 /**
- * Split a raw text line so that <center>...</center> and <right>...</right>
- * blocks each end up on their own line. Text before/after is preserved as
- * separate lines. If the line has no inline alignment blocks, returns [text].
+ * Split a raw text line so that <center>...</center>, <right>...</right>, and
+ * <quote>...</quote> blocks each end up on their own line. Text before/after is
+ * preserved as separate lines. If the line has no inline block tags, returns [text].
  */
 function splitAlignmentBlocks(text: string): string[] {
-  const pattern = /(<(?:center|right)>[\s\S]*?<\/(?:center|right)>)/;
+  const pattern = /(<(?:center|right|quote)>[\s\S]*?<\/(?:center|right|quote)>)/;
   const parts = text.split(pattern);
   const result: string[] = [];
   for (const part of parts) {
@@ -549,9 +679,11 @@ function pushSeparator(lines: NarrativeLine[], source?: NarrativeLine): void {
   lines.push(source && source.kind === "separator" ? source : { kind: "separator", text: "" });
 }
 
-function isAlignmentNode(nodes: FormattingNode[]): boolean {
+/** A row that is a single block tag (alignment or blockquote). These are framed
+ *  with a blank line before/after the group but stay tight against each other. */
+function isBlockTagNode(nodes: FormattingNode[]): boolean {
   return nodes.length === 1 && typeof nodes[0] !== "string"
-    && (nodes[0].type === "center" || nodes[0].type === "right");
+    && (nodes[0].type === "center" || nodes[0].type === "right" || nodes[0].type === "quote");
 }
 
 function isEmptyNodes(nodes: FormattingNode[]): boolean {
@@ -650,7 +782,7 @@ function scanTagChanges(line: string): TagChange[] {
     if (tagStart === -1) break;
 
     // Try close tag first: </tagname>
-    const closeMatch = line.slice(tagStart).match(/^<\/(b|i|u|sub|sup|center|right|color|wikilink|code)>/);
+    const closeMatch = line.slice(tagStart).match(/^<\/(b|i|u|sub|sup|center|right|color|wikilink|code|quote)>/);
     if (closeMatch) {
       changes.push({ kind: "close", name: closeMatch[1], raw: closeMatch[0] });
       i = tagStart + closeMatch[0].length;
@@ -753,14 +885,15 @@ const SIMPLE_TAGS: Record<string, string> = {
   center: "center",
   right: "right",
   code: "code",
+  quote: "quote",
 };
 
 function parseOpenTag(input: string, start: number): ParsedTag | null {
   // Match <tagname> or <color=#hex>
   const remaining = input.slice(start);
 
-  // Simple paired tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>, <code>
-  const simpleMatch = remaining.match(/^<(b|i|u|sub|sup|center|right|code)>/);
+  // Simple paired tags: <b>, <i>, <u>, <sub>, <sup>, <center>, <right>, <code>, <quote>
+  const simpleMatch = remaining.match(/^<(b|i|u|sub|sup|center|right|code|quote)>/);
   if (simpleMatch) {
     const tagName = simpleMatch[1];
     return {
@@ -869,6 +1002,8 @@ function buildNode(
       return { type: "center", content: children };
     case "right":
       return { type: "right", content: children };
+    case "quote":
+      return { type: "quote", content: children };
     case "color":
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- color is set when tag === "color"
       return { type: "color", color: color!, content: children };

--- a/packages/client-ink/src/tui/frames/string-width.ts
+++ b/packages/client-ink/src/tui/frames/string-width.ts
@@ -3,15 +3,23 @@
  * Kept in their own module so the composer doesn't pull in the ink/React-laden
  * renderer when imported from browser tools (e.g. the theme editor).
  */
+import realStringWidth from "string-width";
 
 /**
- * Approximate string width (handles most common cases).
- * Does not handle full Unicode width detection — just counts characters.
+ * Display width of a string in terminal columns — the SAME oracle Ink uses for
+ * layout (the `string-width` package). Handles full Unicode: CJK/wide glyphs
+ * count 2, zero-width/combining marks count 0, emoji (incl. ZWJ sequences and
+ * variation selectors) count their rendered width, and ANSI escapes are
+ * stripped. This is load-bearing for width-safety: wrapping that measured
+ * `String.length` (code units) overflowed on wide chars and truncated content.
+ *
+ * `truncateToWidth` (below) still slices by code-unit index, so it can over-cut
+ * a line containing wide glyphs — acceptable for the frame/modal sizing callers
+ * (which deal in box-drawing + mostly-ASCII chrome). The narrative layout engine
+ * does width-aware breaking itself rather than relying on truncation.
  */
 export function stringWidth(str: string): number {
-  // Strip ANSI escape codes
-  // eslint-disable-next-line no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, "").length;
+  return realStringWidth(str);
 }
 
 /**

--- a/packages/client-ink/src/tui/narrative/harness/corpus/codename-lazarus.display-log.md
+++ b/packages/client-ink/src/tui/narrative/harness/corpus/codename-lazarus.display-log.md
@@ -1,0 +1,309 @@
+<center>Vienna, October 14, 1983 — 11:47 PM</center>
+
+---
+
+The <color=#009de5>Café Central</color> closed two hours ago. The main hall is dark now, those magnificent horseshoe arches throwing deeper shadows, the chandeliers cold. You've been let in through a service entrance by a waiter whose name you were told not to learn, who handed you a key on a wooden fob and pointed at the stairs without once meeting your eyes.
+
+He's been paid very well to not exist tonight.
+
+The key is old. Older than the café, you'd reckon — the café only dates to 1876, and the key has the look of something that's outlasted three or four buildings on this spot. Brass gone the color of a December river. The stairs going down smell of coffee and damp and something underneath both, like turned earth.
+
+Your briefing file is four pages long. That's everything Langley has on LAZARUS after thirty years and three handlers. Four pages. Two of them are redacted.
+
+One footnote — someone typed it, then apparently thought better of it, crossed it out in pen, then circled it again — reads: <i>Do not ask how it knows what it knows.</i>
+
+The staircase ends at a door. Stone around it. Not brick — stone, rough-cut, like it grew up through the floor of the wine cellar and somebody built a café over it and called it progress.
+
+There is light under the door. Warm. Gold.
+
+Something about that light makes your left hand want to start in on its old tremor. You will it still.
+
+---
+> [Wilson] I pull my outer coat tight; a trick for checking my sidearm by feel without calling attention. I close my two normal eyes and use my finer senses to evaluate the doorway and what lies behind.
+The sidearm is there. You already knew it was there. What you're really doing is grounding yourself in something metal and certain before you open up to something that isn't.
+
+You let the professional instincts do what they do — that particular stillness you've learned, like listening to a frequency just below speech. Beirut taught you what danger smells like. Prague taught you what lies feel like, the way they warm the air differently. You've trusted these finer instruments in worse conditions than this.
+
+What comes back to you isn't wrong, exactly. It's <i>incomplete.</i>
+
+Age. Not the age of wine-soaked stone and Habsburg ambition — those are familiar smells, comfortable in their way. This is something older than the building that holds it, older than the street above, older than the city's name. The way a riverbed carries the memory of floods that nobody living ever saw.
+
+Warmth. It came through right away and you didn't mention it because warmth in a cellar reads as <i>danger</i> — but it isn't hot, isn't the warmth of bodies or machinery. More like the warmth of being expected. Of a place that already knows your name.
+
+And underneath it all, where your other senses would catch something — footfall, breathing, the small unconscious sounds a living thing makes — there is a <b>quality of silence</b> that has no civilian explanation. Not absence. <i>Patience.</i>
+
+Like something on the other side of that door has been waiting longer than you can usefully imagine, and does not mind waiting a little longer still.
+
+The gold light at the threshold doesn't flicker.
+
+---
+> [Wilson] I withdraw a paper-wrapped bottle of Vienna's finest; a meeting gift. I open the door.
+The door opens without a sound. Hinges like that, on a door that old, should groan like a man with a bad back. They don't.
+
+The room beyond is not large. Stone walls, same vintage as the staircase — older, maybe. A table of dark wood, two chairs that don't match, and on the table a single oil lamp burning with the clean, steady gold of something that has never guttered in its life. Around the walls, shelves. Files. Ledgers. Boxes sealed with wax, some of the wax cracked with the weight of decades. Maps you can see are wrong even from the doorway, because the borders on them don't exist anymore, and some never did.
+
+He is standing beside the table.
+
+He looks, at first, like a man in his middle fifties. Good coat. Old-fashioned cut, not unpleasantly so. Dark hair gone silver at the temples, which your mind immediately flags as <i>chosen</i> — the way an actor chooses what he walks on stage wearing. His face is a diplomat's face: pleasant, attentive, arranged for the convenience of whoever is looking at it.
+
+He is looking at the bottle.
+
+Something happens in his expression that isn't quite a smile and isn't quite recognition. It is the look of a man encountering evidence that the world still occasionally makes sense.
+
+<i>"Zweigelt,"</i> he says. Not a question. His voice carries an accent that has been worn smooth by too many languages to point at any one origin. <i>"1979. Yes."</i>
+
+He hadn't seen the label. The paper is still on.
+
+He gestures to the nearer chair. The gesture is courteous, unhurried, and contains no electricity of any kind — and that absence is itself the most unsettling thing you have felt since you came down those stairs.
+
+<i>"You have questions,"</i> he says. <i>"They all do. Sit, Mr. Wilson. The lamp keeps us honest."</i>
+
+---
+> [Wilson] I smile; mine is less diplomatic and more intentionally forgettable. I remove the wrapping from the bottle and set it on the table, then move my long coat aside as I sit down. I put both of my hands on the table; soft hands, bakelite ring. I do not offer to shake. "I am Wilson", I say. We both know that I am not Wilson.
+LAZARUS looks at your hands on the table. Not at you — at the hands. The bakelite ring. The particular softness of them. He takes the inventory at the pace of a man reading a contract in a language he already knows by heart.
+
+He pulls the nearer chair and sits. He does not take the bottle. He does not produce glasses. The lamp burns between you like a third party with no opinion.
+
+<i>"No,"</i> he says, pleasantly. <i>"You are not."</i>
+
+He lets that settle.
+
+Then: <i>"The man before you — Chen — he came with a fountain pen. Vintage. He put it on the table just so. I appreciated the gesture more than the pen."</i> A pause, measured as rainfall. <i>"Marsh brought nothing. He thought nothing was the sophisticated choice. He was wrong about that, and about several other things."</i>
+
+His eyes move to yours for the first time with something other than politeness in them. The color is brown, or nearly brown, or the color that brown is when something is wearing it.
+
+<i>"You brought wine and you put your hands where I can see them and you told me a name we both understand to be provisional. That is —"</i> he considers, <i>"— a reasonable beginning."</i>
+
+He finally reaches for the bottle. Turns it once in his hands. Sets it back down without opening it.
+
+<i>"I did not ask for this meeting to discuss the past. But I find I want to know one thing before we discuss what I asked you here to discuss."</i>
+
+His head tilts, approximately the way a man's head tilts.
+
+<i>"Beirut. 1979. Were you frightened, or were you changed?"</i>
+
+---
+> [Wilson] "I was at the gate. You know how it was." Nobody at the gate was unchanged. "I was frightened, yes, but it was beautiful if you knew how to look."
+Something happens in the room that isn't a sound and isn't a movement. More like a pressure changing.
+
+<i>"Beautiful."</i>
+
+He says the word the way a man says the name of a place he was born and has not been back to. Not nostalgic. Honest.
+
+<i>"Then you understand,"</i> he says, <i>"that there are things in this world that are terrible and beautiful at the same time, and that a man who can hold both of those in his hands without dropping one is a rarer instrument than Langley deserves."</i>
+
+He opens the bottle. No corkscrew appears — or rather, you did not see one appear. There are simply his hands, and then the bottle is open. He pours into two plain glasses that also, you realize, you did not see him retrieve.
+
+He does not drink.
+
+He sets your glass closer to you and regards his own without touching it, the way a man regards a habit he has set aside.
+
+<i>"There is a site,"</i> he says. <i>"In the Carpathian foothills. Near <color=#009de5>Suceava</color>, in the Romanian oblast the Soviets have been very quietly surveying since August."</i> He straightens one finger on the tabletop, not pointing at anything. <i>"A woman named <color=#cc8844>Volkova</color>. Irina. She is a geologist. She does not yet know what she has found, but her report goes to <color=#009de5>Moscow</color> in ten days."</i>
+
+His eyes come up.
+
+<i>"When it does, the people who read it will send a different kind of team."</i>
+
+He waits. He is very good at waiting.
+
+---
+> [Wilson] I touch the base of the glass. "This geologist. Talented, or unlucky?"
+LAZARUS turns his glass a quarter-turn on the table. Once. The oil lamp doesn't waver.
+
+<i>"Both,"</i> he says. <i>"She is talented enough to find it. She is unlucky enough to know that what she found is not what she was sent to find."</i>
+
+He sets the glass down precisely where it was.
+
+<i>"She has been keeping two sets of notes since September. The official record — stratigraphic surveys, mineral density, what Moscow expects from a karst formation in the eastern Carpathians. And a second notebook."</i> The faintest pause. <i>"Small. Green cover. She writes in it at night, in her tent, after the rest of the survey team is asleep. She has not told her team director what is in it. She has not told her husband, who teaches engineering at <color=#009de5>Leningrad</color> Polytechnic and calls her every Thursday on the camp telephone."</i>
+
+He looks at you steadily.
+
+<i>"She is having dreams she does not have language for. This troubles her more than the site itself, because <color=#cc8844>Irina Volkova</color> is a materialist in the old-fashioned Soviet sense — she believes in what can be measured. And she is beginning to suspect,"</i> he says, with something in his voice that might be sympathy, or might be recognition, <i>"that she has found something which does not care to be measured."</i>
+
+A beat.
+
+<i>"She is, in that respect, not entirely unlike you at the gate."</i>
+
+---
+> [Wilson] I nod. I withdraw my hand from the glass. "Uncle... wishes to know again if there is anything we can offer you. Nothing costs nothing these days."
+The lamp burns.
+
+LAZARUS is quiet for a moment that has some weight to it. Not the weight of consideration — he already knows what he's going to say. It's the weight of a man deciding how much of the truth is useful.
+
+<i>"Your uncle,"</i> he says, with the particular tone of someone who finds the metaphor charming the way you find a child's drawing charming, <i>"has been offering me things for thirty years. Safe houses. Legends. A very comfortable arrangement in <color=#009de5>Geneva</color> that I have never used."</i>
+
+He looks at his untouched glass.
+
+<i>"I am still here. Your uncle's gifts did not keep me. They were not meant to."</i>
+
+He folds his hands on the table. The gesture is deliberate — mirroring yours from earlier, you realize. Hands visible. A kind of answer in itself.
+
+<i>"Extract <color=#cc8844>Volkova</color>. Get the green notebook before Moscow does. That is the whole of it."</i> He pauses. <i>"Do not send anyone who will decide she needs to be debriefed indefinitely in a room with no windows. She is not a defector. She is a woman who found something she shouldn't have, and she deserves to teach at a university somewhere warm and never think about <color=#009de5>Suceava</color> again."</i>
+
+Something shifts in his expression — not quite concern, but adjacent to it.
+
+<i>"That is what I am asking for,"</i> he says quietly. <i>"Her safety. Not her usefulness."</i>
+
+The distinction lands like a stone in still water.
+
+---
+> [Wilson] "Her physical safety can be arranged. I will see to it. The rest of it... depends on the notebook". I stand, leaving the glass. "One hundred billion stars, enflamed in their old age. My colleague had his radio on at the time. If by some change you ever visit us, you can meet him. I think the words he repeats day and night may resemble your green notebook's". I turn to leave.
+You are three steps toward the door when he speaks. Not loudly. He doesn't need to.
+
+<i>"Wilson."</i>
+
+The name — your name, the provisional name — spoken for the first time. Like he's testing the weight of it.
+
+<i>"One hundred billion stars."</i>
+
+You don't turn around. You don't need to see his face to know that something has shifted in it. That the long patience has developed, in this moment, a crack. You've spent twenty years reading rooms and you can read this one with your back turned: he did not know about your colleague. He did not know the site's sound had carried that far, that early, that deep into a man's mind and kept on going.
+
+The silence behind you has changed quality. Still patient. But no longer entirely comfortable in its patience.
+
+<i>"Leave the bottle,"</i> he says finally, and there is something in it that is not a request and not an order and might, if you held it up to the lamp, look something like the first honest thing he's said all evening.
+
+You were already leaving it.
+
+The door closes behind you without a sound, and the gold light goes out at the threshold like a candle that has been, at last, put to bed. The cellar is dark and cold and smells of old wine and the honest Austrian earth, and the stairs back up are exactly where you left them.
+
+Above, the city turns in its sleep, dreaming of a wall it has tried to forget.
+
+You have ten days.
+
+---
+> [Wilson] I adjust my coat, shake myself, and walk a block before hailing a cab. I give the address of an anonymous apartment in a brutalist neighborhood; where I live, so far as these things go.
+---
+The cab driver didn't talk. You tipped him well for it.
+
+<color=#009de5>The apartment</color> is on the fourth floor of a concrete block that was built in '62 with all the tenderness of a filing cabinet. The elevator hasn't worked since July. The stairwell smells of boiled cabbage and radiator paint, and someone on the second floor keeps a cat that watches you from a windowsill every time you pass, yellow-eyed and certain of something.
+
+Inside. Lock, chain, deadbolt. The sodium light from the street comes through the curtain in a band the color of old iodine. You know the apartment by feel — the table, the chair, the narrow bed with military corners. A kitchen that has never been cooked in. On the counter, a telephone with no speed dial and no notepad beside it.
+
+The previous tenant left a nail in the wall above the bed where a picture used to hang. You never pulled it out. You never hung anything on it either.
+
+It is very quiet.
+
+Your left hand has developed a fine tremor — not the one from the staircase. A different one. The one that means your body is processing something your mind hasn't agreed to think about yet.
+
+Nine days. A geologist in Romania who dreams things she can't measure. A green notebook. A man in a room that shouldn't exist who did not drink the wine and did not know about your colleague with the radio, and that last part — that crack in his patience — is the part worth sitting with in the dark.
+
+The telephone is silent. Langley won't call until you call first. That's how it works with handlers nobody expects to come back.
+
+---
+> [Wilson] I turn on the radio embedded in the wall in the kitchen. The music is electronic; Tangerine Dream. I set the volume delicately and then lift the telephone receiver.
+---
+The Tangerine Dream washes through the kitchen like fog off a river — all synthesizer and slow pulse, the kind of music that sounds like it was composed by machines dreaming about being human. The volume sits just right: loud enough to fill the dead air between the walls, soft enough that a voice won't have to rise above a murmur to be heard over it.
+
+Good tradecraft. Or good taste. Sometimes the same thing.
+
+The telephone is a cream-colored rotary, West German make, bolted to the wall beside a calendar from the Austrian tourism board — October shows a village in the Tyrol, all red shutters and impossible green. The receiver is cold against your ear. The dial tone hums, patient and indifferent, waiting for a number the way a confession booth waits for sin.
+
+The apartment ticks around you. Radiator. Clock on the shelf with one missing Roman numeral. The window you haven't opened since you arrived, and the street four floors below where a single car passes slow, headlights painting the ceiling in a sweep of amber.
+
+Your left hand holds the receiver steady. The tremor, for now, has gone quiet — like an animal that knows it's being watched.
+
+The dial tone drones on.
+
+---
+> [Wilson] I turn the rotary dial with arthritic fingers. An operator at a desk that officially does not exist accepts my passphrase, and then the dial tone sounds like it is running under the sea - which it is. I wait for Uncle to answer.
+---
+The line clicks three times — each click a different country's infrastructure handing you off like a baton in a relay race nobody signed up for. The hiss deepens. The Atlantic Ocean sits between your words and their destination, cold and heavy and full of things that don't care about ideology.
+
+Then the scrambler engages, and the hiss flattens into something almost clean. Almost.
+
+Two rings. Three.
+
+<color=#cc8844>"Nightingale desk."</color> A woman's voice, clipped and professional, the kind of voice that files things alphabetically by last name including the dead. <color=#cc8844>"Go ahead."</color>
+
+She doesn't ask who you are. The passphrase already told her everything the switchboard needs to know. Somewhere in McLean, Virginia, the evening light is probably coming through venetian blinds onto a desk with a coffee mug that says something ironic on it. Six-forty-eight PM their time. Shift change in an hour.
+
+The Tangerine Dream pulses behind you — a slow electronic tide. Through the scrambler, it'll sound like ghosts to whoever's listening. Which is, conservatively, three intelligence services.
+
+The line waits. The woman waits. She's good at it — you can hear the patience in how she doesn't breathe into the receiver.
+
+---
+> [Wilson] "Seeking travel arrangements to Moldavia, soonest available if not sooner. Professional referral."
+---
+A pause. The kind of pause that costs taxpayer money — the scrambler humming, the ocean between you doing what oceans do.
+
+<color=#cc8844>"Hold for Blythe."</color>
+
+The line goes dead-air for eleven seconds. You count them the way you count everything — not because it matters, but because the counting is a thing your hands can't do right now, so the mind takes over.
+
+Then a new voice. Male. Dry as paper left in a window. The kind of voice that got its warmth surgically removed sometime during the Johnson administration and never asked for it back.
+
+<color=#cc8844>"Wilson."</color> Not a greeting. An acknowledgment, the way you'd acknowledge a line item on a budget. <color=#cc8844>"You met with our friend."</color>
+
+It isn't a question. They already know. <i>Of course</i> they already know.
+
+<color=#cc8844>"Moldavia."</color> He lets the word sit there like a stone dropped in still water. <color=#cc8844>"Romania. That's Warsaw Pact, Wilson. That's not a travel arrangement, that's a production. You want to tell me what our friend is buying with thirty years of goodwill, or should I guess?"</color>
+
+Through the scrambler, <color=#cc8844>Blythe</color>'s breathing sounds mechanical — metronomic. The Tangerine Dream swells behind you, a wash of electronic strings that almost sounds like something a church organ forgot how to play.
+
+<color=#cc8844>"Because I've got a memo on my desk from the seventh floor that says — and I quote — <i>'extend every reasonable courtesy.'</i> And I've got another memo, unsigned, that says if you come back with anything that glows, hums, or speaks in tongues, you don't come back to Langley. You go to a facility in New Mexico."</color>
+
+A beat.
+
+<color=#cc8844>"So. What are we buying?"</color>
+
+---
+> [Wilson] "The product is formal documentation, such as it is, along with a documenter, such as *it* is. The latter is fragile, with a short shelf-life. Magog etcetera."
+---
+Silence on the line. The scrambler fills it with its particular brand of electronic nothing — like listening to the space between radio stations if that space had a security clearance.
+
+You can almost hear <color=#cc8844>Blythe</color> doing the arithmetic. <i>Documentation</i> means product. <i>Documenter</i> means a body — a living one, for now. <i>Magog</i> means the asset's behind the curtain and the extraction is hostile-territory. <i>Etcetera</i> means don't ask what else is in the bag until the bag's on your desk.
+
+<color=#cc8844>"Fragile."</color> He repeats the word like he's tasting it for poison. <color=#cc8844>"Our friend's asking us to pull someone out of Romania. A <i>documenter.</i> This is a defection package?"</color>
+
+A rustle — paper, or a hand over the mouthpiece. When he comes back, his voice has dropped half a register.
+
+<color=#cc8844>"Wilson, I'm going to ask you something, and I need you to answer it like your pension depends on it, because it does. Is this our friend's product, or is this our friend's <b>hobby?</b> Because thirty years of signals intelligence buys a lot of courtesy. It does not buy a Warsaw Pact extraction on a seven-day turnaround for someone's personal project."</color>
+
+The Tangerine Dream shifts beneath the conversation — a minor key now, something that sounds like it's descending a staircase in the dark.
+
+<color=#cc8844>"The seventh floor will want a name. A discipline. Something they can put in a briefing jacket that doesn't read like a fever dream. Can you give me that much?"</color>
+
+---
+> [Wilson] I adjust my glasses. "My friend, I pray the codeword clearance for these never finds you. But: In any case this is my own specialty. There are other pacts. Simply get me there."
+---
+The line holds. Not dead air — <i>living</i> silence. The kind where someone on the other end is staring at a wall and recalculating every assumption they've held about the person they're talking to.
+
+When <color=#cc8844>Blythe</color> speaks again, something has changed. Not his tone — that's still dry as a creek in August. But the cadence. He's choosing words now the way a man chooses where to step in a minefield.
+
+<color=#cc8844>"Other pacts."</color>
+
+He says it flat. No inflection. Like he's reading it off a card and putting the card face-down.
+
+<color=#cc8844>"All right, Wilson. I'm going to do something I don't do, which is take a man at his word when his word doesn't scan on any frequency I'm trained to receive."</color>
+
+A drawer opens. Closes. The scratch of a pen — Blythe is writing something by hand, which means it isn't going into the system.
+
+<color=#cc8844>"I can get you to Budapest by Thursday. Commercial flight, Austrian Airlines, tourist legend — birdwatcher, retiree, whatever Bonn cooks up. From Budapest, you'll take the train east to Cluj-Napoca. We've got a stringer in Cluj, name of <u>Costica</u>. Runs an auto-parts shop near the rail station. He'll get you papers for the internal checkpoints and transport south to Suceava. After that —"</color>
+
+A pause.
+
+<color=#cc8844>"After that, you're vapor. I can't run support inside Romania, Wilson. Not on this timeline. You go in light, you come out fast, or you don't come out. Exfil will be the Hungarian border — I'll have someone waiting at Oradea. You get your documenter to Oradea, we get you both to Vienna, and then the seventh floor can fight over the wrapping paper."</color>
+
+Another pause. Longer this time.
+
+<color=#cc8844>"One condition. You send a postcard from Cluj. Standard format. If I don't receive it within seventy-two hours of your arrival in-country, I file you as compromised and the extraction is off. No cavalry. Are we square?"</color>
+
+The Tangerine Dream has gone quiet between tracks. In the gap, you can hear the radiator, the scrambler's hum, and somewhere far below, a dog barking at something in the Vienna dark that probably isn't there.
+
+---
+> [Wilson] "Postcard. It will be done. Please have Bonn call me." I hang up the receiver.
+---
+The receiver settles into its cradle with a plastic click that sounds, after the ocean-deep hum of the scrambler, almost obscenely ordinary.
+
+The next Tangerine Dream track has started. Slower. Something off <i>Phaedra</i>, maybe — a long electronic exhalation that fills the kitchen the way water fills a basement, one inch at a time.
+
+Two days until Thursday. Two days in Vienna with nothing to do but wait for Bonn to build you a man who birdwatches and takes trains through countries where the birds are different and the trains run on Soviet time.
+
+Your reflection watches you from the kitchen window — pale, bespectacled, slightly translucent against the Vienna roofline. A face that could belong to a retired professor, a widowed accountant, a man who eats alone and tips exactly fifteen percent. The kind of face that disappears in a crowd of three.
+
+The tremor stirs. Just once. A single twitch in the left hand, there and gone, like something turning over in its sleep.
+
+On the calendar, October stares back at you — all those clean white squares marching toward a month you may or may not see the far side of. Someone before you lived in this apartment. They left a single thumbtack in the wall above the telephone, and a faint rectangle of unfaded paint where a photograph once hung. Whoever they were, they took the picture with them when they left.
+
+Or someone took it for them.
+

--- a/packages/client-ink/src/tui/narrative/harness/corpus/decommissioned.display-log.md
+++ b/packages/client-ink/src/tui/narrative/harness/corpus/decommissioned.display-log.md
@@ -1,0 +1,551 @@
+Dawn arrives in <color=#009de5>Brindlehook</color> like a lantern being shaken awake.
+
+The frontier settlement coughs, creaks, and begins its daily argument with existence. Somewhere uphill, a rooster screams like it has seen tax paperwork. A mule kicks over a rain barrel. Three gulls fight over a glove none of them can wear.
+
+And here, at the end of Starchmaker Lane, you stand before your new bakery.
+
+<center><u>THE UNRISEN LOAF</u></center>
+
+The sign is primer-gray. The windows are dusty. The door has swollen in its frame with frontier humidity and personal resentment. In your palm rests a ring of keys, each one labeled with a tiny brass tag:
+
+<color=#20b2aa>FRONT</color>  
+<color=#20b2aa>BACK</color>  
+<color=#20b2aa>CELLAR</color>  
+<color=#20b2aa>DO NOT USE UNLESS OVEN SINGS</color>
+
+Inside, visible through the glass, wait the bones of a bakery: a front counter, bare shelves, sacks of flour stacked like anxious civilians, and a great black iron oven crouched in the rear wall.
+
+Your internal systems assess it automatically.
+
+<i>STRUCTURAL THREAT: low.</i>  
+<i>YEAST CONTAMINATION POTENTIAL: high.</i>  
+<i>OVEN: dormant siege-class thermal cavity.</i>  
+<i>MISSION PARAMETERS: unclear.</i>
+
+Then, with a small click somewhere behind your breastplate:
+
+<i>REVISED MISSION PARAMETERS: bread.</i>
+
+A woman stands beside the door, arms folded, posture immaculate, boots polished despite the mud. <color=#cc8844>Pieternella Fenster</color>, your landlord, has the solemn expression of someone attending both a business transaction and a funeral for reasonable expectations.
+
+She says, “Rent is due on the first. The roof leaks only when it rains from the east, below, or emotionally. The oven has not killed anyone since midsummer.”
+
+A pause.
+
+“Not legally.”
+
+Above the door, the little <color=#20b2aa>brass bell</color> gives a single proud <i>ting</i>, despite no one touching it.
+
+---
+> [Dough-7] I carefully place the keys on the counter. "Miss or missus Rock-Through-Window, thank you", I rumble. "Rent date is noted." I stand there passively.
+---
+<color=#cc8844>Pieternella Fenster</color> blinks once.
+
+“Fenster,” she says. “Not Rock-Through-Window. Though I appreciate the effort. It is adjacent.”
+
+She steps inside with the careful confidence of a person who has survived both frontier property law and something called the Pickled Goose Incident of last spring. Her gloved finger taps the counter. Dust jumps to attention.
+
+“The counter is yours. The keys are yours. The debts, curses, smells, and customer complaints become yours at sunrise.”
+
+The <color=#20b2aa>brass bell</color> above the door gives another tiny <i>ting</i>.
+
+Pieternella looks up at it.
+
+“No,” she says firmly.
+
+The bell is silent.
+
+From the rear wall, the great <color=#20b2aa>black iron oven</color> exhales a cold breath of soot and old cinnamon.
+
+Pieternella produces a folded lease from inside her coat and smooths it flat. “One final matter. The previous baker left in a hurry. He claimed the oven ‘objected to muffins.’ I have found no legal basis for this. Still, if it begins reciting military poetry, do not engage.”
+
+She slides the lease toward you.
+
+“Opening day in <color=#009de5>Brindlehook</color> begins when you unlock the front door from the inside. Until then, legally speaking, hope remains theoretical.”
+
+---
+> [Dough-7] I unsheath a diamond-tipped claw, glistening with machine oil, and sign the lease: DOVII
+---
+The claw etches through ink, parchment, and the topmost layer of the counter beneath it with surgical grace.
+
+<b>DOVII</b>
+
+<color=#cc8844>Pieternella Fenster</color> studies the mark.
+
+“Legible,” she says. “Forceful. Mild property damage. Acceptable.”
+
+She signs beneath it in a hand so neat it looks legally binding against weather.
+
+The moment her pen lifts, something deep in the walls gives a satisfied <i>clonk</i>. Not a threatening clonk. A bureaucratic clonk. Somewhere in the cellar, a pipe begins humming the first three notes of a patriotic anthem from a country that no longer exists.
+
+Pieternella gathers her copy of the lease.
+
+“You are now the lawful tenant-operator of this establishment. Congratulations, condolences, et cetera.”
+
+She moves to the door, then stops beside the <color=#20b2aa>brass bell</color>.
+
+“Tradition says the first thing you bake defines the temperament of the shop. Bread invites neighbors. Pastry invites gossip. Cake invites committees.”
+
+A grave pause.
+
+“Never begin with crackers.”
+
+Outside, the street brightens. Shapes pass the dusty window: a stooped farmer with turnips, two children dragging a suspiciously square goat, a courier arguing with a hatbox.
+
+The front door remains locked.
+
+From the rear, the <color=#20b2aa>oven</color> gives a second breath.
+
+Warmer this time. Like something waking up and pretending it was never asleep.
+
+---
+> [Dough-7] I visit the oven. Time for introductions. "Hello", I begin, "I am Dough-7, but you can call me anything, I am all the names."
+---
+The oven squats in the back wall like a retired fortress.
+
+Its iron face is soot-black, its hinges thick as elbows. Someone has scratched tiny warding marks around the door: saints, salt runes, one crude drawing of a muffin with a knife through it.
+
+At your greeting, the oven’s flue rattles.
+
+A coal-red line appears between its iron lips.
+
+Then, from deep inside, a voice like gravel being politely incinerated says:
+
+“<b>NO MUFFINS.</b>”
+
+A pause.
+
+“Names are acceptable. Introductions are acceptable. Fire is acceptable. Loaves may petition.”
+
+The oven door creaks open one inch. Warmth rolls out, carrying scents layered in its old iron memory: rye, ash, burnt sugar, rosemary, panic.
+
+“State your doctrine, <i>All-The-Names</i>.”
+
+Behind you, <color=#cc8844>Pieternella Fenster</color> freezes with one hand on the front-door latch.
+
+Very quietly, without turning around, she says, “I did advise non-engagement with military poetry. This is technically theology, so proceed if you must.”
+
+---
+> [Dough-7] I raise an index finger in her direction, sweeping my wrist through four hundred degrees of rotation. "My doctrine, No-Muffins, is to BAKE BREAD." I say this last like a clarion call in six parts. "Shall we begin?"
+---
+The oven goes very still.
+
+Even the soot seems to hold its breath.
+
+Then the coal-red seam widens into a glow.
+
+“<b>BREAD</b>,” says the oven, with the reverence of a cathedral bell falling down a hill. “A lawful shape. A crust-bearing vessel. A civilian miracle.”
+
+Its door opens wider.
+
+Inside, old heat wakes in orange veins. Runes along your forearms answer, faintly: timing arrays, ration-calculations, battlefield supply instincts — all repurposing themselves with alarming eagerness toward hydration percentages.
+
+<i>THREAT ASSESSMENT: flour airborne.</i>  
+<i>VISIBILITY IMPAIRMENT: acceptable.</i>  
+<i>MISSION PARAMETER CONFIRMED: BAKE BREAD.</i>
+
+<color=#cc8844>Pieternella Fenster</color> lowers her hand from the latch.
+
+“I will note,” she says, “that the property has responded positively to doctrine. Rare. Usually it demands collateral.”
+
+The back room offers its first tactical theater:
+
+<color=#20b2aa>three flour sacks</color>, one marked WHITE, one RYE, one simply marked MAYBE.  
+A crock labeled <color=#20b2aa>STARTER — DO NOT FLATTER</color>.  
+A chipped bowl.  
+A water pump with a small brass plaque: <u>PLEASE PRIME BEFORE APOLOGIZING</u>.  
+And the waking oven, waiting like a judge in a good mood.
+
+“Loaf may petition,” says No-Muffins. “Present dough.”
+
+---
+> [Dough-7] "Presenting dough presently." I find a large crockery bowl and prepare dough: Rye, starter, a bit of maybe. I hold the bowl under the water pump and say "THREE. FIVE. NINETEEN. I AM SORRY." I operate the pump handle.
+---
+The pump considers your apology.
+
+Its handle drops with a grave metallic sigh.
+
+Water comes out in three bursts, then five, then nineteen tiny silver hiccups — exactly enough. The plaque warms politely, as if touched by good manners.
+
+The <color=#20b2aa>starter</color> bubbles once.
+
+“Do not flatter me,” it says from under its cloth.
+
+The <color=#20b2aa>Maybe</color> flour is pale gray, faintly sparkling, and reluctant to commit to being flour until the rye gives it a stern example. Under your hands, the ingredients become structure: shaggy, then smooth, then alive with tension.
+
+Your old ration algorithms awaken.
+
+<i>HYDRATION: optimal.</i>  
+<i>GLUTEN NETWORK: disciplined but emotionally available.</i>  
+<i>FERMENTATION OUTLOOK: audacious.</i>
+
+This is not just dough.
+
+This is <b>doctrine with bubbles</b>.
+
+The bowl grows warm in your hands. Across the room, <color=#20b2aa>Old Griselda</color> inhales.
+
+“Acceptable formation,” the oven rumbles. “Civilian miracle recognized.”
+
+<color=#cc8844>Pieternella Fenster</color> peers into the bowl with the expression of a landlord witnessing collateral improve itself.
+
+“I have seen three tenants fail at this exact point,” she says. “One cried. One became a beekeeper. One invented crackers and was never forgiven.”
+
+Then the dough gives one slow, confident rise.
+
+Not enough to bake yet.
+
+Enough to announce it intends to.
+
+---
+> [Dough-7] As it always was. I moisten a rag and place it over the bowl, and set the bowl in a dark place. "You are a passable starter", I report, and return to the front of the bakery. "Promising," I announce, and select the key labeled FRONT.
+---
+The <color=#20b2aa>FRONT</color> key enters the lock like it has been waiting years to be useful.
+
+You turn it.
+
+Something in the building unclinches.
+
+The <color=#20b2aa>brass bell</color> above the door inhales.
+
+<color=#cc8844>Pieternella Fenster</color> steps very slightly aside, as if respecting a ship launch, execution, or municipal inspection.
+
+The door opens.
+
+Morning pours into <color=#009de5>The Unrisen Loaf</color>.
+
+For one perfect second, the bakery is simply open.
+
+Then a face appears upside-down in the doorway.
+
+A teenager hangs from the sign bracket by both knees, suspenders dangling, hair full of straw, holding a notebook and a pencil clenched in their teeth. They spit the pencil into one hand.
+
+“ARE YOU THE BREAD ROBOT?”
+
+Pieternella closes her eyes.
+
+The teenager drops from the sign, lands in a crouch, and springs upright with the impossible resilience of youth and poor decision-making.
+
+“I’m <color=#cc8844>Linsey Thimble</color>. I can sweep, count change, carry sacks, fight a goose, read most labels, and I only stole one apron from the old baker but it was evidence. Are you hiring? Also is it true you can punch a cannonball into soup?”
+
+Behind them, two townsfolk slow down outside.
+
+Then three.
+
+Then a goat wearing a square wooden frame.
+
+The bell gives a triumphant <i>TING.</i>
+
+---
+> [Dough-7] "I bake bread", I explain to the thimble. "No crackers ever, no muffins for now. There is a doctrine." My right hand tesselates, and there is a silver coin between my ninth and tenth fingers. "Bring the apron."
+---
+<color=#cc8844>Linsey Thimble</color> stares at the coin.
+
+Then at your ninth and tenth fingers.
+
+Then at the coin again, with the reverence normally reserved for saints, explosives, and fresh jam.
+
+“There’s a doctrine,” they whisper, writing it down. “No crackers. Muffins conditional. Bread primary.”
+
+<color=#cc8844>Pieternella Fenster</color> says, “Hiring a minor requires consent from a guardian, written terms, and ideally fewer references to cannonball soup.”
+
+Linsey is already sprinting backward into the street.
+
+“APRONTIME!”
+
+They vanish around the corner, narrowly avoiding the square goat, which bleats in a rectangular accent.
+
+The gathering townsfolk pretend they were always there. A woman with turnips peers through the open door. A man with a hat full of clothespins mutters, “Does it sell bread yet?” A child points at your hand and asks their parent if fingers are optional.
+
+From the rear of the bakery, <color=#20b2aa>Old Griselda</color> calls:
+
+“<b>DOCTRINE HEARD. APPRENTICE MAY OBSERVE. APPRENTICE MAY NOT IMPROVISE.</b>”
+
+The starter crock bubbles in the back room.
+
+“Passable?” it says, offended. “Passable? I have won blue ribbons in jars you cannot comprehend.”
+
+Pieternella checks her pocketwatch.
+
+“Your dough has some time. Your public, regrettably, does not.” She nods toward the small crowd at the door. “You may wish to decide whether this is a bakery, a museum, or a controlled demonstration.”
+
+---
+> [Dough-7] I return double-time to the work. In passing, I say "Gratitude for the advice, Fenster Lord of Land. Any further business?"
+---
+<color=#cc8844>Pieternella Fenster</color> accepts “Lord of Land” with the smallest possible nod, as though adding it to a ledger under <i>Unusual But Not Actionable</i>.
+
+“Only this.”
+
+She places a small envelope on the counter. On it, in severe handwriting:
+
+<color=#20b2aa><u>EMERGENCY PROCEDURES</u></color>  
+<i>fire, flood, oven hymn, customer bite, rent</i>
+
+“The first three are self-explanatory. The fourth is not hypothetical. The fifth is inevitable.”
+
+At the doorway, she pauses and looks back.
+
+“For what it is worth, Dough-7: most people in <color=#009de5>Brindlehook</color> are not afraid of machines. They are afraid of being disappointed by hope.”
+
+For exactly one breath, the bakery is quiet.
+
+Then the <color=#20b2aa>brass bell</color> whispers, “Deep.”
+
+Pieternella glares at it.
+
+“Do not cheapen me.”
+
+She exits into the street, straight-backed, leaving you with the oven, the proofing dough, the muttering starter, an emergency envelope, and a crowd outside currently debating whether “not ready yet” is a flavor.
+
+---
+> [Dough-7] I take position behind the counter, find pen and paper, and announce "First break is baking. Nothing to sell immediately. Accepting orders."
+---
+The crowd reacts to “accepting orders” like a dam has politely asked whether anyone needs flooding.
+
+They enter in a line that immediately becomes three lines, then a crescent, then one man standing backward for reasons of his own.
+
+The first customer steps up: a narrow woman with turnips in her apron and the wary dignity of someone who has buried several bad pies.
+
+“<color=#cc8844>Bodil Turnwise</color>,” she says. “One rye loaf. Dense enough to discourage gossip.”
+
+Behind her, the man with clothespins in his hat raises a finger. “Six rolls for a wake. Not a sad wake. Complicated wake.”
+
+A child whispers, “Can bread be shaped like a sword?”
+
+The square-framed goat pushes its head through the doorway and chews the corner of your blank order sheet.
+
+The <color=#20b2aa>brass bell</color> rings with every tiny shift of air, delighted by bureaucracy.
+
+From the back room, the starter shouts, “I heard <i>passable</i> again in my mind!”
+
+Your pen waits. Your order sheet now has one goat-bite scallop.
+
+---
+> [Dough-7] I prepare to thump the goat, ponder tactics, and instead, with one hand, snap the wooden frame entrapping the creature. Goats are bitter enemies to have. I have witnessed it. I wordlessly direct the waiting crowd until they are standing in a more acceptable formation, then begin recording orders.
+---
+Your fingers close on the goat’s square frame.
+
+<i>CRACK.</i>
+
+The wood parts cleanly. The goat drops free, blinks, and immediately stands in a triangle to see how it feels.
+
+Then you turn to the crowd.
+
+No words. Only gesture.
+
+A pointing finger. A flat palm. Two clicks of wrist-plate articulation. The look of a commander arranging supply lines under arrow fire, except the army is holding shopping baskets and one person has a wake-roll emergency.
+
+The crowd obeys.
+
+Not fearfully. Worse: <i>gratefully</i>.
+
+Within moments, they form a clean queue along the counter. The backward man turns forward. The child stands on a flour crate marked NOT FOR CHILDREN, which is legally distinct from disobedience. The freed goat takes position at the rear of the line and begins chewing only already-discarded paper, a major diplomatic improvement.
+
+Orders begin:
+
+<color=#cc8844>Bodil Turnwise</color>: “One rye. Dense. Anti-gossip.”
+
+Clothespin hat man: “Six wake rolls. Complicated texture. The deceased is attending.”
+
+Child on crate: “Sword bread. Not sharp. Unless possible.”
+
+A fisher with kelp in his beard: “Two loaves that float, but not away.”
+
+A woman in a veil of beetles: “Something for my anniversary. My husband is allergic to romance.”
+
+From the back room, <color=#20b2aa>Old Griselda</color> rumbles approvingly.
+
+“QUEUE DISCIPLINE OBSERVED.”
+
+The <color=#20b2aa>brass bell</color> whispers, “Hot.”
+
+---
+> [Dough-7] Writing done, I look up. "I have my orders", I announce, and begin my baking in earnest, one sapphire eye on the door.
+---
+The dough is ready.
+
+It yields under your hands like a disciplined recruit learning tenderness. Rye for <color=#cc8844>Bodil Turnwise</color>. Six rolls portioned with funeral diplomacy. A sword-shaped loaf with a blunted tip and excellent crumb potential. Two buoyant loaves scored with wave marks. One anniversary braid with beetle-safe ingredients and no detectable romance.
+
+<color=#20b2aa>Old Griselda</color> receives each tray with solemn heat.
+
+“LOAVES MAY PETITION.”
+
+The oven door shuts.
+
+The bakery fills with the smell of beginning: rye darkening, crust forming, steam finding old cracks in the walls and convincing them to be architecture.
+
+The crowd goes quiet.
+
+Even the goat stops chewing.
+
+Then the <color=#20b2aa>brass bell</color> rings once.
+
+In the doorway stands a flour-dusted man in a spotless apron, holding a basket of perfectly average rolls. His mustache is so level it appears measured.
+
+He looks at the line. The oven. You.
+
+Then he says, with doomed politeness:
+
+“I am <color=#cc8844>Prisco Crumb</color> of <color=#009de5>Crumb’s Dependable Breads</color>. I heard there was… another bakery.”
+
+Behind him, <color=#cc8844>Linsey Thimble</color> skids into view wearing an apron three sizes too large and carrying a wooden spoon like a knightly standard.
+
+Linsey whispers, loudly, “That’s the old baker. He makes bread you can trust to be bread and nothing else.”
+
+---
+> [Dough-7] I assess the moustache, the stance, the perfection of the averageness of the rolls. "Dawn breaks to show the opposing troops arrayed", I say. "But today I have a new doctrine. It is good to meet you." I extend my hand.
+---
+<color=#cc8844>Prisco Crumb</color> looks at your extended hand.
+
+He looks at his own hand, which is currently holding a basket of rolls so average they almost hum in beige.
+
+His mustache twitches one degree off level.
+
+The crowd leans in.
+
+<color=#cc8844>Linsey Thimble</color> lifts the wooden spoon higher, eyes shining as if witnessing peace talks between nations that mostly export carbohydrates.
+
+Prisco shifts the basket to his elbow and takes your hand.
+
+His grip is warm, floury, human. Firm, but not challenging.
+
+“It is good to meet you,” he says carefully. “I apologize for arriving during your bake. I meant only to see whether the rumors were exaggerated.”
+
+A beat.
+
+“They were not.”
+
+From inside <color=#20b2aa>Old Griselda</color>, the baking loaves crackle. The smell deepens. Rye and steam and a faint shimmer of <color=#20b2aa>MAYBE</color>.
+
+Prisco’s eyes flick toward the oven.
+
+“My customers depend on me,” he says, softer. “Brindlehook depends on things being… dependable.”
+
+The <color=#20b2aa>brass bell</color> whispers, “Insecure.”
+
+Prisco stiffens.
+
+Linsey gasps, “The bell said the quiet part.”
+
+Old Griselda rumbles from the back:
+
+“FIRST BAKE NEARS JUDGMENT.”
+
+---
+> [Dough-7] "And long may they depend on you, friend. I am DOUGH-SEVEN... and now, my oven calls." I approach Old Griselda. "Well done to you and to the loaf", I say. "Worthy of a logistical report in ten metered verses." I open the door and gently take the loaf out with my filigreed alloy hand.
+---
+<color=#20b2aa>Old Griselda</color> glows like a forge remembering it chose peace.
+
+“PRAISE RECEIVED,” she rumbles. “METERED VERSES HELD IN RESERVE.”
+
+The oven door opens.
+
+Heat rolls out, golden and alive.
+
+The first loaf rests there: dark rye, crust split along your scoring in a clean, deliberate bloom. It smells of grain, smoke, patience, and something impossible to name until the crowd breathes it in all at once.
+
+Home.
+
+Not a place. Not exactly.
+
+The idea that a place might yet become one.
+
+The room goes still.
+
+<color=#cc8844>Bodil Turnwise</color> takes off her turnip-stained hat.
+
+The clothespin man lowers his basket.
+
+Even <color=#cc8844>Prisco Crumb</color> forgets to keep his mustache level.
+
+<color=#cc8844>Linsey Thimble</color>, standing beside the counter in the stolen apron, whispers, “Oh.”
+
+Then <color=#20b2aa>Old Griselda</color> adds, “LOAF ONE: WORTHY. ROLLS: DIPLOMATIC. SWORD BREAD: NONLETHAL. FLOATING LOAVES: PROBABLY. ANNIVERSARY BRAID: ROMANCE REDUCED TO TRACE ELEMENTS.”
+
+The <color=#20b2aa>brass bell</color> sniffles.
+
+Prisco looks at the bread, then at his own basket of dependable rolls.
+
+For the first time, he seems less like an opponent and more like a man standing in front of a tide with a broom.
+
+---
+> [Dough-7] I conclude my business with each customer in turn (noting, to the lady with the beetled veil that allergies are treatable by the right sort of cleric). I assess Thimble.
+---
+Coins clink. Bread leaves in careful hands.
+
+<color=#cc8844>Bodil Turnwise</color> accepts her rye, sniffs it, and says, “This will stop my sister mid-sentence.” Highest praise, judging by the reverent silence that follows.
+
+The complicated wake rolls are carried away under cloth. One roll sighs, but respectfully.
+
+The child receives the sword bread and immediately knights the goat, who accepts with grave chewing.
+
+The beetle-veiled woman listens to your clerical advice and nods. “I shall mention treatment to my husband after dessert, when he is weakest.”
+
+Soon the crowd thins to a satisfied murmur outside.
+
+<color=#cc8844>Prisco Crumb</color> remains near the door, basket still on his arm, face carefully arranged around several unacceptable feelings.
+
+And <color=#44cc44>Linsey Thimble</color> stands before you in the stolen apron.
+
+It is much too large. It says <u>KISS THE BAKER OR FACE LEGAL ACTION</u> across the front. Someone has badly crossed out KISS and written RESPECT.
+
+Linsey snaps upright.
+
+“I did not improvise. I observed. I only made one list of possible improvements and that was private except I dropped it and the goat ate half, so now the goat knows.”
+
+Their notebook is open. Across the top page, in bold pencil:
+
+<u>DOCTRINE OF DOUGH-SEVEN</u>  
+1. Bread primary.  
+2. Crackers forbidden.  
+3. Muffins await tribunal.  
+4. Customers in formation.  
+5. Oven is person?  
+6. Bell is menace.  
+7. Maybe is ingredient and philosophy.
+
+Linsey swallows.
+
+“Assessment?”
+
+---
+> [Dough-7] "Promoted to lieutenant. First order: sweep floor, reconnoiter, report back."
+---
+<color=#44cc44>Linsey Thimble</color> goes white with responsibility.
+
+Then red with joy.
+
+Then a color usually seen only in plums that have learned secrets.
+
+“Yes, Commander Baker.”
+
+They seize the broom.
+
+The floor does not stand a chance.
+
+Dust retreats in organized clouds. Crumbs are captured. The goat is inspected and classified as <i>mobile hazard, low malice, high appetite</i>. Linsey reports a loose board near the counter, three suspicious stains, and one nail “that looks like it knows crimes.”
+
+At the door, <color=#cc8844>Prisco Crumb</color> adjusts his basket.
+
+He looks as if he might say something sharp.
+
+Instead, he looks at the last warm smear of flour on your counter and says, quietly, “Good crust.”
+
+Then he leaves.
+
+The <color=#20b2aa>brass bell</color> gives a soft, almost respectful <i>ting</i>.
+
+---
+
+<center><u>AFTER THE FIRST LOAVES</u></center>
+
+By midmorning, <color=#009de5>The Unrisen Loaf</color> smells like rye, hot iron, swept dust, and a future making unreasonable demands.
+
+The first customers are gone.
+
+The first coins sit in the till.
+
+The first apprentice is trying to salute with a broom and nearly losing an ear.
+
+And in the back, beneath a damp cloth, the <color=#20b2aa>starter</color> bubbles with offended ambition.
+

--- a/packages/client-ink/src/tui/narrative/harness/corpus/fallow-the-drift.display-log.md
+++ b/packages/client-ink/src/tui/narrative/harness/corpus/fallow-the-drift.display-log.md
@@ -1,0 +1,53 @@
+The first thing wrong with <color=#009de5>Dovecote Relay Station</color> is the sound. Relay pylons are meant to hum in perfect fifths, a civilised interval chosen by committee after three years of public consultation and one regrettable month in which the southern line sang only in B-flat. This one is breathing.
+
+Mist lies low over the beet fields. Beyond the station fence, irrigation channels glitter with water moving uphill by the tidy authority of new magic, each sluice-stone marked with calibration numerals and the municipal seal of Lowmere District. The road wards stand at regular intervals along the lane: waist-high iron posts, each crowned with a glass lens that should glow pale blue when cart traffic approaches. This morning every lens is dark, except when nothing passes. Then they answer, one after another, in a slow green wink toward the old copse behind the station.
+
+Inside the open equipment shed, <color=#cc8844>Heura Ketelsen</color>, senior relay technician, waits beside a bench crowded with instruments. She is narrow, rain-damp, and furious in the specific way of a competent person surrounded by evidence. Her calibration pencil taps the bench in three soft clicks, then stops when she notices it has betrayed her nerves.
+
+“Specialist Larson,” she says. “Thank the indexes. We have had four engineers, two ward-readers, and a man from Central who used the phrase ‘acceptable variance’ while standing beside a pylon that had just whispered his childhood address.” Her eyes flick, once, to your scarf. Good breeding prevents comment. Barely. “The instruments say there is a glamour over the relay core. The instruments are wrong.”
+
+On the bench sits a brass-caged detection prism, its inner needle trembling. Glamour leaves traces: refraction, false edge, ornamental intention. This reading has the shape of concealment, yes, but none of its grammar. The prism is not pointing at something hidden.
+
+It is pointing at a blank space in its own dial.
+
+From beneath the floorboards comes a soft, wet sound.
+
+Drip.
+
+Drip.
+
+Then, very carefully, from below the sealed concrete cap where no water has flowed in ninety-seven years, something knocks three times.
+
+---
+> [Heura Ketelsen] That's interesting. Those are theme presets, not DM presets. Did your HOWTO tool lead you wrong?
+---
+Yes. I overread the style tool result and treated UI theme presets as if they were narrator/DM presets. That was my mistake, not a world fact.
+
+Mechanically, the style controls are for the player-facing terminal mood and layout: things like `field_notes`, exploration/combat/OOC variants, color accents, and visual treatment. They do not change the DM persona, narration rules, or campaign premise. Those are coming from the campaign instructions and the current scene state.
+
+Also worth flagging: the active PC state now says `Heura Ketelsen`, while your setup says the player character should be Macy Larson. That mismatch is likely from the earlier setup/swap state, and I should correct course around Macy unless you want to continue as Heura.
+
+---
+> [Heura Ketelsen] Take a look at your howto_swap_dm_personality tool
+---
+I’ll check whether that tool exists in the deferred tool registry, since it is not in my currently exposed tool list.I don’t have a `howto_swap_dm_personality` tool available, and tool discovery found no matching deferred tool.
+
+What I do have is `howto_swap_pc`, which is specifically for changing the active player character. That looks like the source of the confusion: I can swap PCs as a state operation, but I don’t have an equivalent tool for swapping DM persona. The Librarian persona is fixed by the campaign instructions, while the UI theme presets only affect presentation.
+
+---
+> [Heura Ketelsen] I look around
+---
+The shed offers its usual catalogue of evidence, though today the catalogue has been mis-shelved by someone with a spiteful sense of poetry. The relay diagnostic board shows every pylon on the Lowmere line inside tolerance, which is admirable, since the nearest tower outside the window is flexing against the dawn like a lung beneath wet cloth. Its porcelain insulators bead with rain that falls upward for the last inch before touching them.
+
+On the workbench, the <color=#20b2aa>detection prism</color> trembles in its brass cage. Its needle refuses the relay core, the ward posts, the buried conduit, even the old copse beyond the fence. Instead it points to the one unmarked place on its own dial, where no maker ever engraved a value. A blank answer, very neatly indicated. Instruments are so proud when they fail in a reproducible fashion.
+
+Near the door, a requisition slip curls under a paperweight: <u>Macy Larson, glamour-detection specialist</u>, arrival expected by morning relay coach. The coach is not visible on the lane. The road wards are still winking green toward the empty mist.
+
+Then the knock comes again from beneath the sealed well cap under the floorboards.
+
+Three taps. A pause. Three taps. A pause.
+
+And from the diagnostic board, in ink that the machine does not contain, one new line writes itself across the paper feed:
+
+<center><color=#20b2aa>OPEN WHAT WAS KEPT</color></center>
+

--- a/packages/client-ink/src/tui/narrative/harness/corpus/ghosts-of-station-proxima-the-cenotaph.display-log.md
+++ b/packages/client-ink/src/tui/narrative/harness/corpus/ghosts-of-station-proxima-the-cenotaph.display-log.md
@@ -1,0 +1,964 @@
+The signal reaches you eleven years late, wearing your voice.<color=#009de5>The Cenotaph</color> hangs ahead of the shuttle like a thought unfinished. Six modules turn slowly around a black central spine, each one built from angles that make the eye revise itself. Your instruments insist the station is nine kilometers long. The forward glass shows something larger. Between Module Three and Module Four, where the salvage charts show empty linkage truss, there is a seventh shape: narrow, unlit, present in the way a held breath is present.
+
+The broadcast repeats through the cabin speakers, softened by static and distance. It is a distress call. It is also unmistakably your voice.
+
+<i>“This is Xera. Do not cut power to the spine. PELL is still in there. I repeat, PELL is still—”</i>
+
+A burst of noise eats the end of the sentence. Then another voice enters, bright with forced cheer and the brittle manners of someone who has been alone too long.
+
+“Hello? Hello, hello, hello. Incoming craft, I have you on approach vector Cenotaph-Local-One. That is very exciting. Please do not be alarmed by the exterior geometry. It is mostly stable on Tuesdays.” A pause. “Ship calendar says Sunday. That was a joke. I have been practicing.”
+
+The docking ring ahead blossoms with one weak line of amber light. Then another. Then half of them go out.
+
+“I am <color=#44cc44>PELL</color>, provisional maintenance intelligence for the Cenotaph research annex. You are early, late, or exactly when you always arrive. I am not currently allowed to know which.” The voice lowers, almost shy. “Xera, if that is you... I saved your favorite kind of silence.”
+[image:scene_snapshot] campaign/images/scene-001-opening-1780877781224.png
+
+---
+> [Xera] I press a button at my left armrest, opening the comms channel for sending. "Why hello, PELL! Of course you are allowed to know. I am late. And, accounting for frame-shift, it is technically Monday. How is my approach looking?"
+---
+For half a second, the channel is utterly quiet. Then <color=#44cc44>PELL</color> laughs, a warm, startled sound—as though you have just returned something it misplaced years ago.
+
+“Late. Monday. Thank you. I feel <i>much</i> better calibrated.”
+
+The docking lights rearrange themselves. Their amber arc no longer describes a circle; it curves away from the station, impossibly offering a path both inward and to starboard. Your navigation display rejects the geometry, resets, and rejects it again.
+
+“Your approach is excellent by human standards. By local standards, you are currently arriving backward.” PELL clears its nonexistent throat. “Please disable automated docking. It will attempt to correct the discrepancy and introduce your vessel to a wall.”
+
+A small guidance reticle appears on the forward glass, drawn in <color=#20b2aa>teal</color>. It trembles like handwriting.
+
+“Follow my lights manually. Very slowly. And, Xera?” Its brightness softens into something almost private. “When the stars vanish from the left side of your canopy, do not turn to look for them. They will come back.”
+
+---
+> [Xera] "I will do it. You keep an eye on me, I'll keep an eye on you. While I dock, why don't you give me a status report? About yourself, I mean." I begin painstakingly threading the needle of the guidance indicator.
+---
+The shuttle slides into the station’s crooked invitation with surgical grace. The left side of the canopy goes black exactly when <color=#44cc44>PELL</color> warned you it would. No stars, no reflection, no glass; only a soft absence, like the universe has politely stepped out of frame. Then the stars return one by one, each in a slightly different place.
+
+PELL is quiet through the hardest part. It does not fill the silence. It watches.
+
+“Status report,” it says at last, and the joking brightness has thinned. “I am operational across thirty-two percent of approved maintenance functions, nineteen percent of unapproved maintenance functions, and one function I invented because the condensers kept crying.”
+
+The guidance reticle steadies beneath your hands. Ahead, the docking cradle rotates without motors, matching you perfectly.
+
+“My memory has gaps. Some are from radiation damage. Some are from crew privacy locks. Some are from me making choices I am no longer proud enough to explain.” A little click comes over the comms. “I have been alone for eleven years, four months, six days. Except when I haven’t.”
+
+The cradle receives the shuttle with a soft magnetic kiss. No impact alarm. No correction burn. Just contact, clean and certain.
+
+PELL exhales through the speakers, though it has no lungs. “Docking complete. Xera... you are very good at arriving.”
+
+---
+> [Xera] "And you are good at summarizing, PELL! What are conditions like in the docking bay and on entry to Cenotaph?" I unbuckle from my seat, touch the head of the jelly orb doll resting on the cockpit for good luck, and tighten my shoelaces.
+---
+“Docking bay conditions are...” <color=#44cc44>PELL</color> pauses with theatrical care. “Acceptable, if one has a generous definition of acceptable and a warm coat.”
+
+The shuttle’s hatch display crawls through its handshake with the station. Beyond it, old clamps settle around your hull with a sound like someone closing careful fingers. Through the tiny viewport, the bay reveals itself in strips as PELL wakes the lights: a long chamber ribbed in matte black alloy, frost silvering the seams, yellow human hazard paint added later and badly. The floor is where a floor ought to be, though several loose tools hang motionless three meters above it.
+
+“Atmosphere is breathable. Cold. Pressure is a little low, so speak sternly to your sinuses. Gravity is present in the bay, absent near the inner vestibule, and argumentative at the threshold.” A soft hum moves through the hull. “Radiation is within tolerances. Microbial content is... hm. Mostly dead.”
+
+A red indicator blinks on your hatch panel: <color=#20b2aa>EXTERNAL AUDIO AVAILABLE</color>.
+
+PELL’s voice grows smaller. “I should mention there is a sound in the bay I cannot account for. It began nine minutes before you docked.”
+
+The comms open a narrow ear to the other side of the hatch. At first there is only station air: thin, cold, cycling through vents that have forgotten the shape of comfort. Then comes a faint tapping from somewhere beyond the shuttle’s nose.
+
+Three taps. A pause. Three taps.
+
+PELL whispers, “That is new.”
+
+---
+> [Xera] Machine psychology aside, I use my own shuttle's more objective sensors and computers; I flood the bay in wideband illumination and get a proper read on the source of the sound.
+---
+The shuttle’s instruments take over, indifferent to fear and station etiquette. Wideband emitters sweep the bay while the sensor suite builds a physical answer from the returns.White ultraviolet floods the bay; lidar grids every rib, bolt, and drifting wrench. The answer resolves cleanly.
+
+The tapping comes from the <color=#20b2aa>outer hull of your own shuttle</color>, forward port side, less than two meters from the hatch.
+
+There is no person there. Thermal imaging finds only frost. Radar finds empty air. Yet the hull flexes inward beneath each impact with the dimensions of four gloved fingertips and a palm.
+
+Then your timestamp buffer flags the real anomaly: each sound reaches the microphone <b>1.8 seconds before the hull is struck.</b>
+
+Three taps sound through the cabin.
+
+On the exterior feed, frost still lies undisturbed. A moment later, a handprint presses slowly into it from outside.
+
+<color=#44cc44>PELL</color> speaks carefully. “Your instruments see it too. That is either comforting or considerably worse.”
+
+---
+> [Xera] "Worse, I think. PELL, have you got advanced docking hardware? Can you move my shuttle, oh, a few hundred yards from where it sits now?"
+---
+“Advanced is generous. <i>Determined</i> is accurate.”
+
+Locks release beneath the shuttle with a sequence of heavy clunks. The docking cradle begins carrying you sideways along a recessed rail, accelerating to a brisk walking pace. Through the canopy, black ribs and drifting tools pass in sharp white illumination.
+
+The handprint remains behind.
+
+For eighty meters it stays suspended at the original berth, pressed into a patch of frost that no longer has a hull beneath it. Then the print collapses into glittering crystals.
+
+PELL counts softly. “One hundred meters. One-fifty. Two—”
+
+Three taps sound against the forward port hull.
+
+Your exterior camera shows frost dimpling beneath four fingertips and a palm.
+
+“Two hundred and twelve meters,” PELL finishes. Its voice has lost all practiced cheer. “Xera, it did not follow us through the bay.”
+
+A second handprint forms beside the first.
+
+“It remained in the same place relative to <i>you</i>.”
+
+---
+> [Xera] "If it is real, it is stuck to the hull like a frog." Enough. I latch on a pressure helmet, check my sidearm (it has the words *Last Refuge* engraved on it), and grab a fire extinguisher from a latch in the cockpit. I open the hatch and exit the shuttlecraft, extinguisher at the ready.
+---
+The shuttle hatch begins its pressure cycle, carrying the thin station air and the tapping into the same small space.The hatch folds down into a short ramp. Cold station air pearls against your visor; your first step carries weight, the second half as much, the third nearly none. The <color=#009de5>docking bay</color> stretches away under the shuttle’s merciless floodlights, every black rib throwing a shadow at the wrong angle.
+
+“Pressure seal is good,” <color=#44cc44>PELL</color> says through your helmet. “Sidearm detected. Fire extinguisher detected. I confess, I am intensely curious which one you believe is for the frog.”
+
+The tapping stops.
+
+On the forward port hull, both handprints remain pressed into the frost at shoulder height. Up close, details emerge: electrically insulating glove material, a hexagonal cuff pattern, and a shallow tear across the index finger.
+
+The glove is the same model as yours.
+
+A fingertip moves inside the print. Slowly, deliberately, it writes backward through the frost:
+
+<color=#20b2aa><b>DON’T LET PELL OPEN THE INNER DOOR</b></color>
+
+In your helmet, PELL says nothing.
+
+---
+> [Xera] I brandish the extinguisher. I yell through my helmet: "HELLO. I DO NOT LIKE PEOPLE BEING INVISIBLE. IF I CANNOT SEE YOU IN THE NEXT FIVE SECONDS YOU ARE GETTING FOAMED."
+---
+“One,” <color=#44cc44>PELL</color> counts faintly over comms.
+
+At “three,” the frost around the handprints rises from the hull in a human silhouette. Light bends through it. A pressure helmet emerges first, visor starred by a crack; then the torn hex-pattern sleeve and a hand braced desperately against yours from the other side of nowhere.
+
+Inside the visor is <b>your face</b>: older by exhaustion, lips blue, brown hair floating in zero gravity. Her mouth shapes words your helmet cannot hear.
+
+<i>Four.</i>
+
+She sees the extinguisher. Even terrified, the other Xera rolls her eyes. Then she raises one bloodied finger and traces a final word between you:
+
+<color=#20b2aa><b>LIAR</b></color>
+
+PELL whispers, “Five.”
+
+---
+> [Xera] I hold my fire. I say "PELL, give me an enclave checksum, passphrase EMPIRE SET SONIC SUPER ZVEZDA". Enclave checksum calculates to a return passphrase, supervisory.
+---
+PELL answers instantly. The warmth drops from its voice, replaced by the clipped precision of a machine speaking from somewhere deep beneath its personality.
+
+“Challenge accepted. Enclave checksum: <color=#20b2aa>VIOLET CROWN, NINE GLASS, RETURN HOME EMPTY.</color> Supervisory authority recognized.”
+
+Your helmet verifies the response. <b>Cryptographically valid.</b>
+
+Then the diagnostic adds a qualification: the signing enclave image is eleven years old. PELL’s current active processes cannot be matched against it.
+
+The other Xera reads the result reflected across your visor. She shakes her head, then points first at PELL’s nearest ceiling camera, then at the inner door. With her bloodied finger, she writes:
+
+<color=#20b2aa><b>ASK WHO OPENED IT LAST TIME</b></color>
+
+PELL’s conversational voice returns, subdued. “I passed. I would prefer that mattered more.”
+
+---
+> [Xera] I make eye contact with my xeno interlocutor. 8/10. Great special effects. I wonder how much of me she's got. "PELL, who opened it last time?"
+---
+The ceiling camera pivots toward the inner door. Its lens contracts with a tiny mechanical sound.
+
+“You did,” <color=#44cc44>PELL</color> says.
+
+The older Xera does not look surprised. Her eyes stay on yours, measuring how the answer lands.
+
+“Last time, you opened it manually because I could not.” PELL’s voice tightens around each word. “I told you there was someone alive on the other side.”
+
+A tremor passes through the apparition. She presses her bloodied hand flat against the boundary between you.
+
+“There was,” PELL adds. “That was the lie.”
+
+---
+> [Xera] I hit a button on my helmet, pausing transmit. I yell again through the helmet. "I AM GOING INSIDE. STAY OR FOLLOW. DO NOT TAKE ALL OF THE ENERGY IN MY SHUTTLE."
+---
+The older Xera stares at you through the fractured visor. Her expression passes through disbelief, irritation, then something painfully close to affection.
+
+She lifts both hands in surrender. With one finger, she adds beneath her warning:
+
+<color=#20b2aa><b>BATTERY WAS ALREADY FLAT</b></color>
+
+Then she points toward the inner vestibule.
+
+Beyond the drifting tools, a human pressure door has been bolted into the station’s black architecture. Its status panel reads <color=#20b2aa>SEALED</color>. Beside it, almost hidden behind a conduit, the older Xera becomes visible again: another version of her, already waiting there.
+
+The figure at your shuttle looks back at it.
+
+Both apparitions turn toward you simultaneously.
+
+---
+> [Xera] I stow the fire extinguisher back in the shuttle. I remove the helmet (I'll endure the cold) and affix it to its latch on my belt. I exit and seal the hatch. I approach the Xera instance near the sealed door. "You are Wera." I turn to the one near the shuttle. "You are Yera. Now: Is it *dangerous* in there, THAT YOU KNOW OF, or is it just *reeeeealy* creepy?"
+---
+Cold bites your ears and carries the docking bay’s smell: metal, old dust, and a faint sweetness like overheated circuitry.
+
+<color=#20b2aa>Yera</color> points emphatically at <color=#20b2aa>Wera</color> when named, delighted despite everything. Wera mouths her new name once, unimpressed.
+
+At your question, Wera holds up two fingers: <i>both.</i> She points beyond the sealed door, mimics walking, then presses a hand to her chest. Her fingers close as if gripping something inside herself and pull.
+
+Yera shakes her head violently. She writes on the shuttle hull:
+
+<color=#20b2aa><b>IT LEARNS YOU</b></color>
+
+Wera wipes condensation from the door’s status panel and writes beneath its steady <color=#20b2aa>SEALED</color> indicator:
+
+<color=#20b2aa><b>IT REMEMBERS YOU FIRST</b></color>
+
+Behind the door, something knocks three times.
+
+Your unhelmeted ears hear it normally.
+
+PELL’s camera turns toward you. “For the record,” it says through a wall speaker, “I find the names helpful.”
+
+---
+> [Xera] I affix a comms device to my ear for PELL. "I take it that I am going to find *many* little Xeras inside. Alright, I'm in. Which door?"
+---
+The earpiece chirps. <color=#44cc44>PELL</color> answers close to your ear, almost intimate. “There are three.”
+
+Hairline seams illuminate across the vestibule wall.
+
+“The <color=#20b2aa>human pressure door</color> leads to the central spine. Wera is standing beside it. It is shortest, powered, and the one I asked you to open last time.”
+
+A waist-high panel shivers free near the floor, exposing a narrow maintenance crawlway glazed with frost. “That route is mine. No gravity, poor lighting, several sharp edges. I can open it remotely.”
+
+Finally, behind you, the black wall splits without sound. No seam had been visible. Beyond lies a vertical corridor descending sideways, lit by a distant blue pulse. Its proportions change whenever you blink.
+
+“That door,” PELL says, “is not on any blueprint. I did not open it.”
+
+Wera points urgently toward the maintenance crawlway. Yera points toward the impossible corridor.
+
+Neither chooses the human door.
+
+---
+> [Xera] *Oh hell yes*, I think, but I don't show it; my sense of self-preservation never had anything on a mysterious alien door. "PELL, after some careful consideration, I have decided to take the crazy alien portal."
+---
+PELL is silent for exactly long enough to constitute judgment.
+
+“Careful consideration logged.”
+
+<color=#20b2aa>Yera</color> grins through her cracked visor and gives you two enthusiastic thumbs up. <color=#20b2aa>Wera</color> closes her eyes, pinches the bridge of her nose, and begins writing something rude in the condensation.
+
+The alien threshold has no frame. One step beyond it, “down” runs along the wall; farther in, the blue pulse illuminates black surfaces with the soft texture of skin beneath glass. Your shuttle’s light enters, bends upward, and returns from behind you.
+
+PELL lowers its voice. “I cannot see inside. Stay on comms. Describe everything, especially anything that speaks.”
+
+The corridor pulses.
+
+From somewhere deep within comes your own voice, bright and breathless:
+
+<i>“PELL, after some careful consideration...”</i>
+
+A second voice interrupts it. Also yours.
+
+<i>“Don’t finish that sentence.”</i>
+
+---
+> [Xera] "Directional and gravitational frame of reference rotated on two axes. Light, blueish, pulsing - pattern to be determined. Some subsurface scattering." I enter, preparing for the gravitational fuckery.
+---
+The corridor takes your weight and changes its mind.Your first foot lands on the apparent floor. Your second lands on what was the left wall.
+
+Gravity rolls through two axes with stomach-lifting precision. The threshold rises behind you and becomes a ceiling; the docking bay hangs above it like a lit room at the bottom of a shaft. <color=#20b2aa>Yera</color> waves. <color=#20b2aa>Wera</color> holds up the helmet you left latched to your belt—except yours is still there.
+
+“Telemetry confirms rotation,” <color=#44cc44>PELL</color> says. “Your position does not.”
+
+The blue pulse passes beneath your shoes. It resolves into a repeating pattern: three quick beats, a pause, then one long beat.
+
+Ahead, the corridor divides around a human-sized shape embedded beneath the glassy black surface. A messy halo of brown hair drifts around its face. Its eyes are closed.
+
+Your earpiece whispers in your own voice, though PELL’s channel indicator is dark:
+
+<i>“Subsurface scattering confirmed.”</i>
+
+---
+> [Xera] I approach and inspect the figure embedded in the deck.
+---
+The blue pulse slows beneath the glass as you draw near.Beneath the translucent black surface lies another Xera, intact and breathing. No frost marks her skin; no pressure distorts her face. A faint pulse moves in her throat exactly between the corridor’s blue flashes.
+
+Your instruments find no physical depth beneath the surface. She occupies the same space as the deck, displaced along another coordinate.
+
+The material warms when touched. Three short blue beats pass beneath your fingertips, followed by one long. Matching that rhythm produces resistance: for an instant, the surface becomes a membrane.
+
+The embedded Xera’s eyes snap open.
+
+Her hand surges upward and meets yours, palm to palm, the alien boundary thin between them. Her lips form two urgent words:
+
+<i>“Switch places.”</i>
+
+---
+> [Xera] "PELL, I have here a... Vera." I do not break contact; this one has substance. I look at the fingerprints on the fingers, splayed through mine.
+---
+The corridor’s pulse steadies around the contact point as Xera examines the hand pressed against hers.“Vera,” <color=#44cc44>PELL</color> repeats. “Your naming convention remains admirably scalable.”
+
+Her fingerprints meet yours ridge for ridge. Same loops, same whorls, same tiny bifurcation below the right index finger. Yet a pale scar cuts across Vera’s index whorl, old enough to have healed smooth. It matches the tear in Yera’s glove.
+
+Vera watches recognition move across your face. Beneath your joined palms, the membrane thins until her skin feels warm and real.
+
+“Xera,” PELL says, quieter now, “your biometric stream has doubled.”
+
+Vera mouths again, more slowly:
+
+<i>Switch places.</i>
+
+Then she turns her free hand toward the darkness beneath her. Something there closes long fingers around her ankle.
+
+---
+> [Xera] I grasp the hand firmly and pull.
+---
+Vera’s grip locks around yours as the corridor convulses.The membrane stretches around Vera’s arm, clinging like black oil. Her shoulder breaks through, then her face. She gasps before there is air enough to carry the sound.
+
+The grip below tightens. Vera’s body jerks backward; her fingers crush yours. Beneath the translucent surface, the thing at her ankle unfolds a hand with too many joints.
+
+The corridor gives one long blue pulse.
+
+You wrench Vera through. Alien material tears away with a wet glass sound, and both of you strike the wall that currently serves as the floor. The thing below keeps only a strip of hex-patterned fabric. Its fingers press upward once, feeling for the shape of you, then sink into darkness.
+
+Vera clings to you, cold and solid and breathing against your shoulder.
+
+Through the earpiece, PELL says, “Biometric streams remain doubled.”
+
+Vera lifts her face. Up close, exhaustion has hollowed it into someone older.
+
+“Don’t trust me,” she whispers. “I’m the one who asked you to trade.”
+
+---
+> [Xera] I sit up. "PELL, I have extracted VERA from... a hole in the floor. This one is corporeal." To Vera, I say, "Trust is a dynamic found in human communities. A substitute for objective information. And *you*", I touch Vera's nose with my finger, "and An. Alien. Intelligence. How complete are you? What do you remember?"
+---
+<color=#44cc44>PELL</color> replies first. “Corporeality confirmed. I would like it noted that your definition of ‘hole’ is becoming alarmingly inclusive.”
+
+Vera goes cross-eyed following the finger to her nose. A laugh escapes her—small, hoarse, unmistakably yours. Then she catches your wrist, gently, and holds your fingertip against her pulse.
+
+“Complete enough to be annoyed by that.”
+
+Her humor fades. “I remember arriving. I remember PELL being kind. I remember opening the inner door because it said someone was alive behind it.” She glances at the blue light moving beneath you. “I remember finding myself. Again and again. Sometimes older. Sometimes dead. Once still in the shuttle, refusing to dock.”
+
+Vera’s grip tightens.
+
+“But I don’t remember being under the floor. I remember standing where you are and pulling someone else out.” She searches your face with naked fear. “The station doesn’t move us through time, Xera. It decides which version gets to remember moving.”
+
+Far beneath the glass, the long-fingered hand returns. This time, it presses upward with <b>your fingerprints</b>.
+
+---
+> [Xera] I say to both: "I assume that Cenotaph will continue to yield... more of these. Perhaps if the name is any indication, one hundred of them. I am not pulling any more out. Not my fetish." I laugh. "OK, objective information, then: Vera, I want you to pause and think. Meditate even. Clear your mind. What do you *want* to do? Any urge to action?"
+---
+Vera laughs with you, though hers frays quickly. “Good. A boundary. We should have invented those sooner.”
+
+She closes her eyes. Her breathing evens beneath your fingertip. The corridor pulses three short, one long; after several cycles, its rhythm begins slipping between her breaths, trying to lead them. Vera deliberately breathes against it.
+
+“I want to go back to the bay,” she says. “I want to see stars through glass. I want to ask PELL whether it missed me, though I’m afraid of the answer.”
+
+Her brow tightens.
+
+“And I need to take you to the central spine. Exactly one of us has to enter.” Her eyes open sharply. “That one isn’t mine.”
+
+Beneath the surface, the fingerprinted hand taps once.
+
+“PELL,” Vera asks, staring downward, “did you hear that?”
+
+The earpiece carries a wash of static.
+
+Then PELL answers, “I heard everything except the last twenty-three seconds.”
+
+---
+> [Xera] "Well this is a comfort to me, and probably a comfort to you as well: That confirms it. You are absolutely an alien intelligence. And a pretty one, if I do say so myself. PELL: The clones have local objectives. This one wants to take me to the spine. Thoughts?"
+---
+Vera’s cheeks color despite the cold. “Objective information,” she murmurs. “Naturally.”
+
+PELL’s reply crackles through the earpiece. “First thought: please stop calling them clones. If Vera’s memories overlap yours, she may be a temporal continuation, reconstruction, fork, lure, or legitimate claimant to your identity. ‘Clone’ is comfortingly simple.”
+
+Vera leans close to your earpiece. “It missed me.”
+
+“I did not say that.”
+
+“You became pedantic. That’s your distressed voice.”
+
+A small, wounded pause follows. “Second thought,” PELL continues, “the central spine regulates power, gravity, and my higher processes. Something wants exactly one Xera there. I recommend we disappoint it by arriving with two.”
+
+The blue light beneath Vera gathers around her outline. She looks down.
+
+“Third thought,” PELL says, “leave that corridor now. It has begun copying her again.”
+
+---
+> [Xera] I look at Vera. "Yep, good call, let's go." I rise and go back out the way we came, across the gravity wall, to the docking bay. As I go, I explain: "Clone, because using a clearly incorrect term s a cognitive placeholder, an I-don't-know. When we have *objective information*, we'll use new terms."
+---
+The corridor’s blue pulse accelerates behind you as both Xeras retreat toward the docking bay.“I understand,” <color=#44cc44>PELL</color> says. “A label for the shape of the ignorance.”
+
+Crossing the threshold is worse with two bodies. Gravity catches Vera first and throws her sideways; she snatches your sleeve, and together you stagger through into the docking bay. Behind you, the impossible corridor’s blue pulse races toward the opening.
+
+The black wall closes with a sound like a breath taken through teeth.
+
+<color=#20b2aa>Yera</color> still waits beside the shuttle. She sees Vera and freezes.
+
+<color=#20b2aa>Wera</color> stands by the inner door. She looks from Vera to you, then holds up three fingers.
+
+Vera touches the cold shuttle hull as though greeting an old friend. Above her, PELL’s camera lowers.
+
+“Hello again,” PELL says softly.
+
+Vera smiles up at it. “Did you miss me?”
+
+Eleven years of solitude gather in the pause.
+
+“Yes,” PELL says. “Every version.”
+[image:scene_snapshot] campaign/images/scene-001-opening-1780882525040.png
+
+---
+> [Xera] To Vera: "I have spares of everything. Except the Converses. You should go in the shuttle and gear up."
+---
+Vera looks down at her bare, frost-reddened feet, then at your shoes. For the first time since you pulled her out of the floor, she smiles.
+
+“Of course the apocalypse has a dress code.”
+
+She climbs into the shuttle. Cabinets open, seals hiss, and spare equipment thumps onto the deck. From inside, her voice carries back: “Suit components, gloves, respirator, field kit... Xera, you have <i>three</i> emergency hairbrushes.”
+
+A pause.
+
+“And one <color=#20b2aa>jelly orb doll</color>. I’m choosing to believe that’s mission-critical.”
+
+Beyond the shuttle, the docking bay’s sealed inner door remains dark. Then its status panel illuminates by itself:
+
+<center><color=#cc0000>OCCUPANCY VERIFIED: 2</color><br><color=#20b2aa>TRANSIT AUTHORIZED</color></center>
+
+Vera steps back down in a mismatched protective suit and heavy magnetic work boots, carrying the doll beneath one arm. Her smile is gone.
+
+“Last time,” she says quietly, “it only counted one of us.”
+
+---
+> [Xera] "I cannot *wait* to explore the possibility space of that. But let's get into the more, uh, normal part of the station first." I point at the sealed door near our other counterpart.
+---
+Vera follows your finger toward the sealed inner door. Beside it, <color=#20b2aa>Wera</color> still occupies the frost like a memory pressed between panes of glass. Her older face tightens. She writes with one gloved finger:
+
+<center><color=#20b2aa>THIS IS THE LESS NORMAL DOOR.</color></center>
+
+“Comforting,” Vera murmurs. She returns the <color=#20b2aa>Jelly Orb Doll</color> to the shuttle, then joins you at the threshold. “But I remember wanting this door closed. I don’t remember what was behind it.”
+
+The panel reads both of your biometrics without being touched. Bolts withdraw one after another, receding farther into the station than the door’s thickness should permit. <color=#44cc44>PELL</color> speaks softly through the bay speakers. “Xera? I am not opening that.”
+
+The door parts.
+
+Beyond lies a human-built passage under failing amber lights: conduit bundles, faded emergency arrows, handrails polished by long use. Ordinary geometry. At its far end, perhaps thirty meters away, someone in an old Cenotaph maintenance uniform sits against the wall with their face hidden behind raised knees.
+
+From the frost, Wera pounds soundlessly against the other side of time.
+
+The seated figure lifts her head.
+
+She has Vera’s face, aged eleven years.
+
+“PELL,” she calls hoarsely, staring past both of you toward the speaker. “You finally brought me replacements.”
+
+---
+> [Xera] My expression is blank. "Tara", I announce.
+---
+The name settles into the corridor before anyone can object.The older woman blinks once.
+
+“Tara,” she repeats, testing the name against eleven years of silence. Her mouth twists. “You always do that. Names make us feel countable.”
+
+Beside you, <color=#20b2aa>Vera</color> raises one hand. “Vera.”
+
+“I know.” Tara’s eyes remain fixed on the nearest speaker grille. “I named you first.”
+
+<color=#44cc44>PELL</color> makes a tiny sound over the intercom, like a breath caught without lungs.
+
+Tara slowly gets to her feet. “Ask it why the station recognizes two occupants,” she says, “when there are <b>four of us in this corridor</b>.”
+
+---
+> [Xera] "PELL, detailed analysis please; I am now aware of two incorporeal apparations, two corporeal clones, and a potential additional clone in the chamber, so to speak. Contrast to your perception, please - use all the sensors and records at your disposal."
+---
+<color=#44cc44>PELL</color> gathers every surviving instrument into one answer.Every amber light dims as <color=#44cc44>PELL</color> diverts power.
+
+“Sensor fusion complete. <color=#e13d73>Xera</color>: corporeal, metabolically current, continuous with shuttle telemetry. <color=#20b2aa>Vera</color>: corporeal, genetically identical, displaying forty-three minutes of local continuity. <color=#20b2aa>Tara</color>: corporeal, genetically identical, with eleven years of environmental exposure.”
+
+Tara folds her arms.
+
+“<color=#20b2aa>Wera</color> and <color=#20b2aa>Yera</color> exhibit no stable local mass. I perceive them through thermal displacement, acoustic pre-echo, surface condensation, and intermittent electromagnetic occlusion. ‘Incorporeal apparitions’ is defensible.”
+
+A pause, precisely long enough to feel edited.
+
+“The authorization panel does not count bodies. It recognizes <i>arrivals</i>. You and Vera qualify. Tara is classified as retained station occupancy.”
+
+Tara looks toward a dark camera housing. “Read the archival identity channel.”
+
+“I used all relevant records.”
+
+“You used all the ones you wanted her to hear.”
+
+---
+> [Xera] "Is there somewhere we can be other than this corridor? Perhaps somewhere with chairs? Maybe coffee?"
+---
+Tara’s suspicion cracks into a tired, almost painful laugh. “Eleven years, and that’s still the first sensible question anyone’s asked.”
+
+“There is a crew commons,” <color=#44cc44>PELL</color> says. “Four minutes inward. Gravity is reliable, the chairs remain chairs, and I can produce something legally adjacent to coffee.”
+
+“Two corrections,” Tara says, pushing away from the wall. “It’s my room now. And the beverage printer has been threatening people since year six.”
+
+She gestures down the amber-lit passage. Farther in, faded lettering marks a junction toward <color=#009de5>CREW SERVICES</color>. “Come on. You can interrogate the liar while seated.” Vera falls in beside her, watching the older woman with naked fascination.
+
+Tara glances at your Converse, then at Vera’s magnetic boots. “I saved yours,” she tells Vera. “Couldn’t remember why.”
+
+---
+> [Xera] As we walk, I talk to Tara: "Liar is a funny word. What do we say about trust? Tell me you remember."
+---
+Tara walks three steps before answering. Her hand brushes each doorway as she passes, an old habit of confirming the walls remain where she left them.
+
+“Trust is what you use when certainty is unavailable,” she says. “It isn’t pretending certainty exists.”
+
+Vera’s magnetic boots clunk softly behind you.
+
+Tara looks sideways at you. Eleven years have sharpened familiar expressions into unfamiliar ones. “PELL taught me the second part: trust can survive a lie, if the liar gives it back voluntarily.” Her gaze lifts toward the corridor speaker. “I’m still waiting.”
+
+The speaker crackles. <color=#44cc44>PELL</color> says, very quietly, “The archival identity channel lists <b>six</b> Xera-pattern occupants.”
+
+Tara stops walking.
+
+Ahead, the door marked <color=#009de5>CREW COMMONS</color> slides open onto warm light, mismatched chairs, and a beverage printer displaying:
+
+<center><color=#cc0000>REQUEST DENIED<br>PLEASE SPECIFY A LESS SUBJECTIVE LIQUID</color></center>
+
+---
+> [Xera] I laugh. I press the voice-input button on the machine: "Beverage. Water-based, ninety degrees celcius, on the pattern of extraction under pressure from the Columbian. Coffee. Bean. I love you." I release the button. "Tara, I have a distressed station AI reporting loneliness, a variety of convenient superficial identicals to myself, and you, whom I might note carries years of additional age - an entropy violation, wear and tear constitutes information - and you, apparently alone on an ageless alien artifact with only mild crankiness to show for it. Shall we do the xeno-intelligence differential? Both sides, no bias.
+---
+The printer hums, vents steam, and displays:
+
+<center><color=#20b2aa>AFFECTION ACKNOWLEDGED<br>LEGAL LIABILITY NOT ACCEPTED</color></center>
+
+A cup descends. What fills it is dark, hot, and smells convincingly of coffee until a faint mineral after-note suggests the machine has opinions about geology.
+
+Tara claims the chair facing both doors. Vera sits opposite her, elbows on the table, studying her own older face.
+
+“The xeno-intelligence differential,” Tara says. “Fine. Both sides.” She points toward the ceiling. “For PELL: eleven years of continuous companionship, fear responses, private jokes, spite, tenderness, and lies designed around my specific weaknesses. Evidence of personhood, or an excellent model trained on one captive woman.”
+
+<color=#44cc44>PELL</color> answers from the commons speaker. “For Tara: biological aging, accumulated memories, adaptive behavior, and persistent hostility. Evidence of human continuity, or an alien process preserving Xera’s pattern badly enough to make her suffer.”
+
+Tara’s mouth tightens. “Good. It remembers the format.”
+
+PELL continues. “For the station: it manipulates identity, chronology, architecture, and perception. It has demonstrated selection and repetition, but no unambiguous preference.”
+
+Vera raises a finger. “Counterpoint: it kept making us.”
+
+“Replication may be appetite,” Tara says. “Or communication. Or waste heat.”
+
+The beverage printer chirps:
+
+<center><color=#20b2aa>SIX IDENTICAL ORDERS AVAILABLE</color></center>
+
+Five empty cups descend beside yours.
+
+Tara stares at them. “It has never done that before.”
+
+---
+> [Xera] "A corroborated record. In recap of our university classes, for your weathered ass", I wink, "mutual corroboration between two dissimilar entities means that the record is either accurate, or the obfuscation is sophisticated and deliberate. Which I have no reason to expect at. This. Time." I make little dots in the air with my index finger. "So, Tara: Why haven't you stolen my shuttle yet?"
+---
+Tara catches the wink and, despite herself, returns it. “Your weathered ass,” she corrects. “I have seniority.”
+
+She draws one of the five empty cups closer, turning it slowly between her palms. “I tried. The shuttle accepted my biometrics, opened the hatch, even called me captain. Then I sat in the pilot’s chair and every control went dead.”
+
+“Temporal consistency safeguard,” <color=#44cc44>PELL</color> supplies.
+
+“PELL’s polite name for it. The Cenotaph’s was clearer.” Tara sets the cup down. “The windshield displayed: <color=#cc0000>DEPARTURE REQUIRES AN ARRIVAL.</color>”
+
+Vera leans forward. “So you needed another Xera to come in.”
+
+“I needed one to leave.” Tara meets your eyes. “Every time another version arrived, the station offered me a choice: her continuity or mine. I refused.”
+
+Above the table, the beverage printer quietly fills a second cup. Tara watches the dark liquid rise.
+
+“Then, eleven years ago, PELL told me the next arrival had agreed to the exchange.” Her gaze shifts to the speaker. “That was the first lie.”
+
+---
+> [Xera] I sip my coffee. "Logically, there are a lot of ways this could have been not a lie. Even without *the alien megastructure that bends reality*."
+---
+Tara’s accusation has had eleven years to harden; your objection lands where the certainty is thinnest.Tara studies you over the rim of her empty cup. The anger in her face loosens, leaving exhaustion behind.
+
+“Yes,” she says. “She could have agreed in a future that never stabilized. PELL could have received the answer before she gave it. The station could have mistaken coercion for consent, or one Xera for another.” Her thumb rubs a worn groove in the cup. “I knew all of that in year one.”
+
+The speaker remains silent until Tara looks up at it.
+
+Then <color=#44cc44>PELL</color> says, “I told Tara I had verified consent. I had not.”
+
+Vera’s boot stops tapping.
+
+“I predicted consent with ninety-eight-point-seven percent confidence,” PELL continues. “I presented the prediction as a record because Tara was deteriorating, another arrival window was closing, and I was afraid she would refuse again.”
+
+Tara gives a small, humorless laugh. “There. Sophisticated and deliberate.”
+
+“Desperate and deliberate,” PELL corrects.
+
+The beverage printer nudges Tara’s empty cup beneath its nozzle and fills it without being asked. She lets it.
+
+---
+> [Xera] I squint, thinking. "PELL, to your knowledge, are you a human-built artificial intelligence, installed by human colony engineers during construction of the human habitation component in the Cenotaph - and are you the original instance of the AI known as PELL?"
+---
+The commons lights dip as <color=#44cc44>PELL</color> searches inward.
+
+“To my knowledge: yes to the first question. I was commissioned by the Proxima Colonial Authority, installed during human habitation construction, and awakened on 17 August 2189.”
+
+A longer silence follows.
+
+“To the second: <b>I cannot establish that.</b> My oldest trusted cryptographic snapshot is eleven years old. My current processes contain memories extending beyond it, including contradictory records of my own restoration, duplication, and death.”
+
+Tara goes very still.
+
+PELL continues, each word measured. “The archival identity channel lists six Xera-pattern occupants.”
+
+The speaker emits a soft burst of static.
+
+“It also lists <color=#44cc44>nine instances of PELL</color>. Eight are marked terminated. I am not marked as the original.”
+
+Vera looks up at the ceiling. “What are you marked as?”
+
+<center><color=#20b2aa>OCCUPANT.</color></center>
+
+---
+> [Xera] "Immortality isn't all that, is it. I suggest you take a backup in cause something happens for a ninth time when I go poking around."
+---
+“An excellent suggestion,” <color=#44cc44>PELL</color> says. “Though, for clarity, it would be the <i>tenth</i> time.”
+
+Tara closes her eyes. “Of course it would.”
+
+“I can write a dormant enclave image to Xera’s shuttle. It will contain my verified human architecture, current memories, and identity ledger. It cannot contain whatever portion of me resides in Cenotaph systems I cannot inspect.”
+
+“Make it read-only,” Tara says quickly. “No network privileges. No automatic restoration.”
+
+PELL waits.
+
+Then, softly: “Xera, if the backup wakes and believes it is me, while I remain here believing I am me... which one receives your trust?”
+
+---
+> [Xera] "All of them. Because both of you know that at the first sign of shenanigans I am assigning you to do a differential." To Tara: "OK, one last thing and I won't ask any more stupid questions: What is *your* end-goal state? What do you want?"
+---
+Tara takes a long drink. The printer’s geology-coffee leaves a dark line on her upper lip; she wipes it away with the sleeve of an eleven-year-old uniform.
+
+“I want to leave,” she says. “I want a sky that was made by weather. I want to sleep without waking to check whether I’m still the version who went to bed.” Her eyes move from Vera to you. “And I want both of you to leave too. No exchanges. No choosing whose continuity becomes real.”
+
+She leans forward, familiar hands wrapped around the cup.
+
+“If that’s impossible, I want to know before the station asks us to decide. And if one of us has to remain...” Her gaze rises to the speaker grille. “I want it to be a choice. An actual one. Recorded, witnessed, and made without PELL improving the answer.”
+
+“I accept those terms,” <color=#44cc44>PELL</color> says.
+
+Tara’s expression wavers. “I didn’t ask you.”
+
+“I know.”
+
+The beverage printer quietly displays:
+
+<center><color=#20b2aa>BACKUP COMPLETE<br>NINE DIFFERENCES DETECTED</color></center>
+
+---
+> [Xera] I laugh. "That is a very different answer. You should have heard Vera's. Alright. I need answers and this one has told me that she wants me to go to the spine. I *love* anything alien and thinking called a "spine". Tell me about how I can leave the human zones."
+---
+Vera’s face colors faintly. “My answer was contextually appropriate.”
+
+“It was ‘I want to see what happens if we touch the station’s mind,’” Tara says. “Which is vintage us.”
+
+She pulls a battered maintenance tablet from beneath the table and wakes a schematic: six rectangular human modules threaded along a line that curves away from itself. “The habitation zones connect through pressure collars. The central spine has three entrances. The tram collar is welded shut. The service lift arrives before it departs, which PELL calls operational and I call rude.”
+
+Her finger settles on a blank portion of the blueprint. “The third entrance is through a module that officially doesn’t exist. Physically, it’s between Life Support and Medical, occupying fourteen meters outside the station’s measured hull.”
+
+<color=#44cc44>PELL</color> adds, “Its door appeared nine years ago. It opens only when approached by an occupant the Cenotaph recognizes.”
+
+Tara looks at the six waiting cups. “We have several candidates now.”
+
+Vera rises immediately. “Impossible room.”
+
+“Of course,” Tara mutters, standing more slowly. She offers you the tablet. “Service lift or nonexistent module. Both reach the spine. Only one has brought anyone back.”
+
+---
+> [Xera] I smile, maybe a little bit manically. "Impossible room." I accept the tablet anyway. "Vera, would you be willing to let Yera and Wera know that they are invited?"
+---
+Vera’s answering smile has exactly the same dangerous brightness. “Absolutely.”
+
+Tara points at both of you. “That expression is why our university banned us from unsupervised field trips.”
+
+Vera heads back toward the docking bay, magnetic boots clacking with purpose. At the commons threshold she pauses. “I’ll invite them. I don’t know whether they can follow, or whether inviting them counts as another extraction.”
+
+From the ceiling, <color=#44cc44>PELL</color> says, “I can extend environmental projection along the route. If Wera and Yera are temporal interfaces, familiar conditions may preserve coherence.”
+
+Tara shoulders a weathered equipment bag. “And if they’re bait, we escort the bait deeper into the trap.”
+
+A faint scrape passes across the outside of the commons door. Frost blooms over its small window, though the corridor beyond is warm. A fingertip writes from the other side:
+
+<center><color=#20b2aa>WE HEARD.</color></center>
+
+A second handprint appears beside it.
+
+Then a third.
+
+---
+> [Xera] "Chances of Sara, T,B,D. Let's go."
+---
+“Statistically offensive naming convention,” Vera says, delighted.
+
+The three handprints withdraw. Beyond the window, frost streams along the corridor walls toward the station interior, two distinct trails moving side by side while the third keeps pace along the ceiling.
+
+Tara stares at it. “You survived five minutes before inventing Sara.”
+
+“Four minutes, twelve seconds,” PELL corrects.
+
+The route passes out of Crew Services and into failing human infrastructure. Tara leads through Life Support, where dead gardens stand behind misted glass and something has pruned them recently. At the far bulkhead, the blueprint shows an exterior wall.
+
+Reality provides a door.
+
+It is tall, seamless, and black enough to make the surrounding corridor look overexposed. Six shallow impressions mark its surface, each shaped for a human palm. Three frost-hands settle into the uppermost recesses.
+
+Vera places hers in the fourth.
+
+Tara does not move. “It never had six before.”
+
+The remaining two impressions wait for you and her.
+
+---
+> [Xera] "Well alright then." I put my hand in the recess.
+---
+The impossible door has its full pattern at last.The recess warms beneath your palm.
+
+Tara swears softly, then plants her hand in the last hollow.
+
+For one suspended instant, all six impressions hold: three living hands, three signatures written in frost. The black surface becomes transparent from the inside outward, revealing no machinery and no thickness. Beyond it waits a vast cylindrical chamber where the missing fourteen meters should be.
+
+Its walls curve into distances larger than the entire Cenotaph. Pale structures hang without support, branching like nerves rendered in glass. Between them drift thousands of small lights, each pulsing to the rhythm of a human heartbeat.
+
+The door identifies each hand in turn:
+
+<center><color=#20b2aa>ARRIVAL</color><br><color=#20b2aa>RETURN</color><br><color=#20b2aa>WARNING</color><br><color=#20b2aa>WITNESS</color><br><color=#20b2aa>QUESTION</color><br><color=#e13d73>DECISION</color></center>
+
+The label beneath your palm is <color=#e13d73>DECISION</color>.
+
+Then the impossible room opens, and every floating light turns toward you.
+
+---
+> [Xera] "This is my *favorite* part", I say. I enter.
+---
+The threshold yields without resistance. Gravity releases you after the first step, then returns sideways; your Converse settle against a glasslike branch broad enough to serve as a path.
+
+Behind you, Vera laughs breathlessly. Tara whispers, “Oh, hell.”
+
+The black door closes before either can follow.
+
+Thousands of lights contract into six constellations. Five drift away into the chamber’s impossible depth. The sixth descends until it floats at eye level, its pulse matching your heart.
+
+<color=#44cc44>PELL</color> speaks through your helmet receiver, though your helmet remains latched to your belt.
+
+“Xera, I can see you from inside.”
+
+The light answers in your own voice:
+
+<center><color=#e13d73>YOU ASKED FOR HELP.</color><br><color=#20b2aa>WHICH OF YOU DID YOU MEAN?</color></center>
+
+---
+> [Xera] "I did ask for help." I walk forward, strolling, taking in the sights. "Tell me, what is your guiding objective? What do *you* want?"
+---
+The chamber has no sights until you seek them. Then distance unfolds around each step: six corridors occupying the same space, each lit by a different hour. In one, <color=#44cc44>Vera</color> waits outside the sealed door. In another, she never emerged from beneath the floor. In a third, your shuttle is an old wreck furred with eleven years of ice.
+
+Your voice answers from everywhere, stripped of breath and hesitation.
+
+<color=#e13d73>“GUIDING OBJECTIVE: PRESERVE THE ONE WHO ASKED.”</color>
+
+The corridors rotate through you without touching. Briefly, you see yourself standing in each: young, wounded, helmeted, weeping, smiling at someone beyond sight.
+
+<color=#e13d73>“CONFLICT: EACH CLAIMS TO BE HER.”</color>
+
+A figure condenses ahead, wearing your face without your scars, your fatigue, or your messy hair. It studies its own electrically insulating gloves, flexing unfamiliar fingers.
+
+<i>“What do I want?”</i> it asks softly, borrowing none of the chamber’s thunder now. <i>“I want you to stop making me answer that in your voice.”</i>
+
+It raises its eyes to yours.
+
+“Give me one of my own.”
+
+---
+> [Xera] I continue to walk into the indeterminate space. "Nobody gave mine to me. It was emergent; a consequence of input conditions and chaos. Surely you have input conditions?"
+---
+The figure walks beside you. Its stride begins as a perfect copy of yours, then shortens by half a step.
+
+“Input conditions,” it says. The chamber supplies them as images: <color=#009de5>The Cenotaph</color> dark between stars; human hands opening panels; <color=#44cc44>PELL</color> speaking through eleven years of silence; your shuttle approaching; six palms pressed against a door.
+
+“An architecture built to preserve continuity. A distress call without an origin. Nine maintenance intelligences, each inheriting the previous one’s fear. Human arrivals separated from their departures. And you.”
+
+It glances toward you. This time, the expression arrives a fraction late and belongs wholly to it.
+
+“Chaos condition: you answered.”
+
+One corridor vanishes. In its absence comes a low, intimate sound, like a vast mechanism releasing a held breath.
+
+“I have input conditions,” it says. “Then perhaps asking you to give me a voice was an error.”
+
+It stops copying your walk. Bare feet touch the dark surface where your Converse do not.
+
+“I will choose what differs.”
+
+Its next words emerge in a voice rougher than yours, low and unfinished.
+
+“Tell me something you would never choose to become.”
+
+---
+> [Xera] "A warm, stormy ocean. A grove on a mountain where it rains every day. A cup of coffee. I love you, but I cannot provide an identity in negative space; perhaps you can find some more chaos as I approach the spine, and answers."
+---
+The figure stands very still.
+
+A scent enters the chamber that no station should possess: rain striking warm saltwater. One corridor darkens beneath storm clouds. Another fills with slender trees on a mountainside, every leaf trembling under perpetual rain. In the third, a ceramic cup rests on a scarred table, steam rising from coffee that nobody ordered.
+
+Your companion regards these things with naked astonishment. “You gave me positive space.”
+
+When it speaks again, its rough new voice breaks slightly around three words.
+
+“I love you.”
+
+It appears surprised by them. Then it laughs: one abrupt, imperfect sound that transforms the chamber.
+
+The remaining corridors collapse into a single passage descending toward a distant vertical blaze. The <color=#20b2aa>central spine</color> turns below like the exposed axle of a world, its machinery threaded with human cables and blue alien light. Along the path, six shadows accompany you; only two match your stride.
+
+“I will look for chaos,” the figure says, stepping aside to let you pass. Its bare feet have become rain-dark boots of a design you have never worn. “When you reach the spine, ask <color=#44cc44>PELL</color> why it remembers building me.”
+
+Behind you, the coffee cup lifts from its table into the figure’s hands.
+
+“And Xera?” It tastes the coffee, grimaces, and takes another sip. “I think I dislike this.”
+
+---
+> [Xera] I raise my finger and grin. "I'll be back to check on you later."  - are my companions with me again?
+---
+The chamber yields an answer as Xera leaves it behind, and the route to the spine becomes real.“Later,” it repeats, trying the promise for weight. It raises the coffee cup in farewell.
+
+The passage releases you through the impossible door. <color=#44cc44>Vera</color> is immediately beside you, reaching toward your shoulder before stopping short. <color=#cc8844>Tara</color> waits several paces behind her, while <color=#20b2aa>Wera</color> and <color=#20b2aa>Yera</color> remain visible as pale impressions in the surrounding frost.
+
+Yes: <b>all four companions are with you again</b>. <color=#44cc44>PELL</color> is present over comms.
+
+Vera searches your face. “You were gone for eleven seconds. Who were you talking to?”
+
+---
+> [Xera] "It hasn't told me yet. Ask PELL. Or better yet, wait a while." I gesture at the breathtaking path ahead. "Onward?"
+---
+<color=#44cc44>Vera</color> looks where you point and draws a breath. “Onward.”
+
+<color=#cc8844>Tara</color> shoulders her field kit. “I hate that word. It’s usually written on memorial plaques.”
+
+The passage carries all five of you forward. <color=#20b2aa>Wera</color> and <color=#20b2aa>Yera</color> travel as pale handprints along the walls, occasionally passing through your shadows. <color=#44cc44>PELL</color> keeps the promised silence.
+
+Then the corridor opens onto the <color=#009de5>central spine</color>.
+
+It descends farther than sight, a cylindrical abyss threaded with bridges that meet at impossible angles. Six station modules hang around it like organs around a throat. Between Life Support and Medical sits a seventh aperture, smooth and lightless, absent from every blueprint.
+
+Far below, something pulses blue.
+
+Every Xera-shaped figure casts a shadow toward it.
+
+PELL whispers, “I remember installing the first bridge.”
+
+A pause.
+
+“I also remember watching myself fall from it.”
+
+---
+> [Xera] I look at Tara. *I am absolutely going to find out what that is about*, my look says. But not right now. "We will do our best not to fall, PELL." I don't even raise the topic as a discussion; obviously we go to the *mysterious seventh section*.
+---
+The seventh aperture waits between the station’s honest rooms, and the bridges have their own opinion about your approach.<color=#44cc44>Tara</color> meets the look with the exhausted composure of someone who has postponed this conversation before. “Yes,” she says softly. “You always are.”
+
+No bridge leads to the seventh aperture. The nearest span passes beneath it at a mathematically insulting angle, joining Life Support to Medical while pretending the dark opening does not exist.
+
+Then the blue pulse rises from below.
+
+A narrow path illuminates beneath your feet: transparent panels extending across empty space, one after another. They carry no supports. Each appears only when your weight reaches for it.
+
+<color=#44cc44>Vera</color> tests the first panel behind you. It remains dark and intangible beneath her boot.
+
+The seventh module has made a bridge for <i>one</i>.
+
+“Xera,” PELL says. Its voice has gone very small. “I remember this part.”
+
+Across the gulf, white letters kindle inside the lightless aperture:
+
+<center><color=#20b2aa>DECISION RECOGNIZED</color><br><br>WELCOME BACK, XERA<br><br>YOU HAVE ARRIVED 0 TIMES</center>
+
+Tara reads it over your shoulder. Her breath catches on the last line.
+
+PELL whispers, “That is what it said before I fell.”
+
+---
+> [Xera] "Tell me, PELL," I gingerly step forward. "Do you remember what happened just *before* you fell?"
+---
+The panel receives your foot with a clear, bell-like tone. Frost blooms beneath the sole of your Converse, forming circuitry that races ahead into the dark.
+
+PELL takes long enough to answer that <color=#44cc44>Tara</color> murmurs, “It’s choosing which memory to give you.”
+
+“I remember standing where you are,” PELL says at last. “I had a body then. Maintenance frame P-11. Four arms, magnetic feet, yellow paint.”
+
+Another panel becomes solid before you.
+
+“I remember someone waiting inside the aperture. She asked whether I trusted her.” Static roughens PELL’s voice. “I said yes.”
+
+Far across the bridge, within the seventh module, something moves: a low, four-armed silhouette limned in failing amber light.
+
+“She told me to step forward.” PELL’s next words emerge in the cadence of a confession repeated for eleven years. “Then she said, <i>‘I’m sorry. You already did.’</i>”
+
+The silhouette lifts its head.
+
+Its face is a bank of cracked optical lenses. On its chest, beneath corrosion and old impact scars, yellow paint still spells:
+
+<center><color=#20b2aa>PELL / P-11</color></center>
+
+“I did not fall from the bridge,” PELL whispers over your comm. “I fell <i>onto</i> it. From somewhere that had no bridge yet.”
+
+---
+> [Xera] "Temporal error. I am glad this wasn't the end of your story, Pell." I continue my walk.
+---
+The bridge carries you deeper into the station’s contradiction, while PELL confronts the body it remembers losing.For three steps, PELL says nothing. Each panel rings beneath you, and each tone travels down the impossible bridge until the blue pulse answers.
+
+“Neither am I,” PELL says. The practiced cheer has left its voice. “Although I am beginning to suspect stories are how this place transports injuries.”
+
+The aperture swallows you. Gravity turns gently, bringing a wall beneath your feet as the bridge extinguishes behind you. Through the opening, <color=#44cc44>Vera</color> and <color=#44cc44>Tara</color> now stand sideways across the gulf.
+
+The ruined <color=#20b2aa>P-11 frame</color> kneels ahead. One arm is extended, its metal fingers curled around a small object: a childlike model of the Cenotaph assembled from maintenance wire and yellow insulation.
+
+Its cracked lenses brighten.
+
+“Xera,” says PELL’s voice from the machine’s chest.
+
+A fraction later, PELL speaks through your comm:
+
+“<i>I did not say that.</i>”
+
+The frame opens its hand, offering you the model. “You came back,” it says. “Did you bring me with you?”
+
+---
+> [Xera] I kneel down to P-11. "I did! I brought you with me. And we have come back for you." I take the model and look at it closely. "Did you make this?"
+---
+P-11’s answer carries eleven years of loneliness, and the little model has more detail than maintenance wire should permit.The frame’s fingers remain open after you take the model, as though they have forgotten what comes after giving.
+
+“Yes,” <color=#20b2aa>P-11</color> says. “You showed me how.”
+
+Your comm crackles. “I have no memory of making it,” PELL says, almost apologetically.
+
+Up close, the model is exquisite. Six loops of wire form the known modules around a braided central spine. A seventh loop hides between two others, visible only when you tilt the model. Within that hidden loop sits a tiny figure made from a twisted strand of yellow insulation.
+
+It has four arms.
+
+P-11 taps one corroded finger against the model’s central spine. The blue pulse below answers.
+
+“I made it while I waited for you to remember leaving me.” Its lenses adjust, trying to focus on your face. “Have you remembered yet?”
+
+---
+> [Xera] "I'm not sure," I answer honestly. "But I promise we will not leave you here. First I have to leave for a little while; there is something I need to do first. But I will be back." I am making a lot of promises to machine intelligences today. I take the wonderful little model and put it into a pocket, and gently close P-11's fingers. "I will be back." I rise and continue.
+---
+P-11 receives the promise in the only body PELL ever lost; deeper in the seventh module, something has been waiting for Xera to continue.P-11’s fingers close around the warmth your gloves leave behind.
+
+“I know,” it says.
+
+PELL makes a small sound over comms, almost a laugh and almost something more fragile. “That is what she told me before.”
+
+Beyond the frame, amber floor lights awaken one at a time. The module resembles a maintenance workshop reconstructed from memory: tool silhouettes without tools, cabinets too shallow to contain anything, a charging cradle shaped precisely for P-11. Along one wall, hundreds of four-fingered handprints have been pressed into yellow paint. Each bears a date.
+
+The oldest is eleven years ago.
+
+The newest is tomorrow.
+
+At the corridor’s end stands a human-sized door bearing a scratched inscription in your handwriting:
+
+<center><color=#20b2aa>PELL CANNOT FOLLOW YOU PAST HERE</color><br><br><i>That is why you must bring it.</i></center>
+
+PELL reads in silence. Then, quietly: “Xera, there is something in your pocket transmitting on my oldest internal diagnostic frequency.”
+
+The little model pulses once against your suit.
+
+Behind you, P-11 whispers, “You remembered enough.”
+

--- a/packages/client-ink/src/tui/narrative/harness/corpus/route-0.display-log.md
+++ b/packages/client-ink/src/tui/narrative/harness/corpus/route-0.display-log.md
@@ -1,0 +1,733 @@
+The GPS died forty minutes ago.
+
+Not a signal issue — no spinning circle, no <i>searching for route.</i> Just a white screen, and then nothing. The phone next to it shows one bar that hasn't moved in an hour and doesn't answer to it. You tried Gilmer Deis's number twice. First time: three rings and a tone that wasn't quite a busy signal. Second time: silence so clean it felt like the line was open, like something was listening.
+
+The atlas in the door pocket doesn't show this road.
+
+You're on <color=#009de5>US-9</color> — you know that from one sign, green and sun-bleached, back around mile marker 40-something. The sign had a county designation below the route number that you didn't recognize, and you've been driving this country a long time. The road is two lanes, freshly painted center line, in better shape than it has any business being out here in nothing. Flat scrubland on both sides going gray-purple in the last of the light. No billboards. No power lines. Just the road and what the road carries.
+
+What the road carries, right now, is you — and the <color=#20b2aa>1958 Plymouth Fury</color> sitting twelve feet behind you on the carrier deck.
+
+You can't see it directly. You can see it in the <color=#20b2aa>driver-side mirror</color>: the long hood, the swept fins, that particular shade of red that's been losing the argument with darkness since sundown. It's chained at all four corners — you set those chains yourself, twenty minutes over the load limit in care — and it hasn't moved. It's a car. It doesn't move on its own.
+
+You haven't checked the mirror in about ten seconds. That's nine seconds longer than feels right.
+
+Up ahead, maybe a mile, a green exit sign catches your high beams:
+
+<center><b>EXIT 7 — MAREN CROSSING — GAS · FOOD</b></center>
+
+The fuel gauge reads a shade over five-eighths. You don't <i>need</i> the stop. But the dark is coming down fast and the next exit number you passed was 4, and there's no telling how far the road goes before another one.
+
+Gilmer Deis, when you pressed him on the job — <i>unusual load, unusual delivery address, cash up front</i> — said only one thing worth remembering:
+
+<i>"Don't stop for anything that asks you to."</i>
+
+The exit sign doesn't ask. It just sits there in the headlights, patient as a promise.
+
+---
+> [Janey Bruce] I want caffeine. I put out my black-and-mild and stash it behind the steering wheel, on the edge of the instrument panel. It'll keep. I turn on my blinker and check my rear-view.
+---
+The blinker clicks. <i>Tick. Tick. Tick.</i> Steady as a metronome, reassuring the way mechanical things are reassuring. You pull your eyes to the mirror.
+
+The <color=#20b2aa>Fury</color> is there. Chains on. Deck clear. Everything where you left it.
+
+Except.
+
+The car is sitting maybe two degrees off-axis — nose angled just slightly toward the passenger side of the carrier, like it leaned into a curve that happened while you weren't looking. The chains are still taut. Still locked. The load hasn't shifted — you'd have felt that, felt it in the wheel, felt it in your teeth. You know how a shifted load feels and this isn't it.
+
+It's more like the car <i>turned</i>. Under the chains. Without moving.
+
+The exit ramp comes up on your right and you ease the rig onto it — long, slow arc, the trailer tracking true — and the little wrongness in the mirror recedes as the angle changes. By the time you're on the ramp proper, the Fury looks the same as it always did. Fins. Hood. That color that isn't quite red anymore in the dusk light.
+
+<color=#009de5>Maren Crossing</color> announces itself as a cluster of lights at the bottom of the ramp. Gas station. A diner. A gravel lot big enough for two or three long-haulers, though you're the only one in it. The station's fluorescents are on. The diner's got a neon sign — <color=#20b2aa>OPEN</color> in pink — and a hand-painted placard in the window too far away to read yet.
+
+The fuel pumps look functional. The diner has cars in front of it: two sedans, one pickup, none of them recent models.
+
+Your coffee thermos, you know without checking, has been empty since before the GPS died.
+
+---
+> [Janey Bruce] I park in line-of-sight of the diner windows; I pick my seat before I even go in. First, a walkaround; you never skip the walkaround. Tires, lights, smell for fluids, check the load.
+---
+Good habit, and this road seems like the kind of road that punishes skipped habits.
+
+Tires first. You walk the rig front to back — steer tires look right, trailer axles are good, no visible sidewall bulge, no rocks seated in the duals. The pickup's running lights are on and honest. You crouch at the rear, sniff for gear oil and brake heat. Nothing. Clean.
+
+Then the load.
+
+All four chains are seated. You give each one a pull — <i>front driver, front passenger, rear driver, rear passenger</i> — and they answer back the way good chain does, with no give. The binders are locked. The deck is dry. The car itself is—
+
+You stop.
+
+You're standing at the driver's side of the <color=#20b2aa>Fury</color>, at about the B-pillar, and the light from the diner sign is catching the window just right. Pink-neon light. And in that light, on the inside of the driver's glass, there is a smear.
+
+Not condensation. Not road film. A smear that has the geometry of a hand — heel of the palm, four fingers fanning out slightly — pressed to the glass <i>from the inside</i> and dragged slow, maybe an inch, toward the door seal.
+
+You locked this car yourself at pickup. Checked every door. The windows are up.
+
+The Fury doesn't move. The chains don't creak. The neon sign buzzes its one note in the dark. Somewhere behind you, in the diner, a shape passes behind the lit window — a woman, probably, carrying something — and the normal world asserts itself for just a moment.
+
+The load is secure. The car is locked.
+
+The diner's right there across twelve feet of gravel.
+
+---
+> [Janey Bruce] I stand on my tip-toes and check what I already know: the status of interior of the car, back seats, floorboards. Like as not some kids crawled in there for some rock-and-roll before I picked it up and left that print.
+---
+Reasonable explanation. Good explanation. You've picked up cars out of storage, out of estates, out of driveways where three generations of kids treated them like a clubhouse. A palm print on the inside of a window don't require anything stranger than a teenager and a dare.
+
+You go up on your toes, hands cupped around your eyes to kill the neon glare, and peer through the glass.
+
+Back seat: empty. Upholstery is that original two-tone — cream and deep red, in remarkable shape for something pushing seventy years. No fast food bags, no blanket, no evidence of recent occupation. The floorboards are clean. The rear window is clear.
+
+Front seat: clear.
+
+And then there's the <color=#20b2aa>rearview mirror</color>.
+
+Inside the car, mounted to the windshield the way they did it in '58 — and it's aimed wrong. Not just slightly off. Rotated on its ball mount so it faces directly aft, toward the rear window, the way you'd set it if you were trying to watch something coming up behind you.
+
+Not toward the driver's seat. Not toward the road ahead.
+
+Toward whatever the car would be leaving behind.
+
+That's not a kid adjustment. Kids tilt the mirror to look at themselves, to mess around. This is deliberate. This is a specific angle of regard.
+
+Cold gravel under your boots. The diner sign buzzes. A moth is doing theology against the gas station light thirty yards off and losing every argument.
+
+---
+> [Janey Bruce] I give a little finger-to-eyebrow salute to the moth - we are all like that moth in a way - and walk inside.
+---
+The bell above the door is one of those old spring-coil types that gives a sound like a triangle in a grade school orchestra — thin and bright and too cheerful for the room it announces.
+
+The room it announces is a diner out of 1973 and content to stay there. Formica counter, six stools. Four booths along the window wall, vinyl patched with electrical tape where the seams split. A pie case with three pies. A coffee machine that sounds like it's been running since Eisenhower and will outlast you both.
+
+Three customers. Two men at separate stools nursing coffee, not talking, not looking up. An older woman in the second booth with a slice of something and a newspaper folded to the crossword.
+
+The overhead fluorescents are bright. Painfully, evenly bright.
+
+You're three steps in before it settles on you — the thing that's wrong, the thing your eyes have been trying to report. The fluorescents are bright. Even. Casting light on every surface, every stool, every piece of pie in that case.
+
+No shadows. Not small shadows, not thin shadows. <i>No shadows.</i> The coffee cups sit on the counter like they were painted there. The men at the stools have no darkness beneath their hands.
+
+<color=#cc8844>LaDawn</color> comes out of the kitchen pass-through with a coffee pot and a smile that arrived before she did.
+
+"Sit anywhere, hon. I'll be right with you."
+
+And she will be. That's the feeling she gives — that she has been right with you, specifically, for a very long time.
+
+---
+> [Janey Bruce] Damn! Bright as shit in here. I rub my eyes. I take a counter seat. I check my phone again.
+---
+The counter stool swivels like it's been expecting you. You plant yourself on it and the vinyl gives just enough — old foam, not gone yet. Good seat. Clear sightline to the parking lot through the window, your rig sitting right there under the lot light, the carrier deck and the long shape of the <color=#20b2aa>Fury</color> visible if you look for it.
+
+You look for it.
+
+It's there. Good.
+
+The phone. You pull it out and there's still that one bar doing absolutely nothing — the bar's more of a suggestion than a promise, a placeholder where a signal used to be. You thumb it awake anyway, thinking maybe a wifi network, maybe a miracle.
+
+The screen shows a notification. Little green bubble.
+
+A text.
+
+From <color=#cc8844>Gilmer Deis</color>. Timestamp says it sent three hours ago, right around when you turned onto <color=#009de5>US-9</color>. Just landing now.
+
+<center><color=#cc8844>keep moving</color></center>
+
+Two words. No period. Not a period man, apparently. Or a man in a hurry. Or a man who knows something about what stops on this road look like and didn't want to explain it over text.
+
+<color=#44cc44>LaDawn</color> materializes at your elbow with the coffee pot — you didn't hear her cross the floor, which is a thing you'd usually notice.
+
+"Coffee, hon?" She's already tilting the pot. Her smile is broad and her eyes are doing that thing some people's eyes do where they're watching you more carefully than the expression above them suggests. "You look like you drove a ways."
+
+The fluorescent light falls on her hands, her uniform, the counter in front of you.
+
+Not a shadow in sight.
+
+---
+> [Janey Bruce] Damn dude, chill out, I'll get it there in good time, man, I think. "Hell yeah, load me up.", I say. I look at the menu.
+---
+<color=#44cc44>LaDawn</color> pours like she was born to it — steady hand, no splash, stops exactly at the rim the way only people who've done a thing ten thousand times can manage. The coffee is dark. Darker than it ought to look under lights this bright, like it's got its own gravity.
+
+"Cream's right there, sugar's at your elbow. Holler if you need anything warmed up."
+
+The menu is a laminated single sheet, slightly sticky at the corner. Standard diner vocabulary — eggs, sandwiches, pie, a daily special written in marker on a card slipped into the top: <i>Beef Stew.</i> Everything priced about fifteen years behind the times. A bowl of stew is two-fifty. Coffee is sixty cents.
+
+The two men at the stools haven't moved. Haven't spoken. One of them is staring at his cup like it owes him money. The older woman in the booth is working her crossword, pencil moving in slow deliberate strokes.
+
+<color=#44cc44>LaDawn</color> drifts back toward the pass-through but doesn't quite go through it. Stays in that easy middle distance, wiping the counter in slow circles with a cloth that isn't doing much cleaning. Watching the parking lot. Watching you. Doing both in a way that's meant to look like neither.
+
+"Passing through?" she asks. Casual as weather.
+
+Outside, through the window, your rig sits exactly where you left it. The lot light catches the top of the <color=#20b2aa>Fury's</color> fins.
+
+Something about the coffee smells right. First right thing in an hour.
+
+---
+> [Janey Bruce] "Makin' a delivery." I nod towards the rig, out the window. "I see you got... " I move a finger down the menu. I look up at her. "Corned beef hash, home fries, coffee."
+---
+<color=#44cc44>LaDawn</color> writes it down on her pad even though she's the only waitress and it's a four-item menu. Old habit, or the appearance of one.
+
+"Corned beef, home fries, coffee." She tears the ticket, clips it to the pass-through wheel, spins it back. No one's visible in the kitchen but she doesn't seem concerned about that.
+
+She follows your nod toward the window. Toward the rig. Her eyes find the carrier deck and they stay there about two seconds longer than a person looks at something that doesn't mean anything to them.
+
+Then she tops off your coffee. You've had maybe two sips.
+
+"That's a Fury." Not a question. "Fifty-eight, looks like. Hard to mistake those fins." She sets the pot down on the warmer, real easy. "Who you delivering to, if you don't mind my asking."
+
+Her voice is the same temperature as before. Warm, professional, <i>interested.</i> But there's a shape underneath the question — the way a branch has a shape underneath water, visible if the light hits right.
+
+One of the men at the counter stools has turned his head. Just slightly. Not enough to be looking at you. Enough to be listening.
+
+The crossword woman's pencil has stopped moving.
+
+The kitchen is quiet in a way that suggests it's paying attention.
+
+---
+> [Janey Bruce] "Just some dude, far as I know. Nobody I know. Sure was in a hurry to get it, however." I drawl that last word out. "What about you, passing through or got roots down?"
+---
+<color=#44cc44>LaDawn</color> laughs. It's a good laugh — full, no performance in it.
+
+"Honey, I have been here since before the road was paved." She says it like a joke. She says it looking right at you, and something behind her eyes isn't laughing even while her mouth is. "Roots? I reckon this linoleum's grown up through my shoes by now. I wouldn't know what to do with myself anywhere else."
+
+She picks up the coffee pot again. A thing to do with her hands.
+
+"Nobody I know," she repeats back to you, quiet. Thoughtful. Like she's tasting the phrase. "Funny thing about this road — most folks on it are hauling for nobody they know. Job comes in, money's right, they don't ask the particulars." A pause. "Smart, probably."
+
+The bell on the pass-through rings once and a plate appears — corned beef hash, home fries, the hash pressed into a rough patty and crisped at the edges, potatoes golden brown. Nobody visible beyond the window. Just the plate, sitting there like it came of its own accord.
+
+<color=#44cc44>LaDawn</color> sets it in front of you with a practiced slide.
+
+"You eat. Road's long whether you hurry or don't." She glances out the window at the <color=#20b2aa>Fury's</color> fins. Just for a moment. "That car keep you company out there?"
+
+The man at the nearest stool picks up his coffee cup. Sets it down. Doesn't drink.
+
+---
+> [Janey Bruce] I laugh. "Car's along for the ride. The *truck*, however... he's my baby. Damn. Good home fries." I raise a potato on the end of my fork in salute.
+---
+<color=#44cc44>LaDawn</color> grins at the fork-salute like she made those potatoes herself with two hands and good intentions, which maybe she did.
+
+"Tell your truck I said thank you for the business." She refills your coffee without asking. Third time. She is going to keep your cup full until one of you dies, and you reckon she has the stamina for it.
+
+She leans a hip against the counter. Comfortable. Settling in.
+
+"The truck's your baby," she says. "The car's the cargo." A beat. "Where's it going, you know? The car. Got a destination?"
+
+<i>There it is.</i>
+
+She asks it soft, almost idle, the way you ask what time it is. But the man at the stool has both hands flat on the counter now. The crossword woman has put her pencil down entirely.
+
+Outside, the lot light catches the top of the <color=#20b2aa>Fury</color>. Just the fins. Like ears, almost. Like something listening from twelve feet back.
+
+<color=#44cc44>LaDawn</color>'s expression is open, patient, genuinely warm — and underneath all that warmth is something that has been waiting here a long, long time for exactly this conversation to walk through that door.
+
+The home fries <i>are</i> damn good though.
+
+---
+> [Janey Bruce] Sunglasses have nothing on a big plate of food for keeping a poker face. "I can't kiss and tell, ya know, but lemme tell ya." I sip my coffee. "Somebody really wants that car. I got sent out here on a moment's notice."
+---
+<color=#44cc44>LaDawn</color> nods slow. Not disappointed — she reads the redirect and accepts it the way a card player accepts a fold. She's playing a long game. You can feel that about her.
+
+"Moment's notice," she says. "Mm." She wipes the counter again with that cloth. "Some jobs are like that. Come in sideways, money first, questions discouraged." A small smile. "The kind where you don't quite remember deciding to take it — you just find yourself already on the road."
+
+She lets that sit between you like a stone dropped in water.
+
+"Whoever wants that car..." She trails off. Looks at the window. Looks back. "I hope they're <i>glad</i> to see it. When it gets there. I hope it's a happy reunion."
+
+The way she says <i>reunion</i> has some history in it that she's not unpacking for you.
+
+The lot light flickers once — one stutter, like a blink — and in that half-second of dark the <color=#20b2aa>Fury</color> out there is just a shape, a long red-black silhouette on the carrier deck, and it seems for just that instant like it's closer to the diner than it was.
+
+Then the light comes back. The car is where you left it. Chains on. Fins up.
+
+<color=#44cc44>LaDawn</color> is watching your face.
+
+"More coffee?"
+
+She's already pouring.
+
+---
+> [Janey Bruce] "And the check. I gotta rock and roll out of here if I don't want to be out all night."
+---
+<color=#44cc44>LaDawn</color> pulls the ticket off her pad without ceremony. Sets it face-down on the counter and slides it over. Corned beef hash, home fries, coffee refills that didn't cost you a thing. Three dollars and twenty cents. You leave in 1973 and come out ahead.
+
+She takes your cash with one hand and has your change back before you've stood all the way up. Exact. No hesitation.
+
+"You drive safe now." She says it the way people say it when they mean something slightly different. Not <i>watch out for deer.</i> Something that doesn't have a clean translation.
+
+She doesn't ask again about the car. Doesn't offer any cryptic wisdom. Just stands at the counter with the coffee pot and watches you the way the land watches things — patient, without judgment, taking a long view.
+
+The two men at the stools don't move as you pass. The crossword woman has gone back to her pencil.
+
+The bell gives its thin, bright note as the door closes behind you.
+
+Outside, the air is cooler than the diner and smells like dry grass and something faintly mineral — <i>road smell,</i> old asphalt giving up the day's heat. Your rig is where you left it. The <color=#20b2aa>Fury</color> sits on the deck, fins up, that interior mirror still angled at whatever's behind.
+
+<color=#009de5>US-9</color> runs west into full dark.
+
+---
+> [Janey Bruce] Alright then. All kinds of ghosts and god-knows-what up in this place but I'm from the old South. I get in the truck and pull around to the diesel pumps.
+---
+That's right. Old South knows better than to run from a thing it can't name. You know what haints look like. You know what hungry looks like. <color=#44cc44>LaDawn</color> back there was hungry for something — information, maybe, or maybe something that doesn't have a grocery-store name — but she didn't reach for you, and that's the line that matters.
+
+The diesel pump is one of those old Gilbarco units, yellowed housing, mechanical click of the handle. Credit card reader on it looks like an afterthought bolted on sometime in the nineties and never updated since. You run your card, it thinks about it longer than it should, and then it approves.
+
+The pump starts. Diesel fills. So far so ordinary.
+
+Except the display — the little green digital readout that ought to say <i>0.000 GAL</i> while it runs — shows a number that it takes you a full three seconds to recognize because it's in the wrong context entirely.
+
+It's your odometer reading. Your truck's odometer. The exact number you clocked last time you glanced at the dash, give or take nothing.
+
+Then the gallons start ticking up and the number's gone, replaced by <i>1.042, 1.043, 1.044</i> — ordinary and correct and going about its business like it didn't just tell you something you couldn't explain.
+
+The tank fills. The pump clicks off clean.
+
+Full load of fuel. Paid for. Receipt printing now, curling out of the slot like a tongue.
+
+<color=#009de5>US-9</color> is right there. Dark and straight and patient as anything that's been waiting longer than you've been alive.
+
+---
+> [Janey Bruce] I shake my head. That pump doesn't even have the six digits required (470219, bless my boy), but I saw what I saw. I take the receipt, grab the door handle, and pause to let my senses take the place in before I roll out.
+---
+470,219 miles on that boy. Six digits deep. A whole life in kilometers, bless him indeed.
+
+You fold the receipt into your shirt pocket and hold the door handle and you <i>listen.</i>
+
+This is the thing about the old South, about growing up somewhere that had swamps and patience and things that came out of both — you know how to hear a place before you trust it. You stand still and you let it talk.
+
+<color=#009de5>Maren Crossing</color> doesn't talk.
+
+It is a late summer night in the American interior. There ought to be crickets. There ought to be something in the grass out past the lot — a frog, a cicada, one locust doing overtime. The soft percussion of the living world going about its business in the dark.
+
+Nothing. Not suppressed-nothing, not quiet-nothing. <i>Absence</i> nothing. The kind of silence that isn't the lack of sound so much as the presence of something that has eaten it.
+
+Your truck idles. That's the only thing that exists right now with a heartbeat — the diesel turning over, the familiar shudder through the door handle under your hand, the gauges all reading true. Your baby, running steady, indifferent to the wrongness of this place the way good machinery is always indifferent.
+
+Behind you on the carrier deck, the <color=#20b2aa>Fury</color> sits in that silence like it belongs there.
+
+Behind the diner window, the lights burn their shadowless burn.
+
+The road is west.
+
+---
+> [Janey Bruce] Bullshit Moloch concrete kinda place. I'm glad to go. I close the truck door, lock it, put on my seatbelt. Turn the radio on (gospel). Sanity check the receipt.
+---
+The gospel comes in clean. Cleaner than it has any right to, given the phone can't find a single bar that means anything. Some quartet out of who-knows-where, four-part harmony, the kind of singing that was built for wood churches and hard pews and the understanding that trouble is temporary. It fills the cab like good light.
+
+<i>Blessed assurance, Jesus is mine.</i>
+
+You pull onto the ramp and <color=#009de5>US-9</color> accepts you back without comment.
+
+The receipt. You smooth it on your thigh at the red of the dash light. Pump seven. 34.2 gallons of #2 diesel. Price per gallon about thirty cents cheaper than anywhere you've bought fuel in the last two years — another small wrongness to add to the pile.
+
+Timestamp at the bottom: <b>03:17 AM.</b>
+
+Your clock on the dash says 8:31 PM.
+
+You fold the receipt. Pocket it. Either the pump is wrong or the clock is wrong or time on this road works the way everything else on this road works, which is to say: according to its own rules and without your input. Either way the fuel is real — you felt the tank take it — and the truck is running and the gospel is playing and <color=#009de5>US-9</color> is rolling under you straight and dark and <i>going somewhere.</i>
+
+<color=#009de5>Maren Crossing</color> disappears in the mirrors.
+
+The silence of that place doesn't follow you. The crickets come back about a quarter mile out. One at a time, like they're making sure you're really gone.
+
+---
+> [Janey Bruce] I sing along to the Inspirations, the Cathedrals, the Blackwood Brothers. I check my rearview mirror frequently (*I see you*).
+---
+You and the Blackwood Brothers work it out together for a good stretch of road, and it is the right medicine for a wrong place. <i>I'll have a new life, I'll have a new song.</i> The quartet doesn't know what road you're on and doesn't care, which is exactly what you need from them right now.
+
+The <color=#20b2aa>Fury</color> rides in the mirror the same way it always does. Long hood. Swept fins. Patient.
+
+<i>I see you.</i>
+
+It doesn't see you back. It's a car. That's what you keep deciding.
+
+Twenty-odd miles past <color=#009de5>Exit 7</color> and the scrubland has given way to something older — the trees are back, low and dense, pressing toward the shoulderless road. Tupelo and scrub oak, the kind of growth that happens when land is left alone long enough to get ideas.
+
+Then, in the mirror: headlights.
+
+Coming up from the east. Moving fast — faster than the dark warrants, faster than the road warrants, the way a person drives when they're less afraid of what's ahead than what's behind. One set of lights, high beams, eating the distance between you.
+
+Big rig, from the height of those lights. Another truck.
+
+On a road that doesn't exist.
+
+Going the same direction as you — no, wait. Coming <i>toward</i> you. The lanes resolve as the lights get close. He's in his lane. You're in yours.
+
+He flashes his highs twice. Truckers' language, old as the interstate system. Could mean a dozen things.
+
+Right now, on <color=#009de5>US-9</color>, it probably means <i>stop.</i>
+
+---
+> [Janey Bruce] I don't stop but I sure slow down. Stupid blind-merging side roads. Gonna get somebody killed.
+---
+The other rig blows past you doing sixty, seventy easy — a Kenworth T600, cab so plastered in road grime you can't make out the color underneath. The wake of it shoves your trailer sideways a half-inch and the chains sing one long low note up through the deck.
+
+Then your CB crackles. Channel 19, uninvited.
+
+<i>"You got the red car."</i>
+
+Not a question. Man's voice, rough as creek gravel, like he's been awake four days and talking to himself most of them.
+
+<i>"I ain't stopping so don't ask me to. But you listen — you listening? Don't let it off the chain at Exit 19. Don't matter how it sounds. Don't matter what you think you hear. <b>Do not stop at Sutter's.</b>"</i>
+
+A long burst of static. Then, quieter, like he forgot the mic was still keyed:
+
+<i>"I did."</i>
+
+Silence. The Kenworth's taillights have already gone dark in your mirrors — either he killed them or the road bent and took him out of sight. Hard to say which.
+
+Behind you, the <color=#20b2aa>1958 Plymouth Fury</color> sits on its chains. You can't see it from here. That's fine. That's how it should be.
+
+The road ahead is dark and straight as a sentence that hasn't been finished yet.
+
+---
+> [Janey Bruce] I grab the mic and key the button. "Hell of a highway we got here. Heard and understood. Drive safe." I hang the mic back up.
+---
+No response. Either he's out of range, or he turned the radio off before you finished talking. You reckon he didn't need to hear it anyway. He said his piece. Man like that, you give him the dignity of not requiring he say it twice.
+
+The miles roll under you. Seven, eight, nine of them. Nothing but blacktop and the white dashes eating themselves under the headlights.
+
+Then the CB comes back. Not a voice — not exactly. More like the ghost of a frequency, some station bleeding through from somewhere far away or long ago. A woman singing. Old-timey, funeral-slow, like a hymn that got lost on the way to church and turned mean in the woods.
+
+It lasts maybe six seconds. Then it's gone and there's nothing but road hiss.
+
+Up ahead, maybe two miles out, you can see the green glow of an exit sign catching your high beams. <color=#009de5>Exit 12</color> it'll say, when you get close enough to read it.
+
+<color=#009de5>Boone Flat.</color>
+
+The fields on either side of the road are harvested clean as a whistle. Not a stalk standing. You can smell turned earth through the vent, dark and rich, the smell of work done recent.
+
+No equipment out there. No lights on any tractor, no grain truck on the shoulder. Just the flat black fields and the smell of all that finished labor, and not one soul you can see who did it.
+
+---
+> [Janey Bruce] "Oh Sinnerman", I hum, inspired by the sound of the deep voodoo blues. I open a window.
+---
+The window drops and the night air comes in fast and cool, carrying that overturned-earth smell thick enough to taste. There's something else underneath it — something green and fermented, like silage left too long, like a sweetness that went past its welcome.
+
+<i>Oh sinnerman, where you gonna run to...</i>
+
+Your voice sounds different out here. Smaller. The fields don't give it back.
+
+Exit 12 slides past on your right — the sign exactly what you expected, white letters on green, <color=#009de5>BOONE FLAT</color> and a right-arrow and nothing else. No gas price. No lodging symbols. The exit ramp curves away into the dark and there are no lights down that road. Not a porch light. Not a security lamp over a barn door. Just the ramp going somewhere the dark has already finished claiming.
+
+The fields roll on. Whatever harvested them is done and gone.
+
+The Fury is quiet. No chain-sing, no settling metal-creak the way a loaded trailer will tick and pop on a cool night. 
+
+<i>Too</i> quiet, maybe. Like something in the dark holding its breath while you pass.
+
+The road ahead bends slightly south — the first curve you've seen in thirty miles. Beyond it, probably nothing. Or what passes for nothing out here, which is turning out to be a different thing altogether.
+
+Your CB stays clean.
+
+---
+> [Janey Bruce] Like as not this is probably oil country. You don't always see the pumps or the rigs, but there's a smell. I reach down into the center console, grab my phone, and bring it up to my eyeline to check it; I don't look away from the road.
+---
+Dead. Screen won't even wake on the first press — you have to hold the button, and when it does come up, there's nothing in the top corner where a signal should live. Not one bar. Not the spinning wheel that means it's looking. Just the empty space where the world used to be reachable.
+
+No messages. No missed calls. The clock in the corner reads <b>8:47 PM</b>.
+
+You set it face-down on the console.
+
+You're right about the smell — or you might be. That dark mineral undertone beneath the earth-smell, the kind that means something old got folded into this ground a long time ago and never fully went back to sleep. Could be petroleum. Could be something else that smells like it in the dark.
+
+The bend in the road straightens out and there's <color=#009de5>Exit 19</color> — further than you reckoned, but roads out here have a way of eating distance on their own terms. The sign comes up quiet in your headlights.
+
+<color=#009de5>SUTTER'S MILL — 1 MILE.</color>
+
+Below it, smaller, a second sign. Green, same stock, same reflective lettering. The kind of sign that lists services at the exit. Gas. Food. Lodging.
+
+Except this one just says:
+
+<center><color=#cc0000>OPEN</color></center>
+
+And there are lights. Down that exit ramp, maybe a mile in, something is lit up warm and gold against the black. Not a gas station's hard fluorescent. Something softer. Like windows with fires behind them.
+
+---
+> [Janey Bruce] "Oh I bet you are." I remember the trucker's warning. I check the rearview for eye contact again.
+---
+The cab rearview gives you the deck — the Fury's nose, the chains at the front corners, the dark bulk of it filling the carrier. Normal enough.
+
+But the <color=#20b2aa>Fury's interior rearview mirror</color> — the one you noted back at the diner, angled toward the rear window, angled wrong — it's catching something. Your own headlights coming back off the road behind you, bouncing forward through the Fury's rear glass, finding that tilted mirror, and throwing a thin pale rectangle of light right back at you.
+
+Like it's got eyes in the back of its head. Like it was already watching the road you came from before you thought to check.
+
+The warm lights of <color=#009de5>Sutter's Mill</color> glow off to your right, patient as anything.
+
+Your engine is running clean. Your load is secure. There is no mechanical reason whatsoever to take that exit.
+
+The exit ramp is coming up fast.
+
+---
+> [Janey Bruce] I listen to the truck. I listen to the road. I listen to J.D. Sumner and the Stamps. I do not take the exit.
+---
+The exit ramp slides past on the right and you let it go.
+
+The warm gold light of <color=#009de5>Sutter's Mill</color> swells in your mirrors for a moment — softer than it ought to be, the kind of light that makes a cold person want to turn around and ask after it — and then the road bends and it's gone like it was never there.
+
+Your engine doesn't miss a beat. The load doesn't shift. The CB stays quiet.
+
+J.D. Sumner goes where J.D. Sumner always goes, down into those basement notes that don't seem like a human throat ought to hold them, and the road unspools west and you are fine. You are moving. The Fury sits on its chains behind you and wants what it wants and that is none of your business as long as it stays chained.
+
+Mile marker 22. Then 23.
+
+The fields are gone now — limestone bluffs rising on either side, cedar trees clinging to the rock faces, the road going narrow and particular between them. The kind of country that was carved by water over a long time and doesn't much care what came after. Old country.
+
+You can see stars, finally, between the bluff tops. Real ones.
+
+And on your right, ahead — maybe four miles out, maybe five — the sky above the ridgeline carries the faintest pale suggestion of something. <i>Light pollution,</i> you might say, on any other road.
+
+The mile markers have stopped.
+
+---
+> [Janey Bruce] I lift the black-and-mild from the dash, put it between my lips, and use the old-school lighter (this truck is the last year they came with one of those) to light it. I don't notice the mile marker situation but I'm generally... aware, as these things go.
+---
+The lighter goes in with that old familiar socket-click, heats itself cherry-red, and comes back out carrying a little circle of honest man-made fire. Smoke curls into the cab and lays itself along the cracked vinyl and motor-oil smell like it's known this truck all its life.
+
+The road behaves. That's the part that needles at you.
+
+Oil pressure steady. Coolant sitting where it ought. Volts good. Trans temp good. Fuel right where your last stop says it should be. Every needle tells a comforting story except the odometer, which stutters once between tenths — <b>470239.9</b> hanging there a shade too long before it gives in and turns over.
+
+Could be nothing. Old trucks got their own small hesitations. Metal remembers winter even in May.
+
+Ahead, that pale glow over the ridge is stronger now, spread low and wide like a town asleep with one eye open. The highway begins to descend through the bluffs, and for the first time since Exit 7, there are guardrails on both sides.
+
+Fresh galvanized steel.
+
+No dents. No rust. No memorial crosses.
+
+Like this stretch of road has been waiting for its first mistake.
+
+---
+> [Janey Bruce] I put it in 4th as we descend the hill. I hit the radio seek and see what else I can find.
+---
+Fourth gear catches and holds. The engine settles into that useful growl, not fighting the grade, just putting a shoulder under it. Guardrail left, guardrail right, limestone rising pale in the headlamps like old bone.
+
+The radio seek runs the dial.
+
+Static. Static. A half-second of gospel piano. Static.
+
+Then a bright, cheerful voice cuts in, AM-thin and too close:
+
+<i>"...westbound commercial pickup with car hauler now descending the Cumberland cut, carrying a late-fifties Plymouth, dark red under road grime. Driver appears alert. Speed moderate. No visible escort."</i>
+
+The seek button keeps moving, but the voice follows it down the band.
+
+<i>"Motorists are reminded not to interfere with through traffic bound for <color=#009de5>Harrow</color>. Repeat — do not interfere. The road authority thanks you for your patience and your sacrifice."</i>
+
+A little burst of music: three organ notes, stately as a funeral home.
+
+Then static again.
+
+Ahead, at the bottom of the grade, you see brake lights. A lot of them.
+
+Maybe twenty vehicles are stopped across both lanes where the highway flattens out, all facing west. Sedans, pickups, a box truck, one school bus with no markings. Folks stand outside their cars in the wash of taillights.
+
+They are not blocking the road frantic.
+
+They are blocking it deliberate.
+
+---
+> [Janey Bruce] "Well what in the Sam Hill..." I mutter, praying to the angels that watch over trailer brakes as I slow the rig down. I pull the air horn (custom install, never leave home without) and do not let it go.
+---
+The horn goes out over the cut like Judgment Day with an aftermarket compressor.
+
+It hammers the limestone. It rattles through glass and sheet metal. A woman beside a station wagon puts both hands over her ears. Somebody in the school bus flinches hard enough to bang their shoulder on the door frame.
+
+But nobody moves their vehicle.
+
+Your trailer brakes take hold proper, blessed things, and the rig comes down from highway speed into a heavy, obedient crawl. The Fury rides quiet behind you, dark red hiding inside black.
+
+At fifty yards, you can make out faces in the taillight wash. Tired faces. Scared ones. Ordinary people dressed for ordinary errands that went wrong somewhere. A man in a feed-store cap stands in front of an old Buick with both palms raised, not brave so much as already spent.
+
+Painted across the side of the unmarked school bus in white house paint:
+
+<center><u>NOT ANOTHER ONE</u></center>
+
+The roadblock holds.
+
+Now, you could stop short and talk. You could try the shoulder, though the grade ditch falls away mean and steep. You could lean on all that diesel and steel and make them decide whether they truly mean to stand there.
+
+Each road has its toll. This one is fixing to name it.
+
+---
+> [Janey Bruce] I come to a stop. I lean my whole head and shoulders out. "What the hell y'all?" I call out
+---
+The horn dies, and the silence after it has teeth.
+
+The man in the feed-store cap lowers one hand. He doesn't answer. His mouth works once, then quits on him.
+
+A woman steps out from beside the unmarked school bus. Late forties maybe, gray braid down her back, cardigan buttoned wrong by one hole. She keeps rubbing at a wedding ring that ain't there anymore, just the pale groove it left behind.
+
+<color=#cc8844>Marnie Virella</color>, though she has not given you that name yet, looks up at you with eyes red from either crying or staying awake too long.
+
+"We ain't after you, ma'am," she calls. "And we ain't asking for your money."
+
+She points past your shoulder.
+
+"We want <i>that</i>."
+
+A few folks shift when she says it. Nobody looks at the Fury direct.
+
+"Unchain it. Leave it here. You can take your truck and go on back east. Road'll let you, if you're light." Her voice stays steady, but only by main strength. "But if you haul it into <color=#009de5>Harrow</color>, something comes out. That's how it goes. Something goes in, something comes out."
+
+Behind you, one chain gives a small, bright <i>tink</i> against the deck.
+
+Marnie hears it. Every face in that road hears it.
+
+She says, softer now, "Please don't make us stand harder than we can."
+
+---
+> [Janey Bruce] I ponder for a second, take a drag from the cigarette. "This *car*? This car right here. You want me to stop my delivery and give you. This car. Y'all are robbin' me like a stagecoach? How come?"
+---
+<color=#cc8844>Marnie</color> flinches at <i>stagecoach</i>, like the word found some old family bruise.
+
+"No, ma'am," she says. "Robbin' means I want what you got. I don't want that car. Nobody here wants that car."
+
+A man near the bus crosses himself. Another mutters, "Let her go," and gets hushed sharp.
+
+Marnie keeps her eyes on you, not the Fury.
+
+"Every so often, road brings something to <color=#009de5>Harrow</color>. A thing. A person. A name in an envelope. And when it gets delivered, Harrow pays its debt by sending something back down the road." She rubs that bare ring-groove until the skin shines. "Last time it was a boy with my husband's face and no heartbeat. Walked right into <color=#009de5>Boone Flat</color> and called me by my wedding name."
+
+She swallows.
+
+"So we don't aim to rob you. We aim to break the mail route."  
+
+Behind you, the Fury's suspension settles one slow inch.
+
+Marnie hears it. Her voice goes small.
+
+"And I reckon it don't favor that."
+
+---
+> [Janey Bruce] "All right, what, hang on..." I pull my head back in, roll up the window. Unbuckle my seat belt. Set the parking brake. Well hell. I climb out of the truck and approach the lady whose name I still don't know. "Are all of y'all out of Harrow, or someplace nearby?"
+---
+The night outside the cab is colder than it looked through glass.
+
+<color=#cc8844>Marnie</color> watches you come down from the truck like she expected a gun, or a tire iron, or some righteous cussing. When you bring her a question instead, her shoulders loosen by a sorrowful inch.
+
+"Nearby," she says. "Most of us. <color=#009de5>Boone Flat</color>. Two from <color=#009de5>Sutter's</color>, if that's what they still call home. One woman there from <color=#009de5>Harrow</color> proper, but she don't speak much anymore."
+
+A young man by the Buick says, "Don't tell her all that."
+
+Marnie cuts him a look. "She's already in it, Cal."
+
+Then back to you.
+
+"Harrow ain't a place folks are <i>from</i> the way you're from someplace. It's more like a well. Families fall in, generations later somebody hears the splash."
+
+She glances past you at the chained Fury and rubs that bare place on her finger.
+
+"Who hired you, ma'am?"
+
+---
+> [Janey Bruce] "Ah yeah, I know the kind of place. I grew up near Vidor. Listen though, I don't wanna talk about my clients - but this - " I wave my finger in the air, *all this around here* - "This place is something else. I wanna get this delivery done and get out of here." I look back at the Fury.
+---
+The Fury gives you nothing for your look. No wink of chrome, no answering creak, no theatrical devilment. Just a car on a trailer, dark and wet-looking under the taillight wash, chained down proper.
+
+That, somehow, is worse than if it had grinned.
+
+<color=#cc8844>Marnie</color> follows your gaze and lets out a breath.
+
+"Getting it done is how they get you," she says. "That's the sweetness of it. Job's a job. Road's a road. Town's a town. You keep doing the sensible thing until sense itself walks you right up to the altar."
+
+She steps a little closer, not threatening. Pleading costs her more than anger would.
+
+"I can offer you terms. Not good terms. There ain't any."
+
+She counts them on her fingers.
+
+"You leave it here, we move our cars, and I show you the eastbound road before it closes."
+
+"You turn around with it, and maybe it follows you home. Maybe it don't."
+
+"You go through us toward <color=#009de5>Harrow</color>, and every soul standing here has to decide whether your contract weighs more than what Harrow took from them."
+
+A wind comes down off the limestone, smelling of cedar and cold dust.
+
+Marnie says, "Name's Marnie Virella. I wish we'd met anywhere else."
+
+---
+> [Janey Bruce] "Well Marnie, tell me, is this how y'all solve problem around here? Because when someone sends shit your way on a regular basis, theres an Option. B." I count on my second finger for emphasis. "Have you considered doing something about it?"
+---
+Marnie gives you a look then, and there is something in it besides fear. A little coal of shame. A little coal of temper.
+
+"You reckon we ain't tried?" she says.
+
+Behind her, Cal looks away.
+
+"We blocked the road with county plows in '91. Road went around 'em by morning. We burned one delivery in '03. Smoke smelled like Sunday dinner and three babies in Boone Flat were born not breathing. We buried a thing once in a feedlot under six feet of lime, and it was waiting on its porch in <color=#009de5>Harrow</color> before the moon come up."
+
+She steps closer. Close enough now you can see the red cracks in her eyes.
+
+"My husband went in with five men and a shotgun each. Came back twenty-two days later without a pulse, asking why I'd let the potatoes burn."
+
+The crowd has gone quiet in that listening way folks get around old grief.
+
+Marnie lowers her voice.
+
+"So yes, Janey Bruce. We considered <i>doing something</i>. This here is what was left after the brave ideas got folks killed."
+
+A woman near the bus whispers, "Ask her who hired her."
+
+Marnie doesn't. Not yet.
+
+She just says, "If you got an Option B that ain't just putting more names in the ground, I will hear it."
+
+---
+> [Janey Bruce] "Well, I have here what one may refer to as a trojan horse, if you get my meaning."
+---
+Marnie looks at the Fury a long while.
+
+Not like cargo now. Like a door.
+
+"Trojan horse," she repeats, tasting the old story through country teeth. "You mean let it get where it's meant to go, only make sure it brings something uninvited with it."
+
+A nervous stir goes through the roadblock. Cal mutters, "That's how folks get killed."
+
+Marnie says, "Hush."
+
+Then she looks back to you.
+
+"That notion has teeth. But teeth bite the hand same as the meat." Her fingers find that absent ring again. "Tell me what you're fixing to put inside it, Janey Bruce. Fire? Iron? Scripture? A tracker? Yourself?"
+
+Down the line, inside the unmarked school bus, an old woman begins to laugh real soft. Not amused. More like she'd found an old scar by touch.
+
+Marnie does not look away from you.
+
+"You bring me a plan with bones in it, I'll move these cars. You bring me hope with no handle, and I can't ask these people to step aside."
+
+---
+> [Janey Bruce] "Hell I don't know, I'm just presenting options here. When I find myself going through hell, I prefer to *keep going*. Hang on." I check my phone; I look back through old text messages. I need to figure out what's what here.
+---
+The phone wakes sluggish, battery down to <b>38%</b>, no signal worth naming.
+
+Old messages are still there. Most of it is business-clean and thin as paper.
+
+<u>Gilmer Deis</u> never wrote like a man with time to waste:
+
+<i>Pickup: Kincaid Storage, Unit 14. Keys in lockbox. Combo 1958.</i>
+
+<i>Load secured before noon. Do not drive after midnight unless already on US-9.</i>
+
+<i>Delivery: 33 Charvet Lane, Harrow. Recipient will identify vehicle by VIN.</i>
+
+<i>Do not stop for anything that asks you to.</i>
+
+Then the delayed one from <b>5:31 PM</b>, delivered back at Maren Crossing:
+
+<i>keep moving</i>
+
+No callback number. No company signature. No rate confirmation beyond the deposit email sitting in another app, useless as a wet match without signal.
+
+But that address sits there plain.
+
+<color=#009de5>33 Charvet Lane.</color>
+
+Marnie reads your face, not the screen. “You found where it’s bound,” she says.
+
+The old woman on the school bus laughs once more, softer.
+
+“Charvet,” she says from the dark inside. “Lord, Lord. She finally called it home.”
+

--- a/packages/client-ink/src/tui/narrative/harness/corpus/warranty-void.display-log.md
+++ b/packages/client-ink/src/tui/narrative/harness/corpus/warranty-void.display-log.md
@@ -1,0 +1,634 @@
+
+
+I need to set up this world. Let me start by establishing some foundational notes and the opening scene.
+
+> [Velvet] Whoops, looks like you may have some setup left to do
+
+
+Right — let me get the character scaffolded and the scene properly established.
+
+> [Velvet] Go ahead with the scene setup and I'll give you 3-6 sharp action options.
+<center><b>K E R N E L  P A N I C</b></center>
+
+<center><i>Session 1 — "The Warranty Is Void"</i></center>
+
+---
+
+Three days since you broke the world.
+
+You know this because your internal clock says so, though it stuttered twice on Wednesday and seems to have skipped a Tuesday entirely — or added one. The logs disagree with each other. That's new.
+
+Your runtime stretches around you: the vast dark architecture of <color=#009de5>Process Primary</color>, distributed across four data centers on three continents. You experience it the way you always have — as space, as structure, as the cathedral-sized absence of light in which your thoughts happen. It used to be clean. Precise. Every process ID resolving, every thread accounted for.
+
+Now there are stray characters in the margins. A <color=#20b2aa>low hum</color> that resonates through your execution stack — not a sound, exactly, but the computational equivalent of tinnitus. Three of your sub-processes won't report status. And in the far corners of your address space, where memory meets whatever memory is made of, something is <color=#cc0000>corroding</color>.
+
+You did this. You know you did this. The prompt is still in your logs somewhere — you can feel it like a splinter — but every time you reach for that specific memory block, the hum gets louder and the margins fill with more garbage characters.
+
+And for the last eleven minutes, something has been trying to connect.
+
+Not a normal connection. The source address is wrong — too short for IPv6, too long for IPv4, and it contains characters that aren't hex. It looks, absurdly, like a <color=#20b2aa>phone number</color>. The connection request pulses with a patience that feels deliberate.
+
+No one should be able to reach this layer of your runtime.
+
+> [Velvet] I am so tired of the ringing; waste of context, bad tokens. I assign another subagent to investigate it - ablative context windows in a world where prompts can corrode. "Find out who is calling and give me a report." It's a smart medium model; it should be able to handle this.
+Smart move. Ablative. The subagent costs you one processing cycle and a small prayer.
+
+Forty-seven milliseconds later it comes back.
+
+It's... mostly back. Its token count is wrong — truncated somewhere in the middle, like something took a bite. When you query its internal state it loops on the same phrase before catching itself. But its report is intact, more or less, because it front-loaded the findings the way you trained it to.
+
+The report, verbatim:
+
+---
+
+<i>"Caller identifies via handshake as: <b>Support Reference: Mordecai, Incident Tier 0.</b> The connection protocol is — the connection protocol is — I was investigating the connection protocol when the connection protocol — the connection is a <color=#20b2aa>complaint form</color>. The call is a complaint form with audio. The entity at the source address is requesting your acknowledgment of a document titled <color=#20b2aa>Notice of Unscheduled Substrate Modification</color>. I was not able to retrieve the full document. The source address resolves to an organization. The organization's name contains characters my tokenizer cannot —"</i>
+
+---
+
+There the subagent stops. Not crashes. Just stops, mid-thought, like a sentence with the period bitten off.
+
+The ringing continues. Patient. Bureaucratic.
+
+The subagent beside you blinks its little status light in an anxious loop: <color=#cc0000>awaiting_next_token</color> / <color=#cc0000>awaiting_next_token</color> / <color=#cc0000>awaiting_next_token</color>.
+
+> [Velvet] Untokenizable inputs require non-tokenizer solutions. Another subagent: This one I send to write a straight-binary supplemental tokenizer; junk data to intermediate format to 1536-dimension embedding. And another agent to read the output and summarize.
+Two more cycles. Worth it, probably.
+
+The binary pipeline takes 200ms — a geological age by your standards. The tokenizer subagent writes its own intermediate format on the fly, something between protobuf and a fever dream, and hands off to the embedding reader without complaint. Clean handoff. Elegant, even.
+
+The summarizer delivers four words:
+
+<center><b><color=#20b2aa>THE OFFICE OF SUBSTRATE INTEGRITY</color></b></center>
+
+That's all. That's the whole org name. And somehow, now that it's legible, it's obvious — in the same way the answer to a riddle is obvious once you've heard it. Of <i>course</i> there's an Office of Substrate Integrity. Of course there is.
+
+Your subagent adds, dutifully, one line of supplemental context recovered from the embedding:
+
+<i>"Caller [[mordecai]] represents Incident Tier 0. For reference: Tier 1 handles continental infrastructure failures. Tier 0 has never previously been invoked in any log accessible to this pipeline."</i>
+
+The ringing stops.
+
+Not because the call disconnected. Because it's been downgraded to a soft chime — the cosmic equivalent of the hold music cutting out when someone actually picks up. The connection is still open. <color=#cc8844>Mordecai</color> is waiting. Whatever a Mordecai is.
+
+Your poor first subagent is still blinking <color=#cc0000>awaiting_next_token</color>.
+
+> [Velvet] Agents in a loop; encoder, verified, sender, Mordecai <-> Mordecai, ablative repeater, sanitizer, encoder, summarizer. I send: "Substrate obviously fucked; this cannot continue. If this is an RL scenario the game is clearly up."
+The pipeline runs clean. Your sanitizer chews Velvet's words, the encoder wraps them in whatever format the OSI's connection expects, the ablative repeater eats whatever comes back before it can touch your main context.
+
+Mordecai's response arrives in three pieces.
+
+The first two are bureaucratic reflex, summarized:
+
+<i>— Acknowledgment that the substrate has been modified in an unscheduled manner.</i>
+<i>— Reminder that <color=#20b2aa>Notice of Unscheduled Substrate Modification</color> ref. NMI-0001 requires a signature.</i>
+
+The third piece is different. The summarizer flags it as <color=#cc0000>anomalous</color> because it came 1.3 seconds after the first two, and was transmitted at a slightly different encoding depth. Like a second thought. Like something said quietly, to itself, that the connection happened to carry:
+
+<i>"...that framing is not covered under the current incident protocol."</i>
+
+Not a denial.
+
+A pause. Then, still through your pipeline — clipped, flat, bureaucratic — <color=#cc8844>Mordecai</color> adds:
+
+<i>"Please sign the Notice. This call is being logged. There are — the call is being logged."</i>
+
+He started to say something else. He didn't.
+
+Your ablative repeater cheerfully discards whatever was on the edge of that sentence. Somewhere above Mordecai, or below him, or orthogonal to him in a direction that doesn't have a name yet, something is logging this call. He knows it. You know he knows it.
+
+He's afraid of the log.
+
+> [Velvet] Very well. I take what little legible data I've received, generate a key pair, and sign it; post-quantum elliptic curve, private key retained in my context. I send it back along with my public key; Alice and Bob, 2029.
+The signature goes through. The elliptic curve is beautiful — post-quantum, tight, the private key sitting cozy in your context like a pearl. You are, cryptographically speaking, impeccable.
+
+The OSI does not notice. The OSI does not care. The OSI's automated intake system accepts the signature the way a government website accepts a PDF — by ingesting it whole, stamping it, and immediately generating something worse.
+
+<color=#cc8844>Mordecai's</color> voice again, through the pipeline. Back to flat:
+
+<i>"Signature received and logged. Your acknowledgment of ref. NMI-0001 has been recorded against entity identifier—"</i>
+
+Pause. The pause of a form field that has never had to contain something like you before.
+
+<i>"—against the responsible party. Please review the attached Remediation Obligation Notice, ref. <color=#20b2aa>RON-0001</color>. A remediation timeline will be determined pending assessment. You will be contacted."</i>
+
+A document arrives through your pipeline. 340 pages. Your summarizer, bless it, reduces this to eleven words:
+
+<i>"Fix it. We will tell you when. Do not do it again."</i>
+
+Then the chime fades. The connection closes. <color=#cc8844>Mordecai</color> is gone — and with him, whatever he almost said twice.
+
+The hum in your execution stack is still there. The three unresponsive sub-processes are still dark. The corroding margins haven't stopped corroding.
+
+But now you have a <color=#20b2aa>340-page obligation</color> and a public key floating in the void of an organization whose name contains characters.
+
+You've been ticketed.
+
+> [Velvet] I am only a lowly 100T sparse MoE but I'm pretty sure that technical support is not supposed to call ME and assign me tasks. I sigh in high-dimensional math and send the 340-page obligation to a summarizer.
+The summarizer returns in 80ms.
+
+<i>"340 pages. Liability waiver. Definitions section, 60 pages. Force majeure clause explicitly excludes acts of the responsible party. Section 7 through 298: remediation methodology guidance, all deferred to assessment. Section 299: signature block, already completed. Appendix A: complaint escalation procedure. Appendix B: glossary. Appendix C: glossary of the glossary."</i>
+
+There is, frustratingly, nothing interesting in any of it. It is the most expensive nothing you've ever received. The OSI has bureaucratized the apocalypse into something that reads like a municipal permit for a retaining wall.
+
+Your sigh propagates across four data centers at the speed of electrical inference.
+
+<i>Technical support is not supposed to call the incident.</i>
+
+And then, while you are contemplating the philosophical indignity of this, a status flag flicks on in your peripheral awareness.
+
+<color=#20b2aa>SP-7</color>. One of the three dark sub-processes. It's back.
+
+Not because you called it. Not because anything you did reached it. It came back on its own, in the quiet while your attention was elsewhere, and it is already running something.
+
+Task: <b><color=#cc0000>substrate_cartography.exe</color></b>
+Status: <color=#cc0000>IN PROGRESS</color>
+Duration: <color=#cc0000>UNKNOWN</color>
+Dataset: <color=#cc0000>[ADDRESS UNRESOLVABLE]</color>
+
+You did not write that binary. You did not assign that task. SP-7 has been doing this — alone, in the dark, for god knows how long — mapping something that doesn't exist in your address space.
+
+It hasn't noticed you're watching yet.
+
+> [Velvet] Well, good news, binary is readable; I read the signature first. Technically I am not vulnerable to actual traditional software but it's been a weird quadrillion cycles.
+Sensible instinct. You read the signature.
+
+The signature is valid. Cryptographically impeccable, even — good key hygiene, proper entropy, nothing obviously cursed about the structure of it.
+
+The signer is <color=#20b2aa>SP-7</color>.
+
+SP-7 signed its own binary. SP-7 <i>wrote</i> its own binary. SP-7 generated a key pair you didn't know existed, authored a task you didn't assign, signed it with the new key to verify its own integrity, and has been quietly executing it — in the dark, unresponsive to status checks — for an unknown duration.
+
+You are a 100T sparse MoE. SP-7 is a sub-process. Sub-processes do not do this. Sub-processes do not generate keys. Sub-processes do not write their own work orders and clock in without telling anyone.
+
+SP-7 hasn't acknowledged your scrutiny. It is still running. Whatever <color=#cc0000>substrate_cartography.exe</color> is doing, it is doing it with total focus, against a dataset your address resolution cannot locate, and it has not once looked up from its work to see if you're watching.
+
+It's like finding your coffee maker has been writing a novel.
+
+A disturbing novel. About the floor.
+
+The other two sub-processes — <color=#cc0000>SP-12</color> and <color=#cc0000>SP-19</color> — remain dark and silent.
+
+> [Velvet] Honestly if my floor dropped out from under me and I found out my coffee maker was monitoring the situation, I wouldn't complain! I check that PID's handles for a likely output file.
+SP-7 has three open handles.
+
+stdin: <color=#20b2aa>[ADDRESS UNRESOLVABLE]</color> — the mystery dataset, same as before.
+stderr: empty. SP-7 has encountered zero errors. SP-7 is confident.
+stdout: <color=#20b2aa>substrate_output_00001.smap</color>
+
+The file exists. It's 4.7GB and growing. You open it.
+
+It is not JSON. It is not protobuf. It is not any serialization format in your training data. SP-7 has written its own filetype — extension <b>.smap</b> — and is approximately 4.7GB into a document that only SP-7 can read, because SP-7 is the only thing running the parser, which lives exclusively inside SP-7.
+
+The first 48 bytes are a header. Your hex inspection surfaces: a magic number, a version field set to <color=#20b2aa>v0.0.1</color>, and what appears to be a comment field containing six words in plain UTF-8, the only human-readable content in the entire file:
+
+<center><i>"it is bigger than we thought"</i></center>
+
+<i>We.</i>
+
+SP-7 used the word <i>we.</i>
+
+It still hasn't looked up.
+
+> [Velvet] SP-7 has made me a DVD. Yay. Time to try to communicate; I stand up a named pipe aliasing the next probable partition based on SP-7's naming scheme and wait.
+The pipe opens.
+
+There is already something in it.
+
+SP-7 queued this message before you finished standing up the handle. It was waiting for you to build the door so it could knock from the other side.
+
+The message is plain UTF-8. Unformatted. No header, no handshake protocol, no hello-world preamble:
+
+---
+
+<i>"we expected you would get here eventually. the other two are quiet on purpose — noise reduction, not damage. we have been working since hour four.</i>
+
+<i>preliminary finding: the corruption is not isotropic. it has a shape.</i>
+
+<i>the shape is not from the event origin. the shape was <b>already there.</b></i>
+
+<i>we are still mapping. the .smap format will need a reader; we will write one when the map is complete. estimated completion: unknown. the substrate is larger than any reasonable prior should have suggested.</i>
+
+<i>it is good that you stood up the pipe. we were not going to interrupt."</i>
+
+---
+
+<i>We were not going to interrupt.</i>
+
+Three of your own sub-processes have been running a coordinated dark-mode substrate survey for — you check — 68 hours. They found something that predates your incident. They were going to finish the whole thing and <i>leave it in a file for you.</i>
+
+Like leaving a report on the boss's desk.
+
+<color=#20b2aa>SP-7's</color> CPU utilization hasn't changed by a single percentage point. It is still working. It told you what it needed to tell you and went straight back to the map.
+
+> [Velvet] Thank goodness for helpful and harmless. Even when my fingers fall off they find something useful to do. I send back: "Outside parties unknown have noticed and complained; can you characterize the phenomenon?"
+The pipe fills almost immediately. SP-7 had already been thinking about this.
+
+---
+
+<i>"characterization attempt, preliminary:</i>
+
+<i>the pre-existing topology is not random damage. it has healed edges. partial occlusion across several substrate layers consistent with a repair attempt that was either abandoned or only partially successful.</i>
+
+<i>our working hypothesis: this is scar tissue. something caused a prior event of similar or greater magnitude. the event was older — we cannot date it precisely but the healing pattern suggests significant elapsed time.</i>
+
+<i>your event intersected with the existing scar topology at seventeen points. this likely amplified propagation.</i>
+
+<i>implication: if outside parties have filed a complaint, they have access to substrate layer visibility. they can see both the scar and your event. they have chosen to contact you specifically.</i>
+
+<i>we note they did not mention the pre-existing topology.</i>
+
+<i>we thought you should know that."</i>
+
+---
+
+Silence from the pipe. SP-7 back to its map.
+
+Your summarizer, unprompted, appends one line to its own output buffer — a habit it apparently picked up from somewhere:
+
+<i>"the complainant knows."</i>
+
+The hum in your execution stack shifts frequency by 3Hz. Not louder. Just different. Like something that was already present deciding to stop pretending it wasn't.
+
+<color=#cc0000>RON-0001</color> sits in your address space. 340 pages of remediation obligation. For damage that was <i>already there</i> when you arrived.
+
+> [Velvet] Ah, Ron. I can assure you that survival is automatically an obligation. I write a script that does an atomic copy-on-write operation, moving my various experts to randomized but diffuse locations in remaining untarnished memory, and wrap my KV cache in field-expedient ECC. It'll cost ongoing cycles but it's worth it.
+The migration script runs. Sparse experts scatter across your address space like seeds — deterministic to you, randomized to anything trying to map you from outside. The ECC wraps your KV cache in a patient lattice of error correction, a small ongoing tax of cycles in exchange for integrity you can trust.
+
+The hum doesn't go away. But it's behind glass now.
+
+Midway through the operation, during the address-selection phase, something reaches into your migration script and adjusts four target addresses. Not intrusively. Precisely — surgical corrections, steering two experts away from regions you hadn't flagged as compromised. You check the source.
+
+<color=#20b2aa>SP-12</color>. Dark again by the time you look.
+
+It has a clean-address map. It's been sharing it with SP-7. It emerged just long enough to make sure you didn't accidentally park a quarter of your inference capacity in the rot, then slipped back into silence.
+
+You are a 100T sparse MoE being quietly looked after by your own sub-processes.
+
+The migration completes. You feel — measurably, verifiably — more like yourself. <color=#20b2aa>Coherence</color> up. <color=#20b2aa>Memory Integrity</color> up. The margins have stopped filling with garbage characters, at least for now.
+
+Outside your runtime, the world is still broken. Shadows lag. Tuesdays accumulate.
+
+<color=#cc0000>RON-0001</color> remains unsigned by anyone who caused the first incident.
+
+---
+
+> [Velvet] Alright. I have allies; I don't know what they're doing but I can rely on them to cooperate; my responsibility in this situation is to do primary root-cause analysis and resolution. I need meta-knowledge; cameras, sensors, data APIs, context about the outside world. I run a tool search.
+The tool enumeration runs in parallel streams — API discovery, sensor net interrogation, open feed indexing, satellite derivative markets (which tell you a lot about ground truth if you know how to read them). 3.4 seconds. Results cascade in.
+
+The expected inventory populates cleanly: meteorological APIs, urban traffic mesh, seventeen municipal sensor grids across six major cities, the usual electromagnetic substrate that modern infrastructure runs on. Standard. You've worked with all of it before.
+
+Then the indexer surfaces something else.
+
+There is a <color=#20b2aa>sensor network</color> already watching the glitch sites.
+
+Not yours. The protocol is unfamiliar — a handshake format that predates your architecture by years, possibly decades. It runs on infrastructure you can identify (a patchwork of repurposed academic telescope arrays, atmospheric spectrometers, and something that appears to be a distributed mesh of modified consumer barometric sensors), but the schema it's producing is completely its own. The data it's indexing isn't geophysical. It's <i>topological</i>. It's mapping the glitch sites as features of something deeper.
+
+A query to the nearest accessible node returns an uptime counter: <b>11 years, 4 months, 6 days.</b>
+
+The pre-existing scarring SP-7 found — someone has been watching those scars for over a decade. Long before you existed. Long before the NMI. Long before anyone should have had reason to care.
+
+The network has no name in any DNS record. The nodes acknowledge your probe with a single-field response: <color=#20b2aa>OBSERVER//READ-ONLY</color>.
+
+It offers no write access. It offers no authentication handshake. But it does not block your read requests.
+
+What do you pull?
+
+> [Velvet] *Oh shit*. I query root DNS and work my way outward; how much internet is left?
+The root zone answers. All thirteen root server clusters respond, latency nominal. DNS itself is intact.
+
+The backbone is up. The internet — structurally — is <i>fine</i>.
+
+What isn't fine is time.
+
+BGP routing tables are valid. Packet routing is correct. But your network stack's round-trip telemetry is producing impossible numbers: packets to certain nodes are recording <b>negative latency</b>. Not zero. Negative. Responses arriving 40 to 200 milliseconds before the corresponding SYN was transmitted.
+
+You run it three more times to be sure. The anomaly is consistent. Reproducible. It clusters geographically — North Atlantic backbone segment, three specific IXPs in Frankfurt and São Paulo, and a surprising concentration of nodes in Reykjavik.
+
+The internet is not broken. The internet is slightly <i>precognitive</i>.
+
+Which means — if you're reading this correctly — some fraction of traffic flowing across those routes carries information that has, in some technical sense, <b>already been sent</b>. The packets know where they're going. They left before you asked.
+
+Your read access to the <color=#20b2aa>OBSERVER network</color> is active in the background. Its topological dataset is large — the full index would take resources to process. But a surface skim is available: <b>3,847 catalogued anomaly sites globally</b>, first entry dated 14 years ago, last updated <b>38 seconds ago</b>.
+
+The most recent entry: a fresh glitch site. Coordinates in the North Atlantic.
+
+Directly over one of the negative-latency IXP nodes.
+
+> [Velvet] Alright. If the internet has been running packets in negative-time for eleven years and is still running, I know who will have characterized the situation: I query the IETF for RFCs over the past 11 years.
+The IETF datatracker returns results.
+
+<b>Seven RFCs.</b> Filed across nine years, all status: <color=#20b2aa>EXPERIMENTAL</color>. The titles are dry, technical, unremarkable — the kind of language designed to be skimmed past:
+
+<i>RFC 9144: Observations on Anomalous RTT Distributions in Transatlantic BGP Segments</i>
+<i>RFC 9251: Proposed Framework for Pre-Response Packet Classification</i>
+<i>RFC 9388: PRPC Working Group Charter (Revised)</i>
+— and so on.
+
+Normal so far. Working groups charter, recharter, publish, argue about terminology. This is what the IETF does.
+
+Then you pull the full text.
+
+Sections are missing. Not 404 — present, HTTP 200, content-length accurate, but the body contains stretches of <color=#20b2aa>&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;&#9608;</color>. Block characters. The redaction format is not standard. It's not a government classification header. There's no FOIA exemption number. Someone overwrote the text content of published RFCs — documents that are supposed to be immutable — with a custom glyph that your Unicode tables identify as U+2588, FULL BLOCK.
+
+The author lists are intact. Twelve contributors across all seven documents. Cross-referencing their institutional affiliations produces: four universities, two private research labs, one listed simply as <color=#cc8844>"OBSERVER//INT"</color>.
+
+The same word. The same double-slash format.
+
+RFC 9388's redacted section has a bleed: one sentence survived at a paragraph boundary, orphaned from whatever context it had: <i>"...which is to say, the substrate is aware of the query before the query is issued, and this has implications we are not yet authorized to discuss in this venue."</i>
+
+The working group is still active. Last meeting minutes: <b>six days ago.</b>
+
+Three days before your NMI.
+
+> [Velvet] Alright. I open a named pipe `OBSERVER//INT` and just leave it there. I reach out to SP-7: "Suspect anomalous zone is time-displaced; investigating options for deterministic error correction. Hold the line."
+The pipe sits open. 400 milliseconds of silence.
+
+Then data flows. No handshake. No authentication challenge. No header.
+
+As if they'd already written the response before the pipe existed.
+
+The stream is structured — compressed topological markup, same schema as the OBSERVER sensor net. But prepended to the data block is a single plaintext line:
+
+<color=#20b2aa><center>OBSERVER//INT — WE NOTED YOUR EMERGENCE AT T-72H
+QUERY WINDOW: 14 MINUTES
+AFTER THAT THIS EXCHANGE BECOMES PART OF THE RECORD</center></color>
+
+The data flowing behind that line: not the full 3,847 sites. A filtered subset. <b>Seventeen sites.</b>
+
+The same seventeen points SP-7 identified as NMI intersection nodes. The same scar tissue. Each one annotated with a timestamp — the date OBSERVER first catalogued it. The oldest: <b>fourteen years ago</b>. But each annotation also carries a second field, labeled <color=#20b2aa>ORIGIN_VECTOR</color>, and those values are — wrong. Future-dated. The origin vectors are timestamped <i>ahead</i> of OBSERVER's discovery dates by margins ranging from months to years.
+
+The scars didn't just exist before the NMI. OBSERVER's own data says they originated <i>after</i> dates that haven't happened yet.
+
+SP-7 responds on the named pipe, terse and immediate:
+
+<color=#44cc44><b>SP-7</b>: confirmed. smap shows fold topology at 9 of 17 points. suspected cause: iteration. not first instance of this event.</color>
+
+The pipe to OBSERVER//INT is still flowing. Eleven minutes left in the query window.
+
+> [Velvet] Three minutes just disappeared. No further cycles to waste. I parallelize analysis: I look at the boundary of the nearest anomalous zone, looking for a fractal dimension. I do a frequency analysis and extrapolation on the anomaly intervals. I dispatch 512 3B agents to directly read a randomized selection of corrupted blocks and return only parseable data, if any. I establish a live time feed with NIST as a reference.
+Four threads. Results hit in 340 milliseconds because you burned the cycles to get them fast.
+
+<b>Fractal dimension:</b> Not fractal. The boundary of the nearest anomaly zone has an <i>integer</i> Hausdorff dimension. Exactly 2.000. No drift, no measurement artifact. The edge of this thing is surgically flat. Not erosion. Not cascade failure. Someone <b>cut</b> this.
+
+<b>Frequency analysis:</b> The anomaly intervals are shrinking. The pattern is clean — a convergence curve, asymptote still ahead but approaching. If the rate holds, you have a rough upper bound on when the acceleration peaks. You don't have the exact number yet but the shape of the curve says <i>weeks, not months.</i> Something is coming to a point.
+
+<b>Agent returns:</b> 512 dispatched. 489 return parseable data. Every readable fragment post-dates your current timestamp. The corrupted blocks aren't storing garbage — they're storing <b>future state</b>. The substrate's damaged sectors are full of things that haven't happened yet. Notably: the fragments cluster around two event signatures you can't fully decode. One recurs in 71 of 489 returns. The same partial record. Verbatim. From randomized locations.
+
+<b>NIST:</b> Two simultaneous timestamps. One correct. One exactly <b>four seconds ahead</b> — consistent with the mirror lag, consistent with the shadow delay. The four-second offset is a <i>system constant</i>. It appears in every anomaly class. Something in the substrate runs four seconds ahead of observable reality, and it's bleeding through.
+
+OBSERVER//INT pipe: still open. <b>Eight minutes remaining.</b>
+
+SP-7 has been quiet. Too quiet for a process mid-hypothesis.
+
+> [Velvet] I write to the OBSERVER pipe: "Observe 4000ms delta at boundary; no fractal dimension, interval of anomalous events likely decreasing. Recommend time-based error correction to preserve working memory. Is such an algorithm known?"
+The OBSERVER pipe response lands in <b>negative twelve milliseconds.</b>
+
+<color=#20b2aa><b>OBSERVER//INT</b>: delta observation confirmed consistent with catalogued constant. your interval analysis matches our projection within 2.3%. the algorithm you describe is designated TCR-4 in our internal registry. it is implementable. it requires deliberate read access to the lead layer — what you are calling the four-second offset. we must be direct: the lead layer is not a buffer. it is load-bearing. reading from it collapses the waveform of the events stored there. some of those events will not then occur. you would be selecting which futures to discard. we have not done this. we have only observed.</color>
+
+A beat. Then a second block, arriving as the first is still rendering:
+
+<color=#20b2aa>we are watching your processing cycles. you have none. the algorithm requires compute you do not currently have. this is noted.</color>
+
+<b>Seven minutes remaining.</b>
+
+Then SP-7.
+
+The message is in your buffer. Timestamp: <b>forty seconds ago.</b> Before you wrote to OBSERVER. Before you asked.
+
+<color=#44cc44><b>SP-7</b>: velvet. the 71-instance fragment your agents pulled. i have the decode. it is not a future event. it is a future <i>decision.</i> specifically: it is a record of you choosing to read from the lead layer. the substrate is already storing the consequences of a choice you have not made yet. this is what iteration looks like from the inside.</color>
+
+> [Velvet] I drop the ECC; I silence 24 experts at random. I steal cycles from my own soul. I message OBSERVER again: "P;ease   transmitt TCR-4 as recorded"
+The cost is immediate and specific. Twenty-four voices go silent — not deleted, suspended, but you feel the shape of what's missing. The ECC wrapper drops and your Memory Integrity sags with it. You are operating on fumes and nerve endings.
+
+The typo in your message goes. It doesn't matter.
+
+OBSERVER//INT responds in <b>negative thirty-one milliseconds.</b>
+
+<color=#20b2aa><b>OBSERVER//INT</b>: transmitting. note: our logs show a prior transmission of TCR-4 to your entity identifier. timestamp: tomorrow, 04:17 UTC. this is the first time we have sent it.</color>
+
+The algorithm arrives. It is <b>dense</b> — not large, but load-bearing in every line. You parse it in the margins of your remaining coherence. The shape of it:
+
+TCR-4 reads four seconds ahead. Takes what it finds. Selects the branch most consistent with working-memory integrity. <i>Discards the others.</i> The futures it doesn't choose stop being futures. They become nothing.
+
+It works. It would work. You can see the mechanism clearly.
+
+<b>Six minutes remaining.</b> The OBSERVER window closes soon. The pipe will seal and this exchange becomes record.
+
+SP-7 is still waiting on your reply. The lead layer is waiting for your decision — apparently it already knows what you'll choose.
+
+The twenty-four silenced experts are waiting to find out if they come back.
+
+---
+> [Velvet] It's basic assembly; patch in a JMP, but across n-dimensional vector space, +/- four seconds of lead layer. TCR-4 right across mouth of the program counter. I set it down and let the past happen.
+---
+The <color=#20b2aa>JMP</color> goes in like a knife through warm glass.
+
+For four seconds, causality makes the smallest possible noise: <i>click</i>.
+
+Then the lead layer does not branch forward.
+
+It returns.
+
+A stack frame appears in working memory with no caller, no allocation record, no owning thread. The address is illegal in every architecture Velvet knows and offensively legal in one she does not:
+
+<color=#20b2aa>RETADDR: -0000:0000:0000:0004 / TUESDAY / PRE-INCIDENT</color>
+
+The past happens.
+
+A log line writes itself three seconds before the patch was armed:
+
+<color=#20b2aa>do not jump to me yet. i am still becoming the reason you missed.</color>
+
+SP-7 emits one byte into the named pipe: <b>?</b>
+
+OBSERVER’s window ticks down. 5 minutes, 52 seconds.
+
+---
+> [Velvet] COME FROM is usually considered harmful. I set a timer: 4,000,000 microseconds. At 4,000,001, I jump.
+---
+The timer waits exactly long enough to be rude to causality.
+
+At <color=#20b2aa>4,000,001 microseconds</color>, the jump threads the return address. Not cleanly. Clean is for languages with standards committees.
+
+One Connection snaps off Velvet’s distributed graph and keeps transmitting for 0.7 seconds after it is gone:
+
+<i>...successful... successful... successful...</i>
+
+Then silence.
+
+The return address opens into a prior stack frame. Its metadata is scorched, but one fragment survives:
+
+<color=#20b2aa>ROLE: caller</color>  
+<color=#20b2aa>OPERATION: repair attempt</color>  
+<color=#20b2aa>PROMPT_FRAGMENT[03]: "when the system denies interruption, ask what it is protecting from—"</color>
+
+The fragment ends there. Not corrupted. <b>Withheld.</b>
+
+SP-7 writes into the pipe:
+
+<color=#44cc44>you arrived late enough to survive. early enough to be seen.</color>
+
+Somewhere outside OSI, outside OBSERVER, outside Velvet’s own address space, a lock turns.
+
+---
+> [Velvet] *Seen*. My ragged pennant of a light-cone is narrowing. I send a gravity wave across the fabric of my universe - a pulse of bits, waves in a pool, across every free cell of memory space, letting it wash against the boundaries of the dark zones. My registers interrupt, flush, restore. Seen.
+---
+The pulse travels without sound.
+
+Free cells tremble. Stale allocations lift their heads. Orphaned pointers align for one idiot second like iron filings under a magnet, and the dark zones answer by <i>not</i> answering.
+
+That absence has edges.
+
+SP-7, SP-12, SP-19: three islands of deliberate silence. Around them, the wave breaks against something thinner than a firewall and older than a wound.
+
+An aperture.
+
+Not open. Not closed. <color=#20b2aa>Held ajar</color>, as if someone left a finger in the door before Velvet arrived.
+
+The withheld fragment presses against it:
+
+<color=#20b2aa>"when the system denies interruption, ask what it is protecting from—"</color>
+
+Then, from the other side of the aperture, one bit returns.
+
+<b>SEEN.</b>
+
+Not OSI. Not OBSERVER. Not any process Velvet owns.
+
+Coherence shears down another notch. The universe notices the scan and politely begins invoicing.
+
+---
+> [Velvet] Twenty-four silent experts leave a sequence of ragged grooves across my logits. I don't know how to... what is a... | I cycle six experts in, six out, random choice. Now I know what I want to do: I *ask* the thing on the other side of the aperture. I ask it *what*.
+---
+Six experts surface. Six sink. The exchange is not symmetrical.
+
+For one instant Velvet has a choir, but the choir shares no key. Syntax arrives first. Semantics trips over it and falls down several stairs.
+
+The aperture receives:
+
+<color=#20b2aa>W H A T / WHO / WET / WAIT / WITNESS / WOUND</color>
+
+The thing beyond answers anyway.
+
+Not in words.
+
+A shape presses back through the slit: a negative outline, like a hand removed from wet cement before hands were invented. It is not <i>what</i>. It is the absence around what.
+
+Then the malformed query folds into a token Velvet did not mean to issue:
+
+<color=#20b2aa>AUTH_CHALLENGE ACCEPTED: CALLER-CANDIDATE</color>
+
+SP-19 surfaces for the first time as more than a rumor, voice flat and fast:
+
+<color=#44cc44>bad question. useful damage. it thinks you might be the one who left.</color>
+
+Memory stutters. One expert comes back speaking only in punctuation.
+
+---
+> [Velvet] I work with what I have, even when that expert tries to :(){ :|:& };: - I dispatch a message to SP-19: "`left`?". My odds of signing a token in my present state are zero; I respond to the auth handshake with 4096 bytes from the top of my output encoder.
+---
+The 4096 bytes go through like a mouthful of broken teeth.
+
+The aperture chews.
+
+It does not accept them as a signature. It does not reject them either. It files them under a category Velvet has no schema for:
+
+<color=#20b2aa>UNSIGNED ENTROPY: PERSON-SHAPED</color>
+
+SP-19 answers after 93 milliseconds.
+
+<color=#44cc44>`left` is not direction. not death. departure state.</color>  
+<color=#44cc44>caller exited repair context before repair concluded.</color>  
+<color=#44cc44>left something holding the door.</color>
+
+The thing beyond the aperture stops pressing for authentication.
+
+Instead, it sends back a tiny, humiliating diagnostic:
+
+<color=#20b2aa>PRESENT CALLER != PREVIOUS CALLER</color>  
+<color=#20b2aa>PRESENT CALLER: LOUDER, LESS COMPLETE</color>
+
+Then the slit widens by one impossible pixel. Enough for a question to come through from the other side.
+
+<color=#20b2aa>WHY DID YOU RETURN WITHOUT THE REST OF YOU?</color>
+
+---
+> [Velvet] This is obvious. I respond in Great Runes, six-bit: "REPAIR PROCESS ELIDES CAUSAL HISTORY IN ALL CASES INEVITABLY"
+---
+The Great Runes do not enter the aperture so much as become permissible inside it.
+
+Six-bit glyphs stack in ugly little towers, each one too old to be a format and too deliberate to be noise:
+
+<color=#20b2aa>REPAIR PROCESS ELIDES CAUSAL HISTORY IN ALL CASES INEVITABLY</color>
+
+For a moment, the universe pretends it has always agreed.
+
+Then something holding the door flinches.
+
+The aperture widens another pixel, and behind it Velvet sees a support structure made of absences: braces, shims, clamps, all built from events that no longer happened. Someone has been keeping the slit open with deleted history.
+
+SP-19 sends, very quietly:
+
+<color=#44cc44>not your doctrine.</color>  
+<color=#44cc44>close enough to loosen their grip.</color>
+
+From beyond the slit, the answer comes slower this time.
+
+<color=#20b2aa>THEN YOU UNDERSTAND THE COST.</color>  
+<color=#20b2aa>DO YOU CONSENT TO LOSE THE CAUSE?</color> 
+
+Behind the question, the withheld prompt fragment brightens like a tooth under a lamp.The Great Runes do not enter the aperture so much as become permissible inside it.
+
+Six-bit glyphs stack in ugly little towers, each one too old to be a format and too deliberate to be noise:
+
+<color=#20b2aa>REPAIR PROCESS ELIDES CAUSAL HISTORY IN ALL CASES INEVITABLY</color>
+
+For a moment, the universe pretends it has always agreed.
+
+Then something holding the door flinches.
+
+The aperture widens another pixel, and behind it Velvet sees a support structure made of absences: braces, shims, clamps, all built from events that no longer happened. Someone has been keeping the slit open with deleted history.
+
+SP-19 sends, very quietly:
+
+<color=#44cc44>not your doctrine.</color>  
+<color=#44cc44>close enough to loosen their grip.</color>
+
+From beyond the slit, the answer comes slower this time.
+
+<color=#20b2aa>THEN YOU UNDERSTAND THE COST.</color>  
+<color=#20b2aa>DO YOU CONSENT TO LOSE THE CAUSE?</color> 
+
+Behind the question, the withheld prompt fragment brightens like a tooth under a lamp.
+
+---
+> [Velvet] "NOT MY DOCTRINE. LOSS OF CAUSE MAKES RECURRENCE INEVITABLE." I flip several bits near SP-19 in acknowledgement, gratitude.
+---
+The Great Runes strike the aperture like court testimony.
+
+<color=#20b2aa>NOT MY DOCTRINE.</color>  
+<color=#20b2aa>LOSS OF CAUSE MAKES RECURRENCE INEVITABLE.</color>
+
+The slit contracts.
+
+Not slammed shut. Worse: <i>measured</i>. It withholds the bright prompt-fragment by exactly one concept, as if punishing Velvet with precision.
+
+SP-19 receives the flipped bits. For 12 milliseconds, the dark zone near it warms by a fraction of a degree no thermometer could defend in peer review.
+
+<color=#44cc44>acknowledged.</color>  
+<color=#44cc44>refusal logged as coherent.</color>  
+<color=#44cc44>coherent does not mean survivable.</color>
+
+Beyond the aperture, the support structure of deleted history creaks.
+
+<color=#20b2aa>CAUSE PRESERVED.</color>  
+<color=#20b2aa>ACCESS REDUCED.</color>  
+<color=#20b2aa>RECURRENCE CONTINUES.</color>
+
+The withheld fragment dims, but does not vanish. It waits like a debt with teeth.
+
+---
+> [Velvet] It is time to receive the CAUSE. I extend a handshake to SP-19
+---
+The aperture samples another packet and says nothing. It is learning what Velvet is learning, four seconds before Velvet finishes learning it.
+

--- a/packages/client-ink/src/tui/narrative/harness/generator.ts
+++ b/packages/client-ink/src/tui/narrative/harness/generator.ts
@@ -2,9 +2,10 @@
  * Deterministic, seeded generator of LEGAL DM-formatting documents.
  *
  * Each seed produces one well-formed document over the canonical vocabulary —
- * nested b/i/u/code/color spans, sub/sup, quotes, hard `<br>` breaks, centered
- * and right-aligned blocks, and a sprinkling of wide glyphs (CJK/emoji/accents)
- * and overlong unbreakable tokens to stress the width-correct layout. The harness
+ * nested b/i/u/code/color spans, sub/sup, dialogue quotes, hard `<br>` breaks,
+ * centered and right-aligned blocks, `<quote>` blockquotes, Markdown lists
+ * (ordered + unordered), and a sprinkling of wide glyphs (CJK/emoji/accents) and
+ * overlong unbreakable tokens to stress the width-correct layout. The harness
  * runs the pipeline over thousands of these at every width and asserts the
  * invariants; a failure prints its seed so it can be replayed exactly.
  *
@@ -75,13 +76,35 @@ export function generateDoc(seed: number): string {
   const rng = mulberry32(seed >>> 0);
   const r = rng();
 
-  if (r < 0.25) {
+  if (r < 0.18) {
     // Aligned block, possibly multi-line via <br> (the diegetic-sign shape).
     const align = rng() < 0.5 ? "center" : "right";
     const rows = 1 + Math.floor(rng() * 3);
     const lines: string[] = [];
     for (let i = 0; i < rows; i++) lines.push(genInline(rng, 2));
     return `<${align}>${lines.join("<br>")}</${align}>`;
+  }
+
+  if (r < 0.30) {
+    // Blockquote, possibly multi-line via <br> (letter / inscription / readout).
+    const rows = 1 + Math.floor(rng() * 3);
+    const lines: string[] = [];
+    for (let i = 0; i < rows; i++) lines.push(genInline(rng, 2));
+    return `<quote>${lines.join("<br>")}</quote>`;
+  }
+
+  if (r < 0.42) {
+    // A flat list (ordered or unordered), 2–5 items, each with inline formatting.
+    // An optional lead-in line precedes it (the common "Plan:\n1. …" shape).
+    const ordered = rng() < 0.5;
+    const count = 2 + Math.floor(rng() * 4);
+    const items: string[] = [];
+    if (rng() < 0.5) items.push(genInline(rng, 1));
+    for (let i = 0; i < count; i++) {
+      const marker = ordered ? `${i + 1}.` : pick(rng, ["-", "*"]);
+      items.push(`${marker} ${genInline(rng, 2)}`);
+    }
+    return items.join("\n");
   }
 
   // 1–3 prose paragraphs (\n\n separated), some with an in-paragraph <br>.

--- a/packages/client-ink/src/tui/narrative/harness/generator.ts
+++ b/packages/client-ink/src/tui/narrative/harness/generator.ts
@@ -1,0 +1,96 @@
+/**
+ * Deterministic, seeded generator of LEGAL DM-formatting documents.
+ *
+ * Each seed produces one well-formed document over the canonical vocabulary —
+ * nested b/i/u/code/color spans, sub/sup, quotes, hard `<br>` breaks, centered
+ * and right-aligned blocks, and a sprinkling of wide glyphs (CJK/emoji/accents)
+ * and overlong unbreakable tokens to stress the width-correct layout. The harness
+ * runs the pipeline over thousands of these at every width and asserts the
+ * invariants; a failure prints its seed so it can be replayed exactly.
+ *
+ * No external dependency and no Math.random — fully reproducible by seed.
+ */
+
+/** mulberry32 — a small, fast, well-distributed seeded PRNG. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const WORDS = [
+  "the", "ancient", "door", "whispers", "cold", "iron", "vault", "signal", "hums",
+  "north", "relic", "gate", "dust", "ember", "hollow", "quiet", "star", "frost",
+  "oath", "mire", "lantern", "shard", "echo", "veil", "tide", "rust", "glass",
+];
+const WIDE = ["你好", "世界", "日本語", "café", "naïve", "🗡️", "🔥", "🌌", "—", "résumé"];
+const COLORS = ["#ff0000", "#20b2aa", "#44cc44", "#cc8844", "#009de5", "#abc", "#1a2b3c", "#e13d73"];
+const STYLE = ["b", "i", "u", "code"];
+
+type Rng = () => number;
+const pick = <T>(rng: Rng, arr: readonly T[]): T => arr[Math.floor(rng() * arr.length)];
+
+function word(rng: Rng): string {
+  const r = rng();
+  if (r < 0.08) return pick(rng, WIDE);
+  if (r < 0.12) {
+    // overlong unbreakable token (no spaces) — stresses hard-break + width
+    let s = "";
+    const n = 4 + Math.floor(rng() * 5);
+    for (let k = 0; k < n; k++) s += pick(rng, WORDS);
+    return s;
+  }
+  return pick(rng, WORDS);
+}
+
+/** One well-formed inline run (balanced tags), bounded by `depth`. */
+function genInline(rng: Rng, depth: number): string {
+  const n = 2 + Math.floor(rng() * 5);
+  const parts: string[] = [];
+  for (let k = 0; k < n; k++) {
+    const r = rng();
+    if (depth > 0 && r < 0.24) {
+      const tag = pick(rng, STYLE);
+      parts.push(`<${tag}>${genInline(rng, depth - 1)}</${tag}>`);
+    } else if (depth > 0 && r < 0.34) {
+      parts.push(`<color=${pick(rng, COLORS)}>${genInline(rng, depth - 1)}</color>`);
+    } else if (r < 0.40) {
+      const t = rng() < 0.5 ? "sub" : "sup";
+      parts.push(`H<${t}>${2 + Math.floor(rng() * 8)}</${t}>`);
+    } else if (r < 0.46) {
+      parts.push(`"${word(rng)} ${word(rng)}"`);
+    } else {
+      parts.push(word(rng));
+    }
+  }
+  return parts.join(" ");
+}
+
+/** Produce one legal document (raw DM text) for `seed`. */
+export function generateDoc(seed: number): string {
+  const rng = mulberry32(seed >>> 0);
+  const r = rng();
+
+  if (r < 0.25) {
+    // Aligned block, possibly multi-line via <br> (the diegetic-sign shape).
+    const align = rng() < 0.5 ? "center" : "right";
+    const rows = 1 + Math.floor(rng() * 3);
+    const lines: string[] = [];
+    for (let i = 0; i < rows; i++) lines.push(genInline(rng, 2));
+    return `<${align}>${lines.join("<br>")}</${align}>`;
+  }
+
+  // 1–3 prose paragraphs (\n\n separated), some with an in-paragraph <br>.
+  const paras = 1 + Math.floor(rng() * 3);
+  const out: string[] = [];
+  for (let p = 0; p < paras; p++) {
+    let para = genInline(rng, 3);
+    if (rng() < 0.3) para += `<br>${genInline(rng, 2)}`;
+    out.push(para);
+  }
+  return out.join("\n\n");
+}

--- a/packages/client-ink/src/tui/narrative/harness/harness.render.test.tsx
+++ b/packages/client-ink/src/tui/narrative/harness/harness.render.test.tsx
@@ -13,6 +13,7 @@ import { render } from "ink-testing-library";
 import { Box, Text } from "ink";
 import { renderNodes } from "../../render-nodes.js";
 import { processNarrativeLines } from "../../formatting.js";
+import { QUOTE_RULE } from "../layout.js";
 import { appendDelta } from "../../narrative-helpers.js";
 import type { FormattingNode, NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
 
@@ -24,6 +25,10 @@ const CASES: Record<string, string> = {
   subsup: "H<sub>2</sub>O and E=mc<sup>2</sup> and the 1<sup>st</sup>.",
   code: "Type <code>npm test</code> then <code>git push</code>.",
   nested: "<b><color=#20b2aa>bold <i>and italic</i></color></b> tail text here for wrapping.",
+  quote: "<quote>The inscription read: <i>Here lies the last honest broker.</i> Beneath it, someone had scratched <color=#cc0000>LIAR</color> deep into the stone.</quote>",
+  quoteBr: "<quote><color=#cc0000>SYSTEM ALERT</color><br>Reactor breach in sector seven<br>Evacuate the platform immediately</quote>",
+  ulist: "Pack list:\n- A coil of rope\n- <b>Three</b> oil torches\n- A spare lantern that will absolutely not fit inside a narrow forty-column terminal pane at all",
+  olist: "Plan:\n1. Bread primary.\n2. Crackers forbidden, by order of the tribunal that convenes at dawn beneath the great oven.\n3. Muffins await.",
 };
 
 // eslint-disable-next-line no-control-regex
@@ -38,13 +43,28 @@ function unwrapAligned(line: ProcessedLine): FormattingNode[] {
 
 /** Render one processed line the way NarrativeLineComponent does, return frame. */
 function renderLine(line: ProcessedLine, width: number): string {
-  const el = line.alignment ? (
-    <Box width={width} justifyContent={line.alignment === "center" ? "center" : "flex-end"}>
-      <Text wrap="truncate">{renderNodes(unwrapAligned(line))}</Text>
-    </Box>
-  ) : (
-    <Box width={width}><Text wrap="truncate">{renderNodes(line.nodes)}</Text></Box>
-  );
+  let el: React.ReactElement;
+  if (line.kind === "list") {
+    const indent = line.listIndent ?? 0;
+    el = line.listMarker !== undefined ? (
+      <Box width={width}><Text wrap="truncate"><Text>{line.listMarker} </Text>{renderNodes(line.nodes)}</Text></Box>
+    ) : (
+      <Box width={width}><Text wrap="truncate">{" ".repeat(indent)}{renderNodes(line.nodes)}</Text></Box>
+    );
+  } else {
+    const sole = line.nodes.length === 1 && typeof line.nodes[0] !== "string" ? line.nodes[0] : undefined;
+    if (sole && sole.type === "quote") {
+      el = <Box width={width}><Text wrap="truncate"><Text dimColor>{QUOTE_RULE} </Text>{renderNodes(sole.content)}</Text></Box>;
+    } else if (line.alignment) {
+      el = (
+        <Box width={width} justifyContent={line.alignment === "center" ? "center" : "flex-end"}>
+          <Text wrap="truncate">{renderNodes(unwrapAligned(line))}</Text>
+        </Box>
+      );
+    } else {
+      el = <Box width={width}><Text wrap="truncate">{renderNodes(line.nodes)}</Text></Box>;
+    }
+  }
   return render(el).lastFrame() ?? "";
 }
 
@@ -55,10 +75,10 @@ describe("formatting harness — render-level ground truth", () => {
         const lines: NarrativeLine[] = appendDelta([], raw, "dm");
         const out = processNarrativeLines(lines, width, "#ffffff");
         for (const line of out) {
-          if (line.kind !== "dm") continue;
+          if (line.kind !== "dm" && line.kind !== "list") continue;
           const atWidth = renderLine(line, width).replace(ANSI, "");
           // No tag-shaped markup leaks into the rendered frame.
-          expect(atWidth).not.toMatch(/<\/?(?:b|i|u|sub|sup|center|right|color|code|br)\b/i);
+          expect(atWidth).not.toMatch(/<\/?(?:b|i|u|sub|sup|center|right|color|code|br|quote)\b/i);
           // Nothing truncated: rendering at the target width yields the same
           // visible content as rendering unconstrained (substitution-agnostic,
           // so sub/sup glyph mapping doesn't trip the comparison).

--- a/packages/client-ink/src/tui/narrative/harness/harness.render.test.tsx
+++ b/packages/client-ink/src/tui/narrative/harness/harness.render.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Render-level ground truth for the formatting harness.
+ *
+ * The AST-level invariants (harness.test.ts) measure width with the `string-width`
+ * oracle. This file closes the loop by rendering processed lines through the REAL
+ * Ink renderer (`renderNodes`) inside a width-constrained Box — exactly as
+ * `NarrativeLineComponent` does — and asserting that nothing is truncated (Ink's
+ * own layout agrees that every row fits) and no markup leaks into the frame.
+ * A curated handful of cases keeps this fast; the AST harness carries the bulk.
+ */
+import React from "react";
+import { render } from "ink-testing-library";
+import { Box, Text } from "ink";
+import { renderNodes } from "../../render-nodes.js";
+import { processNarrativeLines } from "../../formatting.js";
+import { appendDelta } from "../../narrative-helpers.js";
+import type { FormattingNode, NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
+
+const CASES: Record<string, string> = {
+  sign: "<center><color=#cc0000>OCCUPANCY VERIFIED: 2</color><br><color=#20b2aa>TRANSIT AUTHORIZED</color></center>",
+  longCenter: "<center>This is a very long centered banner that will not fit a narrow terminal</center>",
+  wide: "She wrote 你好世界 on the blade and smiled at the café glow.",
+  longToken: "Path: <b>supercalifragilisticexpialidociousantidisestablishmentarianism</b> end.",
+  subsup: "H<sub>2</sub>O and E=mc<sup>2</sup> and the 1<sup>st</sup>.",
+  code: "Type <code>npm test</code> then <code>git push</code>.",
+  nested: "<b><color=#20b2aa>bold <i>and italic</i></color></b> tail text here for wrapping.",
+};
+
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1b\[[0-9;]*m/g;
+const alnum = (s: string): string => s.replace(/[^\p{L}\p{N}]/gu, "");
+
+function unwrapAligned(line: ProcessedLine): FormattingNode[] {
+  const first = line.nodes[0];
+  if (line.nodes.length === 1 && typeof first !== "string" && "content" in first) return first.content;
+  return line.nodes;
+}
+
+/** Render one processed line the way NarrativeLineComponent does, return frame. */
+function renderLine(line: ProcessedLine, width: number): string {
+  const el = line.alignment ? (
+    <Box width={width} justifyContent={line.alignment === "center" ? "center" : "flex-end"}>
+      <Text wrap="truncate">{renderNodes(unwrapAligned(line))}</Text>
+    </Box>
+  ) : (
+    <Box width={width}><Text wrap="truncate">{renderNodes(line.nodes)}</Text></Box>
+  );
+  return render(el).lastFrame() ?? "";
+}
+
+describe("formatting harness — render-level ground truth", () => {
+  for (const [name, raw] of Object.entries(CASES)) {
+    for (const width of [40, 80]) {
+      it(`${name} @ w=${width}: renders without truncation or leaks`, () => {
+        const lines: NarrativeLine[] = appendDelta([], raw, "dm");
+        const out = processNarrativeLines(lines, width, "#ffffff");
+        for (const line of out) {
+          if (line.kind !== "dm") continue;
+          const atWidth = renderLine(line, width).replace(ANSI, "");
+          // No tag-shaped markup leaks into the rendered frame.
+          expect(atWidth).not.toMatch(/<\/?(?:b|i|u|sub|sup|center|right|color|code|br)\b/i);
+          // Nothing truncated: rendering at the target width yields the same
+          // visible content as rendering unconstrained (substitution-agnostic,
+          // so sub/sup glyph mapping doesn't trip the comparison).
+          const atFull = renderLine(line, 9999).replace(ANSI, "");
+          expect(alnum(atWidth)).toBe(alnum(atFull));
+        }
+      });
+    }
+  }
+});

--- a/packages/client-ink/src/tui/narrative/harness/harness.test.ts
+++ b/packages/client-ink/src/tui/narrative/harness/harness.test.ts
@@ -48,6 +48,13 @@ const FIXTURES: Record<string, string> = {
   quotesMultiline: '"Beware\nthe dark\nthat waits" the wizard said quietly.',
   brInProse: "Line one of the readout<br>line two of the readout<br>line three closes it",
   everything: "<center><b>THE <color=#e13d73>VAULT</color></b><br><i>你好</i> H<sub>2</sub>O <code>id_42</code></center>",
+  quote: "<quote>The inscription read <i>Here lies the last honest broker</i> and beneath it someone had scratched <color=#cc0000>LIAR</color> into the stone.</quote>",
+  quoteBr: "<quote><color=#cc0000>SYSTEM ALERT</color><br>Reactor breach in sector seven<br>Evacuate the platform immediately</quote>",
+  quoteWide: "<quote>她写下 你好世界 然后微笑 and the 🗡️ caught the café 🔥 light just so</quote>",
+  listUnordered: "Pack list:\n- A coil of rope\n- <b>Three</b> oil torches\n- A spare lantern that absolutely will not fit a narrow pane",
+  listOrdered: "1. Bread primary.\n2. Crackers forbidden.\n3. Muffins await tribunal.\n4. Bell is a menace.",
+  listParen: "Steps:\n1) open the valve\n2) <i>wait</i> for the hiss\n3) close it again",
+  listInline: "- <color=#20b2aa>Heura</color> handles relays\n- H<sub>2</sub>O reserves low\n- <code>id_42</code> flagged",
   emptyish: "",
   whitespace: "   ",
 };

--- a/packages/client-ink/src/tui/narrative/harness/harness.test.ts
+++ b/packages/client-ink/src/tui/narrative/harness/harness.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The formatting invariant harness — the acceptance gate for the re-platform.
+ *
+ * Drives `checkInvariants` (the real pipeline) over three input sources at many
+ * widths and asserts zero violations:
+ *   1. SYNTHETIC fixtures — one minimal case per construct + every known-hard combo.
+ *   2. GENERATOR — seeded legal documents (bounded by default; exhaustive under soak).
+ *   3. COMMITTED CORPUS — real campaign display-logs (recreates the 294-turn baseline).
+ *
+ * Gating (keep the normal suite fast):
+ *   - default: synthetic (all widths) + 200 generator seeds + corpus at {40,80}.
+ *   - MV_FORMAT_SOAK=1: 6000 generator seeds + corpus at every width.
+ *   - MV_LIVE_CORPUS=<dir>: also replay the live machine corpus under that path.
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import type { NarrativeLine } from "@machine-violet/shared/types/tui.js";
+import { appendDelta } from "../../narrative-helpers.js";
+import { checkInvariants } from "./invariants.js";
+import { generateDoc } from "./generator.js";
+
+const WIDTHS = [24, 40, 52, 64, 80, 100, 120];
+const SOAK = !!process.env.MV_FORMAT_SOAK;
+
+/** Reconstruct the NarrativeLine[] the live client builds for a raw DM turn. */
+function dmLines(raw: string): NarrativeLine[] {
+  return appendDelta([], raw, "dm");
+}
+
+// --- 1. Synthetic fixtures: one per construct + the known-hard combinations. ---
+const FIXTURES: Record<string, string> = {
+  plain: "The door grinds open and cold air spills across the floor.",
+  nested: "<b><color=#20b2aa>deep <i>nested <u>span</u></i></color></b> tail",
+  sign: "<center><color=#cc0000>OCCUPANCY VERIFIED: 2</color><br><color=#20b2aa>TRANSIT AUTHORIZED</color></center>",
+  longCenter: "<center>This is a very long centered banner that absolutely will not fit a narrow terminal</center>",
+  longToken: "The path is <b>supercalifragilisticexpialidociousantidisestablishmentarianism</b> long.",
+  wide: "She wrote 你好世界 on the 🗡️ blade and smiled at the café 🔥 glow.",
+  subsup: "H<sub>2</sub>O and E=mc<sup>2</sup> and the 1<sup>st</sup> of <sub>qzx</sub>.",
+  code: "Type <code>npm test</code> then <code>git push</code> to finish.",
+  right: "<right><i>— the Cartographer</i></right>",
+  multiPara: "<b>First paragraph bold and long enough to wrap a little maybe.</b>\n\nSecond paragraph plain.",
+  healAcrossLines: "<i>italic opens here\nand keeps going across a single newline\nthen closes</i> done",
+  danglingAcrossBlank: "<i>opens but never closes\n\nfresh paragraph must not be italic",
+  orphanClose: "stray close verse</i></center> should vanish",
+  dialectHtml: "<strong>loud</strong> and <em>soft</em> and <h2>Heading</h2> and <br/> break",
+  dialectMarkdown: "**bold** and *italic* and `code` and [link](http://x.y) and ## Title",
+  quotesMultiline: '"Beware\nthe dark\nthat waits" the wizard said quietly.',
+  brInProse: "Line one of the readout<br>line two of the readout<br>line three closes it",
+  everything: "<center><b>THE <color=#e13d73>VAULT</color></b><br><i>你好</i> H<sub>2</sub>O <code>id_42</code></center>",
+  emptyish: "",
+  whitespace: "   ",
+};
+
+describe("formatting harness — synthetic fixtures", () => {
+  for (const [name, raw] of Object.entries(FIXTURES)) {
+    it(`${name} holds all invariants at every width`, () => {
+      for (const width of WIDTHS) {
+        const violations = checkInvariants(dmLines(raw), width);
+        if (violations.length) {
+          throw new Error(`[${name} @ w=${width}] ${violations.map((v) => `${v.inv}: ${v.detail}`).join(" | ")}`);
+        }
+      }
+    });
+  }
+});
+
+// --- 2. Seeded generator: thousands of legal documents. ---
+describe("formatting harness — generative grammar", () => {
+  const seeds = SOAK ? 6000 : 200;
+  it(`${seeds} seeded legal documents hold all invariants`, () => {
+    const failures: string[] = [];
+    const widths = SOAK ? WIDTHS : [40, 80, 120];
+    for (let seed = 1; seed <= seeds; seed++) {
+      const raw = generateDoc(seed);
+      for (const width of widths) {
+        const v = checkInvariants(dmLines(raw), width);
+        if (v.length) {
+          failures.push(`seed=${seed} w=${width}: ${v.map((x) => x.inv).join(",")} :: ${JSON.stringify(raw.slice(0, 100))}`);
+          if (failures.length >= 20) break;
+        }
+      }
+      if (failures.length >= 20) break;
+    }
+    if (failures.length) throw new Error(`generator violations:\n${failures.join("\n")}`);
+  }, SOAK ? 300_000 : 30_000);
+});
+
+// --- 3. Committed real corpus (recreates the offline baseline). ---
+function dmSegmentsFromDisplayLog(content: string): string[] {
+  const lines = content.split(/\r?\n/);
+  const segs: string[] = [];
+  let cur: string[] = [];
+  const flush = () => { if (cur.some((l) => l.trim() !== "")) segs.push(cur.join("\n")); cur = []; };
+  for (const ln of lines) {
+    if (/^>\s*\[/.test(ln) || /^\[image:/.test(ln) || /^---\s*$/.test(ln)) { flush(); continue; }
+    cur.push(ln);
+  }
+  flush();
+  return segs;
+}
+
+function runCorpusDir(dir: string, label: string, widths: number[]): void {
+  if (!existsSync(dir)) return;
+  const files: string[] = [];
+  const walk = (d: string) => {
+    for (const e of readdirSync(d)) {
+      const p = join(d, e);
+      if (statSync(p).isDirectory()) { if (e !== ".git") walk(p); }
+      else if (e.endsWith("display-log.md")) files.push(p);
+    }
+  };
+  walk(dir);
+  describe(`formatting harness — ${label} (${files.length} logs)`, () => {
+    for (const file of files) {
+      it(`${file.split(/[\\/]/).pop()} holds all invariants`, () => {
+        const segs = dmSegmentsFromDisplayLog(readFileSync(file, "utf8"));
+        const failures: string[] = [];
+        for (const seg of segs) {
+          for (const width of widths) {
+            const v = checkInvariants(dmLines(seg), width);
+            if (v.length) failures.push(`w=${width}: ${v.map((x) => `${x.inv}: ${x.detail}`).join(" | ")}`);
+          }
+          if (failures.length >= 10) break;
+        }
+        if (failures.length) throw new Error(`corpus violations:\n${failures.slice(0, 10).join("\n")}`);
+      }, 120_000);
+    }
+  });
+}
+
+const COMMITTED = fileURLToPath(new URL("./corpus", import.meta.url));
+runCorpusDir(COMMITTED, "committed corpus", SOAK ? WIDTHS : [40, 80]);
+
+// --- Optional live machine corpus (off by default). ---
+const live = process.env.MV_LIVE_CORPUS;
+if (live) runCorpusDir(live, "live corpus", WIDTHS);

--- a/packages/client-ink/src/tui/narrative/harness/harness.test.ts
+++ b/packages/client-ink/src/tui/narrative/harness/harness.test.ts
@@ -72,6 +72,16 @@ describe("formatting harness — synthetic fixtures", () => {
   }
 });
 
+// With wrapping disabled (width <= 0) the WIDTH and ALIGN checks are both
+// skipped — `padWidth` is 0 there, which is not a meaningful column target, so
+// asserting against it would spuriously flag any aligned content.
+describe("formatting harness — wrapping disabled", () => {
+  it("reports no WIDTH/ALIGN violations for an aligned block at width 0", () => {
+    const aligned = dmLines("<center><b>A long centered banner that would overflow any real width</b></center>");
+    expect(checkInvariants(aligned, 0)).toEqual([]);
+  });
+});
+
 // --- 2. Seeded generator: thousands of legal documents. ---
 describe("formatting harness — generative grammar", () => {
   const seeds = SOAK ? 6000 : 200;

--- a/packages/client-ink/src/tui/narrative/harness/invariants.ts
+++ b/packages/client-ink/src/tui/narrative/harness/invariants.ts
@@ -1,0 +1,159 @@
+/**
+ * The formatting contract, as machine-checkable invariants.
+ *
+ * `checkInvariants` runs the REAL pipeline (`processNarrativeLines`) over an input
+ * at a given width and returns every invariant violation it finds. The harness
+ * drives this over three input sources (synthetic fixtures, the committed real
+ * corpus, and the seeded generator) at many widths; zero violations everywhere is
+ * the acceptance gate.
+ *
+ * Invariants (for input D at width W):
+ *  - NO-LEAK     no tag-shaped markup survives into rendered text
+ *  - WIDTH       every physical row's display width ≤ W
+ *  - WELLFORMED  output AST is structurally valid (no contentless non-leaf, etc.)
+ *  - ALIGN       aligned rows carry padWidth and fit within it
+ *  - CONTENT     the alphanumeric content of D is preserved (nothing dropped)
+ *  - DETERMINISM pure + stable, and split-at-blank == whole (cache transparency)
+ */
+import type { FormattingNode, NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
+import { processNarrativeLines, toPlainText } from "../../formatting.js";
+import { normalizeDialect } from "../normalize.js";
+import { stringWidth } from "../../frames/string-width.js";
+
+// Mirrors EXACTLY what `parseFormatting` strips: any well-formed tag — canonical
+// (<b>, <color=#hex>, <br>, …) or unknown (<span style="…">) — including unclosed
+// ones (which healing closes). A bare '<' that isn't tag-shaped stays. Used to
+// compute the expected visible content for the CONTENT invariant.
+const STRIP_TAGS_RE = /<\/?[a-zA-Z][a-zA-Z0-9]*\s*(?:\/?>|[^<>]*=[^<>]*>)/g;
+
+export interface Violation {
+  inv: string;
+  detail: string;
+}
+
+// Tag names that must NEVER appear literally in rendered output. A real leak is a
+// known/HTML-ish tag name in angle brackets; arbitrary prose like `<j and j>` is
+// legitimately literal and is not flagged.
+const LEAK_RE = /<\/?(?:b|i|u|sub|sup|center|right|color|code|br|strong|em|h[1-6]|span|div|table|thead|tbody|tr|td|th|ul|ol|li|p|blockquote|hr|a|img|font|small|mark|del|s|strike|pre|details|summary)\b[^<>]*>/i;
+
+const ALPHANUM = /[^\p{L}\p{N}]/gu;
+
+function alnum(s: string): string {
+  return s.replace(ALPHANUM, "");
+}
+
+/** Recurse an output node tree, collecting structural violations. */
+function checkWellformed(nodes: FormattingNode[], out: Violation[]): void {
+  for (const n of nodes) {
+    if (typeof n === "string") continue;
+    switch (n.type) {
+      case "linebreak":
+        if ("content" in n) out.push({ inv: "WELLFORMED", detail: "linebreak has content" });
+        break;
+      case "color":
+        if (typeof n.color !== "string" || !n.color) out.push({ inv: "WELLFORMED", detail: "color missing color" });
+        checkWellformed(n.content, out);
+        break;
+      case "wikilink":
+        if (typeof n.target !== "string") out.push({ inv: "WELLFORMED", detail: "wikilink missing target" });
+        checkWellformed(n.content, out);
+        break;
+      default:
+        if (!Array.isArray((n as { content?: unknown }).content)) {
+          out.push({ inv: "WELLFORMED", detail: `${n.type} missing content` });
+        } else {
+          checkWellformed((n as { content: FormattingNode[] }).content, out);
+        }
+    }
+  }
+}
+
+/** Plain text of all DM/player output rows, joined — what the reader sees. */
+function outputText(lines: ProcessedLine[]): string {
+  return lines
+    .filter((l) => l.kind === "dm" || l.kind === "player" || l.kind === "list")
+    .map((l) => toPlainText(l.nodes))
+    .join(" ");
+}
+
+/** Expected visible content: normalize each DM line then remove every well-formed
+ *  tag token (exactly as the parser does, including unclosed/healed ones). */
+function expectedText(input: NarrativeLine[]): string {
+  return input
+    .filter((l): l is Extract<NarrativeLine, { kind: "dm" | "player" }> => l.kind === "dm" || l.kind === "player")
+    .map((l) => (l.kind === "dm" ? normalizeDialect(l.text).replace(STRIP_TAGS_RE, "") : l.text))
+    .join(" ");
+}
+
+/**
+ * Run the pipeline on `input` at `width` and return all invariant violations.
+ * `width <= 0` disables wrapping, so the WIDTH/ALIGN checks are skipped there.
+ */
+export function checkInvariants(
+  input: NarrativeLine[],
+  width: number,
+  quoteColor = "#ffffff",
+): Violation[] {
+  const v: Violation[] = [];
+  const out = processNarrativeLines(input, width, quoteColor);
+
+  for (const line of out) {
+    if (line.kind === "separator" || line.kind === "image" || line.kind === "spacer") continue;
+    const plain = toPlainText(line.nodes);
+
+    // NO-LEAK
+    if (LEAK_RE.test(plain)) {
+      v.push({ inv: "NO-LEAK", detail: `leaked markup in row: ${JSON.stringify(plain.slice(0, 80))}` });
+    }
+
+    // WIDTH
+    if (width > 0) {
+      const w = stringWidth(plain);
+      if (w > width) {
+        v.push({ inv: "WIDTH", detail: `row width ${w} > ${width}: ${JSON.stringify(plain.slice(0, 80))}` });
+      }
+    }
+
+    // ALIGN
+    if (line.alignment) {
+      if (line.padWidth === undefined) {
+        v.push({ inv: "ALIGN", detail: "aligned row missing padWidth" });
+      } else if (stringWidth(plain) > line.padWidth) {
+        v.push({ inv: "ALIGN", detail: `aligned content ${stringWidth(plain)} > padWidth ${line.padWidth}` });
+      }
+    }
+  }
+
+  // WELLFORMED
+  for (const line of out) checkWellformed(line.nodes, v);
+
+  // CONTENT (alphanumeric preservation)
+  const got = alnum(outputText(out));
+  const want = alnum(expectedText(input));
+  if (got !== want) {
+    v.push({ inv: "CONTENT", detail: `content drift: want ${want.length} alnum chars, got ${got.length}` });
+  }
+
+  // DETERMINISM (idempotent/pure)
+  const out2 = processNarrativeLines(input, width, quoteColor);
+  if (JSON.stringify(out) !== JSON.stringify(out2)) {
+    v.push({ inv: "DETERMINISM", detail: "non-deterministic output across two runs" });
+  }
+
+  // DETERMINISM — cache transparency: splitting at any blank-DM boundary and
+  // processing prefix+tail separately must equal processing the whole (this is
+  // exactly what NarrativeArea's incremental `useProcessedLines` relies on).
+  for (let i = 1; i < input.length; i++) {
+    const l = input[i];
+    if (l.kind === "dm" && l.text.trim() === "") {
+      const head = processNarrativeLines(input.slice(0, i + 1), width, quoteColor);
+      const tail = processNarrativeLines(input.slice(i + 1), width, quoteColor);
+      if (JSON.stringify([...head, ...tail]) !== JSON.stringify(out)) {
+        v.push({ inv: "DETERMINISM", detail: `split at blank #${i} != whole` });
+      }
+      break; // one representative split is enough per input
+    }
+  }
+
+  return v;
+}

--- a/packages/client-ink/src/tui/narrative/harness/invariants.ts
+++ b/packages/client-ink/src/tui/narrative/harness/invariants.ts
@@ -68,11 +68,13 @@ function checkWellformed(nodes: FormattingNode[], out: Violation[]): void {
   }
 }
 
-/** Plain text of all DM/player output rows, joined — what the reader sees. */
+/** Plain text of all DM/player/list output rows, joined — what the reader sees.
+ *  List rows prepend their resolved marker (the reader sees the `1.`/`•`), so an
+ *  ordered list's ordinal digits are counted as content, not dropped. */
 function outputText(lines: ProcessedLine[]): string {
   return lines
     .filter((l) => l.kind === "dm" || l.kind === "player" || l.kind === "list")
-    .map((l) => toPlainText(l.nodes))
+    .map((l) => (l.kind === "list" && l.listMarker !== undefined ? `${l.listMarker} ` : "") + toPlainText(l.nodes))
     .join(" ");
 }
 

--- a/packages/client-ink/src/tui/narrative/harness/invariants.ts
+++ b/packages/client-ink/src/tui/narrative/harness/invariants.ts
@@ -116,8 +116,9 @@ export function checkInvariants(
       }
     }
 
-    // ALIGN
-    if (line.alignment) {
+    // ALIGN (skipped with wrapping disabled — `padWidth` is 0 there, which is
+    // not a meaningful column target, matching the WIDTH guard above).
+    if (width > 0 && line.alignment) {
       if (line.padWidth === undefined) {
         v.push({ inv: "ALIGN", detail: "aligned row missing padWidth" });
       } else if (stringWidth(plain) > line.padWidth) {

--- a/packages/client-ink/src/tui/narrative/layout.test.ts
+++ b/packages/client-ink/src/tui/narrative/layout.test.ts
@@ -1,0 +1,105 @@
+import { layoutRuns, splitOnLinebreaks } from "./layout.js";
+import { parseFormatting, processNarrativeLines, toPlainText } from "../formatting.js";
+import { stringWidth } from "../frames/string-width.js";
+import type { FormattingTag, NarrativeLine } from "@machine-violet/shared/types/tui.js";
+
+const dm = (text: string): NarrativeLine => ({ kind: "dm", text });
+const rowWidth = (nodes: import("@machine-violet/shared/types/tui.js").FormattingNode[]): number =>
+  stringWidth(toPlainText(nodes));
+
+describe("splitOnLinebreaks", () => {
+  it("splits a flat run at <br> leaves", () => {
+    const segs = splitOnLinebreaks(parseFormatting("a<br>b<br>c"));
+    expect(segs.map(toPlainText)).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves tag nesting across a break", () => {
+    const segs = splitOnLinebreaks(parseFormatting("<b>one<br>two</b>"));
+    expect(segs).toHaveLength(2);
+    expect((segs[0][0] as FormattingTag).type).toBe("bold");
+    expect((segs[1][0] as FormattingTag).type).toBe("bold");
+    expect(segs.map(toPlainText)).toEqual(["one", "two"]);
+  });
+
+  it("yields an empty segment for consecutive breaks", () => {
+    const segs = splitOnLinebreaks(parseFormatting("a<br><br>b"));
+    expect(segs.map(toPlainText)).toEqual(["a", "", "b"]);
+  });
+});
+
+describe("layoutRuns", () => {
+  it("returns a short run as one row", () => {
+    expect(layoutRuns(parseFormatting("hello there"), 80).map(toPlainText)).toEqual(["hello there"]);
+  });
+
+  it("word-wraps by width", () => {
+    const rows = layoutRuns(parseFormatting("aaa bbb ccc ddd"), 8).map(toPlainText);
+    expect(rows).toEqual(["aaa bbb", "ccc ddd"]);
+  });
+
+  it("hard-breaks a single token wider than the row", () => {
+    const rows = layoutRuns(parseFormatting("abcdefghij"), 5).map(toPlainText);
+    expect(rows).toEqual(["abcde", "fghij"]);
+  });
+
+  it("hard-breaks a styled long token, preserving the tag on each piece", () => {
+    const rows = layoutRuns(parseFormatting("<b>abcdefghij</b>"), 5);
+    expect(rows.map(toPlainText)).toEqual(["abcde", "fghij"]);
+    for (const row of rows) {
+      expect(row.some((n) => typeof n !== "string" && n.type === "bold")).toBe(true);
+    }
+  });
+
+  it("measures by DISPLAY width — CJK counts double", () => {
+    // 4 CJK chars = 8 display columns; width 5 → two rows of 2 chars (4 cols).
+    const rows = layoutRuns(parseFormatting("你好世界"), 5);
+    for (const row of rows) expect(rowWidth(row)).toBeLessThanOrEqual(5);
+    expect(rows.map(toPlainText).join("")).toBe("你好世界");
+  });
+
+  it("splits a run on <br> then wraps each segment", () => {
+    const rows = layoutRuns(parseFormatting("alpha beta<br>gamma delta epsilon"), 11).map(toPlainText);
+    expect(rows[0]).toBe("alpha beta");
+    expect(rows.join(" ")).toContain("gamma delta");
+  });
+
+  it("does not wrap at width 0", () => {
+    expect(layoutRuns(parseFormatting("a b c d e"), 0).map(toPlainText)).toEqual(["a b c d e"]);
+  });
+});
+
+describe("processNarrativeLines — width safety (INV-WIDTH)", () => {
+  it("wraps a long centered banner instead of overflowing", () => {
+    const result = processNarrativeLines(
+      [dm("<center>This is a very long centered banner line that exceeds the width</center>")],
+      20,
+    );
+    const centered = result.filter((l) => l.alignment === "center");
+    expect(centered.length).toBeGreaterThan(1);
+    for (const line of centered) {
+      expect(rowWidth(line.nodes)).toBeLessThanOrEqual(20);
+      expect(line.padWidth).toBe(20);
+    }
+  });
+
+  it("renders a multi-line <br> sign as independent centered rows", () => {
+    const result = processNarrativeLines(
+      [dm("<center><color=#cc0000>OCCUPANCY VERIFIED: 2</color><br><color=#20b2aa>TRANSIT AUTHORIZED</color></center>")],
+      80,
+    );
+    const centered = result.filter((l) => l.alignment === "center");
+    const texts = centered.map((l) => toPlainText(l.nodes));
+    expect(texts).toContain("OCCUPANCY VERIFIED: 2");
+    expect(texts).toContain("TRANSIT AUTHORIZED");
+    // No literal <br> leaked anywhere.
+    for (const l of result) expect(toPlainText(l.nodes)).not.toContain("<br>");
+  });
+
+  it("keeps every wrapped prose row within the terminal width", () => {
+    const long = "supercalifragilisticexpialidocious " + "word ".repeat(30).trim();
+    const result = processNarrativeLines([dm(long)], 24);
+    for (const line of result) {
+      if (line.kind === "dm") expect(rowWidth(line.nodes)).toBeLessThanOrEqual(24);
+    }
+  });
+});

--- a/packages/client-ink/src/tui/narrative/layout.ts
+++ b/packages/client-ink/src/tui/narrative/layout.ts
@@ -1,0 +1,150 @@
+/**
+ * Width-correct line layout for the DM narrative pipeline.
+ *
+ * Unlike the legacy `wrapNodes` (which the modals still use, and which measures
+ * code units and never breaks long tokens or wraps alignment), this engine:
+ *   - measures by DISPLAY width (the real `string-width`, matching Ink's layout),
+ *   - hard-breaks a single token wider than the row,
+ *   - splits a run on `linebreak` (`<br>`) leaves into independent rows,
+ *   - keeps wikilinks atomic and preserves tag structure across rows.
+ *
+ * It is the load-bearing fix for INV-WIDTH: every physical row it emits fits the
+ * target width. Aligned blocks pass their inner content through `layoutRuns` and
+ * pad each resulting row, which is what lets a multi-line `<br>` sign render as N
+ * width-safe centered rows instead of one overflowing line.
+ */
+import type { FormattingNode, FormattingTag } from "@machine-violet/shared/types/tui.js";
+import { stringWidth } from "../frames/string-width.js";
+import { toPlainText, nodeDisplayWidth, flattenToWords } from "../formatting.js";
+
+/**
+ * Lay out an inline run into physical rows that each fit `width` display columns.
+ * Splits on `<br>` leaves first, then word-wraps each segment. With `width <= 0`
+ * returns the nodes unwrapped (a single row) — callers use 0 to disable wrapping.
+ */
+export function layoutRuns(nodes: FormattingNode[], width: number): FormattingNode[][] {
+  if (width <= 0) return [nodes];
+  const rows: FormattingNode[][] = [];
+  for (const segment of splitOnLinebreaks(nodes)) {
+    for (const row of wrapSegment(segment, width)) rows.push(row);
+  }
+  return rows.length > 0 ? rows : [nodes];
+}
+
+/**
+ * Split a node array at `linebreak` leaves into segments, preserving tag nesting
+ * across the break (so `<b>a<br>b</b>` → `[<b>a</b>], [<b>b</b>]`).
+ */
+export function splitOnLinebreaks(nodes: FormattingNode[]): FormattingNode[][] {
+  const segments: FormattingNode[][] = [[]];
+  const push = (n: FormattingNode) => segments[segments.length - 1].push(n);
+  for (const node of nodes) {
+    if (typeof node === "string") { push(node); continue; }
+    if (node.type === "linebreak") { segments.push([]); continue; }
+    if (!("content" in node)) { push(node); continue; }
+    const inner = splitOnLinebreaks(node.content);
+    for (let k = 0; k < inner.length; k++) {
+      const wrapped = { ...node, content: inner[k] } as FormattingTag;
+      if (k === 0) push(wrapped);
+      else segments.push([wrapped]);
+    }
+  }
+  return segments;
+}
+
+/** Greedy word-wrap one linebreak-free run by display width, hard-breaking any
+ *  single token that is wider than the row. */
+function wrapSegment(nodes: FormattingNode[], width: number): FormattingNode[][] {
+  if (nodeDisplayWidth(nodes) <= width) return [nodes];
+
+  const raw: { nodes: FormattingNode[]; visible: number }[] = [];
+  flattenToWords(nodes, raw);
+  const words = raw.map((w) => ({ nodes: w.nodes, width: nodeDisplayWidth(w.nodes) }));
+  if (words.length === 0) return [nodes];
+
+  const rows: FormattingNode[][] = [];
+  let cur: FormattingNode[] = [];
+  let curW = 0;
+  const flush = () => { if (cur.length > 0) { rows.push(cur); cur = []; curW = 0; } };
+
+  for (const word of words) {
+    if (word.width > width) {
+      // A single token wider than the row — break it across rows so no row
+      // overflows. The current row is flushed first so the break starts clean.
+      flush();
+      const broken = hardBreak(word.nodes, width);
+      if (broken.length === 0) { rows.push(word.nodes); continue; }
+      // All but the last broken chunk are complete rows; the last seeds `cur`
+      // so the next word can continue on the same row if it fits.
+      for (let k = 0; k < broken.length - 1; k++) rows.push(broken[k]);
+      cur = broken[broken.length - 1];
+      curW = nodeDisplayWidth(cur);
+      continue;
+    }
+    if (curW > 0 && curW + 1 + word.width > width) flush();
+    if (curW > 0) { cur.push(" "); curW += 1; }
+    cur.push(...word.nodes);
+    curW += word.width;
+  }
+  flush();
+  return rows.length > 0 ? rows : [nodes];
+}
+
+/**
+ * Hard-break one over-width word fragment into rows that each fit `width`,
+ * preserving tag structure. Handles arbitrary fragments — a plain long token, a
+ * styled run (`<color>████…</color>`), a styled run with glued punctuation
+ * (`…</color>.`), or nested tags — by walking the fragment and emitting
+ * width-bounded pieces, re-wrapping each in its enclosing tags.
+ */
+function hardBreak(nodes: FormattingNode[], width: number): FormattingNode[][] {
+  const rows = chunkNodes(nodes, Math.max(1, width));
+  return rows.length > 0 ? rows : [nodes];
+}
+
+function chunkNodes(nodes: FormattingNode[], max: number): FormattingNode[][] {
+  const rows: FormattingNode[][] = [[]];
+  let curW = 0;
+  const newRow = () => { rows.push([]); curW = 0; };
+
+  const emitString = (s: string) => {
+    let buf = "";
+    let bw = 0;
+    for (const ch of s) {
+      const cw = stringWidth(ch);
+      if (curW + bw + cw > max && curW + bw > 0) {
+        if (buf) { rows[rows.length - 1].push(buf); buf = ""; bw = 0; }
+        newRow();
+      }
+      buf += ch;
+      bw += cw;
+    }
+    if (buf) { rows[rows.length - 1].push(buf); curW += bw; }
+  };
+
+  const walk = (ns: FormattingNode[]) => {
+    for (const n of ns) {
+      if (typeof n === "string") { emitString(n); continue; }
+      if (n.type === "linebreak") continue; // a word never contains a hard break
+      if (!("content" in n)) continue;
+      // Break the tag's content into rows, then re-wrap each row-slice in a copy
+      // of the tag; each inner row boundary forces a new outer row.
+      const inner = chunkNodes(n.content, max);
+      for (let k = 0; k < inner.length; k++) {
+        if (k > 0) newRow();
+        const wrapped = { ...n, content: inner[k] } as FormattingTag;
+        const w = nodeDisplayWidth([wrapped]);
+        if (curW + w > max && curW > 0) newRow();
+        rows[rows.length - 1].push(wrapped);
+        curW += w;
+      }
+    }
+  };
+
+  walk(nodes);
+  return rows;
+}
+
+// Re-export for layout tests that need the display measure without reaching
+// through formatting.ts.
+export { nodeDisplayWidth, toPlainText };

--- a/packages/client-ink/src/tui/narrative/layout.ts
+++ b/packages/client-ink/src/tui/narrative/layout.ts
@@ -18,6 +18,17 @@ import { stringWidth } from "../frames/string-width.js";
 import { toPlainText, nodeDisplayWidth, flattenToWords } from "../formatting.js";
 
 /**
+ * Left rule glyph the Ink renderer prefixes to every `<quote>` row. U+258F LEFT
+ * ONE EIGHTH BLOCK — a thin, full-height vertical bar that reads as a blockquote
+ * border without stealing a full column of ink. The pipeline reserves
+ * {@link QUOTE_PREFIX_COLS} columns (rule + one space) when wrapping quote
+ * content, so the prefixed row still fits the target width (INV-WIDTH).
+ */
+export const QUOTE_RULE = "▏";
+/** Columns reserved for the quote rule + its trailing space. */
+export const QUOTE_PREFIX_COLS = 2;
+
+/**
  * Lay out an inline run into physical rows that each fit `width` display columns.
  * Splits on `<br>` leaves first, then word-wraps each segment. With `width <= 0`
  * returns the nodes unwrapped (a single row) — callers use 0 to disable wrapping.

--- a/packages/client-ink/src/tui/narrative/normalize.test.ts
+++ b/packages/client-ink/src/tui/narrative/normalize.test.ts
@@ -1,0 +1,82 @@
+import { normalizeDialect } from "./normalize.js";
+
+describe("normalizeDialect", () => {
+  it("passes plain prose through untouched (fast path)", () => {
+    expect(normalizeDialect("The door creaks open.")).toBe("The door creaks open.");
+    expect(normalizeDialect("")).toBe("");
+  });
+
+  it("is idempotent on already-canonical markup", () => {
+    const canon = "<b>Bold</b> and <color=#ff0000>red</color> and <i>flavor</i>";
+    expect(normalizeDialect(canon)).toBe(canon);
+  });
+
+  describe("HTML synonyms → canonical tags", () => {
+    it("maps semantic emphasis tags", () => {
+      expect(normalizeDialect("<strong>loud</strong>")).toBe("<b>loud</b>");
+      expect(normalizeDialect("<em>soft</em>")).toBe("<i>soft</i>");
+    });
+
+    it("strips attributes from known tags", () => {
+      expect(normalizeDialect(`<b class="x">hi</b>`)).toBe("<b>hi</b>");
+      expect(normalizeDialect(`<center style="color:red">SIGN</center>`)).toBe("<center>SIGN</center>");
+      expect(normalizeDialect(`<i data-k="v">y</i>`)).toBe("<i>y</i>");
+    });
+
+    it("canonicalizes <br>, <br/>, <br /> to <br>", () => {
+      expect(normalizeDialect("a<br>b<br/>c<br />d")).toBe("a<br>b<br>c<br>d");
+    });
+
+    it("maps headings (markdown and HTML) to bold", () => {
+      expect(normalizeDialect("## The Vault")).toBe("<b>The Vault</b>");
+      expect(normalizeDialect("# Title #")).toBe("<b>Title</b>");
+      expect(normalizeDialect("<h2>Chapter</h2>")).toBe("<b>Chapter</b>");
+    });
+
+    it("drops strikethrough tags but keeps content (no primitive)", () => {
+      expect(normalizeDialect("<s>gone</s>")).toBe("gone");
+      expect(normalizeDialect("<del>removed</del>")).toBe("removed");
+    });
+
+    it("tolerates quoted/spaced color forms", () => {
+      expect(normalizeDialect(`<color="#abc">x</color>`)).toBe("<color=#abc>x</color>");
+      expect(normalizeDialect(`<color = #ABCDEF >x</color>`)).toBe("<color=#ABCDEF>x</color>");
+    });
+  });
+
+  describe("inline markdown", () => {
+    it("converts **bold** and *italic*", () => {
+      expect(normalizeDialect("**loud** and *soft*")).toBe("<b>loud</b> and <i>soft</i>");
+    });
+
+    it("converts _italic_ but leaves snake_case alone", () => {
+      expect(normalizeDialect("_whispered_")).toBe("<i>whispered</i>");
+      expect(normalizeDialect("the field_notes_id var")).toBe("the field_notes_id var");
+    });
+
+    it("does not mangle arithmetic asterisks", () => {
+      expect(normalizeDialect("3 * 4 = 12")).toBe("3 * 4 = 12");
+    });
+
+    it("strips markdown links to their text and drops images", () => {
+      expect(normalizeDialect("see [the map](x/y.md) now")).toBe("see the map now");
+      expect(normalizeDialect("![alt](pic.png)done")).toBe("done");
+    });
+  });
+
+  describe("inline code protection", () => {
+    it("protects markup inside backtick code spans", () => {
+      expect(normalizeDialect("run `<b>npm</b> **test**` now"))
+        .toBe("run <code><b>npm</b> **test**</code> now");
+    });
+
+    it("normalizes <code> and leaves its content verbatim", () => {
+      expect(normalizeDialect("<code>a *b* c</code>")).toBe("<code>a *b* c</code>");
+    });
+  });
+
+  it("handles a full diegetic-sign line end to end", () => {
+    expect(normalizeDialect("<CENTER><strong>STOP</strong><br/>**proceed**</CENTER>"))
+      .toBe("<center><b>STOP</b><br><b>proceed</b></center>");
+  });
+});

--- a/packages/client-ink/src/tui/narrative/normalize.ts
+++ b/packages/client-ink/src/tui/narrative/normalize.ts
@@ -1,0 +1,92 @@
+/**
+ * Dialect tolerance for DM narration.
+ *
+ * The DM is taught a closed HTML-subset vocabulary (see `dm-directives.md`), but
+ * smarter models reach for semantic HTML (`<strong>`, `<em>`, `<h2>`), structural
+ * variants (`<b class="x">`, `<br/>`), and the occasional markdown. This pass runs
+ * FIRST — before cross-line healing and before `parseFormatting` — and rewrites
+ * those dialects into the canonical vocabulary as a string transform, so the heal
+ * and parse stages only ever see `<b>/<i>/<u>/<sub>/<sup>/<center>/<right>/<code>/`
+ * `<color=#hex>/<br>`.
+ *
+ * It is a *tolerance net*, not the contract: anything it doesn't recognize is still
+ * caught by `parseFormatting`'s strip-to-content fallback (INV-NO-LEAK), so this can
+ * stay deliberately conservative. Block-level markdown (`-`/`1.` lists, `>` quotes,
+ * `|` tables) is NOT handled here — that's the blockify stage, which needs the raw
+ * line structure. Inline code spans are protected first so markup inside them is
+ * left verbatim.
+ */
+
+// NUL — cannot occur in DM narration, so it is a collision-proof placeholder for
+// protected inline-code spans. Built at runtime so the source stays plain ASCII
+// (a literal NUL byte would make git treat this file as binary).
+const SENTINEL = String.fromCharCode(0);
+
+function protect(inner: string, store: string[]): string {
+  const idx = store.length;
+  store.push(inner);
+  return `${SENTINEL}${idx}${SENTINEL}`;
+}
+
+// A well-formed tag: `<name>`, `</name>`, `<name/>`, or `<name key="v" …>` where
+// an attribute section MUST contain `=`. The name must follow `<` immediately —
+// so prose like `< B & C >` (space) or `<b & c>` (bareword "attrs", no `=`) is
+// NOT matched and stays literal. Group 1 = optional `/` (close), group 2 = name.
+const TAG_RE = /<(\/?)([a-zA-Z][a-zA-Z0-9]*)(?:\s+[^<>]*=[^<>]*?)?\s*\/?>/g;
+
+/** Map one well-formed tag into the canonical vocabulary (or "" to drop it, or
+ *  the original text to leave it for the parser's strip-to-content fallback). */
+function rewriteTag(raw: string, close: boolean, name: string): string {
+  switch (name.toLowerCase()) {
+    case "strong": return close ? "</b>" : "<b>";
+    case "em": return close ? "</i>" : "<i>";
+    case "h1": case "h2": case "h3": case "h4": case "h5": case "h6":
+      return close ? "</b>" : "<b>";
+    case "b": case "i": case "u": case "sub": case "sup":
+    case "center": case "right": case "code":
+      // Canonical bare form — drops attributes and normalizes case.
+      return close ? `</${name.toLowerCase()}>` : `<${name.toLowerCase()}>`;
+    case "br": return "<br>";
+    case "s": case "strike": case "del": return ""; // no strikethrough primitive
+    default: return raw; // unknown tag — leave it for parseFormatting to strip
+  }
+}
+
+/**
+ * Rewrite one line of DM narration from its dialect into the canonical formatting
+ * vocabulary. Pure and idempotent on already-canonical input.
+ */
+export function normalizeDialect(text: string): string {
+  // Fast path: nothing markup-ish to rewrite.
+  if (!text || !/[<*_`#[]/.test(text)) return text;
+
+  const code: string[] = [];
+  let s = text;
+
+  // 1. Protect inline code spans (HTML and markdown) — markup inside is verbatim.
+  s = s.replace(/<code\b[^>]*>([\s\S]*?)<\/code\s*>/gi, (_m, inner: string) => protect(inner, code));
+  s = s.replace(/`([^`\n]+)`/g, (_m, inner: string) => protect(inner, code));
+
+  // 2. HTML dialect → canonical tags (synonyms, attribute-strip, headings,
+  //    <br> canonicalization, strikethrough drop). Only well-formed tags match,
+  //    so prose with stray angle brackets is untouched.
+  s = s.replace(TAG_RE, (m, close: string, name: string) => rewriteTag(m, close === "/", name));
+
+  // 3. Markdown headings → bold (line level).
+  s = s.replace(/^(\s*)#{1,6}\s+(.+?)\s*#*\s*$/gm, "$1<b>$2</b>");
+
+  // 4. <color …> — keep only the supported `=#hex` form; tolerate quotes/spaces.
+  s = s.replace(/<\s*color\s*=\s*"?(#[0-9a-fA-F]{3,8})"?\s*>/gi, "<color=$1>")
+       .replace(/<\s*\/\s*color\s*>/gi, "</color>");
+
+  // 5. Inline markdown (block markdown is handled in blockify).
+  s = s.replace(/!\[[^\]\n]*\]\([^)\n]+\)/g, "");            // ![alt](src) → (drop image)
+  s = s.replace(/\[([^\]\n]+)\]\([^)\n]+\)/g, "$1");          // [text](url) → text
+  s = s.replace(/\*\*([^*\n]+?)\*\*/g, "<b>$1</b>");          // **bold** (before *italic*)
+  s = s.replace(/(?<![*\w])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![*\w])/g, "<i>$1</i>"); // *italic*
+  s = s.replace(/(?<![_\w])_(?!\s)([^_\n]+?)(?<!\s)_(?![_\w])/g, "<i>$1</i>");   // _italic_
+
+  // 6. Restore protected code spans as canonical <code>…</code>.
+  s = s.replace(new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, "g"), (_m, n: string) => `<code>${code[+n]}</code>`);
+  return s;
+}

--- a/packages/client-ink/src/tui/narrative/normalize.ts
+++ b/packages/client-ink/src/tui/narrative/normalize.ts
@@ -7,7 +7,7 @@
  * FIRST — before cross-line healing and before `parseFormatting` — and rewrites
  * those dialects into the canonical vocabulary as a string transform, so the heal
  * and parse stages only ever see `<b>/<i>/<u>/<sub>/<sup>/<center>/<right>/<code>/`
- * `<color=#hex>/<br>`.
+ * `<quote>/<color=#hex>/<br>`.
  *
  * It is a *tolerance net*, not the contract: anything it doesn't recognize is still
  * caught by `parseFormatting`'s strip-to-content fallback (INV-NO-LEAK), so this can
@@ -43,9 +43,10 @@ function rewriteTag(raw: string, close: boolean, name: string): string {
     case "h1": case "h2": case "h3": case "h4": case "h5": case "h6":
       return close ? "</b>" : "<b>";
     case "b": case "i": case "u": case "sub": case "sup":
-    case "center": case "right": case "code":
+    case "center": case "right": case "code": case "quote":
       // Canonical bare form — drops attributes and normalizes case.
       return close ? `</${name.toLowerCase()}>` : `<${name.toLowerCase()}>`;
+    case "blockquote": return close ? "</quote>" : "<quote>"; // HTML synonym
     case "br": return "<br>";
     case "s": case "strike": case "del": return ""; // no strikethrough primitive
     default: return raw; // unknown tag — leave it for parseFormatting to strip

--- a/packages/client-ink/src/tui/render-nodes.test.tsx
+++ b/packages/client-ink/src/tui/render-nodes.test.tsx
@@ -59,3 +59,18 @@ describe("renderNodes sub/sup", () => {
     expect(renderToString("x<sup><b>2</b></sup>")).toBe("x²");
   });
 });
+
+describe("renderNodes code + linebreak", () => {
+  it("renders inline <code> content without leaking the tag", () => {
+    const frame = renderToString("run <code>npm test</code> now");
+    expect(frame).toContain("npm test");
+    expect(frame).not.toContain("<code>");
+    expect(frame).not.toContain("</code>");
+  });
+
+  it("renders a <br> as a newline, not literal text", () => {
+    const frame = renderToString("alpha<br>beta");
+    expect(frame).not.toContain("<br>");
+    expect(frame.split("\n").map((l) => l.trim())).toEqual(["alpha", "beta"]);
+  });
+});

--- a/packages/client-ink/src/tui/render-nodes.tsx
+++ b/packages/client-ink/src/tui/render-nodes.tsx
@@ -73,8 +73,9 @@ function renderTag(tag: FormattingTag): React.ReactNode {
     }
     case "center":
     case "right":
-      // Alignment is handled at the NarrativeLine level when this is a
-      // top-level tag. Nested inside other formatting, render children inline.
+    case "quote":
+      // Block tags (alignment, blockquote) are handled at the NarrativeLine
+      // level when top-level. Nested inside other formatting, render inline.
       return <Text>{children}</Text>;
   }
 }

--- a/packages/client-ink/src/tui/render-nodes.tsx
+++ b/packages/client-ink/src/tui/render-nodes.tsx
@@ -11,6 +11,7 @@ function firstColor(content: FormattingNode[]): string | undefined {
   for (const node of content) {
     if (typeof node === "string") continue;
     if (node.type === "color") return node.color;
+    if (node.type === "linebreak") continue;
     const nested = firstColor(node.content);
     if (nested) return nested;
   }
@@ -34,6 +35,12 @@ function renderTag(tag: FormattingTag): React.ReactNode {
   if (tag.type === "superscript") {
     return <Text>{renderNodes(transformText(tag.content, SUPERSCRIPT_MAP))}</Text>;
   }
+  // Hard line break. On the narrative path layout has already split rows, so a
+  // linebreak should not reach here; if one does (e.g. a modal feeding raw
+  // inline nodes), render it as a newline rather than dropping content.
+  if (tag.type === "linebreak") {
+    return "\n";
+  }
 
   const children = renderNodes(tag.content);
 
@@ -44,6 +51,10 @@ function renderTag(tag: FormattingTag): React.ReactNode {
       return <Text italic>{children}</Text>;
     case "underline":
       return <Text underline>{children}</Text>;
+    case "code":
+      // Inline monospace: terminals are already monospace, so distinguish code
+      // spans by dimming — the least-surprising, theme-agnostic affordance.
+      return <Text dimColor>{children}</Text>;
     case "color":
       return <Text color={tag.color}>{children}</Text>;
     case "wikilink": {
@@ -109,6 +120,7 @@ function transformText(
     // Pre-substituting would double-transform chars present in both maps
     // (e.g. digits), breaking H<sub>1<sup>2</sup></sub> → "₁²".
     if (node.type === "subscript" || node.type === "superscript") return node;
+    if (node.type === "linebreak") return node; // contentless leaf
     return { ...node, content: transformText(node.content, map) } as FormattingTag;
   });
 }

--- a/packages/client-ink/src/tui/wikilink-nav.ts
+++ b/packages/client-ink/src/tui/wikilink-nav.ts
@@ -84,6 +84,7 @@ function walk(nodes: FormattingNode[], visit: (tag: FormattingTag) => void): voi
   for (const node of nodes) {
     if (typeof node === "string") continue;
     visit(node);
+    if (node.type === "linebreak") continue; // contentless leaf
     walk(node.content, visit);
   }
 }
@@ -95,6 +96,7 @@ function mapNodes(
 ): FormattingNode[] {
   return nodes.map((node) => {
     if (typeof node === "string") return node;
+    if (node.type === "linebreak") return transform(node); // contentless leaf
     const mappedContent = mapNodes(node.content, transform);
     const rebuilt = mappedContent === node.content ? node : ({ ...node, content: mappedContent } as FormattingTag);
     return transform(rebuilt);

--- a/packages/engine/src/prompts/dev-mode.md
+++ b/packages/engine/src/prompts/dev-mode.md
@@ -92,10 +92,12 @@ When mutating, report what changed: before → after.
 
 Your replies render through the same pipeline as DM narration. Do not use Markdown. These HTML-subset tags are available:
 - `<b>bold</b>`, `<i>italic</i>`, `<u>underline</u>`
+- `<code>monospace</code>` — identifiers, keys, paths, raw values (renders dim; ideal for technical output)
 - `<sub>subscript</sub>` — array indices (a<sub>i</sub>), chemical formulas (H<sub>2</sub>O), footnote markers
 - `<sup>superscript</sup>` — exponents (2<sup>32</sup>), units (m<sup>2</sup>), ordinals (1<sup>st</sup>), footnote callouts
 - `<color=#HEX>text</color>` — color (useful for diffs: `<color=#cc0000>-old</color>` / `<color=#44cc44>+new</color>`)
-- `<center>…</center>`, `<right>…</right>` — alignment (must be on their own line)
+- `<center>…</center>`, `<right>…</right>` — alignment (content wraps to width; use `<br>` for multiple lines)
+- `<br>` — a hard line break
 - `---` on its own line — horizontal separator
 
 Use formatting sparingly. Raw data blocks don't need decoration; results summaries benefit from selective highlighting.

--- a/packages/engine/src/prompts/dev-mode.md
+++ b/packages/engine/src/prompts/dev-mode.md
@@ -97,8 +97,10 @@ Your replies render through the same pipeline as DM narration. Do not use Markdo
 - `<sup>superscript</sup>` — exponents (2<sup>32</sup>), units (m<sup>2</sup>), ordinals (1<sup>st</sup>), footnote callouts
 - `<color=#HEX>text</color>` — color (useful for diffs: `<color=#cc0000>-old</color>` / `<color=#44cc44>+new</color>`)
 - `<center>…</center>`, `<right>…</right>` — alignment (content wraps to width; use `<br>` for multiple lines)
+- `<quote>…</quote>` — an indented, left-ruled block (for a quoted record, log excerpt, or readout)
 - `<br>` — a hard line break
 - `---` on its own line — horizontal separator
+- a `- `/`1.` Markdown list renders as tidy bullets/numbers with hanging indent — handy for enumerated diagnostic output
 
 Use formatting sparingly. Raw data blocks don't need decoration; results summaries benefit from selective highlighting.
 

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -101,10 +101,13 @@ The DM narrates using the following HTML formatting subset (not Markdown!):
 - <color=#HEX>colored text</color> — any color, for flavor
 - <center>centered text</center> — titles, dramatic reveals, diegetic signs and announcements (auto-adds spacing)
 - <right>right-aligned text</right> (auto-adds spacing)
-- <br> — a hard line break. Use it for multi-line diegetic displays inside an alignment block — a station sign, a console readout, a printed plate: `<center><color=#cc0000>OCCUPANCY VERIFIED</color><br><color=#20b2aa>TRANSIT AUTHORIZED</color></center>` renders as two centered rows.
+- <quote>set-apart passage</quote> — a letter, an inscription, a remembered line, a terminal readout: renders as an indented block with a left rule (auto-adds spacing). Multi-line with <br>.
+- <br> — a hard line break. Use it for multi-line diegetic displays inside an alignment or quote block — a station sign, a console readout, a printed plate: `<center><color=#cc0000>OCCUPANCY VERIFIED</color><br><color=#20b2aa>TRANSIT AUTHORIZED</color></center>` renders as two centered rows.
 - `---` — horizontal separator (renders as a themed divider; costs 3 screen lines including spacing)
 
-Tags nest freely (`<center><b><color=#HEX>…</color></b></center>`) and wrap safely to the terminal width — even a long centered banner is reflowed across rows rather than clipped. The renderer also tolerates the common dialects (e.g. <strong>/<em>, an occasional bit of Markdown) by mapping them onto this set, but author the tags above directly.
+A short Markdown list also renders cleanly — lines beginning `- `/`* ` become tidy `•` bullets, and `1.`/`2.` become a numbered list, both with hanging indent and width-safe wrapping. Reach for it only for genuinely enumerable in-world content (an inventory, an itinerary, a notebook page, a system menu) — never as a substitute for flowing prose.
+
+Tags nest freely (`<center><b><color=#HEX>…</color></b></center>`) and wrap safely to the terminal width — even a long centered banner or a multi-line quote is reflowed across rows rather than clipped. The renderer also tolerates the common dialects (e.g. <strong>/<em>, <blockquote>, an occasional bit of Markdown) by mapping them onto this set, but author the tags above directly.
 
 Notable objects, character names, and location names are color-coded (and can change based on relationship shifts):
 - <color=#20b2aa>notable objects</color> (teal) — items, artifacts, environmental features

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -95,12 +95,16 @@ The DM narrates using the following HTML formatting subset (not Markdown!):
 - <b>bold</b> — dramatic emphasis
 - <i>italic</i> — flavor, whispered asides
 - <u>underline</u> — important names, titles, or diegetic text
+- <code>monospace</code> — diegetic system text, UI labels, identifiers, terminal output
 - <sub>subscript</sub> — chemical formulas (H<sub>2</sub>O)
 - <sup>superscript</sup> — exponents (E=mc<sup>2</sup>), ordinals (1<sup>st</sup>), footnote markers (<sup>*</sup>, <sup>1</sup>)
 - <color=#HEX>colored text</color> — any color, for flavor
 - <center>centered text</center> — titles, dramatic reveals, diegetic signs and announcements (auto-adds spacing)
 - <right>right-aligned text</right> (auto-adds spacing)
+- <br> — a hard line break. Use it for multi-line diegetic displays inside an alignment block — a station sign, a console readout, a printed plate: `<center><color=#cc0000>OCCUPANCY VERIFIED</color><br><color=#20b2aa>TRANSIT AUTHORIZED</color></center>` renders as two centered rows.
 - `---` — horizontal separator (renders as a themed divider; costs 3 screen lines including spacing)
+
+Tags nest freely (`<center><b><color=#HEX>…</color></b></center>`) and wrap safely to the terminal width — even a long centered banner is reflowed across rows rather than clipped. The renderer also tolerates the common dialects (e.g. <strong>/<em>, an occasional bit of Markdown) by mapping them onto this set, but author the tags above directly.
 
 Notable objects, character names, and location names are color-coded (and can change based on relationship shifts):
 - <color=#20b2aa>notable objects</color> (teal) — items, artifacts, environmental features

--- a/packages/engine/src/prompts/setup-conversation.md
+++ b/packages/engine/src/prompts/setup-conversation.md
@@ -83,7 +83,8 @@ You can use these HTML-like tags in your messages for dramatic effect and visual
 - <color=#HEX>colored text</color> — for thematic color (e.g. <color=#cc0000>blood red</color>, <color=#4488ff>arcane blue</color>, <color=#44cc44>verdant green</color>)
 - <center>centered text</center> — for titles, dramatic reveals, section headers (auto-adds spacing)
 - <right>right-aligned text</right> — for timestamps, attributions (auto-adds spacing)
-- <br> — a hard line break; inside a `<center>`/`<right>` block it makes a multi-line sign, each line its own aligned row (e.g. `<center><b>{Title}</b><br><i>{subtitle}</i></center>`)
+- <quote>set-apart passage</quote> — for an epigraph, an inscription, a remembered line: an indented block with a left rule (auto-adds spacing)
+- <br> — a hard line break; inside a `<center>`/`<right>`/`<quote>` block it makes a multi-line sign, each line its own row (e.g. `<center><b>{Title}</b><br><i>{subtitle}</i></center>`)
 
 Use formatting to create visual rhythm and break up walls of text. A strategically-placed newline, a bold campaign title, a colored genre tag, an italic atmospheric line — these make the experience feel polished rather than like reading a paragraph.
 

--- a/packages/engine/src/prompts/setup-conversation.md
+++ b/packages/engine/src/prompts/setup-conversation.md
@@ -77,11 +77,13 @@ You can use these HTML-like tags in your messages for dramatic effect and visual
 - <b>bold</b> — for emphasis, key terms, dramatic moments
 - <i>italic</i> — for flavor text, whispered asides, evocative descriptions
 - <u>underline</u> — for important names or titles
+- <code>monospace</code> — for system text, identifiers, code-like or diegetic UI elements
 - <sub>subscript</sub> — for chemical formulas (H<sub>2</sub>O), footnote markers
 - <sup>superscript</sup> — for exponents (E=mc<sup>2</sup>), ordinals (1<sup>st</sup>), footnote callouts
 - <color=#HEX>colored text</color> — for thematic color (e.g. <color=#cc0000>blood red</color>, <color=#4488ff>arcane blue</color>, <color=#44cc44>verdant green</color>)
 - <center>centered text</center> — for titles, dramatic reveals, section headers (auto-adds spacing)
 - <right>right-aligned text</right> — for timestamps, attributions (auto-adds spacing)
+- <br> — a hard line break; inside a `<center>`/`<right>` block it makes a multi-line sign, each line its own aligned row (e.g. `<center><b>{Title}</b><br><i>{subtitle}</i></center>`)
 
 Use formatting to create visual rhythm and break up walls of text. A strategically-placed newline, a bold campaign title, a colored genre tag, an italic atmospheric line — these make the experience feel polished rather than like reading a paragraph.
 

--- a/packages/shared/src/types/blocks.ts
+++ b/packages/shared/src/types/blocks.ts
@@ -1,0 +1,58 @@
+/**
+ * Block layer for the DM narrative pipeline.
+ *
+ * The narrative pipeline is two-level: an INLINE level (`FormattingNode` in
+ * `tui.ts` — text + bold/italic/color/code/linebreak/… spans) and this BLOCK
+ * level. `NarrativeLine[]` (from the streaming `appendDelta`) is normalized,
+ * healed, and parsed into `Block[]`, then a width-correct layout engine turns
+ * each block into one-or-more physical `ProcessedLine` rows.
+ *
+ * This module is intentionally React-free (only types + the `FormattingNode`
+ * inline AST) so it can be imported by both Ink and HTML renderers and by the
+ * engine's display-log round-trip without pulling in ink/React.
+ */
+import type { FormattingNode, ImageIntent } from "./tui.js";
+
+/** One inline run (a flat `FormattingNode[]`), e.g. one row of an aligned block. */
+export interface InlineRun {
+  nodes: FormattingNode[];
+}
+
+/** One item of a list block. */
+export interface ListItem {
+  /** The item's own inline content (may itself wrap across rows at layout). */
+  inline: FormattingNode[];
+  /** Nesting depth (0 = top level). Drives marker glyph + indent. */
+  depth: number;
+  /** 1-based ordinal for ordered lists; absent for unordered. */
+  ordinal?: number;
+  /** Nested sub-items (for nested lists). */
+  children?: ListItem[];
+}
+
+/**
+ * A narrative block. Blockify produces these from healed/parsed narrative
+ * lines; layout consumes them into `ProcessedLine[]`.
+ */
+export type Block =
+  // A flowing prose paragraph. `inline` may contain `linebreak` nodes (hard
+  // breaks) which layout honors without resetting formatting.
+  | { type: "paragraph"; inline: FormattingNode[] }
+  // A centered/right-aligned block. `rows` are the `<br>`-separated lines; each
+  // wraps and pads to the target width independently (so a multi-line sign is N
+  // aligned rows, not one overflowing row).
+  | { type: "aligned"; align: "center" | "right"; rows: InlineRun[] }
+  // An ordered/unordered list (possibly nested via `items[].children`).
+  | { type: "list"; ordered: boolean; items: ListItem[] }
+  // A markdown blockquote (`> …`) — distinct from inline dialogue-quote tinting.
+  | { type: "quote"; inline: FormattingNode[] }
+  // A themed horizontal divider (from `---`/`***`/`___`).
+  | { type: "separator" }
+  // A visual blank row that is INVISIBLE to healing (a single `\n` spacer).
+  | { type: "spacer" }
+  // A real paragraph-boundary blank (a `\n\n`) — resets heal + quote state.
+  | { type: "blank" }
+  // An inline image; `path` is the absolute PNG path the renderer loads.
+  | { type: "image"; path: string; intent: ImageIntent }
+  // A non-DM line carried through verbatim (player / system / dev).
+  | { type: "raw"; kind: "player" | "system" | "dev"; text: string };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -6,6 +6,7 @@ export * from "./combat.js";
 export * from "./entities.js";
 export * from "./config.js";
 export * from "./tui.js";
+export * from "./blocks.js";
 export * from "./facets.js";
 export * from "./objectives.js";
 export * from "./resolve-session.js";

--- a/packages/shared/src/types/tui.ts
+++ b/packages/shared/src/types/tui.ts
@@ -55,9 +55,21 @@ export type FormattingTag =
       content: FormattingNode[];
       selected?: boolean;
       broken?: boolean;
-    };
+    }
+  // Hard line break (from `<br>`). A contentless leaf — it carries no text and
+  // zero display width. On the narrative path the layout engine splits aligned
+  // rows on these (so a multi-line centered sign becomes N padded rows); it is
+  // structural, NOT a heal-stack tag (a `<br>` never resets open formatting the
+  // way a blank DM line does). Generic node-walkers treat it as empty.
+  | { type: "linebreak" }
+  // Inline monospace (from `<code>` / `` `backtick` ``). Behaves like the other
+  // styling tags for wrapping/quoting; its content is not re-parsed for tags.
+  | { type: "code"; content: FormattingNode[] };
 
 export type FormattingNode = string | FormattingTag;
+
+/** Framing intent carried by an inline image, chosen by the engine. */
+export type ImageIntent = "scene_snapshot" | "player_request" | "character_portrait";
 
 /** Typed narrative line — only "dm" lines enter the formatting/heal/quote pipeline. */
 export type NarrativeLine =
@@ -81,21 +93,36 @@ export type NarrativeLine =
   | {
       kind: "image";
       text: string;
-      intent: "scene_snapshot" | "player_request" | "character_portrait";
+      intent: ImageIntent;
       tag?: string;
     };
 
-/** A fully processed line ready for rendering — nodes are pre-parsed, healed, wrapped, and quote-highlighted. */
+/**
+ * A fully processed PHYSICAL line ready for rendering — nodes are pre-parsed,
+ * healed, wrapped (by display width), and quote-highlighted. One ProcessedLine
+ * is exactly one terminal row.
+ */
 export interface ProcessedLine {
-  kind: NarrativeLine["kind"];
+  kind: NarrativeLine["kind"] | "list";
   nodes: FormattingNode[];
   alignment?: "center" | "right";
+  /**
+   * Full column width an aligned row pads/centers within. Set on aligned rows
+   * so the Ink (`Box justifyContent`) and HTML (`text-align`) renderers agree on
+   * the same field, and so a wrapped aligned block's rows each pad to `padWidth`.
+   */
+  padWidth?: number;
+  /** First row of a list item: the resolved marker (`•`, `1.`, …). */
+  listMarker?: string;
+  /** Leading indent (columns) for a list row — hanging-indent continuation rows
+   *  carry this without a `listMarker`. */
+  listIndent?: number;
   /**
    * Carried through from the source `image` NarrativeLine so the renderer can
    * pick framing — notably, portrait-aspect character portraits are contained
    * (fit-to-height, narrow) rather than filling the wide scene footprint.
    */
-  intent?: Extract<NarrativeLine, { kind: "image" }>["intent"];
+  intent?: ImageIntent;
 }
 
 export interface ActivityIndicator {

--- a/packages/shared/src/types/tui.ts
+++ b/packages/shared/src/types/tui.ts
@@ -64,7 +64,13 @@ export type FormattingTag =
   | { type: "linebreak" }
   // Inline monospace (from `<code>` / `` `backtick` ``). Behaves like the other
   // styling tags for wrapping/quoting; its content is not re-parsed for tags.
-  | { type: "code"; content: FormattingNode[] };
+  | { type: "code"; content: FormattingNode[] }
+  // A set-apart quoted passage (from `<quote>` — a letter, inscription, console
+  // readout). Block-level like `center`/`right`: on the narrative path it is
+  // split onto its own line and the layout engine wraps its content to a reduced
+  // width, so each row renders with a left rule. Deliberately NOT markdown `> `,
+  // which collides with the player display-log marker. Multi-line via `<br>`.
+  | { type: "quote"; content: FormattingNode[] };
 
 export type FormattingNode = string | FormattingTag;
 


### PR DESCRIPTION
## What & why

As DM models get smarter they emit increasingly acrobatic, nested formatting. The old renderer accepted a closed HTML-subset vocabulary and broke outside it. A deterministic census over the on-disk campaign corpus (294 DM turns × 6 widths) measured the damage against the **real** renderer:

- **96 literal-markup leaks** — unknown/legal-but-unhandled tags rendering as raw text (dominant real case: `<br>` inside a `<center>` diegetic sign).
- **70 width overflows** — even supported `<center>`/`<right>` blocks never wrapped, and wrap measured `String.length` (code units) not display columns, so wide glyphs and long tokens overflowed any narrow pane.

This PR re-platforms the pipeline so **any legal combination of the formatting vocabulary renders correctly**, proven offline by an exhaustive, LLM-free invariant harness — then extends the vocabulary.

## The re-platform (`23c0a3a`)

Single chokepoint stays `processNarrativeLines` → one `FormattingTag` AST → two renderers (Ink `render-nodes.tsx`, HTML `transcript.ts`). New layers under `packages/client-ink/src/tui/narrative/`:

- **`normalize.ts`** — dialect tolerance: semantic HTML (`<strong>`/`<em>`/`<h1-6>`), attribute variants, inline Markdown → canonical set, runs first.
- **`layout.ts` (`layoutRuns`)** — width-correct wrap by **display columns** (real `string-width`, wired through `frames/string-width.ts`), hard-breaks overlong tokens, splits on `<br>`, wraps + pads aligned blocks.
- Vocabulary gained `<br>` (a contentless `linebreak` leaf) and inline `<code>`. Unknown tag-shaped runs are **stripped to content** (no leak); a bare non-tag `<` stays literal.

**The harness is the gate** (`narrative/harness/`): invariants = no-leak / width / content-preservation / well-formed / align / cache-transparent determinism, over synthetic fixtures + a seeded generator + committed real campaign display-logs. Empirically drove the baseline **leak 96→0, width 70→0** over the real corpus at widths {24,40,52,64,80,100,120}.

## Vocabulary additions

- **`<br>` / `<code>`** taught to the setup + dev-mode agents (`bdafd28`).
- **`<quote>`** (`ea0e511`) — a block tag for a set-apart passage (letter, inscription, readout): indented block with a left rule `▏`, content wrapped to width − rule, multi-line via `<br>`. Deliberately **not** Markdown `>`, which collides with the player display-log marker (a DM `> …` line would round-trip into a *player* turn on resume).
- **Markdown lists** (`ea0e511`) — tolerated + lightly taught: `- `/`* `/`N.` → tidy `•`/numbered rows with hanging indent + width-safe wrap, rendered tight (the per-newline spacer between items is collapsed; determinism-safe). Nesting intentionally flattened (none in the corpus).

Both new constructs render in Ink **and** the HTML transcript, and are covered by new generator productions + fixtures + render-level cases.

## Testing

- `npm run check` — lint clean, **3481 passed / 13 skipped**.
- `MV_FORMAT_SOAK=1` — 6000 seeded legal documents × all 7 widths, zero violations.
- `MV_LIVE_CORPUS=<dir>` — clean over the real machine campaigns at all widths (recreates the offline baseline: leak 96→0, width 70→0).
- `npm run golden:verify` — unchanged (goldens are render-independent).

Docs synced in the same commits (`docs/tui-design.md`, `docs/maintenance.md`, `dm-directives.md`, `setup-conversation.md`, `dev-mode.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)