### PR TITLE
ci: bump Node 20 GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -53,12 +53,12 @@ jobs:
           echo "In the Actions UI, pick 'release' from the 'Use workflow from' branch selector."
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: release
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       timestamp: ${{ steps.ts.outputs.timestamp }}
       nightly_version: ${{ steps.ts.outputs.nightly_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute nightly version
         id: ts
         run: |
@@ -42,9 +42,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm
@@ -95,7 +95,7 @@ jobs:
 
       - name: Azure login (OIDC)
         if: matrix.os == 'windows-latest'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -132,14 +132,14 @@ jobs:
 
       - name: Upload artifact (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: machine-violet-${{ matrix.asset_suffix }}
           path: velopack-out/*
 
       - name: Upload artifact (macOS/Linux)
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: machine-violet-${{ matrix.asset_suffix }}
           path: machine-violet-nightly-*
@@ -161,8 +161,8 @@ jobs:
             asset_suffix: linux-x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm
@@ -170,7 +170,7 @@ jobs:
       - name: Build shared package
         run: npm run build -w packages/shared
       - name: Download packaged artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: machine-violet-${{ matrix.asset_suffix }}
           path: pkg-artifact
@@ -188,11 +188,11 @@ jobs:
     needs: [prepare, build, verify-package]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prep.outputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm
@@ -122,7 +122,7 @@ jobs:
 
       - name: Azure login (OIDC)
         if: matrix.os == 'windows-latest'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -160,14 +160,14 @@ jobs:
 
       - name: Upload artifact (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: machine-violet-${{ matrix.asset_suffix }}
           path: velopack-out/*
 
       - name: Upload artifact (macOS/Linux)
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: machine-violet-${{ matrix.asset_suffix }}
           path: machine-violet-*.${{ matrix.archive }}
@@ -190,10 +190,10 @@ jobs:
             asset_suffix: linux-x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prep.outputs.tag }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm
@@ -201,7 +201,7 @@ jobs:
       - name: Build shared package
         run: npm run build -w packages/shared
       - name: Download packaged artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: machine-violet-${{ matrix.asset_suffix }}
           path: pkg-artifact
@@ -219,12 +219,12 @@ jobs:
     needs: [prep, build, verify-package]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prep.outputs.tag }}
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -25,9 +25,9 @@ jobs:
     if: inputs.windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -105,7 +105,7 @@ jobs:
         run: scripts/ci/velopack-install-smoke.ps1 -ArtifactDir velopack-out -RepoRoot .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-build-windows-x64
           path: velopack-out/*
@@ -114,9 +114,9 @@ jobs:
     if: inputs.macos
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm
@@ -141,7 +141,7 @@ jobs:
           bash scripts/ci/replay-packaged-binary.sh pkg
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-build-darwin-arm64
           path: machine-violet-test-darwin-arm64.tar.gz
@@ -150,9 +150,9 @@ jobs:
     if: inputs.linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: npm
@@ -177,7 +177,7 @@ jobs:
           bash scripts/ci/replay-packaged-binary.sh pkg
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-build-linux-x64
           path: machine-violet-test-linux-x64.tar.gz


### PR DESCRIPTION
## What

GitHub is removing the Node 20 runtime from runners on **2026-09-16** (and force-defaulting these actions to Node 24 on **2026-06-16**) — every CI run was emitting the deprecation annotation. Bumps all affected actions to their current Node-24 majors (verified `runs.using: node24` at each target):

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `azure/login` | v2 | **v3** |

No third-party node20 actions in use (the only other `uses:` is a local reusable-workflow call).

## Why these are safe

The inputs we actually use are all long-stable core ones — `node-version`, `cache`, `name`, `path`, `merge-multiple`, and the OIDC `client-id`/`tenant-id`/`subscription-id` — and none are touched by the breaking notes across these majors (which are: Node-24 runtime + a minimum runner version of 2.327.1, which GitHub-hosted runners satisfy). `upload-artifact@v7` + `download-artifact@v8` are the current GitHub-supported pair; v8's Content-Type-aware decompression and digest-mismatch-error default only affect genuinely corrupt artifacts, not standard uploads.

## Validation

- **checkout + setup-node** — exercised by this PR's `ci.yml` run (every job checks out + sets up node with `cache: npm`), so a green PR validates them directly.
- **upload/download-artifact + azure/login** — only run in release/nightly/test-build, not PR CI. After merge, a forced nightly (`gh workflow run nightly.yml --ref main`) exercises the artifact upload→download pair end-to-end, and the Windows test-build (`--ref main -f windows=true`) re-exercises `azure/login@v3` on the signing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)