### PR TITLE
fix(ci): correct test-build Velopack --mainExe to MachineViolet.exe

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -84,7 +84,7 @@ jobs:
             --packVersion "${VERSION}-test" \
             --packTitle "Machine Violet" \
             --packDir dist \
-            --mainExe machine-violet.exe \
+            --mainExe MachineViolet.exe \
             --icon assets/machine-violet.ico \
             --shortcuts StartMenuRoot \
             --azureTrustedSignFile assets/trusted-signing.json \


### PR DESCRIPTION
## What

One-line fix: the Windows **Package and sign (Velopack)** step in `test-build.yml` passed `--mainExe machine-violet.exe`, but `build-dist.js` emits `MachineViolet.exe` (PascalCase — as `release.yml` already uses). `vpk pack` couldn't find the binary and failed (exit 127), before the packaged-artifact replay gate could run.

## Why it surfaced now

Pre-existing latent bug — test-build's Windows path was never exercised to completion until the new replay gate (PR #622) forced a working bundle. Dispatching `test-build.yml` on `main` after the merge is what caught it.

## Validation

- **mac/linux gate proven on real CI** (run [27391076468](https://github.com/octopollux/machine-violet/actions/runs/27391076468)): both built the SEA binary, packaged it, and replayed the golden against the *packaged* `MachineViolet` binary — `✔ PASS — narrative matched`.
- The Windows signing path can only be validated from `main` (Azure OIDC won't trust a feature-branch token), so this PR merges first; I'll then dispatch `test-build --ref main -f windows=true` to confirm the full Windows pack + replay + install-smoke.

Ground truth for the name: [`scripts/build-dist.js`](scripts/build-dist.js) → `const exeName = isWindows ? "MachineViolet.exe" : "MachineViolet"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)