### PR TITLE
fix(dist): shim sixel's implicit-global UPNG so packaged app launches

### DIFF
--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -56,6 +56,33 @@ mkdirSync(DIST, { recursive: true });
 // --- Step 1: esbuild bundle ---
 console.log("  Bundling with esbuild...");
 
+// `sixel/upng.js` opens with `module.exports = UPNG = {};` — an assignment to
+// an *undeclared* `UPNG`, i.e. an implicit global. Node loads that file as a
+// sloppy-mode CommonJS module in dev, where implicit globals are legal, so it
+// works. But esbuild emits this whole bundle as a single ESM module
+// (`format: "esm"`), and ESM is always strict mode — strictness propagates into
+// esbuild's CJS module wrappers, so the implicit-global assignment throws
+// `ReferenceError: UPNG is not defined` the moment the packaged binary touches
+// sixel (i.e. on first image render). Declare `UPNG` so the assignment binds a
+// module-scoped local instead. Fails loudly if upstream sixel changes the line,
+// so we re-check the shim rather than silently ship a broken binary.
+const fixSixelUpngGlobal = {
+  name: "fix-sixel-upng-global",
+  setup(b) {
+    b.onLoad({ filter: /[\\/]sixel[\\/]upng\.js$/ }, (args) => {
+      const original = readFileSync(args.path, "utf-8");
+      const needle = "module.exports = UPNG = {};";
+      if (!original.includes(needle)) {
+        throw new Error(
+          `fix-sixel-upng-global: expected "${needle}" in ${args.path}. ` +
+            `sixel upstream changed — re-verify whether this shim is still needed.`,
+        );
+      }
+      return { contents: original.replace(needle, `var UPNG;\n${needle}`), loader: "js" };
+    });
+  },
+};
+
 await build({
   entryPoints: [join(ROOT, "scripts/launcher.ts")],
   bundle: true,
@@ -65,6 +92,7 @@ await build({
   format: "esm",
   jsx: "automatic",
   external: ["node:*"],
+  plugins: [fixSixelUpngGlobal],
   define: {
     "process.env.MV_VERSION": JSON.stringify(version),
     "process.env.MV_RELEASE_DATE": JSON.stringify(releaseDate),


### PR DESCRIPTION
## Problem

The packaged app crashes immediately on launch once image support is exercised:

```
file:///.../MachineViolet.exe:156421
    module.exports = UPNG = {};
                          ^
ReferenceError: UPNG is not defined
    at node_modules/sixel/upng.js (...)
    at node_modules/sixel/lib/upng.js (...)
    ...
```

## Root cause

`node_modules/sixel/upng.js:7` is:

```js
module.exports = UPNG = {};
```

That assigns to an **undeclared** `UPNG` — an implicit global. In dev, Node loads `upng.js` as a sloppy-mode CommonJS file where implicit globals are legal, so `npm run dev` works. But `scripts/build-dist.js` bundles the whole binary as a single **ESM** module (`format: "esm"`), and ESM is always strict mode; that strictness propagates into esbuild's CJS module wrappers, so the assignment throws `ReferenceError: UPNG is not defined` the instant the packaged binary first touches sixel. The image-driver registry pulls sixel in eagerly, so the released binary dies on launch.

## Fix

An esbuild `onLoad` plugin in `build-dist.js` that declares `var UPNG;` ahead of the assignment, so it binds a module-scoped local instead of an implicit global. The shim fails the build loudly if upstream sixel ever changes that line, so we re-verify rather than silently ship a broken binary. **Build-time only** — the dev (tsx) path is unaffected, and the path filter matches both Windows (`\`) and macOS/Linux (`/`).

## Verification

1. **Reproduced** the exact error — bundling a minimal `import "sixel"` with the production esbuild config (esm + banner) reproduces the identical `ReferenceError` and stack frames.
2. **Fixed in isolation** — same config + the plugin → sixel loads, exit 0, deterministic across 3 runs.
3. **Against the real launcher bundle** — bundling `scripts/launcher.ts` itself, the shim lands at **line 156421**, the exact line the packaged app crashed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)