### PR TITLE
Fix flaky Velopack install smoke: anchor on completion marker, not a sleep

### DIFF
--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -119,7 +119,12 @@ omit it (default `sign=true`) from `release`/`main` to also exercise signing.
 
 **Velopack install smoke** ([`scripts/ci/velopack-install-smoke.ps1`](../scripts/ci/velopack-install-smoke.ps1)):
 installs `Setup.exe` → replays against the *installed* binary → uninstalls,
-catching install-layout/manifest bugs the portable replay can't. It is
+catching install-layout/manifest bugs the portable replay can't. `Setup.exe
+--silent` returns *before* its background install (post-install hook + a
+"kill every running app instance" sweep) finishes, so the script waits for the
+`Installation completed successfully!` marker in `velopack.log` before launching
+the replay — never a fixed sleep, which races a slow runner and lets Velopack's
+completion sweep kill the replay's own app instance. It is
 **impractical to run locally** (it performs a real machine install → uninstall
 and is Windows-only — signing is optional via the `sign` input, so a signed
 `Setup.exe` is no longer the blocker), so it was validated end-to-end on a clean

--- a/scripts/ci/velopack-install-smoke.ps1
+++ b/scripts/ci/velopack-install-smoke.ps1
@@ -22,11 +22,41 @@ $ErrorActionPreference = "Stop"
 $setup = Get-ChildItem -Path $ArtifactDir -Filter "MachineViolet-*-Setup.exe" -Recurse | Select-Object -First 1
 if (-not $setup) { throw "No MachineViolet-*-Setup.exe found in $ArtifactDir" }
 
+# Velopack writes a completion marker to this log; we anchor on it below rather
+# than on a fixed sleep. Baseline the existing match count first so a re-run on a
+# non-clean machine (where a prior "completed" line lingers) waits for OUR
+# install's marker, not a stale one.
+$velopackLog = Join-Path $env:LOCALAPPDATA "velopack\velopack.log"
+$completeMarker = "Installation completed successfully!"
+$baselineHits = 0
+if (Test-Path $velopackLog) {
+  $baselineHits = (Select-String -Path $velopackLog -SimpleMatch $completeMarker -ErrorAction SilentlyContinue | Measure-Object).Count
+}
+
 Write-Host "Installing $($setup.Name) ..."
 & $setup.FullName --silent
-# Velopack may auto-launch the app post-install; settle, then stop any instance
-# so it can't hold the install dir or hang the runner.
-Start-Sleep -Seconds 10
+
+# `Setup.exe --silent` RETURNS BEFORE its background install finishes (post-install
+# hook + a "kill every running app instance" sweep). A fixed sleep races that work:
+# on a slow runner the sleep elapses, we launch the replay's own app instance, and
+# Velopack's completion sweep kills it -> the harness's next fetch dies with
+# "fetch failed" (nightly run 27864214122). Anchor on the real completion marker
+# in the Velopack log instead.
+$deadline = (Get-Date).AddSeconds(180)
+$installed = $false
+while ((Get-Date) -lt $deadline) {
+  if (Test-Path $velopackLog) {
+    $hits = (Select-String -Path $velopackLog -SimpleMatch $completeMarker -ErrorAction SilentlyContinue | Measure-Object).Count
+    if ($hits -gt $baselineHits) { $installed = $true; break }
+  }
+  Start-Sleep -Milliseconds 500
+}
+if (-not $installed) { throw "Velopack install did not report '$completeMarker' within 180s" }
+
+# Velopack auto-launches the app as part of the post-install hook; with the install
+# now fully settled, stop any lingering instance so it can't hold the install dir
+# or hang the runner before we replay against the installed binary.
+Start-Sleep -Seconds 2
 Get-Process MachineViolet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
 $installRoot = Join-Path $env:LOCALAPPDATA "MachineViolet"

--- a/scripts/ci/velopack-install-smoke.ps1
+++ b/scripts/ci/velopack-install-smoke.ps1
@@ -51,13 +51,19 @@ while ((Get-Date) -lt $deadline) {
   }
   Start-Sleep -Milliseconds 500
 }
-if (-not $installed) { throw "Velopack install did not report '$completeMarker' within 180s" }
+if (-not $installed) { throw "Velopack install did not report '$completeMarker' within 180s (log: $velopackLog)" }
 
 # Velopack auto-launches the app as part of the post-install hook; with the install
 # now fully settled, stop any lingering instance so it can't hold the install dir
-# or hang the runner before we replay against the installed binary.
-Start-Sleep -Seconds 2
-Get-Process MachineViolet -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+# or hang the runner before we replay against the installed binary. Poll-and-kill
+# until none remain (bounded) rather than sleeping a fixed amount and hoping.
+$killDeadline = (Get-Date).AddSeconds(30)
+while ((Get-Date) -lt $killDeadline) {
+  $procs = Get-Process MachineViolet -ErrorAction SilentlyContinue
+  if (-not $procs) { break }
+  $procs | Stop-Process -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Milliseconds 250
+}
 
 $installRoot = Join-Path $env:LOCALAPPDATA "MachineViolet"
 $bin = Join-Path $installRoot "current\MachineViolet.exe"


### PR DESCRIPTION
## Problem

Nightly run [27864214122](https://github.com/octopollux/machine-violet/actions/runs/27864214122) failed in the **Velopack install/uninstall smoke (Windows)** step of `verify-package` — the replay against the *installed* binary died with `✘ FAIL — fetch failed`. The build itself and the packaged-binary replay both passed; this is a **race in the smoke script, not a code regression**.

`Setup.exe --silent` returns *before* Velopack's background install finishes — the post-install hook plus a "kill every running app instance" sweep run afterward. The script's `Start-Sleep -Seconds 10` was a fixed timer racing that work. On a slow runner the sleep elapsed, the replay launched its own app instance, and Velopack's completion sweep killed it:

```
07:32:50.84  replay launches app (PID 2808)
07:32:54.62  [WARN] Killing process: ...MachineViolet.exe (2808)   <-- killed out from under the harness
07:32:54.91  Installation completed successfully!
             -> next fetch to the app sidecar dies with "fetch failed"
```

The healthy run the night before launched the replay *after* `Installation completed successfully!`, so it passed. (The `ERROR: ...valid choices` line is an unrelated cosmetic artifact of Velopack's uninstall `choice` command.)

## Fix

Replace the fixed sleep with a poll anchored to Velopack's real completion signal — the `Installation completed successfully!` marker in `velopack.log` — baselining the existing match count first so a re-run on a non-clean machine waits for *this* install's marker rather than a stale one. Matches the harness's "anchor every wait to an observable state change, never a bare timer" rule.

- `scripts/ci/velopack-install-smoke.ps1` — completion-marker poll (PowerShell parse-validated)
- `docs/e2e-harness.md` — smoke description kept in sync

Cannot be validated locally (real machine install/uninstall, Windows-CI-only); validate via a `test-build.yml` dispatch on this branch (`-f windows=true -f sign=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)