### PR TITLE
test(tui): pin Tab-over-choices quick-view routing (#541)

### DIFF
--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -34,6 +34,7 @@ import { useGameContext } from "../tui/game-context.js";
 import { themeColor } from "../tui/themes/color-resolve.js";
 import { buildTranscriptHtml, loadImageBytes } from "../commands/transcript.js";
 import { openPath, revealInExplorer } from "../commands/open-path.js";
+import { routePlayingPhaseKey } from "./playing-input.js";
 
 export function PlayingPhase() {
   const {
@@ -383,12 +384,38 @@ export function PlayingPhase() {
 
   // --- Input handling ---
   useInput((_input, key) => {
-    // Triple-ESC reset
+    // Triple-Esc panic-reset bookkeeping is stateful (a timestamp ring), so it
+    // stays here; the routing *decision* below is pure (see playing-input.ts).
+    let tripleEscReady = false;
     if (key.escape) {
       const now = Date.now();
       escTimestamps.current.push(now);
       escTimestamps.current = escTimestamps.current.filter((t) => now - t <= 1500);
-      if (escTimestamps.current.length >= 3) {
+      tripleEscReady = escTimestamps.current.length >= 3;
+    }
+
+    // Esc/menu both open the pause menu and refresh the token summary.
+    const openMenu = () => {
+      setMenuOpen(true);
+      apiClient.getCost().then(({ formatted }) => setTokenSummary(formatted)).catch(() => { /* no-op */ });
+    };
+
+    const action = routePlayingPhaseKey(
+      { escape: !!key.escape, tab: !!key.tab, pageUp: !!key.pageUp, pageDown: !!key.pageDown },
+      {
+        tripleEscReady,
+        apiErrorModalActive,
+        hasRetryOverlay: !!retryOverlay,
+        activeModal: !!activeModal,
+        menuOpen,
+        activeChoices: !!activeChoices,
+        characterPaneOpen,
+        mode,
+      },
+    );
+
+    switch (action) {
+      case "tripleEscReset":
         escTimestamps.current = [];
         setActiveChoices(null);
         setActiveModal(null);
@@ -398,63 +425,36 @@ export function PlayingPhase() {
           apiClient.command("exit_mode").catch(() => { /* no-op */ });
         }
         return;
-      }
-    }
-
-    // Esc on the API-error modal dismisses it (latched on attemptId so the
-    // next retry brings it back). Handled before the catch-all blocker below
-    // so the user isn't trapped while the engine retries in the background.
-    if (key.escape && apiErrorModalActive && retryOverlay) {
-      setDismissedAttemptId(retryOverlay.attemptId);
-      return;
-    }
-
-    if (apiErrorModalActive || activeModal || menuOpen) return;
-
-    // ESC while choices are visible opens the menu without clearing them.
-    // The overlay's own input is disabled while the menu is open (isActive
-    // prop), so arrow keys/Enter don't drive both UIs at once.
-    if (key.escape && activeChoices) {
-      setMenuOpen(true);
-      apiClient.getCost().then(({ formatted }) => setTokenSummary(formatted)).catch(() => { /* no-op */ });
-      return;
-    }
-
-    // Tab: toggle the quick-view character pane. Handled before the choices
-    // guard below so the quick view stays reachable while a choice overlay is
-    // on screen — the overlay keeps arrow/Enter for selection, so the two
-    // don't conflict (see #541).
-    if (key.tab) {
-      setCharacterPaneOpen((prev) => !prev);
-      return;
-    }
-
-    if (activeChoices) return;
-
-    // In OOC/Dev mode: ESC exits
-    if (mode === "ooc" || mode === "dev") {
-      if (key.escape) {
+      case "dismissApiError":
+        // Latched on attemptId so the next retry brings the modal back.
+        if (retryOverlay) setDismissedAttemptId(retryOverlay.attemptId);
+        return;
+      // The choice overlay's own input is disabled while the menu is open
+      // (isActive prop), so arrow keys/Enter don't drive both UIs at once.
+      case "openMenuOverChoices":
+      case "openMenu":
+        openMenu();
+        return;
+      case "toggleCharacterPane":
+        setCharacterPaneOpen((prev) => !prev);
+        return;
+      case "exitMode":
         apiClient.command("exit_mode").catch(() => { /* no-op */ });
         return;
-      }
-    }
-
-    // ESC: dismiss character pane first, then open menu
-    if (key.escape) {
-      if (characterPaneOpen) {
+      case "dismissCharacterPane":
         setCharacterPaneOpen(false);
         return;
+      case "scroll": {
+        // Target the character pane when open, else the narrative.
+        const step = scrollAmount(rows);
+        const target = characterPaneOpen ? modalScrollRef.current : narrativeRef.current;
+        target?.scrollBy(key.pageUp ? -step : step);
+        return;
       }
-      setMenuOpen(true);
-      apiClient.getCost().then(({ formatted }) => setTokenSummary(formatted)).catch(() => { /* no-op */ });
-      return;
-    }
-
-    // Scroll keys — target character pane when open, else narrative
-    if (key.pageUp || key.pageDown) {
-      const step = scrollAmount(rows);
-      const target = characterPaneOpen ? modalScrollRef.current : narrativeRef.current;
-      target?.scrollBy(key.pageUp ? -step : step);
+      case "blocked":
+      case "choicesBlocked":
+      case "none":
+        return;
     }
   });
 

--- a/packages/client-ink/src/phases/playing-input.test.ts
+++ b/packages/client-ink/src/phases/playing-input.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { routePlayingPhaseKey } from "./playing-input.js";
+import type { PlayingInputKey, PlayingInputState } from "./playing-input.js";
+
+const NO_KEY: PlayingInputKey = { escape: false, tab: false, pageUp: false, pageDown: false };
+function key(over: Partial<PlayingInputKey>): PlayingInputKey {
+  return { ...NO_KEY, ...over };
+}
+
+const BASE: PlayingInputState = {
+  tripleEscReady: false,
+  apiErrorModalActive: false,
+  hasRetryOverlay: false,
+  activeModal: false,
+  menuOpen: false,
+  activeChoices: false,
+  characterPaneOpen: false,
+  mode: "play",
+};
+function state(over: Partial<PlayingInputState>): PlayingInputState {
+  return { ...BASE, ...over };
+}
+
+describe("routePlayingPhaseKey", () => {
+  // The #541 regression guard: Tab must reach the quick view even while a
+  // choice overlay is up. This is purely a matter of branch order — Tab is
+  // routed before the "choices swallow everything" guard.
+  describe("Tab over a choice overlay (#541)", () => {
+    it("toggles the quick-view pane when choices are active", () => {
+      expect(routePlayingPhaseKey(key({ tab: true }), state({ activeChoices: true })))
+        .toBe("toggleCharacterPane");
+    });
+
+    it("still toggles the pane when no choices are active", () => {
+      expect(routePlayingPhaseKey(key({ tab: true }), state({})))
+        .toBe("toggleCharacterPane");
+    });
+
+    it("proves the choices guard is real: a non-Tab key is swallowed while choices are up", () => {
+      // If Tab weren't routed *before* this guard, it would land here too.
+      expect(routePlayingPhaseKey(key({ pageDown: true }), state({ activeChoices: true })))
+        .toBe("choicesBlocked");
+    });
+
+    it("a blocking modal/menu still swallows Tab (pane is intentionally unreachable then)", () => {
+      expect(routePlayingPhaseKey(key({ tab: true }), state({ activeModal: true }))).toBe("blocked");
+      expect(routePlayingPhaseKey(key({ tab: true }), state({ menuOpen: true }))).toBe("blocked");
+      expect(routePlayingPhaseKey(key({ tab: true }), state({ apiErrorModalActive: true }))).toBe("blocked");
+    });
+  });
+
+  describe("precedence ladder", () => {
+    it("triple-Esc reset wins over every other overlay", () => {
+      expect(
+        routePlayingPhaseKey(key({ escape: true }), state({ tripleEscReady: true, activeModal: true, menuOpen: true })),
+      ).toBe("tripleEscReset");
+    });
+
+    it("Esc dismisses the API-error modal while the engine retries", () => {
+      expect(
+        routePlayingPhaseKey(key({ escape: true }), state({ apiErrorModalActive: true, hasRetryOverlay: true })),
+      ).toBe("dismissApiError");
+    });
+
+    it("a non-Esc key is blocked while the API-error modal is up", () => {
+      expect(
+        routePlayingPhaseKey(key({ tab: true }), state({ apiErrorModalActive: true, hasRetryOverlay: true })),
+      ).toBe("blocked");
+    });
+
+    it("Esc over choices opens the menu without clearing them", () => {
+      expect(routePlayingPhaseKey(key({ escape: true }), state({ activeChoices: true })))
+        .toBe("openMenuOverChoices");
+    });
+
+    it("Esc exits OOC and Dev mode", () => {
+      expect(routePlayingPhaseKey(key({ escape: true }), state({ mode: "ooc" }))).toBe("exitMode");
+      expect(routePlayingPhaseKey(key({ escape: true }), state({ mode: "dev" }))).toBe("exitMode");
+    });
+
+    it("Esc dismisses the character pane before falling through to the menu", () => {
+      expect(routePlayingPhaseKey(key({ escape: true }), state({ characterPaneOpen: true })))
+        .toBe("dismissCharacterPane");
+      expect(routePlayingPhaseKey(key({ escape: true }), state({})))
+        .toBe("openMenu");
+    });
+
+    it("scroll keys scroll; unrelated keys are inert", () => {
+      expect(routePlayingPhaseKey(key({ pageUp: true }), state({}))).toBe("scroll");
+      expect(routePlayingPhaseKey(key({ pageDown: true }), state({}))).toBe("scroll");
+      expect(routePlayingPhaseKey(NO_KEY, state({}))).toBe("none");
+    });
+  });
+});

--- a/packages/client-ink/src/phases/playing-input.ts
+++ b/packages/client-ink/src/phases/playing-input.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure keyboard routing for PlayingPhase.
+ *
+ * The phase's `useInput` handler is a precedence-sensitive ladder of overlay
+ * rules. The fragile one is #541: Tab must toggle the quick-view character pane
+ * *before* the "a choice overlay is up, swallow everything" guard, so the quick
+ * view stays reachable while choices are on screen. A future reorder of that
+ * ladder could silently re-break it.
+ *
+ * Encoding the ladder here — as a pure function of the current overlay state —
+ * lets us unit-test that ordering without rendering the whole phase, which is
+ * entangled with the API client, terminal graphics, and window size. The
+ * component owns all side effects; this function only decides which one to run.
+ * Mirrors the `createEventHandler` reducer pattern used for WebSocket events.
+ */
+
+/** A keypress reduced to the keys PlayingPhase routes on. */
+export interface PlayingInputKey {
+  escape: boolean;
+  tab: boolean;
+  pageUp: boolean;
+  pageDown: boolean;
+}
+
+/** Overlay/mode state the routing ladder branches on. */
+export interface PlayingInputState {
+  /** True when this Esc press is the third within the panic-reset window. */
+  tripleEscReady: boolean;
+  apiErrorModalActive: boolean;
+  hasRetryOverlay: boolean;
+  activeModal: boolean;
+  menuOpen: boolean;
+  activeChoices: boolean;
+  characterPaneOpen: boolean;
+  mode: "play" | "ooc" | "dev" | "setup";
+}
+
+/** The action the handler should perform for a given keypress + state. */
+export type PlayingInputAction =
+  | "tripleEscReset"
+  | "dismissApiError"
+  | "blocked"
+  | "openMenuOverChoices"
+  | "toggleCharacterPane"
+  | "choicesBlocked"
+  | "exitMode"
+  | "dismissCharacterPane"
+  | "openMenu"
+  | "scroll"
+  | "none";
+
+/**
+ * Decide what a keypress should do, as a pure function of the current overlay
+ * state. The branch order here IS the behavior — each `if` is one rung of the
+ * precedence ladder, and they must stay in this sequence.
+ */
+export function routePlayingPhaseKey(
+  key: PlayingInputKey,
+  state: PlayingInputState,
+): PlayingInputAction {
+  // Triple-Esc panic reset wins over everything.
+  if (key.escape && state.tripleEscReady) return "tripleEscReset";
+
+  // Esc dismisses the API-error modal even while the engine retries, so the
+  // user isn't trapped behind the catch-all block below.
+  if (key.escape && state.apiErrorModalActive && state.hasRetryOverlay) {
+    return "dismissApiError";
+  }
+
+  // Catch-all: a blocking overlay swallows the key.
+  if (state.apiErrorModalActive || state.activeModal || state.menuOpen) {
+    return "blocked";
+  }
+
+  // Esc while choices are visible opens the menu without clearing them.
+  if (key.escape && state.activeChoices) return "openMenuOverChoices";
+
+  // Tab toggles the quick-view pane — handled BEFORE the choices guard below
+  // so the quick view stays reachable while a choice overlay is up. The overlay
+  // keeps arrow/Enter for selection, so the two don't conflict (#541).
+  if (key.tab) return "toggleCharacterPane";
+
+  // Otherwise a choice overlay swallows the rest of the ladder.
+  if (state.activeChoices) return "choicesBlocked";
+
+  // In OOC/Dev mode, Esc exits the mode.
+  if ((state.mode === "ooc" || state.mode === "dev") && key.escape) {
+    return "exitMode";
+  }
+
+  // Esc dismisses the character pane first, then opens the menu.
+  if (key.escape) {
+    return state.characterPaneOpen ? "dismissCharacterPane" : "openMenu";
+  }
+
+  // Scroll keys.
+  if (key.pageUp || key.pageDown) return "scroll";
+
+  return "none";
+}


### PR DESCRIPTION
## What

Adds a regression test for #541 ("Choices modal blocks Tab key") and makes its fix testable.

#541 was fixed in #603 by moving the `key.tab` handler *above* the `if (activeChoices) return;` guard in `PlayingPhase`'s `useInput` ladder, so Tab keeps the quick-view character pane reachable while a choice overlay is on screen. That ordering had **no test** — it's a one-line statement-order dependency that a future refactor of the handler could silently undo.

## How

`PlayingPhase`'s `useInput` is entangled with the API client, terminal graphics, and window size, so a full-render test would be heavy and flaky — and the only existing context mock is stale. Instead, I lifted the keyboard-routing *decision* out of the callback into a pure function, mirroring the `createEventHandler` reducer pattern already used for WebSocket events:

- **`playing-input.ts`** — `routePlayingPhaseKey(key, state)` returns the action for a keypress as a pure function of overlay state. The branch order *is* the precedence ladder.
- **`PlayingPhase.tsx`** — `useInput` now dispatches on the returned action. Every side effect stays in the component (stateful triple-Esc bookkeeping included), so behavior is unchanged.
- **`playing-input.test.ts`** — pins the #541 guard (Tab toggles the pane while choices are active; the choices guard still swallows non-Tab keys; modals/menu still block Tab) plus the rest of the ladder (triple-Esc reset, API-error dismiss, Esc-over-choices, OOC/Dev exit, pane-dismiss, scroll).

## Test plan

- `npx vitest related --run packages/client-ink/src/phases/playing-input.ts` → 11/11 pass
- `npm run check` green (one unrelated `server.test.ts` `beforeEach` timeout flake under load; passes in isolation)
- Pure refactor — no behavior, contract, state, or on-disk-format change, so no docs update needed.

Closes #541 (issue was already resolved by #603 but never auto-closed; this adds the missing guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
