### PR TITLE
React perf: extract dev-track suppression + standing guard, add render-frequency meter (#694)

### DIFF
--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -113,6 +113,10 @@ Abstract provider layer: normalizes Anthropic, OpenAI (API key), OpenAI ChatGPT 
 
 Dev-only HTTP server for AI agent integration testing (`--agent-port` or `MV_AGENT_PORT`). Embeds in the TUI client, provides screen capture via `@xterm/headless`, state inspection, and keystroke injection. Endpoints: `GET /screen` (plain text or `?ansi=true`), `GET /state` (JSON), `POST /input` (raw bytes), `POST /input/key` (named key via KEY_MAP). Excluded from release builds.
 
+## Client: tui/render-meter.tsx — Dev-only render-frequency instrument
+
+Diagnoses how often React commits and what re-renders when nothing visibly changed (Ink diffs the whole output tree per commit, so anything re-rendering at animation FPS is expensive). Wrap a region in `<RenderZone id="...">`; with `MV_RENDER_LOG` set it counts that subtree's commits via `React.Profiler` and appends per-2s-window JSONL summaries (`=1` → `<tmpdir>/machine-violet/render-meter.jsonl`, else an explicit path), flushed from a Node timer outside the commit path. Unset, it's a zero-overhead passthrough. Nest zones — a root zone gives the total, inner zones attribute it; the wired zones are `app` (root), `frame` (`FullScreenFrame`), `narrative` (play-area). Only fires under the development reconciler (mvplay / `npm run dev`), so it's dev-only like the leak it chases (#694).
+
 ## Client: tui/ — Terminal UI
 
 Ink (React for CLI) components, formatting pipeline, theme system.

--- a/packages/client-ink/src/react-perf-track.test.ts
+++ b/packages/client-ink/src/react-perf-track.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { disableReactPerfTrackUnlessRequested, shouldKeepReactPerfTrack } from "./react-perf-track.js";
+
+// Reproduce a real Node process — which HAS `console.timeStamp` (vitest's console
+// shim omits it) — then apply our fix, ALL BEFORE Ink/react-reconciler is imported
+// anywhere in this file. react-reconciler captures `supportsUserTiming` exactly
+// ONCE, when it first evaluates (vitest's resetModules can't re-evaluate an
+// externalized node_modules dep — Node's require cache persists), so the state we
+// leave here is the state the GUARD's render observes. Installing the probe and
+// THEN clearing it via the helper makes the GUARD non-trivial: if the helper ever
+// stops clearing it, the reconciler captures `true` and the render below emits.
+(console as { timeStamp?: unknown }).timeStamp = () => {};
+const disabledAtLoad = disableReactPerfTrackUnlessRequested({});
+
+describe("React dev Performance Track suppression (#694)", () => {
+  it("GUARD: a real Ink render emits ZERO performance measures once the track is disabled", async () => {
+    expect(disabledAtLoad).toBe(true);
+    expect(console.timeStamp).toBeUndefined(); // the probe React reads at eval-time is gone
+
+    const React = (await import("react")).default;
+    const { render } = await import("ink-testing-library");
+    const { Text } = await import("ink");
+
+    performance.clearMeasures();
+    const { rerender, unmount } = render(React.createElement(Text, null, "0"));
+    for (let i = 1; i <= 30; i++) rerender(React.createElement(Text, null, String(i)));
+    unmount();
+
+    expect(performance.getEntriesByType("measure").length).toBe(0);
+  });
+
+  it("CANARY: react-reconciler still gates its Performance Track on `typeof console.timeStamp`", () => {
+    // The exact probe our fix neutralizes. If a React upgrade renames/removes this
+    // gate, clearing console.timeStamp would silently stop suppressing the track
+    // (the GUARD could pass vacuously) — fail here so we re-derive the mechanism.
+    const require = createRequire(import.meta.url);
+    const pkgJson = require.resolve("react-reconciler/package.json");
+    const devBuild = join(dirname(pkgJson), "cjs", "react-reconciler.development.js");
+    const src = readFileSync(devBuild, "utf8");
+    expect(src).toContain("typeof console.timeStamp");
+  });
+
+  it("respects MV_REACT_PERF_TRACK opt-in: leaves the probe untouched so profiling still works", () => {
+    for (const v of ["1", "true", "on", "yes", "YES"]) {
+      const stub = () => {};
+      (console as { timeStamp?: unknown }).timeStamp = stub;
+      expect(shouldKeepReactPerfTrack({ MV_REACT_PERF_TRACK: v })).toBe(true);
+      expect(disableReactPerfTrackUnlessRequested({ MV_REACT_PERF_TRACK: v })).toBe(false);
+      expect(console.timeStamp).toBe(stub); // untouched
+    }
+  });
+
+  it("treats absent/empty/other values as opted-out (default off)", () => {
+    for (const env of [{}, { MV_REACT_PERF_TRACK: "" }, { MV_REACT_PERF_TRACK: "0" }, { MV_REACT_PERF_TRACK: "off" }]) {
+      expect(shouldKeepReactPerfTrack(env)).toBe(false);
+    }
+  });
+});

--- a/packages/client-ink/src/react-perf-track.ts
+++ b/packages/client-ink/src/react-perf-track.ts
@@ -1,0 +1,40 @@
+/**
+ * React dev "Performance Track" suppression (#694).
+ *
+ * react-reconciler's DEVELOPMENT build — the one loaded whenever NODE_ENV !==
+ * "production" (i.e. `npm run dev`, mvplay, the golden harness) — emits a
+ * `performance.measure()` per component render to feed React DevTools' component
+ * Performance Track. Node retains every User Timing entry forever and nothing in
+ * this terminal app reads them, so a long session's continuous re-renders fill an
+ * unbounded buffer and OOM the launcher (~14 MB/min even at an idle menu).
+ *
+ * React gates the ENTIRE track on a capability probe captured ONCE when
+ * react-reconciler first evaluates: `typeof console.timeStamp === "function"`. In
+ * a plain Node process (no inspector) `console.timeStamp` is a meaningless no-op
+ * that React nonetheless reads as "profiling wanted." Clearing it BEFORE the
+ * reconciler is imported disables the emission at the source — no measures, no
+ * buffer growth, none of the per-render arg-building churn.
+ *
+ * This is a zero-import leaf on purpose: the launcher imports it statically and
+ * calls it before the client (and its Ink/react-reconciler graph) is dynamically
+ * imported, so importing this must not pull in Ink.
+ */
+
+const TRUTHY = /^(1|true|on|yes)$/i;
+
+/** Whether the caller opted IN to keeping React's dev Performance Track (for profiling). */
+export function shouldKeepReactPerfTrack(env: NodeJS.ProcessEnv = process.env): boolean {
+  return TRUTHY.test(env.MV_REACT_PERF_TRACK ?? "");
+}
+
+/**
+ * Neutralize the `console.timeStamp` probe React reads at reconciler module-eval,
+ * unless profiling was explicitly requested via `MV_REACT_PERF_TRACK`. MUST run
+ * before react-reconciler is first imported. Returns true if the track was
+ * disabled, false if left on (opt-in).
+ */
+export function disableReactPerfTrackUnlessRequested(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (shouldKeepReactPerfTrack(env)) return false;
+  (console as { timeStamp?: (label?: string) => void }).timeStamp = undefined;
+  return true;
+}

--- a/packages/client-ink/src/start-client.ts
+++ b/packages/client-ink/src/start-client.ts
@@ -9,6 +9,7 @@ import React from "react";
 import { Readable } from "node:stream";
 import { render, type RenderOptions } from "ink";
 import { App } from "./app.js";
+import { RenderZone } from "./tui/render-meter.js";
 import { installRawModeGuard } from "./tui/hooks/rawModeGuard.js";
 import { installSyncWriteCombiner } from "./tui/hooks/syncWriteCombiner.js";
 import {
@@ -164,7 +165,11 @@ export async function startClient(opts: StartClientOptions = {}): Promise<Client
   }
 
   const { unmount, waitUntilExit: inkWaitUntilExit } = render(
-    React.createElement(App, { serverUrl, playerId, campaignId, hasKittyProtocol: hasKitty, stdinFilterChain: filterChain, graphicsCaps }),
+    React.createElement(
+      RenderZone,
+      { id: "app" },
+      React.createElement(App, { serverUrl, playerId, campaignId, hasKittyProtocol: hasKitty, stdinFilterChain: filterChain, graphicsCaps }),
+    ),
     renderOpts,
   );
 

--- a/packages/client-ink/src/tui/components/FullScreenFrame.tsx
+++ b/packages/client-ink/src/tui/components/FullScreenFrame.tsx
@@ -4,6 +4,7 @@ import type { ResolvedTheme } from "../themes/types.js";
 import { ThemedHorizontalBorder, ThemedSideFrame } from "./ThemedFrame.js";
 import { useStarfield, StarfieldRows } from "./Starfield.js";
 import type { StarfieldConfig } from "./Starfield.js";
+import { RenderZone } from "../render-meter.js";
 
 export interface FullScreenFrameProps {
   theme: ResolvedTheme;
@@ -95,6 +96,7 @@ export function FullScreenFrame({
   const grid = useStarfield(contentWidth, contentHeight, sfConfig);
 
   return (
+    <RenderZone id="frame">
     <Box flexDirection="column" width={columns} height={rows}>
       <ThemedHorizontalBorder
         theme={theme}
@@ -153,5 +155,6 @@ export function FullScreenFrame({
         position="bottom"
       />
     </Box>
+    </RenderZone>
   );
 }

--- a/packages/client-ink/src/tui/layout.tsx
+++ b/packages/client-ink/src/tui/layout.tsx
@@ -25,6 +25,7 @@ import {
   PlayerPaneSide,
 } from "./components/ThemedFrame.js";
 import { themeColor } from "./themes/color-resolve.js";
+import { RenderZone } from "./render-meter.js";
 import {
   getViewportTier,
   getVisibleElements,
@@ -249,19 +250,21 @@ export const Layout = React.memo(function Layout(props: LayoutProps) {
 
         <Box flexDirection="column" width={innerWidth + 2 * sidePadding} paddingLeft={sidePadding} paddingRight={sidePadding}>
           {/* Narrative Area */}
-          <NarrativeArea
-            ref={narrativeRef}
-            lines={narrativeLines}
-            maxRows={narRows}
-            quoteColor={quoteColor}
-            playerColor={playerColor}
-            width={innerWidth}
-            themeAsset={theme.asset}
-            separatorColor={separatorColor}
-            showVerbose={showVerbose}
-            viewportTop={conversationPaneTop}
-            mouseScrollOverrideRef={mouseScrollOverrideRef}
-          />
+          <RenderZone id="narrative">
+            <NarrativeArea
+              ref={narrativeRef}
+              lines={narrativeLines}
+              maxRows={narRows}
+              quoteColor={quoteColor}
+              playerColor={playerColor}
+              width={innerWidth}
+              themeAsset={theme.asset}
+              separatorColor={separatorColor}
+              showVerbose={showVerbose}
+              viewportTop={conversationPaneTop}
+              mouseScrollOverrideRef={mouseScrollOverrideRef}
+            />
+          </RenderZone>
 
           {/* Activity Line */}
           {elements.activityLine && (

--- a/packages/client-ink/src/tui/render-meter.test.tsx
+++ b/packages/client-ink/src/tui/render-meter.test.tsx
@@ -24,8 +24,12 @@ describe("renderMeterLogPath", () => {
 });
 
 describe("renderMeterEnabled", () => {
-  it("is off by default (the test env sets no MV_RENDER_LOG, so no Profiler/timer is installed)", () => {
-    expect(renderMeterEnabled()).toBe(false);
+  it("matches the env the singleton read at import — deterministic whether or not MV_RENDER_LOG is set", () => {
+    // The meter singleton reads process.env ONCE at module import, so a fixed
+    // `false` expectation is wrong in any shell/CI that has MV_RENDER_LOG set
+    // (e.g. a render-metering session). Derive the expectation from that same
+    // env instead so the assertion holds either way (Copilot #701).
+    expect(renderMeterEnabled()).toBe(renderMeterLogPath(process.env) !== null);
   });
 });
 

--- a/packages/client-ink/src/tui/render-meter.test.tsx
+++ b/packages/client-ink/src/tui/render-meter.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { Text } from "ink";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { renderMeterLogPath, renderMeterEnabled, RenderZone } from "./render-meter.js";
+
+describe("renderMeterLogPath", () => {
+  it("returns null when MV_RENDER_LOG is unset or empty", () => {
+    expect(renderMeterLogPath({})).toBeNull();
+    expect(renderMeterLogPath({ MV_RENDER_LOG: "" })).toBeNull();
+  });
+
+  it("maps truthy flags to the default tmpdir sink", () => {
+    const def = join(tmpdir(), "machine-violet", "render-meter.jsonl");
+    for (const v of ["1", "true", "on", "yes"]) {
+      expect(renderMeterLogPath({ MV_RENDER_LOG: v })).toBe(def);
+    }
+  });
+
+  it("treats any other value as an explicit path", () => {
+    expect(renderMeterLogPath({ MV_RENDER_LOG: "/var/log/rm.jsonl" })).toBe("/var/log/rm.jsonl");
+  });
+});
+
+describe("renderMeterEnabled", () => {
+  it("is off by default (the test env sets no MV_RENDER_LOG, so no Profiler/timer is installed)", () => {
+    expect(renderMeterEnabled()).toBe(false);
+  });
+});
+
+describe("RenderZone", () => {
+  it("is a transparent passthrough when disabled — children render unchanged", () => {
+    const { lastFrame } = render(
+      <RenderZone id="test">
+        <Text>hello-zone</Text>
+      </RenderZone>,
+    );
+    expect(lastFrame()).toContain("hello-zone");
+  });
+});

--- a/packages/client-ink/src/tui/render-meter.tsx
+++ b/packages/client-ink/src/tui/render-meter.tsx
@@ -1,0 +1,132 @@
+/**
+ * Render-frequency instrument (#694 lever 2).
+ *
+ * React/Ink re-reconciles and repaints on every commit, and Ink diffs the WHOLE
+ * output tree each time — so a component that re-renders at animation FPS drags a
+ * full-screen diff along with it even when only a few cells changed. The dev-only
+ * Performance Track leak (react-perf-track.ts) was one symptom of that frequency;
+ * this meter measures the frequency itself so we can see what re-renders when
+ * nothing visibly changed, and confirm fixes.
+ *
+ * Wrap regions in <RenderZone id="...">. When MV_RENDER_LOG is unset the zone is a
+ * transparent passthrough with ZERO overhead (no Profiler in the tree). When set,
+ * each zone's commits are counted via React.Profiler and a per-window summary is
+ * appended as JSONL — flushed from a Node timer OUTSIDE React (never in the commit
+ * path) so the instrument doesn't perturb what it measures.
+ *
+ * MV_RENDER_LOG=1        → <tmpdir>/machine-violet/render-meter.jsonl
+ * MV_RENDER_LOG=<path>   → that file
+ *
+ * Note: React.Profiler's onRender only fires under the DEVELOPMENT reconciler
+ * (npm run dev / mvplay / the harness). The shipped production build has no
+ * profiler, so this is a dev/diagnostic tool — same scope as the leak it chases.
+ */
+import React, { Profiler, type ProfilerOnRenderCallback, type ReactNode } from "react";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+const FLUSH_MS = 2000;
+
+/** Resolve the JSONL sink from MV_RENDER_LOG, or null when the meter is off. */
+export function renderMeterLogPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const v = env.MV_RENDER_LOG;
+  if (!v) return null;
+  return /^(1|true|on|yes)$/i.test(v) ? join(tmpdir(), "machine-violet", "render-meter.jsonl") : v;
+}
+
+interface Bucket {
+  commits: number;
+  mounts: number;
+  updates: number;
+  actualMs: number;
+  maxMs: number;
+}
+function emptyBucket(): Bucket {
+  return { commits: 0, mounts: 0, updates: 0, actualMs: 0, maxMs: 0 };
+}
+const round = (n: number): number => Math.round(n * 100) / 100;
+
+class RenderMeter {
+  private readonly path: string | null;
+  private readonly buckets = new Map<string, Bucket>();
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(env: NodeJS.ProcessEnv) {
+    this.path = renderMeterLogPath(env);
+    if (!this.path) return;
+    try {
+      mkdirSync(dirname(this.path), { recursive: true });
+    } catch {
+      /* best-effort — a missing sink just produces no log */
+    }
+    // Flush on a Node interval, never inside onRender: file I/O in the commit
+    // path would add latency to the very renders we're trying to measure.
+    // unref so the meter never keeps the process alive on its own.
+    this.timer = setInterval(() => this.flush(), FLUSH_MS);
+    this.timer.unref?.();
+  }
+
+  get enabled(): boolean {
+    return this.path !== null;
+  }
+
+  readonly record: ProfilerOnRenderCallback = (id, phase, actualDuration) => {
+    let b = this.buckets.get(id);
+    if (!b) {
+      b = emptyBucket();
+      this.buckets.set(id, b);
+    }
+    b.commits++;
+    if (phase === "mount") b.mounts++;
+    else if (phase === "update") b.updates++;
+    b.actualMs += actualDuration;
+    if (actualDuration > b.maxMs) b.maxMs = actualDuration;
+  };
+
+  private flush(): void {
+    if (!this.path) return;
+    const zones: Record<string, Bucket & { perSec: number }> = {};
+    for (const [id, b] of this.buckets) {
+      // Always emit a line (even an all-zero window) so a truly idle stretch is
+      // explicit in the log rather than indistinguishable from "not running."
+      zones[id] = {
+        commits: b.commits,
+        mounts: b.mounts,
+        updates: b.updates,
+        actualMs: round(b.actualMs),
+        maxMs: round(b.maxMs),
+        perSec: round(b.commits / (FLUSH_MS / 1000)),
+      };
+      this.buckets.set(id, emptyBucket());
+    }
+    if (Object.keys(zones).length === 0) return; // nothing has rendered yet
+    try {
+      appendFileSync(this.path, JSON.stringify({ windowMs: FLUSH_MS, zones }) + "\n");
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+const meter = new RenderMeter(process.env);
+
+/** Whether render metering is active (MV_RENDER_LOG set). */
+export function renderMeterEnabled(): boolean {
+  return meter.enabled;
+}
+
+/**
+ * Count commits for the wrapped subtree under `id`. Transparent passthrough (no
+ * Profiler, zero cost) unless MV_RENDER_LOG is set. Nest freely — each id
+ * aggregates its own subtree, so a root zone shows the total and inner zones
+ * attribute it.
+ */
+export function RenderZone({ id, children }: { id: string; children?: ReactNode }): ReactNode {
+  if (!meter.enabled) return children;
+  return (
+    <Profiler id={id} onRender={meter.record}>
+      {children}
+    </Profiler>
+  );
+}

--- a/packages/client-ink/src/tui/render-meter.tsx
+++ b/packages/client-ink/src/tui/render-meter.tsx
@@ -102,7 +102,7 @@ class RenderMeter {
     }
     if (Object.keys(zones).length === 0) return; // nothing has rendered yet
     try {
-      appendFileSync(this.path, JSON.stringify({ windowMs: FLUSH_MS, zones }) + "\n");
+      appendFileSync(this.path, JSON.stringify({ t: Date.now(), windowMs: FLUSH_MS, zones }) + "\n");
     } catch {
       /* best-effort */
     }

--- a/scripts/launcher.ts
+++ b/scripts/launcher.ts
@@ -31,6 +31,7 @@ import { defaultCampaignRoot } from "../packages/engine/src/tools/filesystem/pla
 import { configDir } from "../packages/engine/src/utils/paths.js";
 import { loadEnv } from "../packages/engine/src/config/first-launch.js";
 import { checkTerminal } from "../packages/engine/src/config/terminal-check.js";
+import { disableReactPerfTrackUnlessRequested } from "../packages/client-ink/src/react-perf-track.js";
 
 // --- Velopack lifecycle hooks (Windows install/update/uninstall) ---
 // Must run before any server/client startup. Exits the process if a hook fires.
@@ -40,27 +41,12 @@ handleVelopackHook();
 loadEnv();
 
 // --- Disable React's dev "Performance Track" unless profiling (#694) ---
-// react-reconciler's DEVELOPMENT build (loaded when NODE_ENV !== "production" —
-// how the harness and `npm run dev` run) emits a `performance.measure()` per
-// component render to feed React DevTools' component Performance Track. Node
-// buffers every User Timing entry forever and nothing in this terminal app reads
-// them, so a long session's continuous re-renders (menu starfield, in-turn
-// thinking ticks, streaming deltas) fill the buffer and OOM the launcher (~4 GB;
-// it climbs ~14 MB/min even at an idle menu). React gates the ENTIRE track on
-// `typeof console.timeStamp === "function"`, captured ONCE when react-reconciler
-// first evaluates — which in a plain Node process (no inspector) is a
-// meaningless no-op that React nonetheless reads as "profiling wanted." Clearing
-// that method here — BEFORE the client (and its Ink/react-reconciler graph) is
-// dynamically imported below — disables the emission at the source: no measures,
-// no buffer growth, and none of the per-render arg-building churn. `console.
-// timeStamp` is a DevTools-timeline no-op unused anywhere in the app. Opt back in
-// with MV_REACT_PERF_TRACK=1 to actually profile React renders. (Production ships
-// the production reconciler with no track, so this is moot there; the flag is
-// honored uniformly regardless.)
-const reactPerfTrack = /^(1|true|on|yes)$/i.test(process.env.MV_REACT_PERF_TRACK ?? "");
-if (!reactPerfTrack) {
-  (console as { timeStamp?: (label?: string) => void }).timeStamp = undefined;
-}
+// Must run BEFORE the client (and its Ink/react-reconciler graph) is dynamically
+// imported below, so the reconciler captures the neutralized probe on first eval.
+// See react-perf-track.ts for the full rationale; opt back in with
+// MV_REACT_PERF_TRACK=1 to profile React renders. The imported helper is a
+// zero-import leaf, so this static import does not pull Ink into --server builds.
+disableReactPerfTrackUnlessRequested(process.env);
 
 // --- Parse args ---
 const serverOnly = process.argv.includes("--server");


### PR DESCRIPTION
Follow-on to #700 (the mvplay OOM fix), addressing the broader concern it raised: **React does dev-only work per render that serves no purpose in our headless use case, and this keeps cropping up.** Two levers, grouped.

## Lever 1 — extract the perf-track suppression + a standing guard

#700 disabled React's dev "Performance Track" inline in `launcher.ts`. This pulls it into a tested, zero-import leaf and adds a regression guard so the leak can't silently return.

- **`packages/client-ink/src/react-perf-track.ts`** — `shouldKeepReactPerfTrack()` + `disableReactPerfTrackUnlessRequested()`, one source of truth for the `MV_REACT_PERF_TRACK` opt-in. Zero imports, so the launcher's static import can't pull Ink into `--server` builds.
- **`react-perf-track.test.ts`**:
  - **GUARD** — installs the `console.timeStamp` probe a real Node process has, applies the fix, renders a real Ink tree 30× through the *actual bundled reconciler*, asserts **zero** `performance.measure()` entries. Non-trivial: with the probe left on the reconciler emits (in fact throws calling the cleared method), so this only passes because the fix worked.
  - **CANARY** — asserts react-reconciler still gates its track on `typeof console.timeStamp`, so a future React upgrade that changes the mechanism fails loudly instead of making the guard vacuous.
  - opt-in / opt-out predicate coverage.

## Lever 2 — a render-frequency instrument (find what re-renders for no reason)

The durable answer to the recurring class: measure how *often* React commits and *what* re-renders when nothing visibly changed. Ink diffs the whole output tree per commit, so anything re-rendering at animation FPS drags a full-screen diff along.

- **`packages/client-ink/src/tui/render-meter.tsx`** — `<RenderZone id="...">` counts a subtree's commits via `React.Profiler` and appends per-2s-window JSONL when `MV_RENDER_LOG` is set (`=1` → `<tmpdir>/machine-violet/render-meter.jsonl`, else an explicit path), flushed from a Node timer **outside** the commit path. Off by default it's a zero-overhead passthrough. Wired zones: `app` (root), `frame` (`FullScreenFrame`), `narrative` (play-area).
- Dev-only: `React.Profiler.onRender` only fires under the development reconciler (mvplay / `npm run dev` / the harness) — same scope as the leak it chases.

### Finding (measured live via mvplay, idle main menu)

~1 commit/sec, and the `app` and `frame` zones report **identical commit counts and near-identical `actualMs`** — i.e. every idle tick re-renders the **entire `FullScreenFrame`** (borders, title, banner, all menu items, key hints), ~4–16ms each, just to move a few stars. Root cause: `useStarfield`/`useAnimation` lives in `FullScreenFrame`'s body, so `setAnimState` re-renders the whole frame instead of an isolated star-cell leaf.

**The fix is deliberately deferred:** the `grid` feeds two `StarfieldRows` regions that bracket static content, so hoisting the animation into a leaf is a real refactor with starfield-rendering / desync risk — to be done under the render-and-eyeball loop, not bundled speculatively here.

## Verification

- `npm run check` green (202 files, 3676 tests).
- `e2e:boot` boots the launcher through the new import path.
- Meter verified live: it produced the finding above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)