### PR TITLE
ci(e2e): make Velopack install-smoke blocking in release/nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -179,9 +179,8 @@ jobs:
         run: bash scripts/ci/replay-packaged-binary.sh pkg-artifact
       - name: Velopack install/uninstall smoke (Windows)
         if: matrix.os == 'windows-latest'
-        # Report-only until a test-build.yml dispatch validates the install CLI;
-        # flip to blocking afterward. See docs/e2e-harness.md.
-        continue-on-error: true
+        # Blocking: validated end-to-end on a clean runner via test-build.yml
+        # (install -> replay installed binary -> uninstall). See docs/e2e-harness.md.
         shell: pwsh
         run: scripts/ci/velopack-install-smoke.ps1 -ArtifactDir pkg-artifact -RepoRoot .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,9 +210,8 @@ jobs:
         run: bash scripts/ci/replay-packaged-binary.sh pkg-artifact
       - name: Velopack install/uninstall smoke (Windows)
         if: matrix.os == 'windows-latest'
-        # Report-only until a test-build.yml dispatch validates the install CLI
-        # on a clean runner; flip to blocking afterward. See docs/e2e-harness.md.
-        continue-on-error: true
+        # Blocking: validated end-to-end on a clean runner via test-build.yml
+        # (install -> replay installed binary -> uninstall). See docs/e2e-harness.md.
         shell: pwsh
         run: scripts/ci/velopack-install-smoke.ps1 -ArtifactDir pkg-artifact -RepoRoot .
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -91,10 +91,11 @@ jobs:
             --channel test \
             --outputDir velopack-out
 
-      # Validate the packaged-artifact gate end-to-end (the same script
-      # release.yml / nightly.yml run). Blocking here so a dispatch surfaces
-      # any breakage; in release/nightly the Velopack-install leg is
-      # report-only until this confirms it. See docs/e2e-harness.md.
+      # Validate the packaged-artifact gate end-to-end (the same scripts
+      # release.yml / nightly.yml run). Both legs are blocking here and in
+      # release/nightly — a dispatch here exercises the Windows signing + pack
+      # path that the OIDC trust boundary keeps off feature branches. See
+      # docs/e2e-harness.md.
       - name: Replay goldens against the packaged binary
         shell: bash
         run: bash scripts/ci/replay-packaged-binary.sh velopack-out

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -118,9 +118,10 @@ can be validated without cutting a release.
 installs `Setup.exe` → replays against the *installed* binary → uninstalls,
 catching install-layout/manifest bugs the portable replay can't. It is **not
 locally validatable** (needs a signed `Setup.exe` + a real machine install), so
-it is **report-only (`continue-on-error`) in release/nightly** and **blocking in
-test-build.yml**. Dispatch `test-build.yml` to validate the install CLI on a
-clean runner, then flip the release/nightly steps to blocking.
+it was validated end-to-end on a clean runner via a `test-build.yml` dispatch
+(install → replay installed binary → uninstall, all green) and is now
+**blocking in release/nightly and test-build.yml** — a broken Windows installer
+blocks publish like any other packaging failure.
 
 **Known gap (by design):** replay returns taped image bytes, so it exercises
 `sharp` rendering but **not** codex generation — replay bypasses codex entirely.
@@ -483,6 +484,6 @@ Conventions:
   (or future agents) will thank you.
 - **Changing the packaged-artifact gate** (the replay knobs, the runner, the CI
   job, or the Velopack smoke): update "Packaged-artifact replay gate" above and
-  keep the workflow comments in sync. If you validate the Velopack install smoke
-  via `test-build.yml`, flip the release/nightly steps from `continue-on-error`
-  to blocking and note it here.
+  keep the workflow comments in sync. The Velopack install smoke is now blocking
+  in release/nightly (validated via a `test-build.yml` dispatch); if it ever
+  proves flaky, re-add `continue-on-error` and note it here.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -61,7 +61,7 @@ The workflow:
 
 RC releases are marked `--prerelease` on GitHub, skip Discord, and skip the Homebrew formula bump. Stable releases do all three.
 
-**Publish is gated on packaging.** A `verify-package` matrix job sits between `build` and `release` (in both [release.yml](../.github/workflows/release.yml) and [nightly.yml](../.github/workflows/nightly.yml)): it replays recorded golden tapes against the built per-OS artifact — deterministic, offline, no API key — and a broken package (SEA injection, asset vendoring, boot, config-dir) fails the replay and blocks the release. The optional Velopack install/uninstall smoke (Windows) is report-only until validated via `test-build.yml`. Full mechanics in [e2e-harness.md](e2e-harness.md#packaged-artifact-replay-gate-release--nightly-ci).
+**Publish is gated on packaging.** A `verify-package` matrix job sits between `build` and `release` (in both [release.yml](../.github/workflows/release.yml) and [nightly.yml](../.github/workflows/nightly.yml)): it replays recorded golden tapes against the built per-OS artifact — deterministic, offline, no API key — and a broken package (SEA injection, asset vendoring, boot, config-dir) fails the replay and blocks the release. The Velopack install/uninstall smoke (Windows) — install → replay the installed binary → uninstall — is also **blocking** (validated end-to-end via `test-build.yml`), so a broken installer blocks publish too. Full mechanics in [e2e-harness.md](e2e-harness.md#packaged-artifact-replay-gate-release--nightly-ci).
 
 ## Release-list hygiene
 

--- a/scripts/ci/velopack-install-smoke.ps1
+++ b/scripts/ci/velopack-install-smoke.ps1
@@ -9,9 +9,9 @@
   bugs that the portable-zip replay can't.
 
   NOT validated locally (a real install modifies the machine and the signed
-  Setup.exe only exists in CI). Wired report-only (continue-on-error) until a
-  test-build.yml dispatch confirms the install/uninstall CLI on a clean runner;
-  flip the step to blocking afterward. See docs/e2e-harness.md.
+  Setup.exe only exists in CI), so it was validated on a clean runner via a
+  test-build.yml dispatch (install -> replay installed binary -> uninstall, all
+  green). Now blocking in release/nightly + test-build. See docs/e2e-harness.md.
 #>
 param(
   [Parameter(Mandatory)][string]$ArtifactDir,


### PR DESCRIPTION
## What

Removes `continue-on-error` from the Velopack install/uninstall smoke step in `release.yml` + `nightly.yml`, so a broken Windows installer blocks publish like any other packaging failure. Docs updated to match.

## Why now

The smoke (install `Setup.exe` → replay against the *installed* binary → uninstall) was wired report-only **until validated on a clean runner** — it can't be validated locally (needs a signed `Setup.exe` + real install). A `test-build.yml` dispatch on `main` ([run 27391372492](https://github.com/octopollux/machine-violet/actions/runs/27391372492)) confirmed it green end-to-end:

```
Installing MachineViolet-test-Setup.exe ...
Replaying goldens against installed binary:
  C:\Users\runneradmin\AppData\Local\MachineViolet\current\MachineViolet.exe → ✔ PASS
Uninstalling ...  → Velopack install smoke passed.
```

The best-guess Velopack CLI calls (`Setup.exe --silent`, `Update.exe --uninstall --silent`) work as written. With this, the packaged-artifact gate is **fully blocking on all three platforms** (mac/linux portable-replay + Windows portable-replay *and* installed-replay).

## Note

`test-build.yml` already ran the smoke blocking. The release-branch workflows don't carry the `verify-package` gate yet (added on `main` via #622), so nothing to port there now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)