### PR TITLE
Promote #672 to release: squash-PR discovery for release notes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -248,12 +248,18 @@ jobs:
           PREV="${{ steps.tags.outputs.prev }}"
 
           if [ -n "$PREV" ]; then
-            # Extract PR numbers from merge commits in the range.
-            # This is deterministic — a commit is in the range or it isn't —
-            # unlike the old timestamp-based gh pr list search which was
-            # off-by-one due to >= and git/GitHub timestamp mismatches.
+            # Extract PR numbers from the range, matching BOTH merge commits
+            # ("Merge pull request #N") and squash-merged commits (GitHub's
+            # default "<subject> (#N)"). Deterministic — a commit is in the
+            # range or it isn't (unlike the old timestamp-based gh pr list).
+            # The squash pattern is essential: with squash merges (the repo
+            # default) or a single-merge promotion, the merge-commit pattern
+            # alone surfaces almost no player-facing PRs — v1.1.0-rc.1 shipped
+            # "Internal improvements and maintenance." for the whole 1.1 line.
+            # Requiring "(#" for the squash form avoids matching bare "#45"
+            # issue mentions; --oneline keeps it to subjects (no body refs).
             PR_NUMBERS=$(git log --oneline "${PREV}..HEAD" \
-              | grep -oP 'Merge pull request #\K[0-9]+' || true)
+              | grep -oP '(?:Merge pull request #|\(#)\K[0-9]+' || true)
 
             PR_CONTEXT=""
             if [ -n "$PR_NUMBERS" ]; then
@@ -368,9 +374,10 @@ jobs:
           # reasoning channel and spills its planning ("Let me look at these
           # PRs...") into the visible response, polluting the notes. With it on,
           # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens raised to leave room for both.
+          # the clean bullet list. max_tokens (4096) leaves room for thinking
+          # plus a full release's worth of bullets over a large PR range.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-sonnet-4-6", max_tokens:2048,
+            '{model:"claude-sonnet-4-6", max_tokens:4096,
               thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,12 +270,18 @@ jobs:
           PREV="${{ steps.tags.outputs.prev }}"
 
           if [ -n "$PREV" ]; then
-            # Extract PR numbers from merge commits in the range.
-            # This is deterministic — a commit is in the range or it isn't —
-            # unlike the old timestamp-based gh pr list search which was
-            # off-by-one due to >= and git/GitHub timestamp mismatches.
+            # Extract PR numbers from the range, matching BOTH merge commits
+            # ("Merge pull request #N") and squash-merged commits (GitHub's
+            # default "<subject> (#N)"). Deterministic — a commit is in the
+            # range or it isn't (unlike the old timestamp-based gh pr list).
+            # The squash pattern is essential: with squash merges (the repo
+            # default) or a single-merge promotion, the merge-commit pattern
+            # alone surfaces almost no player-facing PRs — v1.1.0-rc.1 shipped
+            # "Internal improvements and maintenance." for the whole 1.1 line.
+            # Requiring "(#" for the squash form avoids matching bare "#45"
+            # issue mentions; --oneline keeps it to subjects (no body refs).
             PR_NUMBERS=$(git log --oneline "${PREV}..${TAG}" \
-              | grep -oP 'Merge pull request #\K[0-9]+' || true)
+              | grep -oP '(?:Merge pull request #|\(#)\K[0-9]+' || true)
 
             PR_CONTEXT=""
             if [ -n "$PR_NUMBERS" ]; then
@@ -385,9 +391,10 @@ jobs:
           # reasoning channel and spills its planning ("Let me look at these
           # PRs...") into the visible response, polluting the notes. With it on,
           # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens raised to leave room for both.
+          # the clean bullet list. max_tokens (4096) leaves room for thinking
+          # plus a full release's worth of bullets over a large PR range.
           jq -n --rawfile prompt /tmp/user-prompt.txt \
-            '{model:"claude-sonnet-4-6", max_tokens:2048,
+            '{model:"claude-sonnet-4-6", max_tokens:4096,
               thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 


### PR DESCRIPTION
Brings the release-notes generator fix (#672 — discover squash-merged `(#N)` PRs, `max_tokens` 2048→4096) onto the `release` line so the **re-cut of `v1.1.0-rc.1`** generates real notes instead of the "Internal improvements and maintenance." fallback.

`main` is exactly one commit ahead of `release` (just #672); this merge makes `release` byte-identical to `main` again. Code already reviewed on #672.

Sequence: merge this → delete the existing `v1.1.0-rc.1` release+tag → re-cut `v1.1.0-rc.1` from `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)