### PR TITLE
Fix archive corruption from concurrent archives + harden read-back

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -540,6 +540,14 @@ The modal owns its own countdown timer: a `setInterval` that ticks once per seco
 
 **Code:** `packages/client-ink/src/tui/modals/ApiErrorModal.tsx`, wired in `packages/client-ink/src/phases/PlayingPhase.tsx`. For the retry backoff schedule and error-kind labels, see [error-recovery.md — API Failures](error-recovery.md#api-failures).
 
+### Archiving a campaign
+
+Triggered from the main menu's campaign sub-list by pressing Enter on the Archive column. Unlike resume (which collapses the list) the sub-list **stays expanded**: the triggered row swaps its `Archive`/`Delete` buttons for an inline `Archiving…` label, and the entry drops out of the list on its own when the archive completes and the parent refreshes `campaigns`.
+
+While an archive is in flight, **all actions on that entry are blocked** (resume, re-archive, delete) — the archive deletes the campaign's source folder on success, so acting on it mid-flight would race. This guard is two-layered: the client ignores repeat triggers for an in-flight id (`archivingIds` prop, threaded from `app.tsx`), and the server rejects a concurrent `POST /manage/campaigns/:id/archive` for the same campaign with **409 Conflict** ("Archive already in progress"). The server guard is the authoritative one — two overlapping archives compute the same destination zip path and race each other's source deletion, corrupting the archive ("contents mismatch on disk"). A double-fire from an unguarded UI was the original trigger.
+
+**Code:** `onArchiveCampaign` / `archivingIds` in `packages/client-ink/src/app.tsx` and `packages/client-ink/src/phases/MainMenuPhase.tsx`; the `archivesInProgress` lock in `packages/engine/src/server/routes/management.ts`.
+
 ### Delete Campaign Modal
 
 A confirmation modal shown over the full-screen main-menu frame before a campaign is permanently removed. Triggered from the main menu's campaign sub-list when the player presses Enter on the Delete column.

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -140,10 +140,14 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
     saveClientSettings({ showVerbose, dmTurnLengthPctDefault }).catch(() => { /* best-effort */ });
   }, [showVerbose, dmTurnLengthPctDefault]);
   const [archiveStatus, setArchiveStatus] = useState("");
-  // Campaign ids with an archive POST in flight. Drives the inline "Archiving…"
-  // indicator and blocks a second trigger for the same campaign (a double-fire
-  // used to race the server and corrupt the zip). The server enforces the same
-  // guard; this is the reactive UI half.
+  // Campaign ids with an archive POST in flight. Blocks a second trigger for the
+  // same campaign (a double-fire used to race the server and corrupt the zip;
+  // the server enforces the same guard, but defeating it here would still flash
+  // a spurious 409 and let the loser's .finally() clear the indicator mid-archive).
+  // The REF is the authoritative source of truth: it's mutated synchronously, so
+  // two Enter presses in one render batch can't both pass the guard. `archivingIds`
+  // mirrors it purely to drive the reactive "Archiving…" UI.
+  const archivingIdsRef = useRef<Set<string>>(new Set());
   const [archivingIds, setArchivingIds] = useState<Set<string>>(() => new Set());
   const [deleteModal, setDeleteModal] = useState<CampaignDeleteInfo | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
@@ -513,19 +517,18 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
           // Ignore a duplicate trigger while this campaign's archive is in
           // flight — the source folder isn't deleted until the first POST
           // succeeds, so the entry is still selectable until then.
-          if (archivingIds.has(id)) return;
-          setArchivingIds((prev) => new Set(prev).add(id));
+          // Synchronous guard off the ref — immune to React's deferred state
+          // commit, so a rapid repeat Enter can't slip a second POST through.
+          if (archivingIdsRef.current.has(id)) return;
+          archivingIdsRef.current.add(id);
+          setArchivingIds(new Set(archivingIdsRef.current));
           apiClientRef.current.archiveCampaign(id).then(() => {
             refreshCampaigns();
           }).catch((err) => {
             setErrorMessage(err instanceof Error ? err.message : String(err));
           }).finally(() => {
-            setArchivingIds((prev) => {
-              if (!prev.has(id)) return prev;
-              const next = new Set(prev);
-              next.delete(id);
-              return next;
-            });
+            archivingIdsRef.current.delete(id);
+            setArchivingIds(new Set(archivingIdsRef.current));
           });
         }}
         onDeleteCampaign={(entry) => {

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -140,6 +140,11 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
     saveClientSettings({ showVerbose, dmTurnLengthPctDefault }).catch(() => { /* best-effort */ });
   }, [showVerbose, dmTurnLengthPctDefault]);
   const [archiveStatus, setArchiveStatus] = useState("");
+  // Campaign ids with an archive POST in flight. Drives the inline "Archiving…"
+  // indicator and blocks a second trigger for the same campaign (a double-fire
+  // used to race the server and corrupt the zip). The server enforces the same
+  // guard; this is the reactive UI half.
+  const [archivingIds, setArchivingIds] = useState<Set<string>>(() => new Set());
   const [deleteModal, setDeleteModal] = useState<CampaignDeleteInfo | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
@@ -502,12 +507,25 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
           });
         }}
         onResumeCampaign={(entry) => startCampaign(entry.id ?? entry.name)}
+        archivingIds={archivingIds}
         onArchiveCampaign={(entry) => {
           const id = entry.id ?? entry.name;
+          // Ignore a duplicate trigger while this campaign's archive is in
+          // flight — the source folder isn't deleted until the first POST
+          // succeeds, so the entry is still selectable until then.
+          if (archivingIds.has(id)) return;
+          setArchivingIds((prev) => new Set(prev).add(id));
           apiClientRef.current.archiveCampaign(id).then(() => {
             refreshCampaigns();
           }).catch((err) => {
             setErrorMessage(err instanceof Error ? err.message : String(err));
+          }).finally(() => {
+            setArchivingIds((prev) => {
+              if (!prev.has(id)) return prev;
+              const next = new Set(prev);
+              next.delete(id);
+              return next;
+            });
           });
         }}
         onDeleteCampaign={(entry) => {

--- a/packages/client-ink/src/phases/MainMenuPhase.test.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.test.tsx
@@ -286,6 +286,82 @@ describe("MainMenuPhase", () => {
     const matches = frame.match(/Requires a valid API key/g) ?? [];
     expect(matches.length).toBe(1);
   });
+
+  describe("archive in-flight guard", () => {
+    const DOWN = "[B";
+    const RIGHT = "[C";
+
+    async function expandList(
+      props: MainMenuPhaseProps,
+    ): Promise<ReturnType<typeof render>> {
+      const r = render(<MainMenuPhase {...props} />);
+      const frame = () => r.lastFrame() ?? "";
+      const selected = () => frame().split("\n").find((l) => l.includes("◆")) ?? "";
+      await vi.waitFor(() => {
+        if (selected().includes("New Campaign")) r.stdin.write(DOWN);
+        expect(selected()).toContain("Continue Campaign");
+      });
+      await vi.waitFor(() => {
+        if (!frame().includes("Test Campaign")) r.stdin.write("\r"); // expand
+        expect(frame()).toContain("Test Campaign");
+      });
+      return r;
+    }
+
+    it("renders 'Archiving…' and hides the action buttons for an in-flight campaign", async () => {
+      const props = defaultProps({
+        campaigns: [{ name: "Test Campaign", path: "/t" }],
+        archivingIds: new Set(["Test Campaign"]),
+      });
+      const { lastFrame } = await expandList(props);
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("Archiving");
+      // The actionable buttons are replaced while the archive is in flight.
+      expect(frame).not.toContain("Delete");
+    });
+
+    it("blocks resume/re-archive on a campaign whose archive is in flight", async () => {
+      const onArchiveCampaign = vi.fn();
+      const onResumeCampaign = vi.fn();
+      const props = defaultProps({
+        campaigns: [{ name: "Test Campaign", path: "/t" }],
+        archivingIds: new Set(["Test Campaign"]),
+        onArchiveCampaign,
+        onResumeCampaign,
+      });
+      const { stdin } = await expandList(props);
+      // Hammer Enter across columns — every action on an in-flight entry is inert.
+      for (let i = 0; i < 3; i++) {
+        stdin.write("\r");
+        stdin.write(RIGHT);
+        await new Promise((res) => setTimeout(res, 10));
+      }
+      expect(onArchiveCampaign).not.toHaveBeenCalled();
+      expect(onResumeCampaign).not.toHaveBeenCalled();
+    });
+
+    it("triggers archive and keeps the list expanded for reactive feedback", async () => {
+      const onArchiveCampaign = vi.fn();
+      const props = defaultProps({
+        campaigns: [{ name: "Test Campaign", path: "/t" }],
+        onArchiveCampaign,
+      });
+      const r = await expandList(props);
+      const frame = () => r.lastFrame() ?? "";
+      await vi.waitFor(() => {
+        if (!frame().includes("[Archive]")) r.stdin.write(RIGHT); // to Archive column
+        expect(frame()).toContain("[Archive]");
+      });
+      await vi.waitFor(() => {
+        if (!onArchiveCampaign.mock.calls.length) r.stdin.write("\r");
+        expect(onArchiveCampaign).toHaveBeenCalled();
+      });
+      // Unlike resume, archiving does NOT collapse the list — the entry stays
+      // visible so the parent can swap in the "Archiving…" state and then drop
+      // it on refresh.
+      expect(frame()).toContain("Test Campaign");
+    });
+  });
 });
 
 describe("wrapByWord", () => {

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -20,6 +20,12 @@ const COL_ARCHIVE = 1;
 const COL_DELETE = 2;
 const COL_COUNT = 3;
 
+/** Shared empty set so an absent `archivingIds` prop is a stable reference. */
+const NO_ARCHIVING: ReadonlySet<string> = new Set<string>();
+
+/** Stable id for a campaign entry — matches what the archive handler keys on. */
+const entryId = (e: CampaignEntry): string => e.id ?? e.name;
+
 export interface MainMenuPhaseProps {
   theme: ResolvedTheme;
   campaigns: CampaignEntry[];
@@ -31,6 +37,8 @@ export interface MainMenuPhaseProps {
   onNewCampaign: () => void;
   onResumeCampaign: (entry: CampaignEntry) => void;
   onArchiveCampaign: (entry: CampaignEntry) => void;
+  /** Campaign ids whose archive is in flight — render "Archiving…" and block re-triggers. */
+  archivingIds?: ReadonlySet<string>;
   onDeleteCampaign: (entry: CampaignEntry) => void;
   /** When non-null, the delete confirmation modal is shown. */
   deleteModal: CampaignDeleteInfo | null;
@@ -57,6 +65,7 @@ export function MainMenuPhase({
   onNewCampaign,
   onResumeCampaign,
   onArchiveCampaign,
+  archivingIds = NO_ARCHIVING,
   onDeleteCampaign,
   deleteModal,
   onConfirmDelete,
@@ -86,6 +95,20 @@ export function MainMenuPhase({
   useEffect(() => {
     setMainMenuIndex((i) => Math.min(i, mainMenuItems.length - 1));
   }, [mainMenuItems.length]);
+
+  // The campaign sub-list stays expanded through an archive so the inline
+  // "Archiving…" state is visible; when the archive lands the entry drops out
+  // of `campaigns` (parent refresh). Keep the selection in range, and fold the
+  // list shut if the last campaign just left.
+  useEffect(() => {
+    if (campaigns.length === 0) {
+      setExpandedCampaigns(false);
+      setCampaignColumn(COL_NAME);
+      setCampaignSelectIndex(0);
+      return;
+    }
+    setCampaignSelectIndex((i) => Math.min(i, campaigns.length - 1));
+  }, [campaigns.length]);
 
   const isItemDisabled = (item: string): boolean =>
     API_REQUIRED_ITEMS.has(item) && !apiKeyValid;
@@ -136,14 +159,17 @@ export function MainMenuPhase({
       }
       if (key.return) {
         const entry = campaigns[campaignSelectIndex];
+        // An archive in flight will delete the source on success — block resume,
+        // re-archive, and delete on that entry until it resolves.
+        if (entry && archivingIds.has(entryId(entry))) return;
         if (campaignColumn === COL_NAME) {
           setExpandedCampaigns(false);
           setCampaignColumn(COL_NAME);
           onResumeCampaign(entry);
         } else if (campaignColumn === COL_ARCHIVE) {
+          // Leave the list expanded so the inline "Archiving…" state is visible;
+          // the entry drops out on its own when the parent refresh lands.
           onArchiveCampaign(entry);
-          setExpandedCampaigns(false);
-          setCampaignColumn(COL_NAME);
         } else if (campaignColumn === COL_DELETE) {
           onDeleteCampaign(entry);
         }
@@ -245,6 +271,7 @@ export function MainMenuPhase({
     if (item === "Continue Campaign" && expandedCampaigns) {
       for (let j = 0; j < campaigns.length; j++) {
         const cSelected = j === campaignSelectIndex;
+        const archiving = archivingIds.has(entryId(campaigns[j]));
         const nameActive = cSelected && campaignColumn === COL_NAME;
         const archiveActive = cSelected && campaignColumn === COL_ARCHIVE;
         const deleteActive = cSelected && campaignColumn === COL_DELETE;
@@ -256,9 +283,16 @@ export function MainMenuPhase({
             <Text color={cColor}>{cMarker}</Text>
             <Text color={nameActive ? accentColor : undefined} bold={nameActive}>{` ${campaigns[j].name}`}</Text>
             <Text>{`  `}</Text>
-            <Text color="yellow" bold={archiveActive} dimColor={!cSelected}>{archiveActive ? "[Archive]" : " Archive "}</Text>
-            <Text>{` `}</Text>
-            <Text color="red" bold={deleteActive} dimColor={!cSelected}>{deleteActive ? "[Delete]" : " Delete "}</Text>
+            {archiving ? (
+              // In flight — actions are suppressed (see the Enter guard).
+              <Text color="yellow" dimColor>{`Archiving…`}</Text>
+            ) : (
+              <>
+                <Text color="yellow" bold={archiveActive} dimColor={!cSelected}>{archiveActive ? "[Archive]" : " Archive "}</Text>
+                <Text>{` `}</Text>
+                <Text color="red" bold={deleteActive} dimColor={!cSelected}>{deleteActive ? "[Delete]" : " Delete "}</Text>
+              </>
+            )}
           </Text>,
         );
       }

--- a/packages/engine/src/config/campaign-archive.test.ts
+++ b/packages/engine/src/config/campaign-archive.test.ts
@@ -164,6 +164,72 @@ describe("archiveCampaign", () => {
   });
 });
 
+describe("archiveCampaign read-back verification", () => {
+  // Force the post-write read-back (the only `.zip` read inside the build) to
+  // misbehave, leaving the rest of the in-memory fs intact.
+  function tamperZipReadBack(
+    io: ReturnType<typeof createMockIO>,
+    handler: (zipReadCount: number) => Uint8Array | "throw" | "passthrough",
+  ): () => number {
+    const realReadBinary = io.readBinary.bind(io);
+    let zipReads = 0;
+    io.readBinary = async (path: string) => {
+      if (norm(path).endsWith(".zip")) {
+        zipReads++;
+        const r = handler(zipReads);
+        if (r === "throw") throw new Error("EBUSY: resource busy or locked");
+        if (r !== "passthrough") return r;
+      }
+      return realReadBinary(path);
+    };
+    return () => zipReads;
+  }
+
+  it("retries once and succeeds when the first read-back is a transient miss", async () => {
+    const io = createMockIO();
+    const campaignsDir = "/home/user/campaigns";
+    const campaignPath = `${campaignsDir}/test-campaign`;
+    seedCampaign(io, campaignPath);
+    // First read-back returns garbage (transient AV/sync hold); the retry reads
+    // the real bytes.
+    const reads = tamperZipReadBack(io, (n) => (n === 1 ? new Uint8Array([0, 1, 2]) : "passthrough"));
+
+    const result = await archiveCampaign(campaignPath, campaignsDir, io);
+    expect(result.ok).toBe(true);
+    expect(reads()).toBe(2); // proves the retry ran
+    // Source is deleted only on success — the round-trip completed.
+    expect(await io.exists(norm(campaignPath + "/config.json"))).toBe(false);
+  });
+
+  it("fails with both byte lengths after a persistent mismatch", async () => {
+    const io = createMockIO();
+    const campaignsDir = "/home/user/campaigns";
+    const campaignPath = `${campaignsDir}/test-campaign`;
+    seedCampaign(io, campaignPath);
+    tamperZipReadBack(io, () => new Uint8Array([0, 1, 2])); // always wrong (3 bytes)
+
+    const result = await archiveCampaign(campaignPath, campaignsDir, io);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/expected \d+ bytes, read 3/);
+    // Fail-safe: the source survives a failed archive.
+    expect(await io.exists(norm(campaignPath + "/config.json"))).toBe(true);
+  });
+
+  it("fails clearly when the read-back keeps throwing", async () => {
+    const io = createMockIO();
+    const campaignsDir = "/home/user/campaigns";
+    const campaignPath = `${campaignsDir}/test-campaign`;
+    seedCampaign(io, campaignPath);
+    tamperZipReadBack(io, () => "throw");
+
+    const result = await archiveCampaign(campaignPath, campaignsDir, io);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("could not read back zip");
+    expect(result.error).toContain("EBUSY");
+    expect(await io.exists(norm(campaignPath + "/config.json"))).toBe(true);
+  });
+});
+
 describe("snapshotCampaign", () => {
   it("backs up the campaign without deleting the source", async () => {
     const io = createMockIO();

--- a/packages/engine/src/config/campaign-archive.ts
+++ b/packages/engine/src/config/campaign-archive.ts
@@ -154,6 +154,47 @@ function fileStamp(): string {
   return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
 }
 
+/** Pause before the read-back retry — long enough to outlast a transient hold. */
+const READBACK_RETRY_MS = 50;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Read the just-written zip back and confirm it's byte-identical to what we
+ * wrote. A *transient* external hold on the file — an antivirus real-time scan,
+ * a cloud-sync client briefly re-writing it — can make the immediate read-back
+ * come back short, differ, or throw, then resolve a moment later. So on a first
+ * mismatch or read error we wait briefly and re-read once before declaring the
+ * write corrupt. The failure names both byte lengths (or the read error) so a
+ * genuine corruption is self-diagnosing rather than an opaque "mismatch".
+ */
+async function verifyWrittenZip(
+  io: ArchiveFileIO,
+  zipPath: string,
+  expected: Uint8Array,
+): Promise<ArchiveResult> {
+  const check = async (): Promise<{ ok: true } | { ok: false; detail: string }> => {
+    try {
+      const readBack = await io.readBinary(zipPath);
+      if (bytesEqual(readBack, expected)) return { ok: true };
+      return {
+        ok: false,
+        detail: `zip file contents mismatch on disk (expected ${expected.length} bytes, read ${readBack.length})`,
+      };
+    } catch (e) {
+      return { ok: false, detail: `could not read back zip (${e instanceof Error ? e.message : String(e)})` };
+    }
+  };
+
+  let result = await check();
+  if (!result.ok) {
+    await delay(READBACK_RETRY_MS);
+    result = await check();
+  }
+  if (!result.ok) return { ok: false, error: `Write verification failed: ${result.detail}` };
+  return { ok: true, zipPath };
+}
+
 /**
  * Walk → zip → verify-in-memory → write → read-back-verify. Does NOT modify the
  * source folder. Shared by `archiveCampaign` (which then deletes the source)
@@ -198,12 +239,9 @@ async function buildAndWriteVerifiedZip(
   await io.mkdir(archDir);
   await io.writeBinary(zipPath, zipped);
 
-  // Step 5: Read back and verify byte-level equality
-  const readBack = await io.readBinary(zipPath);
-  if (!bytesEqual(readBack, zipped)) {
-    return { ok: false, error: "Write verification failed: zip file contents mismatch on disk" };
-  }
-  return { ok: true, zipPath };
+  // Step 5: Read back and verify byte-level equality, retrying once to ride out
+  // a transient antivirus/sync hold on the freshly written file.
+  return await verifyWrittenZip(io, zipPath, zipped);
 }
 
 // --- Core operations ---

--- a/packages/engine/src/server/routes/management.test.ts
+++ b/packages/engine/src/server/routes/management.test.ts
@@ -1,0 +1,124 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
+
+// The archive route's concurrency guard is the unit under test: a second
+// archive of the SAME campaign while the first is in flight must be rejected
+// (409), not run concurrently — two overlapping archives race the same zip
+// path and source deletion, corrupting the archive ("contents mismatch on
+// disk"). archiveCampaign itself is covered in campaign-archive.test.ts, so we
+// replace it with a controllable deferred to make the overlap deterministic.
+interface ArchiveResult { ok: boolean; zipPath?: string; error?: string }
+
+// Created via vi.hoisted so they exist before vi.mock's factory (hoisted to the
+// top of the module) references them.
+const { archiveCampaignMock, pending } = vi.hoisted(() => {
+  const pending: ((v: ArchiveResult) => void)[] = [];
+  const archiveCampaignMock = vi.fn(() => new Promise<ArchiveResult>((res) => { pending.push(res); }));
+  return { archiveCampaignMock, pending };
+});
+
+vi.mock("../../config/campaign-archive.js", () => ({
+  archiveCampaign: archiveCampaignMock,
+  deleteCampaign: vi.fn(),
+  listArchivedCampaigns: vi.fn(),
+  unarchiveCampaign: vi.fn(),
+  getCampaignDeleteInfo: vi.fn(),
+  // The route gets its ArchiveFileIO from ../fileio.js, which re-exports this
+  // from the mocked module — stub it so the call doesn't throw (the mocked
+  // archiveCampaign ignores the io anyway).
+  createArchiveFileIO: vi.fn(() => ({})),
+}));
+
+import { managementRoutes } from "./management.js";
+
+// In-process Fastify inject (no network) but boot can blow the 5s default
+// under heavy parallel-suite CPU contention — give headroom (see dev.test.ts).
+vi.setConfig({ testTimeout: 30_000 });
+
+const ARCHIVE_URL = "/campaigns/test-campaign/archive";
+
+async function buildApp(opts: { isBusy?: boolean } = {}): Promise<FastifyInstance> {
+  const app = Fastify();
+  app.decorate("configDir", "/tmp/config");
+  app.decorate("sessionManager", {
+    isBusy: opts.isBusy ?? false,
+    getCampaignsDir: () => "/tmp/campaigns",
+  } as never);
+  await app.register(managementRoutes);
+  await app.ready();
+  return app;
+}
+
+describe("POST /campaigns/:id/archive — concurrency guard", () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    archiveCampaignMock.mockClear();
+    pending.length = 0;
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it("rejects a second concurrent archive of the same campaign with 409", async () => {
+    app = await buildApp();
+
+    // Fire archive A but don't await — its handler takes the lock and parks on
+    // the deferred archiveCampaign.
+    const a = app.inject({ method: "POST", url: ARCHIVE_URL });
+    // Ensure A is actually in flight (lock held) before firing B.
+    await vi.waitFor(() => expect(archiveCampaignMock).toHaveBeenCalledTimes(1));
+
+    // B overlaps A → rejected by the lock, never reaches archiveCampaign.
+    const b = await app.inject({ method: "POST", url: ARCHIVE_URL });
+    expect(b.statusCode).toBe(409);
+    expect(b.json().error).toMatch(/already in progress/i);
+    expect(archiveCampaignMock).toHaveBeenCalledTimes(1);
+
+    // Let A finish.
+    pending[0]({ ok: true, zipPath: "/tmp/campaigns/../archivedcampaigns/Test.zip" });
+    const aRes = await a;
+    expect(aRes.statusCode).toBe(200);
+    expect(aRes.json()).toMatchObject({ ok: true });
+  });
+
+  it("releases the lock so a later archive of the same campaign succeeds", async () => {
+    app = await buildApp();
+
+    const a = app.inject({ method: "POST", url: ARCHIVE_URL });
+    await vi.waitFor(() => expect(archiveCampaignMock).toHaveBeenCalledTimes(1));
+    pending[0]({ ok: true, zipPath: "/x.zip" });
+    expect((await a).statusCode).toBe(200);
+
+    // Same id again, sequentially — the lock must have been released.
+    const c = app.inject({ method: "POST", url: ARCHIVE_URL });
+    await vi.waitFor(() => expect(archiveCampaignMock).toHaveBeenCalledTimes(2));
+    pending[1]({ ok: true, zipPath: "/y.zip" });
+    expect((await c).statusCode).toBe(200);
+  });
+
+  it("releases the lock even when the archive fails", async () => {
+    app = await buildApp();
+
+    const a = app.inject({ method: "POST", url: ARCHIVE_URL });
+    await vi.waitFor(() => expect(archiveCampaignMock).toHaveBeenCalledTimes(1));
+    pending[0]({ ok: false, error: "Failed to create zip archive" });
+    expect((await a).statusCode).toBe(500);
+
+    // A retry isn't wedged behind a stuck lock.
+    const c = app.inject({ method: "POST", url: ARCHIVE_URL });
+    await vi.waitFor(() => expect(archiveCampaignMock).toHaveBeenCalledTimes(2));
+    pending[1]({ ok: true, zipPath: "/y.zip" });
+    expect((await c).statusCode).toBe(200);
+  });
+
+  it("rejects archiving while a session is active before taking the lock", async () => {
+    app = await buildApp({ isBusy: true });
+
+    const res = await app.inject({ method: "POST", url: ARCHIVE_URL });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toMatch(/session is active/i);
+    expect(archiveCampaignMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -532,6 +532,16 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
     }
   });
 
+  // Per-campaign in-flight archive guard. Two concurrent archives of the same
+  // campaign race each other: both compute the same destination zip path (it
+  // doesn't exist yet for either), both write to it, and one's source deletion
+  // races the other's walk/read-back — yielding a corrupt or "contents mismatch
+  // on disk" archive. A double-fire from the UI (no input block) is the common
+  // trigger. Reject the duplicate rather than queueing it: one archive is one
+  // intentional action. The `isBusy` check above only covers active *sessions*,
+  // not a second archive of an idle campaign.
+  const archivesInProgress = new Set<string>();
+
   /** Archive a campaign to zip. */
   server.post("/campaigns/:id/archive", {
     schema: {
@@ -544,14 +554,23 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
       return reply.status(409).send({ error: "Cannot archive while a session is active." });
     }
 
-    const campaignPath = join(campaignsDir(), (request.params as { id: string }).id);
-    const io = createArchiveFileIO();
-    const result = await archiveCampaign(campaignPath, campaignsDir(), io);
-
-    if (!result.ok) {
-      return reply.status(500).send({ error: result.error ?? "Archive failed." });
+    const id = (request.params as { id: string }).id;
+    if (archivesInProgress.has(id)) {
+      return reply.status(409).send({ error: "Archive already in progress for this campaign." });
     }
-    return { ok: true, zipPath: result.zipPath };
+    archivesInProgress.add(id);
+    try {
+      const campaignPath = join(campaignsDir(), id);
+      const io = createArchiveFileIO();
+      const result = await archiveCampaign(campaignPath, campaignsDir(), io);
+
+      if (!result.ok) {
+        return reply.status(500).send({ error: result.error ?? "Archive failed." });
+      }
+      return { ok: true, zipPath: result.zipPath };
+    } finally {
+      archivesInProgress.delete(id);
+    }
   });
 
   /** Permanently delete a campaign. */


### PR DESCRIPTION
## Problem

Archiving a campaign could fail with a "zip data not matching" / "contents mismatch on disk" verification error. Root cause: the archive trigger was **fire-and-forget with no input block**, so re-selecting **Archive** before the first request returned launched a second `POST /manage/campaigns/:id/archive`. Both server handlers computed the same destination zip path (neither existed yet), wrote to it, and one handler's source-folder deletion raced the other's walk/read-back — corrupting the archive.

The pipeline already **fails safe** (the source is only deleted after every verification passes, so no campaign data was lost), but the archive never completed.

## Fix — two layers

The UI guard alone can't close the race (fast input, two clients, Discord + TUI all still race), so both layers are addressed.

### Server lock (authoritative) — `bae7495`
Per-campaign `archivesInProgress` set in the management routes. A second concurrent archive of the same id returns **409 "Archive already in progress"**. `try/finally` releases the lock on success, failure, and throw.

### Reactive UI guard — `bae7495`
`archivingIds` state in `app.tsx`, threaded to `MainMenuPhase`. While an archive is in flight the campaign sub-list **stays expanded** and the row shows an inline `Archiving…` label (previously it collapsed instantly with zero feedback). All actions on that entry — resume, re-archive, delete — are blocked until it resolves; the entry drops out when the parent refresh lands. Added a clamp effect so removing the archived entry can't strand the selection index past the end.

### Read-back hardening — `4f4459f`
Independently, the post-write read-back verification now **retries once** (50ms) on a first mismatch *or* a throwing read, to ride out a transient external hold on the freshly written file (antivirus scan, cloud-sync client re-writing it). The failure is now **self-diagnosing**: `…contents mismatch on disk (expected N bytes, read M)` or `…could not read back zip (<error>)` instead of an opaque "mismatch". Applies to both `archiveCampaign` and `snapshotCampaign` (rollback backups).

## Tests
- `management.test.ts` (new) — in-process Fastify `inject` with a controllable `archiveCampaign`: concurrent archive → 409; lock released after both success and failure; `isBusy` still 409s first.
- `MainMenuPhase.test.tsx` — renders `Archiving…` / hides buttons for an in-flight entry; blocks resume/re-archive while in flight; happy-path fires once and keeps the list expanded.
- `campaign-archive.test.ts` — transient first-read miss retries and succeeds; persistent mismatch fails with both byte lengths and leaves the source intact; a read-back that keeps throwing fails with a clear message.

## Docs
New "Archiving a campaign" section in `docs/tui-design.md` covering the two-layer guard and the inline in-flight state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)