### PR TITLE
ci(test-build): add `sign` input to decouple packaging from signing

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       windows:
-        description: "Build Windows (installer + signing)"
+        description: "Build Windows (installer)"
+        type: boolean
+        default: true
+      sign:
+        description: "Sign the Windows installer (Azure OIDC — protected branches only; set false on feature/Dependabot branches)"
         type: boolean
         default: true
       macos:
@@ -63,6 +67,7 @@ jobs:
           fi
 
       - name: Azure login (OIDC)
+        if: inputs.sign
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -75,10 +80,17 @@ jobs:
           dotnet tool install -g vpk
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
-      - name: Package and sign (Velopack)
+      - name: Package (Velopack)
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
+          # Signing is gated on the `sign` input: Azure Trusted Signing only
+          # authenticates from protected refs, so feature/Dependabot branches
+          # pack unsigned (sign=false) to still exercise the gate below.
+          SIGN_ARGS=()
+          if [ "${{ inputs.sign }}" = "true" ]; then
+            SIGN_ARGS+=(--azureTrustedSignFile assets/trusted-signing.json)
+          fi
           vpk pack \
             --packId MachineViolet \
             --packVersion "${VERSION}-test" \
@@ -87,14 +99,15 @@ jobs:
             --mainExe MachineViolet.exe \
             --icon assets/machine-violet.ico \
             --shortcuts StartMenuRoot \
-            --azureTrustedSignFile assets/trusted-signing.json \
+            "${SIGN_ARGS[@]}" \
             --channel test \
             --outputDir velopack-out
 
       # Validate the packaged-artifact gate end-to-end (the same scripts
       # release.yml / nightly.yml run). Both legs are blocking here and in
-      # release/nightly — a dispatch here exercises the Windows signing + pack
-      # path that the OIDC trust boundary keeps off feature branches. See
+      # release/nightly. With sign=false the package is unsigned, which lets
+      # this gate (pack + replay + install smoke) run on feature/Dependabot
+      # branches where the OIDC trust boundary blocks signing. See
       # docs/e2e-harness.md.
       - name: Replay goldens against the packaged binary
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ All cuts dispatch GitHub workflows via `gh`. Common commands:
 | Promote RC → stable | `gh workflow run cut-release.yml --ref release -f kind=stable -f bump=none` | Tags the version that's been RC'd. Purges that line's RC releases as part of publish. |
 | Cut stable, no RC soak | `gh workflow run cut-release.yml --ref release -f kind=stable -f bump=patch` | For hotfixes / confident small changes. `minor`/`major` also valid. |
 | Force a nightly now | `gh workflow run nightly.yml --ref main` | Useful when you've changed the nightly pipeline and want immediate verification, or to refresh the release-list cleanup. |
-| Test a Windows build without releasing | `gh workflow run test-build.yml -f windows=true` | Run on any PR touching build/installer/signing before merging — the Windows signing path has no other pre-merge coverage. Add `-f sign=false` when dispatching against a feature/Dependabot branch (Azure Trusted Signing only authenticates from protected refs): it packs unsigned but still runs the full pack → replay → install-smoke gate. |
+| Test a Windows build without releasing | `gh workflow run test-build.yml -f windows=true` | Run on any PR touching build/installer/signing before merging — the Windows signing path has no other pre-merge coverage. **Without `--ref`, `gh workflow run` targets the default branch (`main`), not your branch.** To validate a feature/Dependabot branch use `gh workflow run test-build.yml --ref <branch> -f windows=true -f sign=false` — Azure Trusted Signing only authenticates from protected refs, so feature branches must pack unsigned, but still run the full pack → replay → install-smoke gate. |
 
 `cut-release.yml` self-aborts if dispatched from any branch but `release` — the `--ref release` arg is mandatory.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ All cuts dispatch GitHub workflows via `gh`. Common commands:
 | Promote RC → stable | `gh workflow run cut-release.yml --ref release -f kind=stable -f bump=none` | Tags the version that's been RC'd. Purges that line's RC releases as part of publish. |
 | Cut stable, no RC soak | `gh workflow run cut-release.yml --ref release -f kind=stable -f bump=patch` | For hotfixes / confident small changes. `minor`/`major` also valid. |
 | Force a nightly now | `gh workflow run nightly.yml --ref main` | Useful when you've changed the nightly pipeline and want immediate verification, or to refresh the release-list cleanup. |
-| Test a Windows build without releasing | `gh workflow run test-build.yml -f windows=true` | Run on any PR touching build/installer/signing before merging — the Windows signing path has no other pre-merge coverage. |
+| Test a Windows build without releasing | `gh workflow run test-build.yml -f windows=true` | Run on any PR touching build/installer/signing before merging — the Windows signing path has no other pre-merge coverage. Add `-f sign=false` when dispatching against a feature/Dependabot branch (Azure Trusted Signing only authenticates from protected refs): it packs unsigned but still runs the full pack → replay → install-smoke gate. |
 
 `cut-release.yml` self-aborts if dispatched from any branch but `release` — the `--ref release` arg is mandatory.
 

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -112,13 +112,17 @@ artifact, runs [`scripts/ci/replay-packaged-binary.sh`](../scripts/ci/replay-pac
 `release` job's `needs:` so a red replay blocks publish. **Not** in PR `ci.yml` —
 this gate is for the release/nightly pipelines only.
 [`test-build.yml`](../.github/workflows/test-build.yml) runs the same gate so it
-can be validated without cutting a release.
+can be validated without cutting a release. Dispatch with `sign=false` to run the
+pack → replay → install-smoke gate on a feature/Dependabot branch (the package is
+unsigned), since Azure Trusted Signing only authenticates from protected refs;
+omit it (default `sign=true`) from `release`/`main` to also exercise signing.
 
 **Velopack install smoke** ([`scripts/ci/velopack-install-smoke.ps1`](../scripts/ci/velopack-install-smoke.ps1)):
 installs `Setup.exe` → replays against the *installed* binary → uninstalls,
 catching install-layout/manifest bugs the portable replay can't. It is **not
-locally validatable** (needs a signed `Setup.exe` + a real machine install), so
-it was validated end-to-end on a clean runner via a `test-build.yml` dispatch
+locally validatable** (needs a built `Setup.exe` + a real machine install; signing
+is optional via the `sign` input), so it was validated end-to-end on a clean
+runner via a `test-build.yml` dispatch
 (install → replay installed binary → uninstall, all green) and is now
 **blocking in release/nightly and test-build.yml** — a broken Windows installer
 blocks publish like any other packaging failure.

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -119,9 +119,10 @@ omit it (default `sign=true`) from `release`/`main` to also exercise signing.
 
 **Velopack install smoke** ([`scripts/ci/velopack-install-smoke.ps1`](../scripts/ci/velopack-install-smoke.ps1)):
 installs `Setup.exe` → replays against the *installed* binary → uninstalls,
-catching install-layout/manifest bugs the portable replay can't. It is **not
-locally validatable** (needs a built `Setup.exe` + a real machine install; signing
-is optional via the `sign` input), so it was validated end-to-end on a clean
+catching install-layout/manifest bugs the portable replay can't. It is
+**impractical to run locally** (it performs a real machine install → uninstall
+and is Windows-only — signing is optional via the `sign` input, so a signed
+`Setup.exe` is no longer the blocker), so it was validated end-to-end on a clean
 runner via a `test-build.yml` dispatch
 (install → replay installed binary → uninstall, all green) and is now
 **blocking in release/nightly and test-build.yml** — a broken Windows installer


### PR DESCRIPTION
## Why

Azure Trusted Signing only authenticates from **protected refs**, so a `test-build` dispatched on a feature/Dependabot branch dies at the **Azure login (OIDC)** step — and because a *failed* step aborts the rest of the job, it takes the whole Velopack **pack → packaged-binary golden replay → install/uninstall smoke** gate down with it. None of those legs actually need a signature; they were just collateral behind the signing credential.

(Surfaced while validating the esbuild bump in #628: the `test-build` dispatch on that Dependabot branch failed at Azure login even though `npm ci` + the esbuild bundle/SEA build were green.)

## What

Surface signing as a **`sign` boolean input (default `true`)**:

- **`sign=true`** (default, unchanged): Azure login runs, `vpk pack` gets `--azureTrustedSignFile` → signed package. Protected-branch dispatches behave exactly as before.
- **`sign=false`**: Azure login is **skipped** (`if: inputs.sign`) — and a *skipped* step, unlike a *failed* one, does not abort the job — and `--azureTrustedSignFile` is dropped, so `vpk pack` produces an **unsigned** package. The same workflow then still runs pack → replay → install smoke on feature/Dependabot branches. Only the signature itself is untestable off protected refs (by definition of the OIDC trust boundary).

One parameterized workflow, both use cases.

## Validation

Default (`sign=true`) is byte-for-byte the old behavior. The new `sign=false` path is validated post-merge on `main` (a protected ref) by dispatching `test-build` in **both** modes — the "complete" check the feature branch cannot do, since it can only reach `sign=false`.

Docs kept in sync: `docs/e2e-harness.md` and the CLAUDE.md release-commands table both document `-f sign=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
