### PR TITLE
Fix scribe newline accumulation: strip trailing blanks per section

### DIFF
--- a/packages/engine/src/agents/subagents/scribe.test.ts
+++ b/packages/engine/src/agents/subagents/scribe.test.ts
@@ -578,9 +578,18 @@ describe("splitSections", () => {
     const result = splitSections(body);
     expect(result).toHaveLength(3);
     expect(result[0].heading).toBe("");
-    expect(result[0].content).toBe("Preamble.\n");
+    // Trailing blank line (the separator before ## Stats) is stripped from content.
+    expect(result[0].content).toBe("Preamble.");
     expect(result[1].heading).toBe("## Stats");
+    expect(result[1].content).toBe("## Stats\nHP: 42");
     expect(result[2].heading).toBe("## Inventory");
+  });
+
+  it("strips trailing blank lines from section content (no separator baked in)", () => {
+    const body = "## Stats\nHP: 42\n\n\n## Inventory\n- Sword\n\n";
+    const result = splitSections(body);
+    expect(result[0].content).toBe("## Stats\nHP: 42");
+    expect(result[1].content).toBe("## Inventory\n- Sword");
   });
 
   it("does not split on ### headings", () => {
@@ -606,6 +615,17 @@ describe("mergeSectionBodies", () => {
     expect(result).toContain("Dagger");
     expect(result).toContain("## Notes");
     expect(result).toContain("Brave.");
+  });
+
+  it("does not accumulate blank lines across repeated merges (regression)", () => {
+    let body = "## Stats\nHP: 3/3\n\n## Skills\n- Salvage `d8`\n\n## Inventory\n- Tool belt";
+    const once = mergeSectionBodies(body, "## Inventory\n- Tool belt\n- Wrench");
+    // Re-merging the same incoming must be a fixed point — no growing gaps.
+    const twice = mergeSectionBodies(once, "## Inventory\n- Tool belt\n- Wrench");
+    expect(twice).toBe(once);
+    // Even after many section-touching writes, no blank-line run (3+ newlines) appears.
+    for (let i = 0; i < 6; i++) body = mergeSectionBodies(body, "## Stats\nHP: 2/3");
+    expect(body).not.toMatch(/\n\n\n/);
   });
 
   it("preserves preamble text before first heading", () => {

--- a/packages/engine/src/agents/subagents/scribe.test.ts
+++ b/packages/engine/src/agents/subagents/scribe.test.ts
@@ -592,6 +592,13 @@ describe("splitSections", () => {
     expect(result[1].content).toBe("## Inventory\n- Sword");
   });
 
+  it("preserves meaningful trailing whitespace on a content line (markdown hard break)", () => {
+    // The two trailing spaces on "first line" are a hard break — keep them;
+    // only the trailing blank lines get stripped.
+    const result = splitSections("## Notes\nfirst line  \nsecond line\n\n\n");
+    expect(result[0].content).toBe("## Notes\nfirst line  \nsecond line");
+  });
+
   it("does not split on ### headings", () => {
     const body = "## Stats\nHP: 42\n### Substats\nSTR: 10";
     const result = splitSections(body);
@@ -626,6 +633,14 @@ describe("mergeSectionBodies", () => {
     // Even after many section-touching writes, no blank-line run (3+ newlines) appears.
     for (let i = 0; i < 6; i++) body = mergeSectionBodies(body, "## Stats\nHP: 2/3");
     expect(body).not.toMatch(/\n\n\n/);
+  });
+
+  it("does not create a blank-line run joining a preamble-only body with a section", () => {
+    // `existing` has no ## heading and ends in a blank line — the early-return
+    // split path must strip it so the join can't produce \n\n\n.
+    const result = mergeSectionBodies("A brave knight.\n", "## Inventory\n- Sword");
+    expect(result).toBe("A brave knight.\n\n## Inventory\n- Sword");
+    expect(result).not.toMatch(/\n\n\n/);
   });
 
   it("preserves preamble text before first heading", () => {

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -201,6 +201,15 @@ const H2_RE = /^## (?!#)/m;
  * Returns an array of { heading, content } where heading is the full
  * `## Foo` line (or "" for preamble text before the first heading).
  * Content includes the heading line itself.
+ *
+ * Trailing blank lines are stripped from each section's content: the blank
+ * line that visually separates one section from the next is *presentation*,
+ * re-added by the joiner (see {@link mergeSectionBodies}). If it were kept in
+ * `content`, every merge would join sections whose content already ends in the
+ * separator with another `\n\n`, so each write would grow the gaps by a blank
+ * line — a slow, silent newline-accumulation bug across an entity's lifetime.
+ * Trimming here makes a parse→merge round-trip idempotent (and self-heals a
+ * file that already accumulated runs, the next time it is written).
  */
 export function splitSections(body: string): { heading: string; content: string }[] {
   if (!H2_RE.test(body)) return [{ heading: "", content: body }];
@@ -208,10 +217,13 @@ export function splitSections(body: string): { heading: string; content: string 
   const sections: { heading: string; content: string }[] = [];
   const lines = body.split("\n");
   let current: { heading: string; lines: string[] } | null = null;
+  const finish = () => {
+    if (current) sections.push({ heading: current.heading, content: current.lines.join("\n").trimEnd() });
+  };
 
   for (const line of lines) {
     if (line.startsWith("## ") && !line.startsWith("### ")) {
-      if (current) sections.push({ heading: current.heading, content: current.lines.join("\n") });
+      finish();
       current = { heading: line, lines: [line] };
     } else {
       if (!current) {
@@ -220,7 +232,7 @@ export function splitSections(body: string): { heading: string; content: string 
       current.lines.push(line);
     }
   }
-  if (current) sections.push({ heading: current.heading, content: current.lines.join("\n") });
+  finish();
 
   return sections;
 }

--- a/packages/engine/src/agents/subagents/scribe.ts
+++ b/packages/engine/src/agents/subagents/scribe.ts
@@ -197,28 +197,39 @@ import { sanitizeFrontMatter } from "../../tools/filesystem/frontmatter.js";
 const H2_RE = /^## (?!#)/m;
 
 /**
+ * Strip trailing *blank lines* (empty or whitespace-only) from a chunk of
+ * markdown. Only whole trailing blank lines go — meaningful trailing whitespace
+ * on the last content line (e.g. the two-space markdown hard break) is left
+ * intact, because the pattern only matches from a newline onward.
+ */
+function stripTrailingBlankLines(s: string): string {
+  return s.replace(/(?:\n[ \t]*)+$/, "");
+}
+
+/**
  * Split a markdown body into sections keyed by `## Heading`.
  * Returns an array of { heading, content } where heading is the full
  * `## Foo` line (or "" for preamble text before the first heading).
  * Content includes the heading line itself.
  *
- * Trailing blank lines are stripped from each section's content: the blank
- * line that visually separates one section from the next is *presentation*,
- * re-added by the joiner (see {@link mergeSectionBodies}). If it were kept in
- * `content`, every merge would join sections whose content already ends in the
- * separator with another `\n\n`, so each write would grow the gaps by a blank
- * line — a slow, silent newline-accumulation bug across an entity's lifetime.
- * Trimming here makes a parse→merge round-trip idempotent (and self-heals a
- * file that already accumulated runs, the next time it is written).
+ * Trailing *blank lines* are stripped from each section's content (via
+ * {@link stripTrailingBlankLines}): the blank line that visually separates one
+ * section from the next is *presentation*, re-added by the joiner (see
+ * {@link mergeSectionBodies}). If it were kept in `content`, every merge would
+ * join sections whose content already ends in the separator with another
+ * `\n\n`, so each write would grow the gaps by a blank line — a slow, silent
+ * newline-accumulation bug across an entity's lifetime. Stripping here makes a
+ * parse→merge round-trip idempotent (and self-heals a file that already
+ * accumulated runs, the next time it is written).
  */
 export function splitSections(body: string): { heading: string; content: string }[] {
-  if (!H2_RE.test(body)) return [{ heading: "", content: body }];
+  if (!H2_RE.test(body)) return [{ heading: "", content: stripTrailingBlankLines(body) }];
 
   const sections: { heading: string; content: string }[] = [];
   const lines = body.split("\n");
   let current: { heading: string; lines: string[] } | null = null;
   const finish = () => {
-    if (current) sections.push({ heading: current.heading, content: current.lines.join("\n").trimEnd() });
+    if (current) sections.push({ heading: current.heading, content: stripTrailingBlankLines(current.lines.join("\n")) });
   };
 
   for (const line of lines) {
@@ -246,9 +257,11 @@ export function splitSections(body: string): { heading: string; content: string 
  */
 export function mergeSectionBodies(existing: string, incoming: string): string {
   // If incoming has no ## headings, append as before (backward compat for
-  // plain-text updates like adding a paragraph of description).
+  // plain-text updates like adding a paragraph of description). Strip trailing
+  // blanks off `existing` first so a preamble that ends in blank lines can't
+  // combine with the `\n\n` joiner into a growing gap.
   if (!H2_RE.test(incoming)) {
-    return existing ? `${existing}\n\n${incoming}` : incoming;
+    return existing ? `${stripTrailingBlankLines(existing)}\n\n${incoming}` : incoming;
   }
 
   const existingSections = splitSections(existing);


### PR DESCRIPTION
## The bug

Long-standing, programmatic (not generative): entity files grew an **extra blank line between every `## section` on each scribe write**, so a well-played character sheet ended up with tall runs of blank lines throughout its Stats / Skills / Inventory / Notes. Confirmed on a real long campaign save.

## Root cause

A non-idempotent parse→merge round-trip in the scribe's section-aware body merge ([`scribe.ts`](packages/engine/src/agents/subagents/scribe.ts)):

- `splitSections` captured each section's **trailing blank line** — the separator before the next `## heading` — *into that section's `content`*.
- `mergeSectionBodies` then rejoined sections with an **additional `\n\n`**.

So every section-touching write double-counted the separator and added one blank line between **every** adjacent section pair — deterministically, even for sections that weren't edited. Reproduces as **+2 blank lines per merge** in a 3-section body (4 → 6 → 8 → 10 …).

```
start:  2 blank lines
merge1: 4   merge2: 6   merge3: 8   merge4: 10   ...
```

## Fix

`splitSections` now trims trailing blank lines from each section's content — the separator is *presentation*, re-added by the joiner. That makes the round-trip a **fixed point**, and it **self-heals**: the next scribe write on an already-bloated file collapses the runs back to single-blank separators (so existing saves recover on their own).

After the fix: 5 merges → still exactly 2 blank lines, no `\n\n\n` runs; a pre-bloated body collapses to normal on one merge.

## Tests

- New regression: a re-merge is a fixed point, and no 3+ newline run survives repeated writes (would have caught this).
- Updated the one `splitSections` test that asserted the buggy "trailing separator baked into content" contract.
- `npm run check` green (**3642 tests**); typecheck + goldens green. `splitSections` is used only by `mergeSectionBodies` (+ tests), so blast radius is contained.

## Not in scope

I also noticed **duplicate changelog *entries*** on the same save (a block repeated ~6×). That's a separate symptom (changelog is parsed out before the body merge) — possibly generative or rollback-related — and isn't touched here. Flagging for a follow-up if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)