### PR TITLE
Promote #676 to release: disable thinking in release-notes generator

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -380,15 +380,17 @@ jobs:
           # intelligence regressions at this prompt size. Nightlies are frequent
           # so cost adds up faster than for stable, but the daily-token budget
           # is still small relative to user value.
-          # Adaptive thinking ON: without it, Sonnet 4.6 has no dedicated
-          # reasoning channel and spills its planning ("Let me look at these
-          # PRs...") into the visible response, polluting the notes. With it on,
-          # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens (4096) leaves room for thinking
-          # plus a full release's worth of bullets over a large PR range.
+          # Thinking is intentionally OFF. This is a bounded summarization, and
+          # on a large PR range adaptive thinking consumes the ENTIRE max_tokens
+          # budget on reasoning (stop_reason=max_tokens, a thinking-only response
+          # with no text block) -> empty extraction -> the "Internal improvements
+          # and maintenance." fallback. That is exactly what shipped on the first
+          # v1.1.0-rc.1 cuts. The "Output ONLY the bullet list" instruction keeps
+          # the response clean without a thinking channel; verified against the
+          # real 112-PR range (a full 1.1-sized changelog was ~730 output tokens,
+          # well within max_tokens 4096).
           jq -n --rawfile prompt /tmp/user-prompt.txt \
             '{model:"claude-sonnet-4-6", max_tokens:4096,
-              thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           # Call the API
@@ -398,11 +400,11 @@ jobs:
             -H "content-type: application/json" \
             -d @/tmp/api-request.json) || RESPONSE=""
 
-          # Select the text block explicitly — with thinking on, content[0] is a
-          # thinking block, so the old .content[0].text returned null. The
-          # optional iterator (.content[]?) yields empty rather than a "cannot
-          # iterate over null" error when the API returns a JSON error payload
-          # with no content array — falls through cleanly to the fallback below.
+          # Select the first text block explicitly (not content[0]): the response
+          # may carry non-text blocks, and the optional iterator (.content[]?)
+          # yields empty rather than a "cannot iterate over null" error when the
+          # API returns a JSON error payload with no content array — flowing
+          # cleanly to the fallback below.
           NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[]? | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,15 +397,17 @@ jobs:
           # Sonnet (not Haiku) — Haiku's player-facing summaries had noticeable
           # intelligence regressions at this prompt size. The cost bump for the
           # few hundred input tokens per release is negligible.
-          # Adaptive thinking ON: without it, Sonnet 4.6 has no dedicated
-          # reasoning channel and spills its planning ("Let me look at these
-          # PRs...") into the visible response, polluting the notes. With it on,
-          # reasoning goes to separate `thinking` blocks and `content[]` text is
-          # the clean bullet list. max_tokens (4096) leaves room for thinking
-          # plus a full release's worth of bullets over a large PR range.
+          # Thinking is intentionally OFF. This is a bounded summarization, and
+          # on a large PR range adaptive thinking consumes the ENTIRE max_tokens
+          # budget on reasoning (stop_reason=max_tokens, a thinking-only response
+          # with no text block) -> empty extraction -> the "Internal improvements
+          # and maintenance." fallback. That is exactly what shipped on the first
+          # v1.1.0-rc.1 cuts. The "Output ONLY the bullet list" instruction keeps
+          # the response clean without a thinking channel; verified against the
+          # real 112-PR range (a full 1.1-sized changelog was ~730 output tokens,
+          # well within max_tokens 4096).
           jq -n --rawfile prompt /tmp/user-prompt.txt \
             '{model:"claude-sonnet-4-6", max_tokens:4096,
-              thinking:{type:"adaptive"},
               messages:[{role:"user",content:$prompt}]}' > /tmp/api-request.json
 
           RESPONSE=$(curl -sf https://api.anthropic.com/v1/messages \
@@ -414,11 +416,11 @@ jobs:
             -H "content-type: application/json" \
             -d @/tmp/api-request.json) || RESPONSE=""
 
-          # Select the text block explicitly — with thinking on, content[0] is a
-          # thinking block, so the old .content[0].text returned null. The
-          # optional iterator (.content[]?) yields empty rather than a "cannot
-          # iterate over null" error when the API returns a JSON error payload
-          # with no content array — falls through cleanly to the fallback below.
+          # Select the first text block explicitly (not content[0]): the response
+          # may carry non-text blocks, and the optional iterator (.content[]?)
+          # yields empty rather than a "cannot iterate over null" error when the
+          # API returns a JSON error payload with no content array — flowing
+          # cleanly to the fallback below.
           NOTES=$(echo "$RESPONSE" | jq -r 'first(.content[]? | select(.type=="text") | .text) // empty') || NOTES=""
           if [ -z "$NOTES" ]; then
             NOTES="Internal improvements and maintenance."


### PR DESCRIPTION
Brings #676 (remove the `thinking` parameter — it consumed the entire `max_tokens` budget on reasoning, yielding a thinking-only response → empty notes → fallback) onto `release` so the **re-cut of `v1.1.0-rc.1`** finally generates the real changelog.

`main` is one commit ahead of `release` (#676); this makes `release` == `main`. Verified locally against the real 112-PR range: thinking-off produces a clean ~730-token player-facing changelog. Code reviewed on #676 (Copilot's one comment — stale doc — addressed).

Sequence: merge → delete the `v1.1.0-rc.1` release + tag → re-cut (the happy path, end to end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)