### PR TITLE
chore(deps): sync package-lock with client-ink string-width dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10621,7 +10621,8 @@
         "ink-scroll-view": "^0.3.6",
         "react": "^19.2.0",
         "sharp": "^0.34.5",
-        "sixel": "^0.16.0"
+        "sixel": "^0.16.0",
+        "string-width": "^8.2.1"
       },
       "devDependencies": {
         "@types/react": "^19.2.0",


### PR DESCRIPTION
## What

`packages/client-ink/package.json` declares `string-width@^8.2.1` as a direct dependency, but `package-lock.json` never recorded it in the client-ink workspace's `dependencies` block. As a result, running any workspace npm command (e.g. `npm run build -w packages/client-ink`) reconciles the drift and dirties the lockfile out from under you.

This syncs the lockfile so it matches `package.json`.

## Scope

- **No installed versions change.** `string-width@8.2.1` already resolved as a transitive dependency; this only records the direct reference in the workspace block.
- Generated with `npm install --package-lock-only` — single-line diff.

```diff
         "react": "^19.2.0",
         "sharp": "^0.34.5",
-        "sixel": "^0.16.0"
+        "sixel": "^0.16.0",
+        "string-width": "^8.2.1"
```

Surfaced while working on #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)