### PR TITLE
Restore concurrency guard + truthful archive-size note (follow-up to #656)

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -550,6 +550,8 @@ While an archive is in flight, **all actions on that entry are blocked** (resume
 
 **Restore (the symmetric twin).** Restoring an archive from the Archived Campaigns list (Enter on an entry, ArchivedCampaignsPhase) carries the same two-layer guard, keyed by **zip path** instead of campaign id. The selected row shows an inline `Restoring…` and ignores repeat Enter while in flight (`restoringPaths` prop from `app.tsx`); the server rejects a concurrent `POST /manage/campaigns/archived/:name/restore` for the same zip with **409 Conflict** ("Restore already in progress"), via the `restoresInProgress` lock. Restore is actually the *more* double-fire-prone of the two — the screen doesn't move on Enter — and a duplicate restore races the unique-slot loop (TOCTOU between the `exists` check and `mkdir`), colliding on one dir or spawning duplicate `-2`/`-3` slots. Restore is non-destructive (it never deletes the archive or an existing campaign), so the stakes are lower than archive, but the guard keeps the behavior clean.
 
+The restore route resolves its target **strictly inside `archiveDir()`** (the canonical `archivedcampaigns/` dir — a *sibling* of the campaigns dir, not a child): the client echoes back a `zipPath` from the list endpoint, but the server trusts only its filename component, so a crafted body or `:name` can't traverse out (`..`) or turn the endpoint into an arbitrary-zip reader. A target whose basename isn't a `.zip` is rejected with **400**.
+
 ### Delete Campaign Modal
 
 A confirmation modal shown over the full-screen main-menu frame before a campaign is permanently removed. Triggered from the main menu's campaign sub-list when the player presses Enter on the Delete column.

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -548,6 +548,8 @@ While an archive is in flight, **all actions on that entry are blocked** (resume
 
 **Code:** `onArchiveCampaign` / `archivingIds` in `packages/client-ink/src/app.tsx` and `packages/client-ink/src/phases/MainMenuPhase.tsx`; the `archivesInProgress` lock in `packages/engine/src/server/routes/management.ts`.
 
+**Restore (the symmetric twin).** Restoring an archive from the Archived Campaigns list (Enter on an entry, ArchivedCampaignsPhase) carries the same two-layer guard, keyed by **zip path** instead of campaign id. The selected row shows an inline `Restoring…` and ignores repeat Enter while in flight (`restoringPaths` prop from `app.tsx`); the server rejects a concurrent `POST /manage/campaigns/archived/:name/restore` for the same zip with **409 Conflict** ("Restore already in progress"), via the `restoresInProgress` lock. Restore is actually the *more* double-fire-prone of the two — the screen doesn't move on Enter — and a duplicate restore races the unique-slot loop (TOCTOU between the `exists` check and `mkdir`), colliding on one dir or spawning duplicate `-2`/`-3` slots. Restore is non-destructive (it never deletes the archive or an existing campaign), so the stakes are lower than archive, but the guard keeps the behavior clean.
+
 ### Delete Campaign Modal
 
 A confirmation modal shown over the full-screen main-menu frame before a campaign is permanently removed. Triggered from the main menu's campaign sub-list when the player presses Enter on the Delete column.

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -149,6 +149,12 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
   // mirrors it purely to drive the reactive "Archiving…" UI.
   const archivingIdsRef = useRef<Set<string>>(new Set());
   const [archivingIds, setArchivingIds] = useState<Set<string>>(() => new Set());
+  // Same pattern for restore (keyed by zip path): the archived-campaigns screen
+  // doesn't move on Enter, so a mashed Enter would otherwise fire N concurrent
+  // restores of one archive. Ref = synchronous source of truth; state mirrors it
+  // to drive the reactive "Restoring…" UI.
+  const restoringPathsRef = useRef<Set<string>>(new Set());
+  const [restoringPaths, setRestoringPaths] = useState<Set<string>>(() => new Set());
   const [deleteModal, setDeleteModal] = useState<CampaignDeleteInfo | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
@@ -635,7 +641,13 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
         theme={theme}
         archives={archivedCampaigns}
         statusMessage={archiveStatus}
+        restoringPaths={restoringPaths}
         onUnarchive={(entry) => {
+          // Synchronous guard off the ref — a mashed Enter can't fire a second
+          // restore of the same archive before the state commits.
+          if (restoringPathsRef.current.has(entry.zipPath)) return;
+          restoringPathsRef.current.add(entry.zipPath);
+          setRestoringPaths(new Set(restoringPathsRef.current));
           apiClientRef.current.restoreArchivedCampaign(entry.name, entry.zipPath).then(() => {
             setArchiveStatus(`Restored "${entry.name}"`);
             refreshCampaigns();
@@ -643,6 +655,9 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
             apiClientRef.current.listArchivedCampaigns().then((resp) => setArchivedCampaigns(resp.archives)).catch(() => { /* ignore */ });
           }).catch((err) => {
             setErrorMessage(err instanceof Error ? err.message : String(err));
+          }).finally(() => {
+            restoringPathsRef.current.delete(entry.zipPath);
+            setRestoringPaths(new Set(restoringPathsRef.current));
           });
         }}
         onBack={() => { setArchiveStatus(""); setPhase("settings"); }}

--- a/packages/client-ink/src/phases/ArchivedCampaignsPhase.test.tsx
+++ b/packages/client-ink/src/phases/ArchivedCampaignsPhase.test.tsx
@@ -73,6 +73,32 @@ describe("ArchivedCampaignsPhase", () => {
     expect(onUnarchive).not.toHaveBeenCalled();
   });
 
+  it("shows 'Restoring…' for an archive whose restore is in flight", () => {
+    const archives: ArchivedCampaignEntry[] = [
+      { name: "My Campaign", zipPath: "/a.zip", archivedDate: "2026-03-20T00:00:00.000Z" },
+    ];
+    const { lastFrame } = render(
+      <ArchivedCampaignsPhase {...defaultProps({ archives, restoringPaths: new Set(["/a.zip"]) })} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Restoring");
+    // The "Archived <date>" suffix is swapped out while restoring.
+    expect(frame).not.toContain("Archived Mar");
+  });
+
+  it("blocks a second restore trigger while one is in flight", () => {
+    const onUnarchive = vi.fn();
+    const archives: ArchivedCampaignEntry[] = [
+      { name: "My Campaign", zipPath: "/a.zip", archivedDate: "2026-03-20T00:00:00.000Z" },
+    ];
+    const { stdin } = render(
+      <ArchivedCampaignsPhase {...defaultProps({ archives, onUnarchive, restoringPaths: new Set(["/a.zip"]) })} />,
+    );
+    stdin.write("\r");
+    stdin.write("\r");
+    expect(onUnarchive).not.toHaveBeenCalled();
+  });
+
   it("does not crash on arrow keys with empty list", () => {
     const { stdin } = render(<ArchivedCampaignsPhase {...defaultProps()} />);
     // Should not throw

--- a/packages/client-ink/src/phases/ArchivedCampaignsPhase.tsx
+++ b/packages/client-ink/src/phases/ArchivedCampaignsPhase.tsx
@@ -12,7 +12,12 @@ export interface ArchivedCampaignsPhaseProps {
   onUnarchive: (entry: ArchivedCampaignEntry) => void;
   onBack: () => void;
   statusMessage?: string;
+  /** Zip paths whose restore is in flight — render "Restoring…" and block re-triggers. */
+  restoringPaths?: ReadonlySet<string>;
 }
+
+/** Shared empty set so an absent `restoringPaths` prop is a stable reference. */
+const NO_RESTORING: ReadonlySet<string> = new Set<string>();
 
 function formatDate(iso: string): string {
   try {
@@ -29,6 +34,7 @@ export function ArchivedCampaignsPhase({
   onUnarchive,
   onBack,
   statusMessage,
+  restoringPaths = NO_RESTORING,
 }: ArchivedCampaignsPhaseProps) {
   const { columns: cols, rows: termRows } = useWindowSize();
   const [menuIndex, setMenuIndex] = useState(0);
@@ -48,7 +54,11 @@ export function ArchivedCampaignsPhase({
       return;
     }
     if (key.return && archives.length > 0) {
-      onUnarchive(archives[menuIndex]);
+      const entry = archives[menuIndex];
+      // Ignore Enter on an archive that's already restoring (the synchronous
+      // ref guard in app.tsx is authoritative; this just avoids the no-op call).
+      if (restoringPaths.has(entry.zipPath)) return;
+      onUnarchive(entry);
     }
   });
 
@@ -78,6 +88,7 @@ export function ArchivedCampaignsPhase({
     for (let i = 0; i < archives.length; i++) {
       const entry = archives[i];
       const isSelected = i === menuIndex;
+      const restoring = restoringPaths.has(entry.zipPath);
       const marker = isSelected ? "◆" : "○";
       const markerColor = isSelected ? accentColor : dimColor;
       const dateStr = formatDate(entry.archivedDate);
@@ -86,7 +97,9 @@ export function ArchivedCampaignsPhase({
         <Text key={entry.zipPath}>
           <Text color={markerColor}>{marker}</Text>
           <Text color={isSelected ? accentColor : undefined} bold={isSelected}>{` ${entry.name}`}</Text>
-          <Text color={dimColor}>{`  Archived ${dateStr}`}</Text>
+          {restoring
+            ? <Text color="#66cc66">{`  Restoring…`}</Text>
+            : <Text color={dimColor}>{`  Archived ${dateStr}`}</Text>}
         </Text>,
       );
     }

--- a/packages/engine/src/server/routes/management.test.ts
+++ b/packages/engine/src/server/routes/management.test.ts
@@ -10,18 +10,21 @@ import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
 interface ArchiveResult { ok: boolean; zipPath?: string; error?: string }
 
 // Created via vi.hoisted so they exist before vi.mock's factory (hoisted to the
-// top of the module) references them.
-const { archiveCampaignMock, pending } = vi.hoisted(() => {
+// top of the module) references them. Both archive and restore are replaced with
+// controllable deferreds so a concurrent overlap is deterministic.
+const { archiveCampaignMock, pending, unarchiveCampaignMock, pendingRestore } = vi.hoisted(() => {
   const pending: ((v: ArchiveResult) => void)[] = [];
   const archiveCampaignMock = vi.fn(() => new Promise<ArchiveResult>((res) => { pending.push(res); }));
-  return { archiveCampaignMock, pending };
+  const pendingRestore: ((v: ArchiveResult) => void)[] = [];
+  const unarchiveCampaignMock = vi.fn(() => new Promise<ArchiveResult>((res) => { pendingRestore.push(res); }));
+  return { archiveCampaignMock, pending, unarchiveCampaignMock, pendingRestore };
 });
 
 vi.mock("../../config/campaign-archive.js", () => ({
   archiveCampaign: archiveCampaignMock,
   deleteCampaign: vi.fn(),
   listArchivedCampaigns: vi.fn(),
-  unarchiveCampaign: vi.fn(),
+  unarchiveCampaign: unarchiveCampaignMock,
   getCampaignDeleteInfo: vi.fn(),
   // The route gets its ArchiveFileIO from ../fileio.js, which re-exports this
   // from the mocked module — stub it so the call doesn't throw (the mocked
@@ -120,5 +123,66 @@ describe("POST /campaigns/:id/archive — concurrency guard", () => {
     expect(res.statusCode).toBe(409);
     expect(res.json().error).toMatch(/session is active/i);
     expect(archiveCampaignMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /campaigns/archived/:name/restore — concurrency guard", () => {
+  let app: FastifyInstance;
+
+  const restoreReq = (zipPath: string) => ({
+    method: "POST" as const,
+    url: "/campaigns/archived/Test/restore",
+    payload: { zipPath },
+  });
+
+  beforeEach(() => {
+    unarchiveCampaignMock.mockClear();
+    pendingRestore.length = 0;
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it("rejects a second concurrent restore of the same archive with 409", async () => {
+    app = await buildApp();
+
+    const a = app.inject(restoreReq("/arch/Test.zip"));
+    await vi.waitFor(() => expect(unarchiveCampaignMock).toHaveBeenCalledTimes(1));
+
+    const b = await app.inject(restoreReq("/arch/Test.zip"));
+    expect(b.statusCode).toBe(409);
+    expect(b.json().error).toMatch(/already in progress/i);
+    expect(unarchiveCampaignMock).toHaveBeenCalledTimes(1);
+
+    pendingRestore[0]({ ok: true });
+    expect((await a).statusCode).toBe(200);
+  });
+
+  it("locks per archive — a different zip restores concurrently", async () => {
+    app = await buildApp();
+
+    const a = app.inject(restoreReq("/arch/One.zip"));
+    const b = app.inject(restoreReq("/arch/Two.zip"));
+    // Distinct zip paths → both pass the guard and run in parallel.
+    await vi.waitFor(() => expect(unarchiveCampaignMock).toHaveBeenCalledTimes(2));
+    pendingRestore[0]({ ok: true });
+    pendingRestore[1]({ ok: true });
+    expect((await a).statusCode).toBe(200);
+    expect((await b).statusCode).toBe(200);
+  });
+
+  it("releases the lock so the same archive can be restored again", async () => {
+    app = await buildApp();
+
+    const a = app.inject(restoreReq("/arch/Test.zip"));
+    await vi.waitFor(() => expect(unarchiveCampaignMock).toHaveBeenCalledTimes(1));
+    pendingRestore[0]({ ok: true });
+    expect((await a).statusCode).toBe(200);
+
+    const c = app.inject(restoreReq("/arch/Test.zip"));
+    await vi.waitFor(() => expect(unarchiveCampaignMock).toHaveBeenCalledTimes(2));
+    pendingRestore[1]({ ok: true });
+    expect((await c).statusCode).toBe(200);
   });
 });

--- a/packages/engine/src/server/routes/management.test.ts
+++ b/packages/engine/src/server/routes/management.test.ts
@@ -1,5 +1,6 @@
 import Fastify, { type FastifyInstance } from "fastify";
 import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
+import { norm } from "../../utils/paths.js";
 
 // The archive route's concurrency guard is the unit under test: a second
 // archive of the SAME campaign while the first is in flight must be rejected
@@ -20,17 +21,17 @@ const { archiveCampaignMock, pending, unarchiveCampaignMock, pendingRestore } = 
   return { archiveCampaignMock, pending, unarchiveCampaignMock, pendingRestore };
 });
 
-vi.mock("../../config/campaign-archive.js", () => ({
-  archiveCampaign: archiveCampaignMock,
-  deleteCampaign: vi.fn(),
-  listArchivedCampaigns: vi.fn(),
-  unarchiveCampaign: unarchiveCampaignMock,
-  getCampaignDeleteInfo: vi.fn(),
-  // The route gets its ArchiveFileIO from ../fileio.js, which re-exports this
-  // from the mocked module — stub it so the call doesn't throw (the mocked
-  // archiveCampaign ignores the io anyway).
-  createArchiveFileIO: vi.fn(() => ({})),
-}));
+// Keep the real module (the route relies on the real `archiveDir` for path
+// resolution, and `createArchiveFileIO` re-exported via ../fileio.js); override
+// only the two long-running ops with controllable deferreds.
+vi.mock("../../config/campaign-archive.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../config/campaign-archive.js")>();
+  return {
+    ...actual,
+    archiveCampaign: archiveCampaignMock,
+    unarchiveCampaign: unarchiveCampaignMock,
+  };
+});
 
 import { managementRoutes } from "./management.js";
 
@@ -184,5 +185,43 @@ describe("POST /campaigns/archived/:name/restore — concurrency guard", () => {
     await vi.waitFor(() => expect(unarchiveCampaignMock).toHaveBeenCalledTimes(2));
     pendingRestore[1]({ ok: true });
     expect((await c).statusCode).toBe(200);
+  });
+
+  // campaignsDir is "/tmp/campaigns" → archives live in the SIBLING
+  // "/tmp/archivedcampaigns", never the child "/tmp/campaigns/archivedcampaigns".
+  const firstZipArg = () => norm(unarchiveCampaignMock.mock.calls[0][0] as string);
+
+  it("restore-by-name resolves into the sibling archive dir, not a child", async () => {
+    app = await buildApp();
+
+    // No zipPath in the body → reconstruct from the :name param.
+    const a = app.inject({ method: "POST", url: "/campaigns/archived/Test/restore", payload: {} });
+    await vi.waitFor(() => expect(unarchiveCampaignMock).toHaveBeenCalledTimes(1));
+    expect(firstZipArg()).toBe(norm("/tmp/archivedcampaigns/Test.zip"));
+    // The old bug pointed at the child dir.
+    expect(firstZipArg()).not.toContain("campaigns/archivedcampaigns");
+    pendingRestore[0]({ ok: true });
+    expect((await a).statusCode).toBe(200);
+  });
+
+  it("confines an out-of-dir zipPath to the archive dir (no arbitrary read)", async () => {
+    app = await buildApp();
+
+    const a = app.inject(restoreReq("/etc/evil.zip"));
+    await vi.waitFor(() => expect(unarchiveCampaignMock).toHaveBeenCalledTimes(1));
+    // Only the basename survives; the restore can't escape the archive dir.
+    expect(firstZipArg()).toBe(norm("/tmp/archivedcampaigns/evil.zip"));
+    expect(firstZipArg()).not.toContain("/etc/");
+    pendingRestore[0]({ ok: true });
+    expect((await a).statusCode).toBe(200);
+  });
+
+  it("rejects a target whose basename isn't a .zip with 400", async () => {
+    app = await buildApp();
+
+    const res = await app.inject(restoreReq("/etc/passwd"));
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/invalid archive/i);
+    expect(unarchiveCampaignMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -25,8 +25,9 @@ import {
 import type { OAuthFlow } from "../../providers/openai-chatgpt/index.js";
 import {
   archiveCampaign, deleteCampaign, listArchivedCampaigns,
-  unarchiveCampaign, getCampaignDeleteInfo,
+  unarchiveCampaign, getCampaignDeleteInfo, archiveDir,
 } from "../../config/campaign-archive.js";
+import { norm } from "../../utils/paths.js";
 import { loadDiscordSettings, saveDiscordSettings } from "../../config/discord.js";
 import { loadMachineSettings, saveMachineSettings } from "../../config/machine-settings.js";
 import { createArchiveFileIO } from "../fileio.js";
@@ -615,18 +616,30 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
   // `-2`/`-3` slots. Keyed by the resolved zip path; reject the duplicate.
   const restoresInProgress = new Set<string>();
 
-  /** Restore an archived campaign. Body includes zipPath from the list response. */
+  /** Restore an archived campaign. Body may carry the zipPath from the list response. */
   server.post("/campaigns/archived/:name/restore", {
     schema: {
       tags: ["Management"],
       params: NameParams,
       body: RestoreRequest,
-      response: { 200: OkResponse, 409: ErrorResponse, 500: ErrorResponse },
+      response: { 200: OkResponse, 400: ErrorResponse, 409: ErrorResponse, 500: ErrorResponse },
     },
   }, async (request, reply) => {
-    // Prefer explicit zipPath from body; fall back to reconstructing from name
-    const zipPath = (request.body as { zipPath?: string })?.zipPath
-      ?? join(campaignsDir(), "archivedcampaigns", `${(request.params as { name: string }).name}.zip`);
+    // Resolve the target strictly INSIDE the canonical archive dir. The client
+    // echoes back a zipPath from the list endpoint, but we never trust it as a
+    // path: take only its filename component (everything after the last
+    // separator drops directory parts and `..`), so a crafted body or `:name`
+    // can't turn this into an arbitrary-zip reader or escape via traversal.
+    // Archives live in archiveDir() — a SIBLING of campaignsDir, not a child —
+    // so the by-name fallback must reconstruct from there, not from campaignsDir.
+    const archDir = norm(archiveDir(campaignsDir()));
+    const requested = ((request.body as { zipPath?: string }).zipPath
+      ?? `${(request.params as { name: string }).name}.zip`).replace(/\\/g, "/");
+    const fileName = requested.slice(requested.lastIndexOf("/") + 1);
+    if (!fileName || fileName.includes("\0") || !fileName.toLowerCase().endsWith(".zip")) {
+      return reply.status(400).send({ error: "Invalid archive name." });
+    }
+    const zipPath = norm(join(archDir, fileName));
 
     if (restoresInProgress.has(zipPath)) {
       return reply.status(409).send({ error: "Restore already in progress for this archive." });

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -607,25 +607,42 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
     return { archives };
   });
 
+  // Per-archive in-flight restore guard — the symmetric twin of the archive
+  // lock. Restore stays on the archived-campaigns screen with no input block, so
+  // a mashed Enter is even easier than the archive double-fire: two concurrent
+  // restores of the same zip race the unique-dir loop (TOCTOU between the
+  // `exists` check and `mkdir`) and can collide on one dir or spawn duplicate
+  // `-2`/`-3` slots. Keyed by the resolved zip path; reject the duplicate.
+  const restoresInProgress = new Set<string>();
+
   /** Restore an archived campaign. Body includes zipPath from the list response. */
   server.post("/campaigns/archived/:name/restore", {
     schema: {
       tags: ["Management"],
       params: NameParams,
       body: RestoreRequest,
-      response: { 200: OkResponse, 500: ErrorResponse },
+      response: { 200: OkResponse, 409: ErrorResponse, 500: ErrorResponse },
     },
   }, async (request, reply) => {
     // Prefer explicit zipPath from body; fall back to reconstructing from name
     const zipPath = (request.body as { zipPath?: string })?.zipPath
       ?? join(campaignsDir(), "archivedcampaigns", `${(request.params as { name: string }).name}.zip`);
-    const io = createArchiveFileIO();
-    const result = await unarchiveCampaign(zipPath, campaignsDir(), io);
 
-    if (!result.ok) {
-      return reply.status(500).send({ error: result.error ?? "Restore failed." });
+    if (restoresInProgress.has(zipPath)) {
+      return reply.status(409).send({ error: "Restore already in progress for this archive." });
     }
-    return { ok: true };
+    restoresInProgress.add(zipPath);
+    try {
+      const io = createArchiveFileIO();
+      const result = await unarchiveCampaign(zipPath, campaignsDir(), io);
+
+      if (!result.ok) {
+        return reply.status(500).send({ error: result.error ?? "Restore failed." });
+      }
+      return { ok: true };
+    } finally {
+      restoresInProgress.delete(zipPath);
+    }
   });
 
   // -----------------------------------------------------------------------

--- a/packages/engine/src/utils/archive.ts
+++ b/packages/engine/src/utils/archive.ts
@@ -1,8 +1,17 @@
 /**
  * Zip/unzip utility for campaign archival, sharing, and import.
  *
- * Uses `fflate` (pure JS, zero dependencies) for synchronous zip operations.
- * Designed for sub-megabyte payloads — no streaming needed.
+ * Uses `fflate` (pure JS, zero dependencies) for synchronous, fully in-memory
+ * zip operations: the whole payload is held in memory, and archival also
+ * round-trips it (zip → unzip → read-back) to verify, so peak usage is a few
+ * multiples of the campaign size. That was negligible when campaigns were
+ * sub-megabyte, but a long campaign can now reach tens of MB once it
+ * accumulates full-resolution portrait PNGs and their `portrait-history/`
+ * (see `agents/dm-portraits.ts`) — so the old "sub-megabyte, no streaming"
+ * assumption no longer holds. It's still fine at present scale, and archival
+ * only runs with no active session (`isBusy` gate), so the synchronous CPU
+ * cost never stalls a live turn; if campaigns grow much larger, move to
+ * fflate's async/worker variants (`zip`/`unzip`).
  *
  * - `zipFiles(files)` packs a filename→content map into a zip buffer.
  * - `unzipFiles(data)` unpacks a zip buffer into a filename→content map.


### PR DESCRIPTION
Two robustness follow-ups to the archive-corruption fix ([#656](https://github.com/octopollux/machine-violet/pull/656)).

## 1. Restore gets the same two-layer guard as archive

Restore was the one remaining mutating campaign op without a concurrency guard — and the **most** double-fire-prone: the Archived Campaigns screen doesn't move on Enter, so a mashed Enter fired N concurrent restores of one archive, racing the unique-slot loop (TOCTOU between the `exists` check and `mkdir`) into a collided dir or duplicate `-2`/`-3` slots.

- **Server** — per-zip `restoresInProgress` lock in the restore route; a concurrent restore of the same zip returns **409 "Restore already in progress"** (added 409 to the route schema). `try/finally` releases it. Keyed by zip path, so distinct archives still restore in parallel.
- **Client** — ref-backed *synchronous* guard (`restoringPathsRef`) in `app.tsx`, mirrored to `restoringPaths` state. `ArchivedCampaignsPhase` shows an inline `Restoring…` on the row and ignores repeat Enter while in flight. This mirrors the ref-backed archive guard from #656 (Copilot's note there), so a rapid Enter can't slip a second POST through and flash a spurious 409.

Restore is non-destructive (never deletes the archive or an existing campaign), so the stakes are lower than archive — but the behavior is now clean and symmetric.

## 2. `archive.ts` header was lying about size

The comment said *"Designed for sub-megabyte payloads — no streaming needed."* That stopped being true once full-resolution portrait PNGs (~1–3 MB each) and their `portrait-history/` persist inside the campaign folder — a long campaign reaches tens of MB. Rewrote it to describe the real in-memory + round-trip cost, why it's still fine at present scale (synchronous CPU runs only with no active session, per the `isBusy` gate), and the fflate async/worker escape hatch if campaigns grow much larger.

## Tests
- `management.test.ts` — restore concurrency: 409 on duplicate, per-zip isolation (distinct zips run in parallel), lock release after completion.
- `ArchivedCampaignsPhase.test.tsx` — `Restoring…` indicator + re-trigger block.

## Docs
- "Restore (the symmetric twin)" note added to the Archiving section in `tui-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)