### PR TITLE
Fix mvplay long-session OOM: disable React dev Performance Track by default (#694)

### DIFF
--- a/scripts/launcher.ts
+++ b/scripts/launcher.ts
@@ -20,6 +20,8 @@
  *   MV_PLAYER     — Player name (default "Player")
  *   MV_CAMPAIGN   — Campaign ID to auto-start
  *   MV_AGENT_PORT — Port for the dev-only agent sidecar
+ *   MV_REACT_PERF_TRACK — set to 1 to keep React's dev DevTools Performance
+ *                 Track on (off by default; leaving it on OOMs long dev sessions — #694)
  *   ANTHROPIC_API_KEY — Required for the engine
  */
 import { join } from "node:path";
@@ -36,6 +38,29 @@ handleVelopackHook();
 
 // --- Load environment ---
 loadEnv();
+
+// --- Disable React's dev "Performance Track" unless profiling (#694) ---
+// react-reconciler's DEVELOPMENT build (loaded when NODE_ENV !== "production" —
+// how the harness and `npm run dev` run) emits a `performance.measure()` per
+// component render to feed React DevTools' component Performance Track. Node
+// buffers every User Timing entry forever and nothing in this terminal app reads
+// them, so a long session's continuous re-renders (menu starfield, in-turn
+// thinking ticks, streaming deltas) fill the buffer and OOM the launcher (~4 GB;
+// it climbs ~14 MB/min even at an idle menu). React gates the ENTIRE track on
+// `typeof console.timeStamp === "function"`, captured ONCE when react-reconciler
+// first evaluates — which in a plain Node process (no inspector) is a
+// meaningless no-op that React nonetheless reads as "profiling wanted." Clearing
+// that method here — BEFORE the client (and its Ink/react-reconciler graph) is
+// dynamically imported below — disables the emission at the source: no measures,
+// no buffer growth, and none of the per-render arg-building churn. `console.
+// timeStamp` is a DevTools-timeline no-op unused anywhere in the app. Opt back in
+// with MV_REACT_PERF_TRACK=1 to actually profile React renders. (Production ships
+// the production reconciler with no track, so this is moot there; the flag is
+// honored uniformly regardless.)
+const reactPerfTrack = /^(1|true|on|yes)$/i.test(process.env.MV_REACT_PERF_TRACK ?? "");
+if (!reactPerfTrack) {
+  (console as { timeStamp?: (label?: string) => void }).timeStamp = undefined;
+}
 
 // --- Parse args ---
 const serverOnly = process.argv.includes("--server");


### PR DESCRIPTION
Fixes #694.

## Root cause (measured, not guessed)

The mvplay launcher OOM'd (~4 GB heap by ~turn 42) in long interactive sessions. I instrumented the launcher with a memory sampler + heap-snapshot diffs and pinned it:

- **The heap climbs at a completely idle main menu** — no turns, no images — at **~14 MB/min**, driven by the ambient starfield animation's continuous re-renders. So it's **time/render-scaled, not turn-scaled** — the opposite of the issue's original "accumulates conversation + game state" hypothesis.
- `external`/`arrayBuffers` stay flat; the growth is pure JS objects. A snapshot diff (91→126 MB over 157 s) showed **+1.19 M nodes led by `PerformanceMeasure` (+25k, ~160/sec)** plus their name strings and backing arrays.
- **Source:** `react-reconciler`'s *development* build emits a `performance.measure()` per component render to feed React DevTools' component Performance Track. Node buffers every User Timing entry forever and nothing in this terminal app reads them. Any continuous re-render fills it — the menu starfield, and in-play the DM-thinking `ActivityLine` tick + streaming deltas — so it reaches 4 GB over a long session. (The starfield and the ActivityLine ticker are both correctly gated; they merely *drive renders*. The leak is the unbounded buffer.)

## The fix — disable at the source

React exposes no runtime toggle, but it gates the **entire** track on `typeof console.timeStamp === "function"`, captured once when the reconciler first evaluates. In a plain Node process (no inspector) `console.timeStamp` is a meaningless no-op that React nonetheless reads as "profiling wanted." Clearing it **before** the client's dynamic `import()` (which loads Ink/react-reconciler) makes React skip the track entirely: **no measures emitted, no buffer growth, and none of the per-render arg-building churn** — strictly better than clearing the buffer after the fact.

Raised to an **app-level flag `MV_REACT_PERF_TRACK` (default off)**; set it to `1` to profile React renders. `console.timeStamp` is unused anywhere in the app (verified), and production ships the production reconciler with no track — so this is moot there and the flag is honored uniformly.

**Ordering is safe:** the disable sits in the launcher body *before* the `startClient` dynamic import, and the launcher's static imports are engine-only (no Ink), so it runs before React captures `supportsUserTiming` — confirmed empirically (`measures` stays 0).

## Verification

Idle-menu measurement, watching the live measure count:

| | before | after |
|---|---|---|
| `performance.getEntriesByType("measure").length` | ~160/sec, retained | **0** |
| `heapTotal` over ~3–4 min idle | 98 → **157 MB** (~14 MB/min) | flat at **~98 MB** |
| per-render CPU churn | yes | none |

Scope: dev/harness-mode only (production reconciler has no track); one file, `scripts/launcher.ts`. `npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)