### PR TITLE
test(dev-routes): de-flake GET /tape by building Fastify once in beforeAll

### DIFF
--- a/packages/engine/src/server/routes/dev.test.ts
+++ b/packages/engine/src/server/routes/dev.test.ts
@@ -1,5 +1,5 @@
-import Fastify from "fastify";
-import { vi, beforeEach, describe, it, expect } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { vi, beforeAll, afterAll, beforeEach, describe, it, expect } from "vitest";
 import type { Tape } from "../../providers/tape.js";
 
 // The route's only logic is "404 when not recording, else return the tape
@@ -20,17 +20,34 @@ async function buildApp() {
 }
 
 describe("GET /tape", () => {
+  let app: FastifyInstance;
+
+  // Build the Fastify app once for the file. Construction (register + ready +
+  // route/serializer setup) is the only heavy step here (~150ms cold); under
+  // full-suite fork-pool CPU contention it can stretch past the 5s default,
+  // which is what made this test flaky when buildApp() ran inside the timed
+  // `it` body. Isolating construction in beforeAll with explicit headroom keeps
+  // it off the per-test budget (matching server.test.ts) — the route is
+  // stateless and reads the mocked getRecordedTape() fresh per request, so one
+  // shared app is safe — and leaves the assertions on the tight default timeout
+  // so a genuine route hang still surfaces fast.
+  beforeAll(async () => {
+    app = await buildApp();
+  }, 20000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
   beforeEach(() => {
     mockGetTape.mockReset();
   });
 
   it("404s when the process isn't recording", async () => {
     mockGetTape.mockReturnValue(null);
-    const app = await buildApp();
     const res = await app.inject({ method: "GET", url: "/tape" });
     expect(res.statusCode).toBe(404);
     expect(res.json()).toHaveProperty("error");
-    await app.close();
   });
 
   it("returns the recorded tape verbatim (deep fields survive)", async () => {
@@ -49,10 +66,8 @@ describe("GET /tape", () => {
       ],
     };
     mockGetTape.mockReturnValue(tape);
-    const app = await buildApp();
     const res = await app.inject({ method: "GET", url: "/tape" });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual(tape);
-    await app.close();
   });
 });

--- a/packages/engine/src/server/routes/dev.test.ts
+++ b/packages/engine/src/server/routes/dev.test.ts
@@ -36,7 +36,10 @@ describe("GET /tape", () => {
   }, 20000);
 
   afterAll(async () => {
-    await app.close();
+    // Guard: if beforeAll's construction threw/timed out, `app` is undefined —
+    // an unconditional close() would throw a secondary error that buries the
+    // real setup failure (the very failure mode this test guards against).
+    await app?.close();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
@-