### PR TITLE
ci(release-notes): tolerate non-PR numbers in GraphQL; cap PR bodies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -280,18 +280,28 @@ jobs:
                   }"
               done
 
-              PR_CONTEXT=$(gh api graphql \
+              # GitHub GraphQL returns an error (and gh exits non-zero) for any
+              # number that resolves to an issue rather than a PR — and commit
+              # subjects can carry issue refs in "(#N)" form, so PR_NUMBERS may
+              # include a few. Capture the response tolerantly (|| true; gh still
+              # prints the body, with the bad aliases null and an errors array)
+              # and filter to resolved PRs ourselves — nulls and errors ignored.
+              # The first v1.1.0-rc.1 re-cut aborted right here on "Could not
+              # resolve to a PullRequest". A real failure (auth/rate-limit) still
+              # surfaces as an empty PR_JSON -> the git-log fallback below.
+              PR_JSON=$(gh api graphql \
                 --raw-field query="query {
                   repository(owner: \"${REPO_OWNER}\", name: \"${REPO_NAME}\") {${QUERY_FIELDS}
                   }
-                }" \
-                --jq '
-                  .data.repository
+                }" || true)
+
+              PR_CONTEXT=$(printf '%s' "$PR_JSON" | jq -r '
+                  (.data.repository // {})
                   | to_entries
                   | map(select(.value != null) | .value)
                   | sort_by(.number)
                   | map(
-                      "## PR #\(.number): \(.title)\n\(.body // "(no description)")"
+                      "## PR #\(.number): \(.title)\n\((.body // "(no description)")[0:500])"
                       + (.closingIssuesReferences as $cir
                          | if ($cir.nodes | length) > 0
                            then "\n\nCloses issues:\n"
@@ -306,7 +316,7 @@ jobs:
                       + "\n---"
                     )
                   | join("\n")
-                ')
+                ' || true)
             fi
 
             # Fall back to commit log if no PRs found (direct pushes)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,18 +302,28 @@ jobs:
                   }"
               done
 
-              PR_CONTEXT=$(gh api graphql \
+              # GitHub GraphQL returns an error (and gh exits non-zero) for any
+              # number that resolves to an issue rather than a PR — and commit
+              # subjects can carry issue refs in "(#N)" form, so PR_NUMBERS may
+              # include a few. Capture the response tolerantly (|| true; gh still
+              # prints the body, with the bad aliases null and an errors array)
+              # and filter to resolved PRs ourselves — nulls and errors ignored.
+              # The first v1.1.0-rc.1 re-cut aborted right here on "Could not
+              # resolve to a PullRequest". A real failure (auth/rate-limit) still
+              # surfaces as an empty PR_JSON -> the git-log fallback below.
+              PR_JSON=$(gh api graphql \
                 --raw-field query="query {
                   repository(owner: \"${REPO_OWNER}\", name: \"${REPO_NAME}\") {${QUERY_FIELDS}
                   }
-                }" \
-                --jq '
-                  .data.repository
+                }" || true)
+
+              PR_CONTEXT=$(printf '%s' "$PR_JSON" | jq -r '
+                  (.data.repository // {})
                   | to_entries
                   | map(select(.value != null) | .value)
                   | sort_by(.number)
                   | map(
-                      "## PR #\(.number): \(.title)\n\(.body // "(no description)")"
+                      "## PR #\(.number): \(.title)\n\((.body // "(no description)")[0:500])"
                       + (.closingIssuesReferences as $cir
                          | if ($cir.nodes | length) > 0
                            then "\n\nCloses issues:\n"
@@ -328,7 +338,7 @@ jobs:
                       + "\n---"
                     )
                   | join("\n")
-                ')
+                ' || true)
             fi
 
             if [ -z "$PR_CONTEXT" ]; then


### PR DESCRIPTION
## Problem

The `v1.1.0-rc.1` re-cut (with #672's squash-PR discovery) **failed in the release-notes step**:

```
gh: Could not resolve to a PullRequest with the number of 436.
… 464, 541, 558, 560, 588, 597, 598, 599, 607, 620
##[error]Process completed with exit code 1.
```

#672's `(#N)` grep also captures **issue** references that appear in commit subjects (e.g. `(#558)` is the OAuth *issue*, not a PR). Querying an issue number via `pullRequest(number: N)` makes the whole GraphQL query error, and `gh api graphql` had no `|| true`, so the step aborted. Some commits even carry an issue ref as their *only* trailing `(#N)`, so this can't be fixed by tightening the regex.

## Fix

1. **Tolerate non-PR numbers.** Capture the GraphQL body with `|| true` (gh still returns it — bad aliases come back `null` with an `errors` array) and apply `jq` ourselves on `(.data.repository // {})`, keeping resolved PRs and ignoring nulls/errors. A *real* failure (auth/rate-limit) still yields an empty `PR_JSON` → the existing `git log` fallback.
2. **Cap PR bodies to 500 chars.** Untrimmed context for 112 PRs was **~279 KB**; capping brings it to **~63 KB (~16k tokens)** so it flows safely through `$GITHUB_OUTPUT` → env var → the API. Full titles + `Closes issues` are kept.

## Validation (local, against the real `v1.0.2..v1.1.0-rc.1` range)

- 123 captured numbers → **112 real PRs resolved**, 11 issue-numbers skipped, **all headline features present** (#661, #664, #663, #644, #645).
- Tolerant query confirmed to return partial data on the mixed PR/issue batch; emulated `jq` output is well-formed; size bounded.
- Both workflows parse.

The Anthropic call itself only runs in a real cut — this is the last untested hop, and it's a straightforward 16k-token summarization.

## Next

Merge → promote to `release` → delete the orphan `v1.1.0-rc.1` tag (the failed cut's `tag` job pushed it) → re-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)