### PR TITLE
ci(release-notes): discover squash-merged (#N) PRs, not just merge commits

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -248,12 +248,18 @@ jobs:
           PREV="${{ steps.tags.outputs.prev }}"
 
           if [ -n "$PREV" ]; then
-            # Extract PR numbers from merge commits in the range.
-            # This is deterministic — a commit is in the range or it isn't —
-            # unlike the old timestamp-based gh pr list search which was
-            # off-by-one due to >= and git/GitHub timestamp mismatches.
+            # Extract PR numbers from the range, matching BOTH merge commits
+            # ("Merge pull request #N") and squash-merged commits (GitHub's
+            # default "<subject> (#N)"). Deterministic — a commit is in the
+            # range or it isn't (unlike the old timestamp-based gh pr list).
+            # The squash pattern is essential: with squash merges (the repo
+            # default) or a single-merge promotion, the merge-commit pattern
+            # alone surfaces almost no player-facing PRs — v1.1.0-rc.1 shipped
+            # "Internal improvements and maintenance." for the whole 1.1 line.
+            # Requiring "(#" for the squash form avoids matching bare "#45"
+            # issue mentions; --oneline keeps it to subjects (no body refs).
             PR_NUMBERS=$(git log --oneline "${PREV}..HEAD" \
-              | grep -oP 'Merge pull request #\K[0-9]+' || true)
+              | grep -oP '(?:Merge pull request #|\(#)\K[0-9]+' || true)
 
             PR_CONTEXT=""
             if [ -n "$PR_NUMBERS" ]; then
@@ -368,9 +374,10 @@ jobs:
           # reasoning channel and spills its planning ("Let me look at these
           # PRs...") into the visible response, polluting the notes. With it on,
           # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens raised to leave room for both.
+          # the clean bullet list. max_tokens (4096) leaves room for thinking
+          # plus a full release's worth of bullets over a large PR range.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-sonnet-4-6", max_tokens:2048,
+            '{model:"claude-sonnet-4-6", max_tokens:4096,
               thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,12 +270,18 @@ jobs:
           PREV="${{ steps.tags.outputs.prev }}"
 
           if [ -n "$PREV" ]; then
-            # Extract PR numbers from merge commits in the range.
-            # This is deterministic — a commit is in the range or it isn't —
-            # unlike the old timestamp-based gh pr list search which was
-            # off-by-one due to >= and git/GitHub timestamp mismatches.
+            # Extract PR numbers from the range, matching BOTH merge commits
+            # ("Merge pull request #N") and squash-merged commits (GitHub's
+            # default "<subject> (#N)"). Deterministic — a commit is in the
+            # range or it isn't (unlike the old timestamp-based gh pr list).
+            # The squash pattern is essential: with squash merges (the repo
+            # default) or a single-merge promotion, the merge-commit pattern
+            # alone surfaces almost no player-facing PRs — v1.1.0-rc.1 shipped
+            # "Internal improvements and maintenance." for the whole 1.1 line.
+            # Requiring "(#" for the squash form avoids matching bare "#45"
+            # issue mentions; --oneline keeps it to subjects (no body refs).
             PR_NUMBERS=$(git log --oneline "${PREV}..${TAG}" \
-              | grep -oP 'Merge pull request #\K[0-9]+' || true)
+              | grep -oP '(?:Merge pull request #|\(#)\K[0-9]+' || true)
 
             PR_CONTEXT=""
             if [ -n "$PR_NUMBERS" ]; then
@@ -385,9 +391,10 @@ jobs:
           # reasoning channel and spills its planning ("Let me look at these
           # PRs...") into the visible response, polluting the notes. With it on,
           # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens raised to leave room for both.
+          # the clean bullet list. max_tokens (4096) leaves room for thinking
+          # plus a full release's worth of bullets over a large PR range.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-sonnet-4-6", max_tokens:2048,
+            '{model:"claude-sonnet-4-6", max_tokens:4096,
               thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 


### PR DESCRIPTION
## Problem

`v1.1.0-rc.1` shipped release notes reading **"Internal improvements and maintenance."** for the *entire* 1.1 line. Root cause: the notes generator discovers PRs by grepping only `Merge pull request #N` commits. This repo squash-merges by default (`<subject> (#N)`), and the `main → release` promotion collapsed 1.1 into a single merge — so the generator captured a CI/infra-heavy subset and **missed every squash-merged feature PR**.

This is **not** a regression from the adaptive-thinking fix (#670): `v1.0.2`, cut with the old generator, emitted the identical fallback. It's a long-standing discovery gap that only became glaring on a feature-deep, promotion-style cut.

## Fix

- Match **both** `Merge pull request #N` and the squash form `<subject> (#N)` in the PR-number grep (`release.yml` + `nightly.yml`). Requiring `(#` avoids matching bare `#45` issue refs; `--oneline` keeps it to subjects (no body refs).
- Bump `max_tokens` 2048 → 4096 so adaptive thinking + a full release's worth of bullets fit over the now-larger PR context.

## Verification (on the real `v1.0.2..v1.1.0-rc.1` range)

| | Captured PRs |
|---|---|
| Old (merge-only) | 37 |
| **New (merge + squash)** | **121** |

All headline 1.1 features now captured — DM personalities (#661), facial-expression portraits (#664), image-gen wiring (#644/#645), etc. Zero bogus matches (no out-of-range numbers). Both workflows still parse.

## Impact

The eventual **stable 1.1.0** cut spans the same `v1.0.2..` range, so it would hit the identical thin-notes problem without this. Lands on `main`, rides the next promotion to `release`. A re-cut RC (`rc.2`) would also pick up real notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)