### PR TITLE
ci(release-notes): disable thinking — it consumed the whole token budget

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -380,15 +380,17 @@ jobs:
           # intelligence regressions at this prompt size. Nightlies are frequent
           # so cost adds up faster than for stable, but the daily-token budget
           # is still small relative to user value.
-          # Adaptive thinking ON: without it, Sonnet 4.6 has no dedicated
-          # reasoning channel and spills its planning ("Let me look at these
-          # PRs...") into the visible response, polluting the notes. With it on,
-          # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens (4096) leaves room for thinking
-          # plus a full release's worth of bullets over a large PR range.
+          # Thinking is intentionally OFF. This is a bounded summarization, and
+          # on a large PR range adaptive thinking consumes the ENTIRE max_tokens
+          # budget on reasoning (stop_reason=max_tokens, a thinking-only response
+          # with no text block) -> empty extraction -> the "Internal improvements
+          # and maintenance." fallback. That is exactly what shipped on the first
+          # v1.1.0-rc.1 cuts. The "Output ONLY the bullet list" instruction keeps
+          # the response clean without a thinking channel; verified against the
+          # real 112-PR range (a full 1.1-sized changelog was ~730 output tokens,
+          # well within max_tokens 4096).
           jq -n --rawfile prompt /tmp/user-prompt.txt \
             '{model:"claude-sonnet-4-6", max_tokens:4096,
-              thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           # Call the API

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -400,11 +400,11 @@ jobs:
             -H "content-type: application/json" \
             -d @/tmp/api-request.json) || RESPONSE=""
 
-          # Select the text block explicitly — with thinking on, content[0] is a
-          # thinking block, so the old .content[0].text returned null. The
-          # optional iterator (.content[]?) yields empty rather than a "cannot
-          # iterate over null" error when the API returns a JSON error payload
-          # with no content array — falls through cleanly to the fallback below.
+          # Select the first text block explicitly (not content[0]): the response
+          # may carry non-text blocks, and the optional iterator (.content[]?)
+          # yields empty rather than a "cannot iterate over null" error when the
+          # API returns a JSON error payload with no content array — flowing
+          # cleanly to the fallback below.
           NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[]? | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,15 +397,17 @@ jobs:
           # Sonnet (not Haiku) — Haiku's player-facing summaries had noticeable
           # intelligence regressions at this prompt size. The cost bump for the
           # few hundred input tokens per release is negligible.
-          # Adaptive thinking ON: without it, Sonnet 4.6 has no dedicated
-          # reasoning channel and spills its planning ("Let me look at these
-          # PRs...") into the visible response, polluting the notes. With it on,
-          # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens (4096) leaves room for thinking
-          # plus a full release's worth of bullets over a large PR range.
+          # Thinking is intentionally OFF. This is a bounded summarization, and
+          # on a large PR range adaptive thinking consumes the ENTIRE max_tokens
+          # budget on reasoning (stop_reason=max_tokens, a thinking-only response
+          # with no text block) -> empty extraction -> the "Internal improvements
+          # and maintenance." fallback. That is exactly what shipped on the first
+          # v1.1.0-rc.1 cuts. The "Output ONLY the bullet list" instruction keeps
+          # the response clean without a thinking channel; verified against the
+          # real 112-PR range (a full 1.1-sized changelog was ~730 output tokens,
+          # well within max_tokens 4096).
           jq -n --rawfile prompt /tmp/user-prompt.txt \
             '{model:"claude-sonnet-4-6", max_tokens:4096,
-              thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           RESPONSE=$(curl -sf https://api.anthropic.com/v1/messages \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,11 +416,11 @@ jobs:
             -H "content-type: application/json" \
             -d @/tmp/api-request.json) || RESPONSE=""
 
-          # Select the text block explicitly — with thinking on, content[0] is a
-          # thinking block, so the old .content[0].text returned null. The
-          # optional iterator (.content[]?) yields empty rather than a "cannot
-          # iterate over null" error when the API returns a JSON error payload
-          # with no content array — falls through cleanly to the fallback below.
+          # Select the first text block explicitly (not content[0]): the response
+          # may carry non-text blocks, and the optional iterator (.content[]?)
+          # yields empty rather than a "cannot iterate over null" error when the
+          # API returns a JSON error payload with no content array — flowing
+          # cleanly to the fallback below.
           NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[]? | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."


### PR DESCRIPTION
## Definitive root cause of the thin notes

`v1.1.0-rc.1` shipped "Internal improvements and maintenance." on every cut. I reproduced the exact release-notes API call locally against the real 112-PR range:

```
thinking:{type:"adaptive"}, max_tokens:4096
→ HTTP 200, stop_reason: max_tokens, content blocks: [thinking]  (NO text block)
→ usage.thinking_tokens: 4096   ← the model spent the ENTIRE budget thinking
→ text extraction empty → "Internal improvements and maintenance." fallback
```

This is a **#670 regression**: adaptive thinking is overkill for a bounded summarization, and on a large PR range it burns all of `max_tokens` on reasoning and never writes the notes. Both prior cuts (2048 and 4096) failed identically.

## Fix

Remove the `thinking` parameter. Same request, thinking **off**, against the same real data:

```
→ HTTP 200, stop_reason: end_turn, content blocks: [text], ~730 output tokens
→ clean, comprehensive, player-facing changelog — no reasoning leak
```

The existing "Output ONLY the markdown bullet list" instruction keeps the response clean without a thinking channel. (My original #670 worry — that thinking-off leaks reasoning — does not reproduce here.)

Keeps the squash-PR discovery (#672), GraphQL tolerance + 500-char body cap (#674), and the null-safe text extraction.

## Verification

Live API call against `v1.0.2..v1.1.0-rc.1` (112 PRs) — output is the full 1.1 changelog (inline images, character-reference consistency, rollback, mid-campaign PC swap, DM voice switching, Windows Enter fix, ChatGPT login self-heal, …). Both workflows parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)