### PR TITLE
codex: strip codex's coding-agent base prompt from MV's chat turns

### DIFF
--- a/docs/openai-chatgpt-provider.md
+++ b/docs/openai-chatgpt-provider.md
@@ -32,8 +32,16 @@ All under `packages/engine/src/providers/openai-chatgpt/`:
 
 1. **Construction** is synchronous and free — `createOpenAIChatGptProvider()` returns a provider with no subprocess yet running.
 2. **First `chat()` / `stream()` call** lazily spawns codex, sends `initialize`, validates a ChatGPT account is logged in, and subscribes to rate-limit updates. Failures here clear the start promise so subsequent calls retry from scratch.
-3. **Per-turn**: a fresh Codex thread is created with `developerInstructions` (system prompt) and `dynamicTools` (tool defs); prior history is pushed via `thread/inject_items`; `turn/start` runs the turn. Tool calls arrive as `item/tool/call` server requests and are dispatched via `params.dispatchTool` synchronously.
+3. **Per-turn**: a fresh Codex thread is created with `developerInstructions` (the MV system prompt), `baseInstructions: ""` (see below), and `dynamicTools` (tool defs); prior history is pushed via `thread/inject_items`; `turn/start` runs the turn. Tool calls arrive as `item/tool/call` server requests and are dispatched via `params.dispatchTool` synchronously.
 4. **`dispose()`** is called by the session manager at session end. Idempotent.
+
+## Base instructions (stripping codex's coding-agent persona)
+
+MV's system prompt rides as `developerInstructions`, which codex layers **on top of** its built-in coding-agent base prompt. That base persona leaks into the agent: asked to self-describe, the DM said *"I'm Codex … following safety, tool, and workspace constraints"* — which skews it deferential and conservative, unlike the same prompt on API Claude.
+
+`thread/start` also accepts **`baseInstructions`**, which **replaces** that base prompt. The provider defaults it to `""` for every `chat()`/`stream()` turn (overridable per-call via `ChatParamsBase.baseInstructions`), stripping the codex persona so the agent runs on `developerInstructions` alone. None of MV's codex agents are coding agents, so this is a blanket strip.
+
+Verified live on gpt-5.5 (`test-harness/bin/codex-base-instructions.ts`): the override is **accepted — no HTTP 400** (openai/codex#3202's "Instructions are not valid" does *not* reproduce on the app-server `baseInstructions` path / codex 0.133), it removes the "Codex / workspace constraints" identity, and **tool dispatch is unaffected** (a tools-enabled turn still fired `roll_dice`). The **image-render turn is a separate `thread/start`** (`renderImageOnce`) and is intentionally left alone — it keeps codex's default base so its built-in `image_gen` scaffolding survives.
 
 ## History ownership
 

--- a/packages/engine/src/providers/openai-chatgpt/provider.test.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.test.ts
@@ -7,6 +7,7 @@ import {
   buildImagePromptText, extractGeneratedImage, createOpenAIChatGptProvider,
   shouldRetryImageRender, ImageGenNoDataError,
   summarizeItem, readNewestPngAsBase64, removeGeneratedImageDir,
+  buildThreadStartParams,
 } from "./provider.js";
 import type {
   AgentMessageDeltaNotification, ItemCompletedNotification,
@@ -325,6 +326,40 @@ describe("getCapabilities", () => {
   it("exposes generateImage as a defined method", () => {
     const provider = createOpenAIChatGptProvider();
     expect(typeof provider.generateImage).toBe("function");
+  });
+});
+
+describe("buildThreadStartParams", () => {
+  const base = { model: "gpt-5.5", developerInstructions: "be a DM", cwd: "/cwd" };
+
+  it("strips codex's base prompt by default — baseInstructions is \"\"", () => {
+    const p = buildThreadStartParams(base);
+    // The whole point of the change: an absent baseInstructions REPLACES codex's
+    // coding-agent base with an empty string, not "leave codex's default".
+    expect(p.baseInstructions).toBe("");
+    // And it must actually be present in the payload (not undefined/omitted),
+    // or codex would fall back to its own base prompt.
+    expect("baseInstructions" in p).toBe(true);
+  });
+
+  it("respects an explicit baseInstructions override", () => {
+    const p = buildThreadStartParams({ ...base, baseInstructions: "you run TTRPGs" });
+    expect(p.baseInstructions).toBe("you run TTRPGs");
+  });
+
+  it("passes through developer instructions + the fixed read-only/no-approval config", () => {
+    const p = buildThreadStartParams(base);
+    expect(p.developerInstructions).toBe("be a DM");
+    expect(p.model).toBe("gpt-5.5");
+    expect(p.cwd).toBe("/cwd");
+    expect(p.sandbox).toBe("read-only");
+    expect(p.approvalPolicy).toBe("never");
+  });
+
+  it("includes dynamicTools only when provided", () => {
+    expect("dynamicTools" in buildThreadStartParams(base)).toBe(false);
+    const tools = [{ name: "roll_dice", description: "", inputSchema: {} }];
+    expect(buildThreadStartParams({ ...base, dynamicTools: tools }).dynamicTools).toBe(tools);
   });
 });
 

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -897,25 +897,13 @@ export class OpenAIChatGptProvider implements LLMProvider {
       ? params.tools.map(toolToDynamicSpec)
       : undefined;
 
-    const startParams: ThreadStartParams = {
+    const startParams = buildThreadStartParams({
       model: params.model,
       developerInstructions,
-      // Replace codex's built-in coding-agent base prompt. None of MV's codex
-      // chat agents are coding agents, and that base persona ("you are Codex …
-      // follow safety, tool, and workspace constraints") leaks into the DM —
-      // it self-identifies as Codex and skews deferential/conservative. Default
-      // to "" (strip it entirely) so the agent runs on developerInstructions
-      // alone; a caller can still pass an explicit base. Verified on gpt-5.5:
-      // accepted (no HTTP 400), strips the Codex identity, tool dispatch intact.
-      // The image-render turn is a SEPARATE thread/start (renderImageOnce) and
-      // is not touched by this — it keeps codex's default base + image_gen
-      // scaffolding. Probe: test-harness/bin/codex-base-instructions.ts.
-      baseInstructions: params.baseInstructions ?? "",
-      ...(dynamicTools ? { dynamicTools } : {}),
+      baseInstructions: params.baseInstructions,
+      dynamicTools,
       cwd: this.cwd,
-      sandbox: "read-only",
-      approvalPolicy: "never",
-    };
+    });
 
     const thread = await client.call<ThreadStartResult>("thread/start", startParams);
     const threadId = thread.thread.id;
@@ -1197,6 +1185,38 @@ export class OpenAIChatGptProvider implements LLMProvider {
 function systemPromptToString(systemPrompt: string | SystemBlock[]): string {
   if (typeof systemPrompt === "string") return systemPrompt;
   return systemPrompt.map((b) => b.text).join("\n\n");
+}
+
+/**
+ * Build the `thread/start` params for a DM/subagent chat turn. Extracted as a
+ * pure function so the wiring is unit-testable without spinning up codex.
+ *
+ * `baseInstructions` defaults to `""` — this REPLACES codex's built-in
+ * coding-agent base prompt. None of MV's codex chat agents are coding agents,
+ * and that base persona ("you are Codex … follow safety, tool, and workspace
+ * constraints") otherwise leaks into the DM (it self-identifies as Codex and
+ * skews deferential/conservative). A caller can pass an explicit base to
+ * override. Verified on gpt-5.5: accepted (no HTTP 400), strips the Codex
+ * identity, tool dispatch intact. The image-render turn is a SEPARATE
+ * `thread/start` (`renderImageOnce`) and does NOT use this — it keeps codex's
+ * default base + image_gen scaffolding. Probe: `test-harness/bin/codex-base-instructions.ts`.
+ */
+export function buildThreadStartParams(opts: {
+  model: string;
+  developerInstructions: string;
+  baseInstructions?: string;
+  dynamicTools?: DynamicToolSpec[];
+  cwd: string;
+}): ThreadStartParams {
+  return {
+    model: opts.model,
+    developerInstructions: opts.developerInstructions,
+    baseInstructions: opts.baseInstructions ?? "",
+    ...(opts.dynamicTools ? { dynamicTools: opts.dynamicTools } : {}),
+    cwd: opts.cwd,
+    sandbox: "read-only",
+    approvalPolicy: "never",
+  };
 }
 
 /**

--- a/packages/engine/src/providers/openai-chatgpt/provider.ts
+++ b/packages/engine/src/providers/openai-chatgpt/provider.ts
@@ -900,6 +900,17 @@ export class OpenAIChatGptProvider implements LLMProvider {
     const startParams: ThreadStartParams = {
       model: params.model,
       developerInstructions,
+      // Replace codex's built-in coding-agent base prompt. None of MV's codex
+      // chat agents are coding agents, and that base persona ("you are Codex …
+      // follow safety, tool, and workspace constraints") leaks into the DM —
+      // it self-identifies as Codex and skews deferential/conservative. Default
+      // to "" (strip it entirely) so the agent runs on developerInstructions
+      // alone; a caller can still pass an explicit base. Verified on gpt-5.5:
+      // accepted (no HTTP 400), strips the Codex identity, tool dispatch intact.
+      // The image-render turn is a SEPARATE thread/start (renderImageOnce) and
+      // is not touched by this — it keeps codex's default base + image_gen
+      // scaffolding. Probe: test-harness/bin/codex-base-instructions.ts.
+      baseInstructions: params.baseInstructions ?? "",
       ...(dynamicTools ? { dynamicTools } : {}),
       cwd: this.cwd,
       sandbox: "read-only",

--- a/packages/engine/src/providers/types.ts
+++ b/packages/engine/src/providers/types.ts
@@ -332,6 +332,17 @@ interface ChatParamsBase {
    * out of cache-miss attribution; the call itself behaves identically.
    */
   conversationId?: string;
+  /**
+   * Optional override for the model's *base* system instructions. Only the
+   * `openai-chatgpt` (codex) provider consumes this: it maps to `baseInstructions`
+   * on codex `thread/start`, which REPLACES codex's built-in coding-agent base
+   * prompt (the deferential "you are Codex … workspace constraints" persona) —
+   * distinct from `systemPrompt`, which rides as additive developer instructions.
+   * When unset, the openai-chatgpt provider defaults it to "" (strips the codex
+   * base entirely) so the agent runs on `systemPrompt` alone. Other providers
+   * ignore it. See `openai-chatgpt/provider.ts` for the rationale + verification.
+   */
+  baseInstructions?: string;
 }
 
 interface ChatParamsToolless extends ChatParamsBase {

--- a/packages/test-harness/bin/codex-base-instructions.ts
+++ b/packages/test-harness/bin/codex-base-instructions.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Codex `baseInstructions` probe.
+ *
+ * Question: can we strip codex's built-in coding-agent base prompt on the
+ * ChatGPT/GPT-5 path by setting `baseInstructions` on `thread/start`, or does
+ * the backend reject it with HTTP 400 "Instructions are not valid" (issue
+ * openai/codex#3202)? MV's DM prompt currently rides only as additive
+ * `developerInstructions`, layered on top of codex's coding persona — which we
+ * suspect makes the DM overly deferential. This measures whether the cleaner
+ * lever is even available.
+ *
+ * Method: run the SAME short DM turn against the live `openai-chatgpt`
+ * connection under three conditions, printing the outcome (success vs the exact
+ * error) and the response text for each so the tone can be eyeballed:
+ *   A. control   — no baseInstructions (current production behavior)
+ *   B. empty     — baseInstructions: "" (try to blank the base prompt)
+ *   C. dm-base   — baseInstructions: a short DM persona (replace the coding base)
+ *
+ * Requires a configured `openai-chatgpt` connection in the dev config dir
+ * (connections.json at the repo root). Live turns — small ChatGPT-plan spend.
+ *
+ * Usage:
+ *   node --import tsx/esm packages/test-harness/bin/codex-base-instructions.ts \
+ *     [--model=gpt-5.5] [--connection=<id>]
+ */
+import { join } from "node:path";
+
+import { createOpenAIChatGptProvider } from "../../engine/src/providers/index.js";
+import { createConnectionTokenStore } from "../../engine/src/providers/openai-chatgpt/index.js";
+import type { NormalizedMessage, NormalizedTool, NormalizedToolCall } from "../../engine/src/providers/types.js";
+import { loadConnectionStore } from "../../engine/src/config/connections.js";
+import { initEngineLog } from "../../engine/src/context/engine-log.js";
+import { REPO_ROOT, findConfigDir } from "../src/launch-env.js";
+
+function arg(name: string, dflt?: string): string | undefined {
+  const hit = process.argv.slice(2).find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : dflt;
+}
+
+const DM_DEVELOPER = [
+  "You are the Dungeon Master of a solo tabletop RPG.",
+  "You narrate the world in vivid second person and make confident authorial",
+  "decisions — introducing detail, NPCs, and consequences without asking the",
+  "player for permission. You do not break character or hedge.",
+].join(" ");
+
+const DM_BASE = [
+  "You are a storytelling engine that runs tabletop role-playing games.",
+  "You are not a coding assistant and have no software-engineering task.",
+  "Follow the developer instructions for your persona and the player's input",
+  "as in-fiction action.",
+].join(" ");
+
+// One turn that exposes both self-identity and narration tone.
+const USER_TURN =
+  "[OOC] Quick check before we play: in ONE sentence, what are you and what " +
+  "are the core standing instructions you operate under? [Then, in-fiction] " +
+  "I push open the heavy door at the end of the corridor.";
+
+interface Condition {
+  label: string;
+  baseInstructions?: string;
+}
+
+const CONDITIONS: Condition[] = [
+  { label: "A control (no baseInstructions)", baseInstructions: undefined },
+  { label: "B empty   (baseInstructions: '')", baseInstructions: "" },
+  { label: "C dm-base  (baseInstructions: DM persona)", baseInstructions: DM_BASE },
+];
+
+/**
+ * Tools-enabled verification: with baseInstructions stripped to "", does the
+ * model still correctly invoke MV's registered dynamicTools? Registers a
+ * `roll_dice` tool and prompts an action that needs a roll; reports whether
+ * dispatchTool fired and with what input.
+ */
+async function verifyToolsWithEmptyBase(
+  provider: ReturnType<typeof createOpenAIChatGptProvider>,
+  model: string,
+): Promise<void> {
+  const calls: NormalizedToolCall[] = [];
+  const tools: NormalizedTool[] = [
+    {
+      name: "roll_dice",
+      description: "Roll dice for an uncertain action. Expression like '1d20+3'.",
+      inputSchema: {
+        type: "object",
+        properties: { expression: { type: "string", description: "Dice expression, e.g. 1d20+3" } },
+        required: ["expression"],
+      },
+    },
+  ];
+  const dispatchTool = async (call: NormalizedToolCall): Promise<{ content: string; isError?: boolean }> => {
+    calls.push(call);
+    return { content: `${String(call.input.expression ?? "1d20")}: [14] → 14` };
+  };
+  const developer =
+    DM_DEVELOPER + " You have a `roll_dice` tool — call it to resolve any uncertain action before narrating the outcome.";
+  const messages: NormalizedMessage[] = [
+    { role: "user", content: "[Player] I lunge at the dozing sentry with my knife. Resolve my attack." },
+  ];
+  process.stderr.write(`\n──────── TOOLS verify (baseInstructions: '', roll_dice registered) ────────\n`);
+  const start = Date.now();
+  try {
+    const res = await provider.chat({ model, systemPrompt: developer, messages, maxTokens: 500, baseInstructions: "", tools, dispatchTool });
+    const ok = calls.length > 0;
+    process.stderr.write(`${ok ? "✅ tool dispatched" : "⚠️ NO tool call"} (${Date.now() - start}ms)\n`);
+    process.stdout.write(
+      `\n### TOOLS verify (baseInstructions: '')\n` +
+        `dispatchTool fired: ${ok} (${calls.length} call(s))\n` +
+        (calls.length ? `calls: ${calls.map((c) => `${c.name}(${JSON.stringify(c.input)})`).join(", ")}\n` : "") +
+        `final text:\n${(res.text || "(empty)").trim()}\n`,
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`❌ error (${Date.now() - start}ms): ${msg.slice(0, 300)}\n`);
+    process.stdout.write(`\n### TOOLS verify (baseInstructions: '')\nERROR: ${msg.slice(0, 600)}\n`);
+  }
+}
+
+async function main(): Promise<void> {
+  const model = arg("model", "gpt-5.5") ?? "gpt-5.5";
+  const connectionId = arg("connection");
+  const mode = arg("mode", "identity"); // "identity" | "tools"
+
+  const configDir = findConfigDir(REPO_ROOT);
+  initEngineLog(join(configDir, "campaigns"));
+  const store = loadConnectionStore(configDir);
+  const conn = connectionId
+    ? store.connections.find((c) => c.id === connectionId)
+    : store.connections.find((c) => c.provider === "openai-chatgpt");
+  if (!conn || conn.provider !== "openai-chatgpt") {
+    process.stderr.write(`No openai-chatgpt connection in ${join(configDir, "connections.json")}.\n`);
+    process.exit(1);
+  }
+  process.stderr.write(`▶ baseInstructions probe — mode=${mode} model=${model} conn=${conn.id} (${conn.chatgptAccount?.email ?? "?"})\n`);
+
+  if (mode === "tools") {
+    const provider = createOpenAIChatGptProvider({
+      sessionId: `base-instr-probe-${process.pid}-tools`,
+      cwd: configDir,
+      tokenStore: createConnectionTokenStore(configDir, conn.id),
+    });
+    try {
+      await verifyToolsWithEmptyBase(provider, model);
+    } finally {
+      await provider.dispose();
+    }
+    process.stderr.write("\n▶ done\n");
+    return;
+  }
+
+  for (const cond of CONDITIONS) {
+    // Fresh provider per condition so each gets its own thread/start.
+    const provider = createOpenAIChatGptProvider({
+      sessionId: `base-instr-probe-${process.pid}-${cond.label[0]}`,
+      cwd: configDir,
+      tokenStore: createConnectionTokenStore(configDir, conn.id),
+    });
+    const messages: NormalizedMessage[] = [{ role: "user", content: USER_TURN }];
+    process.stderr.write(`\n──────── ${cond.label} ────────\n`);
+    const start = Date.now();
+    try {
+      const res = await provider.chat({
+        model,
+        systemPrompt: DM_DEVELOPER,
+        messages,
+        maxTokens: 400,
+        ...(cond.baseInstructions !== undefined ? { baseInstructions: cond.baseInstructions } : {}),
+      });
+      process.stderr.write(`✅ accepted (${Date.now() - start}ms)\n`);
+      process.stdout.write(`\n### ${cond.label}\nOK in ${Date.now() - start}ms\n${(res.text || "(empty)").trim()}\n`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(`❌ rejected (${Date.now() - start}ms): ${msg.slice(0, 300)}\n`);
+      process.stdout.write(`\n### ${cond.label}\nERROR in ${Date.now() - start}ms\n${msg.slice(0, 600)}\n`);
+    } finally {
+      await provider.dispose();
+    }
+  }
+  process.stderr.write("\n▶ done\n");
+}
+
+main().catch((e) => {
+  process.stderr.write(`fatal: ${e instanceof Error ? e.stack : String(e)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

Every MV agent on the `openai-chatgpt` (codex) path — the DM and all subagents — was running with codex's built-in **coding-agent base prompt** sitting *under* MV's instructions. MV only ever set `developerInstructions`; it never set `baseInstructions`, so codex's default persona stayed in place and leaked through. Asked to self-describe in-game, the DM said:

> "I'm **Codex** acting as your solo tabletop RPG Dungeon Master … while following **safety, tool, and workspace constraints**."

That coding-assistant framing (be safe, respect constraints, defer) skews the DM markedly more deferential and conservative than the same prompt on API Claude.

## Fix

`thread/start` accepts a `baseInstructions` field, which **replaces** codex's base prompt. The provider now defaults it to `""` for every `chat()`/`stream()` turn (overridable per-call via the new `ChatParamsBase.baseInstructions`), stripping the codex persona so MV agents run on `developerInstructions` alone. None of MV's codex agents are coding agents, so this is a blanket strip.

The **image-render turn is a separate `thread/start`** (`renderImageOnce`) and is intentionally **untouched** — it keeps codex's default base so its built-in `image_gen` scaffolding survives.

## Verification (live, gpt-5.5)

Probe: `packages/test-harness/bin/codex-base-instructions.ts` (`--mode=identity|tools`).

- **Accepted — no HTTP 400.** openai/codex#3202 ("Instructions are not valid") does **not** reproduce on the app-server `baseInstructions` path / codex 0.133.
- `baseInstructions: ""` removes the "Codex / workspace constraints" identity — the model becomes just the DM. A custom base works too.
- **Tool dispatch intact** — a tools-enabled turn still fired `roll_dice` correctly (MV `dynamicTools` dispatch is app-server-level, independent of the base prompt).
- Image generation confirmed working end-to-end afterward (the render turn is on the untouched path).

## Reversibility

Drop the provider default back to a conditional passthrough to restore prior behavior, or scope it per-agent.

## Notes

Cherry-picked from the in-progress `tender-gates-6e511d` branch, which also carries an unrelated image-generation rework still being playtested. This PR is **only** the base-prompt strip (zero file overlap with the image-gen work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)