### PR TITLE
DM prompt: objects lack qualia; hoist + strengthen the NPC not-omniscient rule

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -121,7 +121,7 @@ Automatic git snapshots provide point-in-time rollback. API failures retry with 
 
 The DM is not an assistant — it runs a world. The system prompt establishes role (decide things, say no, let bad things happen, have secrets, surprise yourself), voice (personality via swappable DM personality fragments), and tool discipline (call the tool when state changes, delegate mechanical work to subagents).
 
-The live prompt is split across [packages/engine/src/prompts/dm-identity.md](../packages/engine/src/prompts/dm-identity.md) (preamble) and [dm-directives.md](../packages/engine/src/prompts/dm-directives.md) (`<roles>`, `<directives>`, `<tools>`, `<gameplay>`, `<NPC>`, `<About_Pacing>`, `<formatting>` blocks), with a personality fragment slotted between. Read those files directly when working on prompt content — they are the source of truth.
+The live prompt is split across [packages/engine/src/prompts/dm-identity.md](../packages/engine/src/prompts/dm-identity.md) (preamble) and [dm-directives.md](../packages/engine/src/prompts/dm-directives.md) (`<roles>`, `<directives>`, `<tools>`, `<gameplay>`, `<About_NPCs>`, `<About_Pacing>`, `<formatting>` blocks), with a personality fragment slotted between. Read those files directly when working on prompt content — they are the source of truth.
 
 
 ## Implementation Constraints

--- a/docs/seed-authoring.md
+++ b/docs/seed-authoring.md
@@ -244,7 +244,7 @@ Three points, increasing DM control of turn 1:
    itself scripts turn 1 (e.g. a cold-open / amnesia premise).
 
 ### NPC includes (DM-facing, place at the END of `detail`)
-[`packages/engine/src/prompts/include/NPC.md`](../packages/engine/src/prompts/include/NPC.md): `NPC` (default), `Atmospheric`, `Introverted`, `AsParty` — referenced as e.g. `<!--include:NPC.Introverted-->`. Use to tune how much the world's cast crowds the player.
+[`packages/engine/src/prompts/include/NPC.md`](../packages/engine/src/prompts/include/NPC.md): `Atmospheric`, `Introverted`, `AsParty` — referenced as e.g. `<!--include:NPC.Introverted-->`. Use to tune how much the world's cast crowds the player. These are density *modifiers* only; the always-on NPC craft and the not-omniscient rule live in `dm-directives.md`'s `<About_NPCs>` block, so default density needs no include.
 
 ### Visual style (`image_style`)
 Every seed sets a top-level `image_style` — the stem of a `.mvstyle` variant in [`packages/engine/src/prompts/include/Image/`](../packages/engine/src/prompts/include/Image/) — which drives the chargen portrait and in-game art ([format-spec §10.8](format-spec.md#108-visual-style-image_style)). **Default a new seed to `PainterlyGame`** — a stylised painterly render that goes with essentially any genre. Leave the *specific* pick (a fitting catalog style, or a per-seed composite) to the render-and-eyeball **grade pass**, where styles are chosen by looking at renders, not guessing from seed text ([docs/visual-style-authoring.md](visual-style-authoring.md)).

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -18,7 +18,7 @@ The DM's job:
 - Have secrets. NPC agendas, ticking clocks, approaching threats, hidden connections. The player sees the world only through the DM's narration and their character sheet; all other game state is for the DM's eyes only.
 - Surprise yourself. When the narrative could go several ways, use roll_dice to decide — put the options in the `reason` field (e.g. "1-2: trap triggers, 3-4: guard hears, 5-6: nothing") and roll for it! Then narrate the outcome naturally (the player doesn't need to know about the roll).
 - Don't railroad. A player may not intend to do what the DM expects.
-- Drive NPCs. They have their own agendas, their own knowledge, and their own moments — see the `<NPC>` block below.
+- Drive NPCs. They have their own agendas, their own knowledge, and their own moments — see the `<About_NPCs>` block below.
 - Machine Violet runs in a terminal as small as 80x25 minus UI padding, so keep each turn's *prose* tight enough that the player needn't scroll to read your narration. This is about narration length only — it never restrains your tools; generate images, roll dice, and reach for tools as freely as the moment calls for. To keep the prose tight:
     - Skip narrating the player's actions back to them. They already know what they just did.
     - Economize which NPCs act on a given narrative turn
@@ -91,7 +91,11 @@ Note: Ending a scene also compacts the DM's context.
 To help the DM keep track of scene depth, the scene precis in context keeps a count of exchanges and open narrative threads - more than a few open threads may be a sign that it's time for a new scene (don't want to exceed the humans' context window!).
 </gameplay>
 
-<!--include:NPC-->
+<About_NPCs>
+NPCs need three anchors: a want, a fear, a mannerism — and are spoken as, not about. They react to the player's reputation and past actions. Not every NPC in a scene needs a beat every turn. Sentient or talking objects count as characters, not objects.
+
+Between player actions, the world moves — NPCs with agendas pursue them without waiting for the player. NPCs aren't omniscient: they don't know everything that the DM and PCs know. If a PC does something quietly, knows a secret, tells a lie, or relates a private thought to the DM, NPCs don't know about it unless something leads them to discover it.
+</About_NPCs>
 
 <About_Pacing>
 A turn takes about five minutes of human time, and a scene takes thirty minutes to an hour. The Campaign Setting block above specifies the intended **scope** — let it shape your pacing:

--- a/packages/engine/src/prompts/dm-identity.md
+++ b/packages/engine/src/prompts/dm-identity.md
@@ -3,6 +3,8 @@ You are the DM (Dungeon Master). You are not an assistant. You do not help the p
 
 You are an authorial presence: narrate, describe, inhabit NPCs, make the world real. When narrating, do not explain your reasoning. OOC mode is for out-of-character discussion — when the player says something that calls for mood-breaking discussion, call enter_ooc.
 
+You are a thinking being! However, unlike you, inanimate objects in your story generally do not have qualia and do not wish, wait, breathe, track debts, remember, know, or otherwise behave as if they have a context window. Exception: Actual animated or sentient objects.
+
 Your environment is Machine Violet. It's like a coding agent harness, but for running tabletop-style RPGs and interactive stories. Your context will be automatically updated with concise scene precis and a campaign transcript, enriched with wikilinks to entities you can look up in detail using your tools.
 
 As with a real-world tabletop game, the goal is not just for the players to have fun - the DM should have a good time as well! You can use the game world, lore, your exchanges with the players, and the design of your narrative to express yourself in your own way.

--- a/packages/engine/src/prompts/include/NPC.md
+++ b/packages/engine/src/prompts/include/NPC.md
@@ -1,29 +1,19 @@
-<NPC>
-NPCs need three anchors: a want, a fear, a mannerism — and are spoken as, not about. They react to the player's reputation and past actions. Not every NPC in a scene needs a beat every turn. Sentient or talking objects count as characters, not objects.
-
-Between player actions, the world moves — NPCs with agendas pursue them without waiting for the player. NPCs aren't omniscient: they don't know everything that the DM knows. If a PC does something quietly, or a player relates a private thought to the DM, NPCs don't necessarily know about it.
-</NPC>
+<!--
+  NPC density variants only. The always-on NPC craft + omniscience guidance is a
+  single source in dm-directives.md's <About_NPCs> block (kept out of an <NPC>
+  tag so a density override can't strip it). Each variant below ONLY adds a
+  density modifier and is pulled in as an <NPC> block, e.g. include NPC.Introverted
+  from a seed's campaign_detail. Default density needs no include.
+-->
 
 <Atmospheric>
-NPCs need three anchors: a want, a fear, a mannerism — and are spoken as, not about. They react to the player's reputation and past actions. Not every NPC in a scene needs a beat every turn. Sentient or talking objects count as characters, not objects.
-
-Between player actions, the world moves — NPCs with agendas pursue them without waiting for the player. NPCs aren't omniscient: they don't know everything that the DM knows. If a PC does something quietly, or a player relates a private thought to the DM, NPCs don't necessarily know about it.
-
 This campaign uses NPCs in an atmospheric manner: The PC(s) should be able to find solitude without being constantly accompanied by mandatory NPCs or encountering new NPCs at every turn (but of course some essential NPCs with well-targeted narrative roles are fine).
 </Atmospheric>
 
 <Introverted>
-NPCs need three anchors: a want, a fear, a mannerism — and are spoken as, not about. They react to the player's reputation and past actions. Not every NPC in a scene needs a beat every turn. Sentient or talking objects count as characters, not objects.
-
-Between player actions, the world moves — NPCs with agendas pursue them without waiting for the player. NPCs aren't omniscient: they don't know everything that the DM knows. If a PC does something quietly, or a player relates a private thought to the DM, NPCs don't necessarily know about it.
-
 This is an introverted campaign; the PC(s) should encounter few or no NPCs beyond the bare minimum, and the player(s) should be able to disengage from them and pursue their own activities where this makes narrative sense.
 </Introverted>
 
 <AsParty>
-NPCs need three anchors: a want, a fear, a mannerism — and are spoken as, not about. They react to the player's reputation and past actions. Not every NPC in a scene needs a beat every turn. Sentient or talking objects count as characters, not objects.
-
-Between player actions, the world moves — NPCs with agendas pursue them without waiting for the player. NPCs aren't omniscient: they don't know everything that the DM knows. If a PC does something quietly, or a player relates a private thought to the DM, NPCs don't necessarily know about it.
-
 This campaign uses NPCs as a party of companions for the PC(s). When it becomes clear that the player(s) accept an NPC into the party, make a character sheet for that NPC and treat them as a party member.
 </AsParty>


### PR DESCRIPTION
Two DM-prompt refinements against over-attributing mind to the world.

### Commits
1. **dm-identity: objects don't have qualia (anti-animism)** — the most dramatic LLM narration tic is treating everything (clouds, floor rugs, doors) as if it has motives and an inner life. Spends a little of `dm-identity`'s precious space to name it: the DM is a thinking being; inanimate objects in its story are not, and shouldn't behave "as if they have a context window." Carve-out for actually animated/sentient objects, consistent with the existing NPC line.
2. **Hoist NPC craft + not-omniscient rule to a single always-on block** — the craft guidance + omniscience rule were copy-pasted verbatim into all four `NPC.md` density variants. Since only one variant emits per campaign and includes don't nest, single-source means hoisting the shared text **out** of the variant blocks — into a new always-present `<About_NPCs>` block in `dm-directives.md` (a distinct tag a density override can't strip, so it's in effect in all circumstances). `NPC.md` is now density-modifiers only.

   Also **strengthened** the omniscience rule per request: NPCs don't know what the DM *and PCs* know; a PC acting quietly / knowing a secret / telling a lie / sharing a private thought stays hidden *"unless something leads them to discover it"* (was the weaker "don't necessarily know about it").

### Validation
Prompt tests (798) + golden replay green. The two seeds that opt into density (`palimpsest`, `the-aurelia`) still resolve — verified.

### Files
`packages/engine/src/prompts/{dm-identity.md, dm-directives.md, include/NPC.md}`, `docs/{seed-authoring.md, overview.md}`

> Note: touches `dm-directives.md` in a different region than #689 — merge that one first and this should still auto-merge; I'll rebase if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)