### PR TITLE
ci(release-notes): enable adaptive thinking so reasoning stops leaking into notes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -382,8 +382,11 @@ jobs:
             -d @/tmp/api-request.json) || RESPONSE=""
 
           # Select the text block explicitly — with thinking on, content[0] is a
-          # thinking block, so the old .content[0].text returned null.
-          NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[] | select(.type=="text") | .text) // empty') || NOTES=""
+          # thinking block, so the old .content[0].text returned null. The
+          # optional iterator (.content[]?) yields empty rather than a "cannot
+          # iterate over null" error when the API returns a JSON error payload
+          # with no content array — falls through cleanly to the fallback below.
+          NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[]? | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -364,8 +364,14 @@ jobs:
           # intelligence regressions at this prompt size. Nightlies are frequent
           # so cost adds up faster than for stable, but the daily-token budget
           # is still small relative to user value.
+          # Adaptive thinking ON: without it, Sonnet 4.6 has no dedicated
+          # reasoning channel and spills its planning ("Let me look at these
+          # PRs...") into the visible response, polluting the notes. With it on,
+          # reasoning goes to separate `thinking` blocks and `content[]` text is
+          # the clean bullet list. max_tokens raised to leave room for both.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-sonnet-4-6", max_tokens:1024,
+            '{model:"claude-sonnet-4-6", max_tokens:2048,
+              thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           # Call the API
@@ -375,7 +381,9 @@ jobs:
             -H "content-type: application/json" \
             -d @/tmp/api-request.json) || RESPONSE=""
 
-          NOTES=$(echo "$RESPONSE" | jq -r '.content[0].text // empty') || NOTES=""
+          # Select the text block explicitly — with thinking on, content[0] is a
+          # thinking block, so the old .content[0].text returned null.
+          NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[] | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,8 +381,14 @@ jobs:
           # Sonnet (not Haiku) — Haiku's player-facing summaries had noticeable
           # intelligence regressions at this prompt size. The cost bump for the
           # few hundred input tokens per release is negligible.
+          # Adaptive thinking ON: without it, Sonnet 4.6 has no dedicated
+          # reasoning channel and spills its planning ("Let me look at these
+          # PRs...") into the visible response, polluting the notes. With it on,
+          # reasoning goes to separate `thinking` blocks and `content[]` text is
+          # the clean bullet list. max_tokens raised to leave room for both.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-sonnet-4-6", max_tokens:1024,
+            '{model:"claude-sonnet-4-6", max_tokens:2048,
+              thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           RESPONSE=$(curl -sf https://api.anthropic.com/v1/messages \
@@ -391,7 +397,9 @@ jobs:
             -H "content-type: application/json" \
             -d @/tmp/api-request.json) || RESPONSE=""
 
-          NOTES=$(echo "$RESPONSE" | jq -r '.content[0].text // empty') || NOTES=""
+          # Select the text block explicitly — with thinking on, content[0] is a
+          # thinking block, so the old .content[0].text returned null.
+          NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[] | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,8 +398,11 @@ jobs:
             -d @/tmp/api-request.json) || RESPONSE=""
 
           # Select the text block explicitly — with thinking on, content[0] is a
-          # thinking block, so the old .content[0].text returned null.
-          NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[] | select(.type=="text") | .text) // empty') || NOTES=""
+          # thinking block, so the old .content[0].text returned null. The
+          # optional iterator (.content[]?) yields empty rather than a "cannot
+          # iterate over null" error when the API returns a JSON error payload
+          # with no content array — falls through cleanly to the fallback below.
+          NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[]? | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."
           fi

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -57,7 +57,7 @@ The workflow:
 1. Bumps `package.json` if requested, commits to `release`.
 2. Computes the tag (failing if a stable tag already exists for the current version).
 3. Pushes branch + tag.
-4. The push of `v*` triggers [release.yml](../.github/workflows/release.yml), which builds Win/macOS/Linux, signs Windows via Velopack + Azure Trusted Signing, **replays the golden corpus against each packaged binary** (the `verify-package` gate), generates AI release notes (Haiku), and creates the GitHub release on the appropriate channel.
+4. The push of `v*` triggers [release.yml](../.github/workflows/release.yml), which builds Win/macOS/Linux, signs Windows via Velopack + Azure Trusted Signing, **replays the golden corpus against each packaged binary** (the `verify-package` gate), generates AI release notes (Sonnet, adaptive thinking), and creates the GitHub release on the appropriate channel.
 
 RC releases are marked `--prerelease` on GitHub, skip Discord, and skip the Homebrew formula bump. Stable releases do all three.
 


### PR DESCRIPTION
## Problem

The release-notes generator (`release.yml` + `nightly.yml`) called Sonnet 4.6 with **no `thinking` field**, so the model had no dedicated reasoning channel and wrote its planning (*"Let me look at these PRs…"*) straight into the visible response — polluting the player-facing notes. The symptom was reported as "reasoning into its output"; the prompt already says "Output ONLY the markdown bullet list," so this is a reasoning-config issue, not a prompt one.

## Fix

1. **Adaptive thinking on** (`thinking:{type:"adaptive"}`, GA on Sonnet 4.6, no beta header) — reasoning now goes to separate `thinking` blocks; the `text` block is the clean list.
2. **Extraction fixed** — `.content[0].text` → `first(.content[] | select(.type=="text") | .text)`. With thinking on, `content[0]` is now a *thinking* block, so the old expression returned null and would have silently fallen back to "Internal improvements and maintenance." on **every** release. This is the load-bearing half: flipping thinking on without it would break the notes entirely.
3. **`max_tokens` 1024 → 2048** so thinking tokens don't crowd out the notes.
4. Stale doc: `docs/releases.md` "(Haiku)" → "(Sonnet, adaptive thinking)".

## Validation

CI-YAML + doc only (no TS), so the test/lint suite doesn't cover it — validated directly: both workflows parse as YAML with the release-notes step intact, and the jq extraction returns the text block in the normal case and empties cleanly (→ existing bash fallback) when there's no text block. Full `npm run check` green on push.

## Context

Lands on `main` ahead of the imminent **main → release** promotion (v1.1 → RC1) so it reaches the release line in that move — no separate back-port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)