### PR TITLE
feat(menu): collapse campaign list when scrolling past its end

### DIFF
--- a/docs/game-initialization.md
+++ b/docs/game-initialization.md
@@ -73,7 +73,7 @@ When "Continue Campaign" is selected and campaigns exist, the menu expands an in
 | Delete (red) | — | Open the Delete Campaign confirmation modal |
 
 - **Left/Right** arrows cycle columns within the selected row (clamped at the ends).
-- **Up/Down** arrows move between campaign rows. Up from the first row collapses the sub-list back to the main menu.
+- **Up/Down** arrows move between campaign rows. Up from the first row collapses the sub-list and reselects "Continue Campaign"; Down from the last row collapses it and advances to the menu item below "Continue Campaign" — so the sub-list reads as woven into the main menu rather than a one-way trap.
 - **ESC** collapses the sub-list.
 
 The archive action calls `archiveCampaign()` from [campaign-archive.ts](../packages/engine/src/config/campaign-archive.ts) — zip → verify round-trip → move → verify → delete source. The delete action opens the confirmation modal (below), populated with summary data from `getCampaignDeleteInfo()` before any files are removed. Source: [packages/client-ink/src/phases/MainMenuPhase.tsx](../packages/client-ink/src/phases/MainMenuPhase.tsx).

--- a/packages/client-ink/src/phases/MainMenuPhase.test.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.test.tsx
@@ -180,6 +180,50 @@ describe("MainMenuPhase", () => {
     expect(lastFrame()).not.toContain("Requires a valid API key");
   });
 
+  it("collapses the campaign list and advances to the next menu item when scrolling past the end", async () => {
+    // Mirror of the up-arrow collapse at the top: down-arrow on the last
+    // campaign should close the sub-list and land on the main-menu item
+    // *below* Continue Campaign (here, Settings), not clamp in place.
+    const props = defaultProps({
+      campaigns: [
+        { name: "Alpha Campaign", path: "/a" },
+        { name: "Beta Campaign", path: "/b" },
+      ],
+    });
+    const { stdin, lastFrame } = render(<MainMenuPhase {...props} />);
+    const frame = () => lastFrame() ?? "";
+    const selected = () => frame().split("\n").find((l) => l.includes("◆")) ?? "";
+    // ink only parses an arrow when the chunk is the real CSI escape
+    // sequence (its fnKeyRe requires a leading \x1b); a bare "[B" matches
+    // nothing.
+    const DOWN = "\u001B[B";
+
+    // ink-testing-library's stdin listener attaches in an effect, and ink
+    // re-registers the useInput closure on every commit. A fixed sleep
+    // races both, so each step re-sends its key (guarded on the current
+    // frame so it can't overshoot — the frame and the live closure are
+    // both products of the last commit) until the move is observable.
+    await vi.waitFor(() => {
+      if (selected().includes("New Campaign")) stdin.write(DOWN);
+      expect(selected()).toContain("Continue Campaign");
+    });
+    await vi.waitFor(() => {
+      if (!frame().includes("Alpha Campaign")) stdin.write("\r"); // expand
+      expect(frame()).toContain("Alpha Campaign");
+    });
+    await vi.waitFor(() => {
+      if (selected().includes("Alpha Campaign")) stdin.write(DOWN); // to last
+      expect(selected()).toContain("Beta Campaign");
+    });
+    await vi.waitFor(() => {
+      if (frame().includes("Alpha Campaign")) stdin.write(DOWN); // past the end
+      // Sub-list collapsed (campaign names gone) and selection advanced
+      // to the main-menu item below Continue Campaign.
+      expect(frame()).not.toContain("Alpha Campaign");
+      expect(selected()).toContain("Settings");
+    });
+  });
+
   it("renders the disabled hint only once even with multiple disabled items", () => {
     const props = defaultProps({
       apiKeyValid: false,

--- a/packages/client-ink/src/phases/MainMenuPhase.test.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.test.tsx
@@ -224,6 +224,55 @@ describe("MainMenuPhase", () => {
     });
   });
 
+  it("clamps campaign selection when several Down events arrive before a re-render (#631)", async () => {
+    // A held ↓ can dispatch multiple events against the same useInput
+    // closure before React commits. The selection must stay clamped at
+    // the last campaign — never run off the end into an undefined entry.
+    const onResumeCampaign = vi.fn();
+    const props = defaultProps({
+      campaigns: [
+        { name: "Alpha Campaign", path: "/a" },
+        { name: "Beta Campaign", path: "/b" },
+        { name: "Gamma Campaign", path: "/c" },
+      ],
+      onResumeCampaign,
+    });
+    const { stdin, lastFrame } = render(<MainMenuPhase {...props} />);
+    const frame = () => lastFrame() ?? "";
+    const selected = () => frame().split("\n").find((l) => l.includes("◆")) ?? "";
+    const DOWN = "\u001B[B";
+
+    // Navigate to Continue Campaign and expand (guarded; see sibling test).
+    await vi.waitFor(() => {
+      if (selected().includes("New Campaign")) stdin.write(DOWN);
+      expect(selected()).toContain("Continue Campaign");
+    });
+    await vi.waitFor(() => {
+      if (!frame().includes("Alpha Campaign")) stdin.write("\r"); // expand
+      expect(frame()).toContain("Alpha Campaign");
+    });
+
+    // Burst: more Down events than there are rows, delivered synchronously
+    // so they all hit the same (index 0) closure before any commit.
+    stdin.write(DOWN);
+    stdin.write(DOWN);
+    stdin.write(DOWN);
+    stdin.write(DOWN);
+
+    // Selection pins to the last campaign — not an out-of-range index that
+    // would leave no row marked and resume an undefined campaign.
+    await vi.waitFor(() => {
+      expect(frame()).toContain("Gamma Campaign"); // still expanded
+      expect(selected()).toContain("Gamma Campaign"); // last row selected
+    });
+    stdin.write("\r"); // resume the selected campaign
+    await vi.waitFor(() => {
+      expect(onResumeCampaign).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "Gamma Campaign" }),
+      );
+    });
+  });
+
   it("renders the disabled hint only once even with multiple disabled items", () => {
     const props = defaultProps({
       apiKeyValid: false,

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -117,7 +117,12 @@ export function MainMenuPhase({
           const continueIndex = mainMenuItems.indexOf("Continue Campaign");
           setMainMenuIndex(Math.min(mainMenuItems.length - 1, continueIndex + 1));
         } else {
-          setCampaignSelectIndex((i) => i + 1);
+          // Clamp inside the updater, not via the closure's stale
+          // campaignSelectIndex: a held ↓ can fire several events against
+          // the same render before React commits, and an unclamped i + 1
+          // would then run repeatedly and overshoot campaigns.length - 1
+          // (making campaigns[campaignSelectIndex] undefined on Enter).
+          setCampaignSelectIndex((i) => Math.min(campaigns.length - 1, i + 1));
         }
         return;
       }

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -106,7 +106,19 @@ export function MainMenuPhase({
         return;
       }
       if (key.downArrow) {
-        setCampaignSelectIndex((i) => Math.min(campaigns.length - 1, i + 1));
+        if (campaignSelectIndex === campaigns.length - 1) {
+          // Scrolling past the end collapses the list and advances to the
+          // main-menu item below "Continue Campaign" — the mirror of the
+          // up-arrow collapse at the top. Together they make the sub-list
+          // feel woven into the parent menu rather than a trap you can
+          // only back out of the way you came in.
+          setExpandedCampaigns(false);
+          setCampaignColumn(COL_NAME);
+          const continueIndex = mainMenuItems.indexOf("Continue Campaign");
+          setMainMenuIndex(Math.min(mainMenuItems.length - 1, continueIndex + 1));
+        } else {
+          setCampaignSelectIndex((i) => i + 1);
+        }
         return;
       }
       if (key.rightArrow) {


### PR DESCRIPTION
## What

The main menu's **Continue Campaign** sub-list already collapses when you press **↑** past the top (returning to the parent item). Going **↓** past the *bottom* only clamped, so the expanded list felt like a one-way trap.

Now pressing **↓** on the last campaign collapses the sub-list and advances the selection to the menu item **below** "Continue Campaign" (Settings, or Add Content in dev mode) — the mirror of the up-arrow collapse.

The two exits make the sub-list read as *woven into* the parent menu: **↑** returns through the header above it, **↓** exits past the whole group to the next sibling below it — exactly how a flattened inline list moves.

## Changes

- [`MainMenuPhase.tsx`](packages/client-ink/src/phases/MainMenuPhase.tsx) — down-arrow on the last campaign row collapses + advances instead of clamping.
- [`MainMenuPhase.test.tsx`](packages/client-ink/src/phases/MainMenuPhase.test.tsx) — regression test driving the full expand → scroll-to-end → collapse path.
- [`docs/game-initialization.md`](docs/game-initialization.md) — documents the new down-past-end behavior alongside the existing up-collapse.

## Test notes

The new test surfaced two non-obvious facts about ink 7 input under `ink-testing-library`, handled in-test (no production impact):
- ink 7's keypress parser requires the **real CSI escape** (`[B`); a bare `"[B"` matches nothing.
- Keystrokes can race ink's input-listener attach and per-commit `useInput` closure re-registration, so each key is **re-sent guarded on the observed frame** rather than waited on with a fixed sleep.

## Verification

`MainMenuPhase` suite **27/27** (run 3×), eslint clean, `tsc -b` clean. Pre-push `npm run check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)