### PR TITLE
fix(usage-gauge): order drain states by perceived brightness, not gem value

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -132,10 +132,12 @@ The gauge represents remaining capacity as a unary countdown of 25 ticks (4% per
 | State | Glyph | Color | Ticks in cell |
 |---|---|---|---|
 | Full | `◆` | Light blue (`#529EAB`) | 5 |
-| Ruby | `⬢` | Red (`#781313`) | 4 |
-| Garnet | `■` | Brown (`#A87712`) | 3 |
+| Topaz | `■` | Yellow-gold (`#A88912`) | 4 |
+| Ruby | `⬢` | Red (`#781313`) | 3 |
 | Tarnished | `*` | Grey | 1–2 (collapsed) |
 | Empty | (space) | — | 0 |
+
+The middle two states are ordered by perceived brightness rather than gemstone value: the warm topaz reads as "more remaining" to the eye than the dark ruby, so it sits higher in the drain.
 
 Because ticks 1 and 2 within a cell both render as `*`, the bottom 8% of each cell's drain is visually compressed into one state; the gauge still updates on every 4% step. The `primary` segment must be a `percentage` segment carrying a `usedPercent` — currently only the openai-chatgpt provider supplies one (its 5-hour rate-limit window); see [openai-chatgpt-provider.md](openai-chatgpt-provider.md) for the server-side `subscribeUsage` implementation.
 

--- a/packages/client-ink/src/tui/components/UsageGauge.test.tsx
+++ b/packages/client-ink/src/tui/components/UsageGauge.test.tsx
@@ -38,22 +38,22 @@ describe("gaugeCells", () => {
   });
 
   it("degrades the leftmost cell first", () => {
-    // 96% remaining: 24 ticks → leftmost cell holds 4 (⬢), rest 5 (◆)
+    // 96% remaining: 24 ticks → leftmost cell holds 4 (■), rest 5 (◆)
     const cells = gaugeCells(96);
-    expect(cells.map((c) => c.glyph)).toEqual(["⬢", "◆", "◆", "◆", "◆"]);
+    expect(cells.map((c) => c.glyph)).toEqual(["■", "◆", "◆", "◆", "◆"]);
   });
 
   it("walks the leftmost cell through all states before touching the next", () => {
     expect(gaugeCells(100).map((c) => c.glyph)).toEqual(["◆", "◆", "◆", "◆", "◆"]);
-    expect(gaugeCells(96).map((c) => c.glyph)).toEqual(["⬢", "◆", "◆", "◆", "◆"]);
-    expect(gaugeCells(92).map((c) => c.glyph)).toEqual(["■", "◆", "◆", "◆", "◆"]);
+    expect(gaugeCells(96).map((c) => c.glyph)).toEqual(["■", "◆", "◆", "◆", "◆"]);
+    expect(gaugeCells(92).map((c) => c.glyph)).toEqual(["⬢", "◆", "◆", "◆", "◆"]);
     expect(gaugeCells(88).map((c) => c.glyph)).toEqual(["*", "◆", "◆", "◆", "◆"]);
     // 84% (21 ticks): cell 0 has 1 bucket left → still `*`
     expect(gaugeCells(84).map((c) => c.glyph)).toEqual(["*", "◆", "◆", "◆", "◆"]);
     // 80% (20 ticks): cell 0 fully empty, cell 1 still full
     expect(gaugeCells(80).map((c) => c.glyph)).toEqual([" ", "◆", "◆", "◆", "◆"]);
-    // 76% (19 ticks): cell 1 drops to ⬢
-    expect(gaugeCells(76).map((c) => c.glyph)).toEqual([" ", "⬢", "◆", "◆", "◆"]);
+    // 76% (19 ticks): cell 1 drops to ■
+    expect(gaugeCells(76).map((c) => c.glyph)).toEqual([" ", "■", "◆", "◆", "◆"]);
   });
 
   it("renders only the rightmost cell at very low remaining", () => {

--- a/packages/client-ink/src/tui/components/UsageGauge.tsx
+++ b/packages/client-ink/src/tui/components/UsageGauge.tsx
@@ -9,10 +9,14 @@
  * passes through five visual states as it drains:
  *
  *   ◆  light blue  (full)
+ *   ■  yellow-gold (topaz)
  *   ⬢  red         (ruby)
- *   ■  brown       (garnet)
  *   *  grey        (tarnished)
  *   (space)        (empty)
+ *
+ * The topaz → ruby ordering is by eye, not gemstone value: the brighter,
+ * warmer gold reads as "more left" than the dark red, so it sits higher in
+ * the drain even though a ruby is the costlier stone.
  *
  * Because the user only specified four glyphs plus an empty cell, ticks 1
  * and 2 within a cell share the `*` rendering — visually compressing the
@@ -38,7 +42,7 @@ interface Cell {
 
 const FULL: Cell = { glyph: "◆", color: "#529EAB" };       // light-blue diamond
 const RUBY: Cell = { glyph: "⬢", color: "#781313" };       // red hexagon
-const GARNET: Cell = { glyph: "■", color: "#A87712" };     // brown square
+const TOPAZ: Cell = { glyph: "■", color: "#A88912" };      // yellow-gold square
 const TARNISHED: Cell = { glyph: "*", color: "gray" };     // grey asterisk
 const EMPTY: Cell = { glyph: " " };
 
@@ -48,8 +52,8 @@ const EMPTY: Cell = { glyph: " " };
  */
 function cellFor(buckets: number): Cell {
   if (buckets >= 5) return FULL;
-  if (buckets === 4) return RUBY;
-  if (buckets === 3) return GARNET;
+  if (buckets === 4) return TOPAZ;
+  if (buckets === 3) return RUBY;
   if (buckets >= 1) return TARNISHED;
   return EMPTY;
 }


### PR DESCRIPTION
## What

The bottom-right usage gauge drained its cells in gemstone-value order — `◆` diamond → `⬢` ruby → `■` gem → `*`. But to a human eye, color brightness reads as "amount remaining" more strongly than gem rarity does, so the value order felt backwards.

This swaps the two middle states so each cell drains **◆ → ■ → ⬢ → \***: the warm yellow-gold now sits higher than the dark red.

While here:
- Renamed the middle gem constant `GARNET` → `TOPAZ` so the name matches its (now clearly yellow) color.
- Warmed the color `#A87712` → `#A88912` (green channel +~15%, hue ~40°→~48°) so it reads as yellow-gold rather than brown.

## Changed

- `packages/client-ink/src/tui/components/UsageGauge.tsx` — swap the two middle states in `cellFor`, rename/recolor the constant, update the header comment.
- `packages/client-ink/src/tui/components/UsageGauge.test.tsx` — update the drain-order assertions for the swapped glyphs.
- `docs/tui-design.md` — update the gauge states table and note the brightness-based ordering.

## Testing

`npm run check` — lint clean, full suite (3528 passed | 13 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)