### PR TITLE
Grade catalog visual styles by seed-usage frequency (provisional S–D ratings)

### DIFF
--- a/docs/visual-style-authoring.md
+++ b/docs/visual-style-authoring.md
@@ -240,6 +240,13 @@ Author **one style at a time**, eyeballed by a human before banking.
      related styles with `[Other](./Other.mvstyle)`. (A `tokens:` frontmatter
      key — the emitted `# Direction`+`# Style` weight — is **auto-stamped** by
      `npm run tokens` at pre-push; don't hand-author it. See format-spec §10.9.)
+   - The `rating` is a coarse quality tier — `S` > `A` > `B` > `C` > `D`, with
+     `"?"` meaning *ungraded*. The bundled catalog's current ratings are a
+     **provisional usage-frequency proxy**, not an eyeball grade: each style is
+     ranked by how many seeds reached for it across the campaign↔style taste pass
+     (S = 5 seeds, A = 4, B = 3, C = 2, D = 1). Catalog styles no seed used, and
+     the per-seed composites, are left `"?"`. Re-grade by eye when you have
+     renders in front of you — the same "show renders before banking" rule.
    - Copy the **approved** render to `ImageStyleExample/<Tag>.example.png` and
      reference it from the `# Example` section.
    - Add the variant to the list in [image-generation.md](image-generation.md)

--- a/docs/visual-style-authoring.md
+++ b/docs/visual-style-authoring.md
@@ -177,7 +177,7 @@ seed. The surveillance cluster (`NightVisionCam`, `ThermalCam`, `ThermalGrain`,
   flair (a legend, a prophecy, a relic, a vision). Don't judge an elaborate style
   by "would you run a whole campaign in it."
 
-*(Wiring styles onto seeds is deferred — no seed currently selects a variant.)*
+*(Styles are wired end-to-end: every bundled seed sets an `image_style` — often a per-seed **composite** that bundles a default look plus situational variants into one include — which drives both the chargen portrait and in-game art. See format-spec §10.8.)*
 
 ## Practical constraints
 

--- a/packages/engine/src/prompts/include/Image/Adventure2000s.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Adventure2000s.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Adventure2000s"
-rating: "?"
+rating: "D"
 description: "Clean flat 2000s point-and-click adventure art: vector-like cel-shaded shapes, hard flat tones, bright limited palette"
 tags: [game-render, stylized, graphic, color, whimsical]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Agfacolor.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Agfacolor.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Agfacolor"
-rating: "?"
+rating: "D"
 description: "Early Agfacolor European stock: warm-but-muted earthy ambers, dusty reds and olive, low saturation, faded continental feel"
 tags: [film-stock, period, muted, warm, nostalgic, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/AnimatedFamilyFilm.mvstyle
+++ b/packages/engine/src/prompts/include/Image/AnimatedFamilyFilm.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "AnimatedFamilyFilm"
-rating: "?"
+rating: "C"
 description: "Late-80s/90s hand-drawn animation cel: flat ink-and-paint figures over lush gouache multiplane painted backgrounds"
 tags: [animation, stylized, warm, whimsical, color]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/AnimeIllustration.mvstyle
+++ b/packages/engine/src/prompts/include/Image/AnimeIllustration.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "AnimeIllustration"
-rating: "?"
+rating: "C"
 description: "Polished modern anime illustration with crisp lineart, flat cel shading, and a softly painted atmospheric background"
 tags: [illustration, stylized, color, warm, portrait]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Anscochrome.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Anscochrome.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Anscochrome"
-rating: "?"
+rating: "C"
 description: "1950s Anscochrome slide film: warm off-balance magenta-shifting colour, gently faded low-contrast mid-century album feel"
 tags: [film-stock, vintage, warm, muted, nostalgic, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/ArtNouveau.mvstyle
+++ b/packages/engine/src/prompts/include/Image/ArtNouveau.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "ArtNouveau"
-rating: "?"
+rating: "D"
 description: "Decorative Art Nouveau poster with sinuous linework, flat period pigments, ornament, and burnished gold-leaf borders"
 tags: [illustration, period, muted, romantic, portrait]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Autochrome.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Autochrome.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Autochrome"
-rating: "?"
+rating: "D"
 description: "Earliest-colour Autochrome plate (1907): dreamy muted low-contrast colour with delicate pointillist starch-grain stipple"
 tags: [photographic, vintage, muted, dreamy, nostalgic, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/BakedAAA.mvstyle
+++ b/packages/engine/src/prompts/include/Image/BakedAAA.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "BakedAAA"
-rating: "?"
+rating: "D"
 description: "Mid-2000s AAA game screenshot with baked lightmap GI, DXT textures, faceted geometry and warm early-HDR bloom"
 tags: [game-render, stylized, warm, nostalgic, interior-friendly]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/BleachBypass.mvstyle
+++ b/packages/engine/src/prompts/include/Image/BleachBypass.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "BleachBypass"
-rating: "?"
+rating: "D"
 description: "Gritty bleach-bypass war/thriller frame: desaturated near-monochrome, crushed blacks, metallic sheen, heavy grain"
 tags: [motion-picture, stylized, muted, grim, gritty]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/CandlelitNatural.mvstyle
+++ b/packages/engine/src/prompts/include/Image/CandlelitNatural.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "CandlelitNatural"
-rating: "?"
+rating: "C"
 description: "Film shot purely by natural candlelight: warm low-light glow, ultra-shallow focus, painterly old-master tableau, fine grain"
 tags: [motion-picture, painterly, warm, intimate, interior-friendly, tender]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/CelMultiplane.mvstyle
+++ b/packages/engine/src/prompts/include/Image/CelMultiplane.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "CelMultiplane"
-rating: "?"
+rating: "D"
 description: "Cel-shaded animated frame built as stacked flat transparent cel planes with depth from layering and atmospheric haze"
 tags: [animation, stylized, color, dreamy, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Chiaroscuro.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Chiaroscuro.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Chiaroscuro"
-rating: "?"
+rating: "D"
 description: "Single-source low-key chiaroscuro: deep black swallowing the frame, one hard amber pool on the subject, operatic dread"
 tags: [motion-picture, stylized, warm, dread, intimate, interior-friendly]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/CinematicFilm.mvstyle
+++ b/packages/engine/src/prompts/include/Image/CinematicFilm.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "CinematicFilm"
-rating: "?"
+rating: "C"
 description: "Prestige 35mm anamorphic film still: gentle horizontal flares, shallow DoF, grain, teal/warm grade, letterbox title"
 tags: [motion-picture, photoreal, muted, cool, glamorous]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/CinematicFlare.mvstyle
+++ b/packages/engine/src/prompts/include/Image/CinematicFlare.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "CinematicFlare"
-rating: "?"
+rating: "D"
 description: "Blockbuster 35mm anamorphic film still: prominent blue-streak lens flares, stacked halos, veiling glare, letterbox title"
 tags: [motion-picture, photoreal, cool, glamorous]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/ConceptPoster.mvstyle
+++ b/packages/engine/src/prompts/include/Image/ConceptPoster.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "ConceptPoster"
-rating: "?"
+rating: "B"
 description: "Cinematic concept-poster key art: a single striking graphic idea in a restrained palette, richly painterly, clean caption"
 tags: [illustration, painterly, muted, epic, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/CrossProcess.mvstyle
+++ b/packages/engine/src/prompts/include/Image/CrossProcess.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "CrossProcess"
-rating: "?"
+rating: "C"
 description: "Cross-processed film: wildly shifted colour with cyan-green shadows and acid highlights, boosted contrast, lurid analog look"
 tags: [film-stock, stylized, high-saturation, gritty, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DX9Interior.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DX9Interior.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DX9Interior"
-rating: "?"
+rating: "D"
 description: "2004 DirectX 9 game screenshot: hard stencil-volume shadows, normal-mapped speculars, DXT blocking, early-HDR bloom"
 tags: [game-render, stylized, interior-friendly, nostalgic]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DarkAirbrush.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DarkAirbrush.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DarkAirbrush"
-rating: "?"
+rating: "B"
 description: "Silver-age sci-fi masked-airbrush illustration: crisp masked edges over smooth graded fills, moody low-key palette"
 tags: [illustration, stylized, muted, dreamy, period]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DashCam.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DashCam.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DashCam"
-rating: "?"
+rating: "C"
 description: "Forward-facing night dashcam still: hood edge across the bottom, headlight cone into dark, washed feed with bloom, OSD"
 tags: [surveillance, lo-fi, cool, tense, action, first-person]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DayForNight.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DayForNight.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DayForNight"
-rating: "?"
+rating: "B"
 description: "Day-for-night technique: deep cool-blue moonlit grade carrying daylight tells like too-crisp shadows and a sun-as-moon"
 tags: [motion-picture, stylized, cool, dreamy, outdoor-revealing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DeferredDX11.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DeferredDX11.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DeferredDX11"
-rating: "?"
+rating: "D"
 description: "2011 DirectX 11 game render: deferred shading, overdone SSAO, FXAA smear, pre-PBR gloss, teal-and-orange grade"
 tags: [game-render, stylized, muted, nostalgic]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DiffusionGlamour.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DiffusionGlamour.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DiffusionGlamour"
-rating: "?"
+rating: "C"
 description: "Heavy diffusion soft-focus glamour: blooming halated highlights, gauzy romantic glow, lifted milky blacks, pearlescent palette"
 tags: [motion-picture, stylized, warm, glamorous, dreamy, portrait]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DigitalPainting.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DigitalPainting.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DigitalPainting"
-rating: "?"
+rating: "C"
 description: "Polished painterly concept art: confident digital brushwork, harmonious limited palette, focal hierarchy, depth haze"
 tags: [painting, painterly, muted, epic, any-scene]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DocumentaryPhoto.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DocumentaryPhoto.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DocumentaryPhoto"
-rating: "?"
+rating: "A"
 description: "Candid photojournalistic DSLR still: available light, handheld imperfection, muted true-to-life colour, high-ISO grain"
 tags: [photographic, photoreal, muted, gritty, any-scene]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DroneCam.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DroneCam.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DroneCam"
-rating: "?"
+rating: "B"
 description: "Military UAV aerial surveillance still: steep top-down night-vision feed, small tracked subject, grainy mono, targeting HUD"
 tags: [surveillance, lo-fi, monochrome, clinical, wide-vista]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/DyeTransfer.mvstyle
+++ b/packages/engine/src/prompts/include/Image/DyeTransfer.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "DyeTransfer"
-rating: "?"
+rating: "C"
 description: "Dye-transfer imbibition Technicolor print: lush velvety ultra-saturated colour, dense blacks, near-grainless, glamorous"
 tags: [film-stock, vintage, high-saturation, glamorous, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/EightiesSciFi.mvstyle
+++ b/packages/engine/src/prompts/include/Image/EightiesSciFi.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "EightiesSciFi"
-rating: "?"
+rating: "B"
 description: "1980s sci-fi action frame: anamorphic flares, atmospheric haze, hard backlight, glowing neon practicals, 35mm grain"
 tags: [motion-picture, retro, cool, tense, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Ektachrome.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Ektachrome.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Ektachrome"
-rating: "?"
+rating: "D"
 description: "Kodak Ektachrome E100 slide film: clean neutral-to-cool rendition, accurate saturation, bright blues, sharp clarity"
 tags: [film-stock, photoreal, cool, clinical, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/FixedCamHorror.mvstyle
+++ b/packages/engine/src/prompts/include/Image/FixedCamHorror.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "FixedCamHorror"
-rating: "?"
+rating: "B"
 description: "Fixed-camera survival-horror render: single static canted dramatic angle, character dwarfed and vulnerable, crushed blacks"
 tags: [game-render, stylized, horror, dread, scene-coupled]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/GildedVellum.mvstyle
+++ b/packages/engine/src/prompts/include/Image/GildedVellum.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "GildedVellum"
-rating: "?"
+rating: "C"
 description: "Single gilded illumination on aged vellum: flat egg-tempera planes with burnished tooled gold-leaf sky and accents"
 tags: [painting, period, warm, epic, limited-palette]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/GraphicNovel.mvstyle
+++ b/packages/engine/src/prompts/include/Image/GraphicNovel.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "GraphicNovel"
-rating: "?"
+rating: "B"
 description: "Painted European bande-dessinée graphic-novel look with ink contours over rich atmospheric painted colour"
 tags: [comic, painterly, color, muted, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/InkComicColor.mvstyle
+++ b/packages/engine/src/prompts/include/Image/InkComicColor.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "InkComicColor"
-rating: "?"
+rating: "C"
 description: "Bold brush-and-ink comic with flat cel color: heavy spotted blacks, limited two-temperature palette, hard key light"
 tags: [comic, graphic, color, limited-palette, tense]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/InkNoir.mvstyle
+++ b/packages/engine/src/prompts/include/Image/InkNoir.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "InkNoir"
-rating: "?"
+rating: "C"
 description: "Bold brush-and-ink noir comic: stark chiaroscuro, heavy spotted blacks, varied brush line, one restrained spot accent"
 tags: [comic, graphic, noir, monochrome, tense, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/InkWash.mvstyle
+++ b/packages/engine/src/prompts/include/Image/InkWash.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "InkWash"
-rating: "?"
+rating: "D"
 description: "Sumi-e ink-wash on fibrous washi paper: graded black washes, decisive strokes, and large areas of bare paper as space"
 tags: [painting, painterly, monochrome, dreamy, wide-vista]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/IntaglioVignette.mvstyle
+++ b/packages/engine/src/prompts/include/Image/IntaglioVignette.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "IntaglioVignette"
-rating: "?"
+rating: "D"
 description: "Steel-plate banknote intaglio vignette in single dark ink, fading into bare cream paper with sparse burin line"
 tags: [printmaking, graphic, monochrome, sepia, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/JRPGCinematic.mvstyle
+++ b/packages/engine/src/prompts/include/Image/JRPGCinematic.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "JRPGCinematic"
-rating: "?"
+rating: "C"
 description: "Epic anime-flavoured JRPG cutscene render with cinematic depth of field, volumetric god-rays, and atmospheric distance"
 tags: [game-render, stylized, high-saturation, epic, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Kodachrome.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Kodachrome.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Kodachrome"
-rating: "?"
+rating: "D"
 description: "Kodachrome archival slide film: luminous warm reds and earth tones, high microcontrast, fine grain, golden cast"
 tags: [film-stock, photoreal, warm, nostalgic, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/LandCamera.mvstyle
+++ b/packages/engine/src/prompts/include/Image/LandCamera.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "LandCamera"
-rating: "?"
+rating: "D"
 description: "Low-key black-and-white Land-camera instant snapshot: harsh flash into depthless black, silver grain, thick white border"
 tags: [photographic, lo-fi, black-and-white, horror, dread]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/LargeFormat70.mvstyle
+++ b/packages/engine/src/prompts/include/Image/LargeFormat70.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "LargeFormat70"
-rating: "?"
+rating: "B"
 description: "Large-format 65/70mm epic frame: extraordinary clarity, deep front-to-back focus, near-grainless tonality, monumental scale"
 tags: [motion-picture, photoreal, muted, epic, wide-vista, establishing, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/LobbyCam.mvstyle
+++ b/packages/engine/src/prompts/include/Image/LobbyCam.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "LobbyCam"
-rating: "?"
+rating: "C"
 description: "Cheap ancient lobby CCTV still: upscaled macro-pixel blocks, soft out-of-focus blur, fisheye, washed colour, crude time OSD"
 tags: [surveillance, lo-fi, muted, grim, interior-friendly]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/LowPoly.mvstyle
+++ b/packages/engine/src/prompts/include/Image/LowPoly.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "LowPoly"
-rating: "?"
+rating: "D"
 description: "Stylised low-poly 3D render with flat-shaded polygon facets, crisp edges, and a coordinated limited swatch palette"
 tags: [game-render, stylized, limited-palette, cool, any-scene]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/MidGenConsole.mvstyle
+++ b/packages/engine/src/prompts/include/Image/MidGenConsole.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "MidGenConsole"
-rating: "?"
+rating: "D"
 description: "2007 Xbox-360/PS3 game render: waxy pre-PBR speculars, bloom-drunk HDR, crude SSAO halos, brown/teal grade, jaggies"
 tags: [game-render, retro, muted, nostalgic]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/ModernIllustration.mvstyle
+++ b/packages/engine/src/prompts/include/Image/ModernIllustration.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "ModernIllustration"
-rating: "?"
+rating: "C"
 description: "Clean friendly contemporary illustration: soft cel-like shading, warm limited palette, calm background, subtle paper grain"
 tags: [illustration, stylized, warm, cozy, any-scene]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/NightVisionCam.mvstyle
+++ b/packages/engine/src/prompts/include/Image/NightVisionCam.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "NightVisionCam"
-rating: "?"
+rating: "C"
 description: "Low-key infrared CCD security-camera still: IR cone into crushed black, sensor noise, fixed high-corner wide, time-only OSD"
 tags: [surveillance, lo-fi, monochrome, tense, interior-friendly]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/NinetiesComic.mvstyle
+++ b/packages/engine/src/prompts/include/Image/NinetiesComic.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "NinetiesComic"
-rating: "?"
+rating: "B"
 description: "Gritty late-90s CMYK comic scan: fine halftone rosette screen over dark-age ink, weathered faces, muddy muted palette"
 tags: [comic, printmaking, muted, grim, gritty]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/NoirCinema.mvstyle
+++ b/packages/engine/src/prompts/include/Image/NoirCinema.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "NoirCinema"
-rating: "?"
+rating: "B"
 description: "Black-and-white film-noir still: hard-key chiaroscuro, inky blacks, slatted light and smoke, grain, low dramatic angle"
 tags: [motion-picture, photoreal, black-and-white, noir, tense]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/NurseryWatercolor.mvstyle
+++ b/packages/engine/src/prompts/include/Image/NurseryWatercolor.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "NurseryWatercolor"
-rating: "?"
+rating: "D"
 description: "Vintage nursery spot illustration: a lone figure in living dip-pen line and faded washes floating on a wide white page"
 tags: [illustration, painterly, muted, tender, intimate, scene-coupled]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/PainterlyGame.mvstyle
+++ b/packages/engine/src/prompts/include/Image/PainterlyGame.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "PainterlyGame"
-rating: "?"
+rating: "S"
 description: "Hand-painted stylised game render: visible brushwork in textures, characterful proportions, warm palette, wide 20mm lens"
 tags: [game-render, painterly, warm, whimsical, wide-vista]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/PaperbackCover.mvstyle
+++ b/packages/engine/src/prompts/include/Image/PaperbackCover.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "PaperbackCover"
-rating: "?"
+rating: "C"
 description: "Hand-airbrushed gouache 1970s sci-fi paperback cover: muted palette, flat value masses, soft lost edges, print grain"
 tags: [painting, vintage, muted, limited-palette, epic, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Portra.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Portra.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Portra"
-rating: "?"
+rating: "C"
 description: "Kodak Portra 400 negative film: gentle natural skin tones, low contrast, creamy highlights, warm muted pastel palette"
 tags: [film-stock, photoreal, warm, muted, tender, portrait, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/PracticalMiniature.mvstyle
+++ b/packages/engine/src/prompts/include/Image/PracticalMiniature.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "PracticalMiniature"
-rating: "?"
+rating: "C"
 description: "Pre-CGI late-70s practical motion-control miniature on anamorphic film: hard key, smoke-filled black, shallow focus"
 tags: [motion-picture, film-stock, retro, muted, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/RayTracedAAA.mvstyle
+++ b/packages/engine/src/prompts/include/Image/RayTracedAAA.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "RayTracedAAA"
-rating: "?"
+rating: "D"
 description: "2019 flagship AAA game render: full PBR, hybrid ray-traced reflections and GI, TAA, volumetrics, photogrammetry detail"
 tags: [game-render, photoreal, cool, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/RetroPSX.mvstyle
+++ b/packages/engine/src/prompts/include/Image/RetroPSX.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "RetroPSX"
-rating: "?"
+rating: "D"
 description: "Late-90s PlayStation-era 3D render with low-poly jitter, warping affine textures, dithering, and thick draw-distance fog"
 tags: [game-render, retro, lo-fi, nostalgic, gritty]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/SilentFilm.mvstyle
+++ b/packages/engine/src/prompts/include/Image/SilentFilm.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "SilentFilm"
-rating: "?"
+rating: "A"
 description: "Early-1920s silent-film frame: high-contrast ortho black-and-white, iris vignette, film damage, ornate intertitle caption"
 tags: [motion-picture, period, black-and-white, nostalgic, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Sovcolor.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Sovcolor.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Sovcolor"
-rating: "?"
+rating: "D"
 description: "Sovcolor Eastern-bloc stock: cool muted sickly desaturated greens and anaemic blues, flat grey institutional melancholy"
 tags: [film-stock, period, muted, cool, grim, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Storybook.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Storybook.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Storybook"
-rating: "?"
+rating: "D"
 description: "Warm picture-book illustration: figure-first cross-hatch ink with soft wet-into-wet watercolor washes dissolving the distance"
 tags: [illustration, painterly, warm, tender, limited-palette]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/StreetCam.mvstyle
+++ b/packages/engine/src/prompts/include/Image/StreetCam.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "StreetCam"
-rating: "?"
+rating: "C"
 description: "Municipal street-CCTV still: high wide vantage over wet night road, pooled sodium light into blue-black, soft feed, OSD"
 tags: [surveillance, lo-fi, muted, tense, wide-vista, outdoor-revealing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Super8.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Super8.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Super8"
-rating: "?"
+rating: "C"
 description: "Super-8 home-movie frame: heavy grain, warm faded colour, corner vignette, gate-weave jitter, dust and orange light leaks"
 tags: [motion-picture, lo-fi, vintage, warm, nostalgic, intimate, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/SurvivalHorror.mvstyle
+++ b/packages/engine/src/prompts/include/Image/SurvivalHorror.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "SurvivalHorror"
-rating: "?"
+rating: "D"
 description: "Low-key flash photo, harsh on-camera flash falling to crushed black, grain and burned-in data strip — reads as AAA horror photo mode"
 tags: [photographic, lo-fi, black-and-white, dread, horror, any-scene]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Symmetrical.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Symmetrical.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Symmetrical"
-rating: "?"
+rating: "C"
 description: "Rigorously symmetrical planimetric frame: dead-centered subject, mirror-balanced pastel set, flat front-on camera, deadpan"
 tags: [motion-picture, stylized, limited-palette, whimsical, scene-coupled]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/TealOrange.mvstyle
+++ b/packages/engine/src/prompts/include/Image/TealOrange.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "TealOrange"
-rating: "?"
+rating: "D"
 description: "Modern blockbuster frame with the teal-and-orange grade: cool teal shadows, warm orange skin, glossy digital sheen"
 tags: [motion-picture, stylized, color, cool, warm, glamorous]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/TriX.mvstyle
+++ b/packages/engine/src/prompts/include/Image/TriX.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "TriX"
-rating: "?"
+rating: "D"
 description: "Kodak Tri-X 400 B&W reportage film: gritty visible grain, rich tonal range, punchy contrast, raw documentary feel"
 tags: [film-stock, photoreal, black-and-white, gritty, caption-title-only]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Ukiyoe.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Ukiyoe.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Ukiyoe"
-rating: "?"
+rating: "D"
 description: "Photo of an antique ukiyo-e woodblock print: flat colour blocks, black key-line, bokashi, woodgrain, mis-registration"
 tags: [printmaking, period, limited-palette, dreamy, establishing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/ValueBlocked.mvstyle
+++ b/packages/engine/src/prompts/include/Image/ValueBlocked.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "ValueBlocked"
-rating: "?"
+rating: "C"
 description: "Bold digital illustration designed around a few big interlocking light-and-shadow shapes for a strong notan value read"
 tags: [illustration, graphic, limited-palette, any-scene]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/WesternRPG.mvstyle
+++ b/packages/engine/src/prompts/include/Image/WesternRPG.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "WesternRPG"
-rating: "?"
+rating: "C"
 description: "Realistic gritty Western open-world RPG photo-mode screenshot with PBR materials and naturalistic global-illumination lighting"
 tags: [game-render, photoreal, gritty, establishing, outdoor-revealing]
 made-for-model: gpt-image-2

--- a/packages/engine/src/prompts/include/Image/Woodcut.mvstyle
+++ b/packages/engine/src/prompts/include/Image/Woodcut.mvstyle
@@ -1,7 +1,7 @@
 ---
 type: visual-style
 title: "Woodcut"
-rating: "?"
+rating: "D"
 description: "Bold black-and-white woodcut broadsheet: solid black masses, coarse gouge-hatching, off-register inking, carved block caption"
 tags: [printmaking, graphic, black-and-white, grim, wide-vista]
 made-for-model: gpt-image-2


### PR DESCRIPTION
A "cheat" pass on the long-open `rating: "?"` fields, now that the campaign↔style taste pass (#650, #651, #652) gives us real signal: **how often each style was reached for across the seeds** is a usable proxy for the author's eyeballed preference. The more seeds picked a style, the higher its provisional grade.

## Scale (user-chosen)
`S` > `A` > `B` > `C` > `D`, mapped from seed-count: **S = 5 seeds, A = 4, B = 3, C = 2, D = 1.**

| Tier | Styles |
|---|---|
| **S** (5) | PainterlyGame |
| **A** (4) | DocumentaryPhoto · SilentFilm |
| **B** (3) | ConceptPoster · DarkAirbrush · DayForNight · DroneCam · EightiesSciFi · FixedCamHorror · GraphicNovel · LargeFormat70 · NinetiesComic · NoirCinema |
| **C** (2) | 25 styles |
| **D** (1) | 28 styles |

66 catalog styles graded.

## Left ungraded (`"?"`)
- The **41 catalog styles no seed used** — usage frequency says nothing about them; they await an eyeball pass.
- All **36 per-seed composites** — derived bundles, not catalog building blocks.

66 graded + 41 unused = 107 catalog ✓.

## Notes
- **Provisional, not gospel.** A few D-tier styles are "low" only because they happened to fit a single seed (e.g. InkWash, RayTracedAAA). Re-grade by eye when renders are in front of you — the standing "show renders before banking" rule.
- Documented the rating scale + its usage-proxy basis in `docs/visual-style-authoring.md`.
- **Frontmatter only** — one `rating:` line per file, no engine behavior change. `tokens:` unaffected.

## Verification
Full `npm run check` green (197 files, 3586 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)