### PR TITLE
Parallel mvplay sessions + bulk-playtest dispatch (#696)

### DIFF
--- a/.claude/skills/play/SKILL.md
+++ b/.claude/skills/play/SKILL.md
@@ -38,10 +38,17 @@ node --import tsx/esm packages/test-harness/bin/mvplay.ts <cmd> [args]
 | `pick <N\|text>` | Select a choice by 1-based number or by label substring. |
 | `wait [--for beat\|handoff\|choices] [--timeout SEC]` | Block until a new beat lands, print it, exit. **Run in background.** |
 | `log [--tail N]` | Tail the launcher log (crash diagnostics). |
+| `list` | List all sessions (id, pid, port, liveness). |
 | `stop` | Kill the session. |
 
-One session at a time (state lives under the system temp dir). Read-back is over
-the sidecar's HTTP `/screen` + `/state` — nothing blocks on stdio.
+**Concurrent sessions.** Every command takes a global `--session <id>` (or the
+`MVPLAY_SESSION` env var); omit it for the single `"default"` session, which is
+unchanged. Distinct ids run fully isolated — separate state file, launcher log,
+temp campaigns dir, ephemeral ports, and per-session `CODEX_HOME` — so multiple
+playtests / golden recordings run at once. `mvplay list` shows them all; each
+`start`/`say`/`wait`/`stop`/… must carry the same `--session <id>` to target the
+right one. Read-back is over the sidecar's HTTP `/screen` + `/state` — nothing
+blocks on stdio.
 
 ## Temp dir vs. the user's live campaigns (`--live`)
 

--- a/.claude/skills/playtest-sweep/SKILL.md
+++ b/.claude/skills/playtest-sweep/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: playtest-sweep
+description: Bulk-dispatch LIVE Machine Violet playtests in parallel — you are the dispatcher, fanning out N subagents that each drive their own isolated mvplay session, then aggregating their reports. USE THIS when the user wants breadth fast: "sweep the seeds", "playtest N campaigns at once", "bulk playtest", "run playtests in parallel", "dispatch playtests", curate voices across many seeds, or regression-check a batch of campaigns live. For a single hands-on playthrough use /play instead; for the deterministic pass/fail check use /smoketest.
+---
+
+# Playtest Sweep (bulk live playtests)
+
+Fan out many **live** playtests at once. Each playtest runs in its own subagent
+driving its own **isolated mvplay session** (the parallel-sessions feature, #696).
+You are the **dispatcher**: you assign each subagent a unique session id + a
+disjoint port-base, spawn them in quota-safe batches, and aggregate what they
+report. This is for **breadth** (cover many seeds/campaigns quickly). For one
+hands-on playthrough, use `/play`.
+
+The subagents are as capable as you and already know how to use `mvplay` — do
+**not** paste them a tutorial. Your job is the orchestration and the one thing
+that isn't automatic: **handing out ports**.
+
+## The isolation contract (what keeps N sessions from colliding)
+
+Every subagent MUST receive three things, and must pass the first two on *every*
+`mvplay` command:
+
+1. **A unique `--session <id>`** — its own state dir, launcher log, temp
+   campaigns. Slug the target (e.g. `pt-ghosts-proxima`).
+2. **A disjoint `--port-base <N>`** — assign `30000 + 2*i` to the i-th subagent
+   (engine `N`, sidecar `N+1`; step by **2** so pairs never overlap). **This is
+   the part you can't skip:** the default port pick is random with *no* free-port
+   probe, so at fan-out two sessions can grab the same port and the loser just
+   fails to launch. A handed-out base is collision-free by construction.
+3. **A distinct target.** In `--live`, **never point two subagents at the same
+   campaign** — they'd race one save. (Different campaigns are fine; the engine
+   isolates per campaign.) For fresh-seed sweeps in the temp dir, distinct seeds.
+
+Example assignment for 4 targets:
+
+| i | target | `--session` | `--port-base` |
+|---|--------|-------------|---------------|
+| 0 | seed A | `pt-a` | 30000 |
+| 1 | seed B | `pt-b` | 30002 |
+| 2 | seed C | `pt-c` | 30004 |
+| 3 | seed D | `pt-d` | 30006 |
+
+## Concurrency & quota
+
+Codex (ChatGPT/Pro) rate-limits, and a **drained quota hangs turns** (bounded by
+the StallWatchdog, but it burns wall-time). So **cap concurrency** — ~**3–4 live
+sessions at once** is a safe default; run more targets as sequential batches.
+Don't fan out 20 simultaneously (~a dozen back-to-back runs is enough to drain a
+day's quota). Keep port-bases unique across the *whole* sweep, not just per batch,
+so a straggler from batch 1 can't collide with batch 2.
+
+## Dispatch loop
+
+1. **Build the target list** — the seeds to sweep, or the campaigns to resume.
+2. **Assign** each a session id + `port-base = 30000 + 2*i` (i over the whole list).
+3. **Spawn a batch** of subagents (Agent tool — multiple in one message run
+   concurrently). Cap the batch at your concurrency limit.
+4. **Collect** each batch's reports; spawn the next batch as slots free.
+5. **Aggregate** into one summary for the user, then **clean up** (below).
+
+## Subagent prompt (keep it lean)
+
+Give each subagent only its assignment and the report shape — not a command
+reference. Template:
+
+> You're running one **live playtest**. Pass **`--session <id> --port-base <N>`**
+> on *every* `mvplay` command (this isolates you from the other concurrent
+> playtests — never omit them).
+> **Target:** _<seed name, or "resume campaign X">_.
+> **Do:** boot (`start [--live] --session <id> --port-base <N> [--fresh]`), then
+> _<goal: e.g. "drive setup + play 5 turns" / "resume + play 3 turns">_, watching
+> for _<criteria: crashes, DM naming tics, incoherence, image failures, pacing>_.
+> **Waits are 1–5 min** — run `mvplay wait` in the background.
+> When done, **`stop --session <id>`** and return ONLY a compact report:
+> `{ target, turnsPlayed, crashed, findings: [...], verdict: "clean" | "issues" }`.
+> You already know `mvplay`; if you want the command reference it's the `/play` skill.
+
+## Cleanup (always)
+
+A crashed or interrupted subagent can leave its launcher running. After the sweep
+(and if anything looks off mid-sweep):
+
+```bash
+node --import tsx/esm packages/test-harness/bin/mvplay.ts list      # any survivors?
+node --import tsx/esm packages/test-harness/bin/mvplay.ts stop --session <id>   # reap each
+```
+
+## Safety
+
+- **`--live` MUTATES real saves** (narration, saves, images written). Only sweep
+  live campaigns the user explicitly named. Default a sweep to the **temp dir**
+  (fresh seeds, `start` without `--live`) so nothing real is touched.
+- **One subagent per `--live` campaign.** Two on the same save corrupt it.
+- Prefer `--fresh` per session only if you intend to replace a same-named session;
+  with unique ids you never need it.

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -159,7 +159,11 @@ For "did I break it?", reach for **Tier 2** (`/replay-goldens`), not a live prob
 keeps the launcher + sidecar alive in a **detached background process** that
 outlives each command, so you submit one turn per invocation across as many
 invocations as the game lasts. State (ports, pid, and a read cursor) lives in a
-session file under the system temp dir — one session at a time.
+session file under `<tmpdir>/mvplay/<session-id>/`. Sessions are isolated per id,
+so multiple run concurrently (parallel playtests / recordings, #696): pass
+`--session <id>` (or set `MVPLAY_SESSION`) on every command, default `"default"`;
+`mvplay list` shows all live sessions. Each session also gets its own ephemeral
+ports and `CODEX_HOME`, so concurrent codex sessions don't contend.
 
 This exists because `runProbe` kills the process the moment its scripted body
 returns; nothing survives between an agent's tool calls, so there's no session

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -163,7 +163,11 @@ session file under `<tmpdir>/mvplay/<session-id>/`. Sessions are isolated per id
 so multiple run concurrently (parallel playtests / recordings, #696): pass
 `--session <id>` (or set `MVPLAY_SESSION`) on every command, default `"default"`;
 `mvplay list` shows all live sessions. Each session also gets its own ephemeral
-ports and `CODEX_HOME`, so concurrent codex sessions don't contend.
+ports and `CODEX_HOME`, so concurrent codex sessions don't contend. Ports are
+random-picked (no free-port probe), which is fine for one session; for **bulk
+concurrent dispatch** hand each session a disjoint `--port-base <N>` (engine `N`,
+sidecar `N+1`) so starts can't collide. The `playtest-sweep` skill is the
+dispatcher playbook for fanning out N live playtests across subagents this way.
 
 This exists because `runProbe` kills the process the moment its scripted body
 returns; nothing survives between an agent's tool calls, so there's no session

--- a/packages/engine/src/config/connections.test.ts
+++ b/packages/engine/src/config/connections.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -81,6 +81,25 @@ describe("saveConnectionStore", () => {
     const loaded = loadConnectionStore(tempDir);
     expect(loaded.connections).toHaveLength(1);
     expect(loaded.connections[0]).toMatchObject(conn);
+  });
+
+  it("writes atomically — no temp file is left behind (#696 parallel-safe)", () => {
+    const empty: ConnectionStore = { connections: [], tierAssignments: { large: null, medium: null, small: null } };
+    saveConnectionStore(tempDir, empty);
+    // The atomic write stages a `.connections.json.<pid>.<rand>.tmp` then renames
+    // it over the target; on success nothing temp should remain in the dir.
+    const leftovers = readdirSync(tempDir).filter((f) => f.startsWith(".connections.json.") && f.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+    expect(readdirSync(tempDir)).toContain("connections.json");
+  });
+
+  it("stays valid JSON across many back-to-back saves (crash/interleave surrogate)", () => {
+    const store: ConnectionStore = { connections: [], tierAssignments: { large: null, medium: null, small: null } };
+    for (let i = 0; i < 20; i++) saveConnectionStore(tempDir, store);
+    // Every intermediate state was a complete file (rename is atomic), so the
+    // final read must parse cleanly — never a half-written truncation.
+    expect(() => loadConnectionStore(tempDir)).not.toThrow();
+    expect(loadConnectionStore(tempDir).connections).toEqual([]);
   });
 });
 

--- a/packages/engine/src/config/connections.ts
+++ b/packages/engine/src/config/connections.ts
@@ -157,14 +157,26 @@ export function saveConnectionStore(appDir: string, store: ConnectionStore): voi
 }
 
 /**
+ * Block the current thread for `ms` without spinning. `saveConnectionStore` is
+ * synchronous (its callers — token refresh, settings routes — are sync), so the
+ * retry backoff below can't `await`; `Atomics.wait` on a throwaway buffer times
+ * out after `ms`, giving a real sync sleep. Node permits this on the main thread.
+ */
+function sleepSync(ms: number): void {
+  if (ms > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
  * `renameSync` over an existing file can transiently fail on Windows (EPERM/
- * EBUSY/EACCES) when another process holds the target open for a read; a few
- * immediate retries clear it. On POSIX the first rename just succeeds. On final
- * failure the temp file is cleaned up so we don't litter the config dir.
+ * EBUSY/EACCES) when another process holds the target open for a read. Retry with
+ * an escalating backoff so the attempts actually SPAN the lock window instead of
+ * burning through in one timeslice (Copilot #702). On POSIX the first rename just
+ * succeeds. On final failure the temp file is cleaned up so we don't litter.
  */
 function renameOverwrite(from: string, to: string): void {
+  const MAX = 6;
   let lastErr: unknown;
-  for (let attempt = 0; attempt < 10; attempt++) {
+  for (let attempt = 0; attempt < MAX; attempt++) {
     try {
       renameSync(from, to);
       return;
@@ -172,6 +184,7 @@ function renameOverwrite(from: string, to: string): void {
       lastErr = err;
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") break;
+      if (attempt < MAX - 1) sleepSync(20 * (attempt + 1)); // 20,40,60,80,100ms
     }
   }
   try { rmSync(from, { force: true }); } catch { /* best-effort cleanup */ }

--- a/packages/engine/src/config/connections.ts
+++ b/packages/engine/src/config/connections.ts
@@ -8,7 +8,7 @@
  * Environment keys (ANTHROPIC_API_KEY, OPENAI_API_KEY) auto-create
  * connections at runtime via buildEffectiveConnections().
  */
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getModelsForProvider, getTierDefaults, modelFamilyFor } from "./model-registry.js";
@@ -144,7 +144,38 @@ export function saveConnectionStore(appDir: string, store: ConnectionStore): voi
     connections: store.connections.filter((c) => c.source !== "env"),
     tierAssignments: store.tierAssignments,
   };
-  writeFileSync(join(appDir, STORE_FILENAME), JSON.stringify(toSave, null, 2) + "\n");
+  const target = join(appDir, STORE_FILENAME);
+  // Atomic write: serialize to a unique temp file in the same dir, then rename
+  // over the target. A rename is atomic on a filesystem, so a reader — or a
+  // concurrent writer, e.g. a second parallel mvplay session whose codex
+  // provider refreshes its OAuth token at the same moment (#696) — never sees a
+  // half-written store, and a crash mid-write can't truncate it. This file holds
+  // the user's API keys / OAuth tokens; a corrupt one bricks every connection.
+  const tmp = join(appDir, `.${STORE_FILENAME}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`);
+  writeFileSync(tmp, JSON.stringify(toSave, null, 2) + "\n");
+  renameOverwrite(tmp, target);
+}
+
+/**
+ * `renameSync` over an existing file can transiently fail on Windows (EPERM/
+ * EBUSY/EACCES) when another process holds the target open for a read; a few
+ * immediate retries clear it. On POSIX the first rename just succeeds. On final
+ * failure the temp file is cleaned up so we don't litter the config dir.
+ */
+function renameOverwrite(from: string, to: string): void {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      renameSync(from, to);
+      return;
+    } catch (err) {
+      lastErr = err;
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") break;
+    }
+  }
+  try { rmSync(from, { force: true }); } catch { /* best-effort cleanup */ }
+  throw lastErr;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/test-harness/bin/mvplay.ts
+++ b/packages/test-harness/bin/mvplay.ts
@@ -69,6 +69,11 @@ Global:
   --session <id>                    Target a named session (default "default"; also
                                     settable via MVPLAY_SESSION). Distinct ids run
                                     fully isolated, so sessions play concurrently.
+  --port-base <N>                   (start/record) Assign ports deterministically:
+                                    engine N, sidecar N+1. For bulk concurrent
+                                    dispatch, give each session a disjoint base
+                                    (30000, 30002, …) so ports can't collide.
+                                    Omit to pick at random (fine for one session).
 
 Notes:
   - Sessions are isolated per --session id (state/log/temp-campaigns under the
@@ -98,7 +103,7 @@ function positionals(args: string[]): string[] {
     const a = args[i];
     if (a.startsWith("--")) {
       // Skip a value for known value-taking flags.
-      if (a === "--player" || a === "--for" || a === "--timeout" || a === "--tail" || a === "--data-dir" || a === "--session") i++;
+      if (a === "--player" || a === "--for" || a === "--timeout" || a === "--tail" || a === "--data-dir" || a === "--session" || a === "--port-base") i++;
       continue;
     }
     out.push(a);
@@ -121,6 +126,7 @@ async function main(): Promise<void> {
         live: flag(rest, "live"),
         dataDir: opt(rest, "data-dir"),
         session,
+        portBase: opt(rest, "port-base") ? Number(opt(rest, "port-base")) : undefined,
       });
       break;
     case "record": {
@@ -133,6 +139,7 @@ async function main(): Promise<void> {
         live: flag(rest, "live"),
         dataDir: opt(rest, "data-dir"),
         session,
+        portBase: opt(rest, "port-base") ? Number(opt(rest, "port-base")) : undefined,
       });
       break;
     }

--- a/packages/test-harness/bin/mvplay.ts
+++ b/packages/test-harness/bin/mvplay.ts
@@ -37,6 +37,7 @@ import {
   pick,
   wait,
   log,
+  list,
   status,
   stop,
   saveTape,
@@ -51,6 +52,7 @@ Commands:
                                     Like start, but tape every LLM call (MV_TAPE_MODE=record).
                                     Play the scenario, then \`save-tape\`.
   save-tape <path>                  Pull the recorded tape and write a golden to <path>.
+  list                              List all sessions (id, pid, port, liveness).
   status                            Is a session alive? Show its vitals.
   screen [--ansi]                   Print the rendered terminal screen.
   state                             Print a compact state summary (engine/turn/choices).
@@ -63,8 +65,15 @@ Commands:
   log [--tail N]                    Tail the launcher log (crash diagnostics).
   stop                              Kill the session.
 
+Global:
+  --session <id>                    Target a named session (default "default"; also
+                                    settable via MVPLAY_SESSION). Distinct ids run
+                                    fully isolated, so sessions play concurrently.
+
 Notes:
-  - One session at a time (under the system temp dir).
+  - Sessions are isolated per --session id (state/log/temp-campaigns under the
+    system temp dir); omit it for the single "default" session. Use 'list' to see
+    all live sessions.
   - 'wait' is the slow one (a DM turn is 1-5 min). Launch it with run_in_background
     so you're re-invoked on exit instead of blocking a tool call.
   - By default you play in a throwaway temp campaigns dir (isolated, safe).
@@ -89,7 +98,7 @@ function positionals(args: string[]): string[] {
     const a = args[i];
     if (a.startsWith("--")) {
       // Skip a value for known value-taking flags.
-      if (a === "--player" || a === "--for" || a === "--timeout" || a === "--tail" || a === "--data-dir") i++;
+      if (a === "--player" || a === "--for" || a === "--timeout" || a === "--tail" || a === "--data-dir" || a === "--session") i++;
       continue;
     }
     out.push(a);
@@ -100,6 +109,9 @@ function positionals(args: string[]): string[] {
 async function main(): Promise<void> {
   const [cmd, ...rest] = process.argv.slice(2);
   const pos = positionals(rest);
+  // Which session to target (default "default"). Threaded into every command so
+  // concurrent sessions stay isolated; falls back to MVPLAY_SESSION in the driver.
+  const session = opt(rest, "session");
 
   switch (cmd) {
     case "start":
@@ -108,6 +120,7 @@ async function main(): Promise<void> {
         fresh: flag(rest, "fresh"),
         live: flag(rest, "live"),
         dataDir: opt(rest, "data-dir"),
+        session,
       });
       break;
     case "record": {
@@ -119,57 +132,61 @@ async function main(): Promise<void> {
         fresh: flag(rest, "fresh"),
         live: flag(rest, "live"),
         dataDir: opt(rest, "data-dir"),
+        session,
       });
       break;
     }
     case "save-tape": {
       const out = pos[0];
       if (!out) throw new Error(`save-tape needs an output path: mvplay save-tape path/to/scene.golden.json`);
-      await saveTape(out);
+      await saveTape(out, session);
       break;
     }
+    case "list":
+      await list();
+      break;
     case "status":
-      await status();
+      await status(session);
       break;
     case "screen":
-      await screen(flag(rest, "ansi"));
+      await screen(flag(rest, "ansi"), session);
       break;
     case "state":
-      await state();
+      await state(session);
       break;
     case "narrative":
-      await narrative({ all: flag(rest, "all") });
+      await narrative({ all: flag(rest, "all") }, session);
       break;
     case "say": {
       const text = pos.join(" ");
       if (!text) throw new Error(`say needs text: mvplay say "I open the door"`);
-      await say(text);
+      await say(text, session);
       break;
     }
     case "key": {
       const name = pos[0];
       if (!name) throw new Error(`key needs a name: mvplay key return`);
-      await key(name);
+      await key(name, session);
       break;
     }
     case "pick": {
       const query = pos.join(" ");
       if (!query) throw new Error(`pick needs a number or label: mvplay pick 1`);
-      await pick(query);
+      await pick(query, session);
       break;
     }
     case "wait": {
       const forRaw = opt(rest, "for");
       const forWhat = forRaw === "handoff" || forRaw === "choices" ? forRaw : "beat";
       const timeoutSec = opt(rest, "timeout") ? Number(opt(rest, "timeout")) : undefined;
-      await wait({ for: forWhat, timeoutSec });
+      await wait({ for: forWhat, timeoutSec }, session);
       break;
     }
     case "log":
-      await log(opt(rest, "tail") ? Number(opt(rest, "tail")) : undefined);
+      await log(opt(rest, "tail") ? Number(opt(rest, "tail")) : undefined, session);
       break;
     case "stop":
-      await stop();
+      await stop(session);
       break;
     case undefined:
     case "help":

--- a/packages/test-harness/src/index.ts
+++ b/packages/test-harness/src/index.ts
@@ -53,8 +53,12 @@ export {
   pick as playPick,
   wait as playWait,
   log as playLog,
-  SESSION_DIR,
+  list as playList,
+  resolveSessionId,
+  sessionPaths,
+  DEFAULT_SESSION_ID,
   type StartOptions,
+  type SessionPaths,
   type WaitOptions as PlayWaitOptions,
   type WaitFor,
 } from "./session-driver.js";

--- a/packages/test-harness/src/session-driver.test.ts
+++ b/packages/test-harness/src/session-driver.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveSessionId, sessionPaths, DEFAULT_SESSION_ID } from "./session-driver.js";
+
+const norm = (p: string): string => p.replace(/\\/g, "/");
+const ROOT = norm(join(tmpdir(), "mvplay"));
+
+describe("resolveSessionId", () => {
+  const saved = process.env.MVPLAY_SESSION;
+  beforeEach(() => { delete process.env.MVPLAY_SESSION; });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.MVPLAY_SESSION;
+    else process.env.MVPLAY_SESSION = saved;
+  });
+
+  it("defaults to the default id when nothing is given", () => {
+    expect(resolveSessionId()).toBe(DEFAULT_SESSION_ID);
+    expect(resolveSessionId("")).toBe(DEFAULT_SESSION_ID);
+  });
+
+  it("prefers an explicit id over the env var over the default", () => {
+    process.env.MVPLAY_SESSION = "from-env";
+    expect(resolveSessionId("explicit")).toBe("explicit"); // explicit wins
+    expect(resolveSessionId()).toBe("from-env");            // env when no explicit
+    delete process.env.MVPLAY_SESSION;
+    expect(resolveSessionId()).toBe(DEFAULT_SESSION_ID);    // default when neither
+  });
+
+  it("sanitizes filesystem-unsafe characters so an id can't escape the root", () => {
+    expect(resolveSessionId("a/b\\c")).toBe("abc");        // slashes stripped
+    expect(resolveSessionId("weird id!@#")).toBe("weirdid"); // punctuation/spaces stripped
+    expect(resolveSessionId("keep.dot_dash-1")).toBe("keep.dot_dash-1"); // safe chars survive
+  });
+
+  it("maps traversal ids (., ..) and all-unsafe ids to the default", () => {
+    // '.' / '..' survive the char class but join()'d would be the root or its
+    // PARENT — must never become a real session dir.
+    expect(resolveSessionId(".")).toBe(DEFAULT_SESSION_ID);
+    expect(resolveSessionId("..")).toBe(DEFAULT_SESSION_ID);
+    expect(resolveSessionId("///")).toBe(DEFAULT_SESSION_ID);
+  });
+});
+
+describe("sessionPaths", () => {
+  it("lays every session out under its own subdir of the sessions root", () => {
+    const p = sessionPaths("alpha");
+    expect(p.id).toBe("alpha");
+    expect(norm(p.dir)).toBe(`${ROOT}/alpha`);
+    expect(norm(p.file)).toBe(`${ROOT}/alpha/session.json`);
+    expect(norm(p.log)).toBe(`${ROOT}/alpha/launcher.log`);
+    expect(norm(p.campaignsDir)).toBe(`${ROOT}/alpha/campaigns`);
+  });
+
+  it("keeps distinct sessions fully disjoint (no shared file/log/campaigns)", () => {
+    const a = sessionPaths("a");
+    const b = sessionPaths("b");
+    expect(a.dir).not.toBe(b.dir);
+    expect(a.file).not.toBe(b.file);
+    expect(a.log).not.toBe(b.log);
+    expect(a.campaignsDir).not.toBe(b.campaignsDir);
+  });
+
+  it("puts the default session under its own subdir too (back-compat isolation)", () => {
+    expect(norm(sessionPaths(DEFAULT_SESSION_ID).dir)).toBe(`${ROOT}/default`);
+  });
+});

--- a/packages/test-harness/src/session-driver.test.ts
+++ b/packages/test-harness/src/session-driver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveSessionId, sessionPaths, DEFAULT_SESSION_ID } from "./session-driver.js";
+import { resolveSessionId, sessionPaths, resolvePorts, DEFAULT_SESSION_ID } from "./session-driver.js";
 
 const norm = (p: string): string => p.replace(/\\/g, "/");
 const ROOT = norm(join(tmpdir(), "mvplay"));
@@ -63,5 +63,32 @@ describe("sessionPaths", () => {
 
   it("puts the default session under its own subdir too (back-compat isolation)", () => {
     expect(norm(sessionPaths(DEFAULT_SESSION_ID).dir)).toBe(`${ROOT}/default`);
+  });
+});
+
+describe("resolvePorts", () => {
+  it("pins ports deterministically from a base (engine=base, sidecar=base+1)", () => {
+    expect(resolvePorts(30000)).toEqual({ serverPort: 30000, agentPort: 30001 });
+    expect(resolvePorts(30002)).toEqual({ serverPort: 30002, agentPort: 30003 });
+  });
+
+  it("gives disjoint bases disjoint port pairs (bulk dispatch is collision-free)", () => {
+    const used = new Set<number>();
+    for (const base of [30000, 30002, 30004, 30006]) {
+      const { serverPort, agentPort } = resolvePorts(base);
+      expect(used.has(serverPort)).toBe(false);
+      expect(used.has(agentPort)).toBe(false);
+      used.add(serverPort);
+      used.add(agentPort);
+    }
+  });
+
+  it("random-picks two distinct ports when no base is given", () => {
+    const { serverPort, agentPort } = resolvePorts();
+    expect(serverPort).not.toBe(agentPort);
+    for (const p of [serverPort, agentPort]) {
+      expect(p).toBeGreaterThanOrEqual(30000);
+      expect(p).toBeLessThan(40000);
+    }
   });
 });

--- a/packages/test-harness/src/session-driver.ts
+++ b/packages/test-harness/src/session-driver.ts
@@ -33,6 +33,7 @@ import {
   closeSync,
   readFileSync,
   writeFileSync,
+  readdirSync,
   rmSync,
 } from "node:fs";
 import { tmpdir, homedir } from "node:os";
@@ -46,11 +47,54 @@ import type { RecordedInput, FullStackGolden } from "./golden.js";
 // Session file
 // ---------------------------------------------------------------------------
 
-/** One interactive session at a time, under the system temp dir. */
-export const SESSION_DIR = join(tmpdir(), "mvplay");
-const SESSION_FILE = join(SESSION_DIR, "session.json");
-const LAUNCHER_LOG = join(SESSION_DIR, "launcher.log");
-const CAMPAIGNS_DIR = join(SESSION_DIR, "campaigns");
+/**
+ * Each interactive session gets its own subdir under this root, keyed by a
+ * session id (default "default"). Concurrent sessions — parallel playtests or
+ * golden recordings — stay fully isolated: separate state file, launcher log,
+ * and temp campaigns dir, and (via ephemeral ports + per-session CODEX_HOME)
+ * separate processes. Select a session with the `--session <id>` CLI flag or
+ * the MVPLAY_SESSION env var; omit both for the "default" session, which keeps
+ * single-session usage byte-for-byte unchanged. (#696)
+ */
+const SESSIONS_ROOT = join(tmpdir(), "mvplay");
+export const DEFAULT_SESSION_ID = "default";
+
+/** Absolute paths for one session, derived from its id. */
+export interface SessionPaths {
+  id: string;
+  dir: string;
+  file: string;
+  log: string;
+  campaignsDir: string;
+}
+
+/**
+ * Strip anything not filesystem-safe so an id can't escape SESSIONS_ROOT. Slashes
+ * are removed by the char class; `.` / `..` survive it but would resolve to the
+ * root or its PARENT via join(), so they're mapped to the default explicitly.
+ */
+function sanitizeSessionId(id: string): string {
+  const clean = id.replace(/[^A-Za-z0-9._-]/g, "").slice(0, 64);
+  if (clean === "" || clean === "." || clean === "..") return DEFAULT_SESSION_ID;
+  return clean;
+}
+
+/** Resolve the target session id: explicit arg → MVPLAY_SESSION env → default. */
+export function resolveSessionId(explicit?: string): string {
+  return sanitizeSessionId(explicit || process.env.MVPLAY_SESSION || DEFAULT_SESSION_ID);
+}
+
+/** Compute a session's paths from its id (pure — no I/O). */
+export function sessionPaths(id: string): SessionPaths {
+  const dir = join(SESSIONS_ROOT, id);
+  return {
+    id,
+    dir,
+    file: join(dir, "session.json"),
+    log: join(dir, "launcher.log"),
+    campaignsDir: join(dir, "campaigns"),
+  };
+}
 
 /**
  * The user's REAL, machine-scope data root — where the installed app and
@@ -94,24 +138,26 @@ interface SessionFile {
   inputs?: RecordedInput[];
 }
 
-function readSession(): SessionFile | null {
-  if (!existsSync(SESSION_FILE)) return null;
+function readSession(paths: SessionPaths): SessionFile | null {
+  if (!existsSync(paths.file)) return null;
   try {
-    return JSON.parse(readFileSync(SESSION_FILE, "utf8")) as SessionFile;
+    return JSON.parse(readFileSync(paths.file, "utf8")) as SessionFile;
   } catch {
     return null;
   }
 }
 
-function writeSession(s: SessionFile): void {
-  writeFileSync(SESSION_FILE, JSON.stringify(s, null, 2));
+function writeSession(paths: SessionPaths, s: SessionFile): void {
+  writeFileSync(paths.file, JSON.stringify(s, null, 2));
 }
 
-function requireSession(): SessionFile {
-  const s = readSession();
+function requireSession(paths: SessionPaths): SessionFile {
+  const s = readSession(paths);
   if (!s) {
+    const suffix = paths.id === DEFAULT_SESSION_ID ? "" : ` --session ${paths.id}`;
     throw new Error(
-      "No mvplay session. Run `mvplay start` first.",
+      `No mvplay session${paths.id === DEFAULT_SESSION_ID ? "" : ` "${paths.id}"`}. ` +
+      `Run \`mvplay start${suffix}\` first.`,
     );
   }
   return s;
@@ -306,6 +352,12 @@ export interface StartOptions {
    * behavior with a custom location. Overrides `live`.
    */
   dataDir?: string;
+  /**
+   * Session id to run under (default "default"). Distinct ids get isolated
+   * state/log/temp-campaigns dirs, so multiple sessions run concurrently. Also
+   * settable via the MVPLAY_SESSION env var. (#696)
+   */
+  session?: string;
 }
 
 /**
@@ -314,12 +366,15 @@ export interface StartOptions {
  * screen (the main menu).
  */
 export async function start(opts: StartOptions = {}): Promise<void> {
-  const existing = readSession();
+  const paths = sessionPaths(resolveSessionId(opts.session));
+  const existing = readSession(paths);
   if (existing && isAlive(existing.pid)) {
     if (!opts.fresh) {
+      const suffix = paths.id === DEFAULT_SESSION_ID ? "" : ` --session ${paths.id}`;
       throw new Error(
-        `A session is already running (pid ${existing.pid}, port ${existing.agentPort}). ` +
-        `Use \`mvplay stop\` first, or \`mvplay start --fresh\` to replace it.`,
+        `A session${paths.id === DEFAULT_SESSION_ID ? "" : ` "${paths.id}"`} is already ` +
+        `running (pid ${existing.pid}, port ${existing.agentPort}). ` +
+        `Use \`mvplay stop${suffix}\` first, or \`mvplay start${suffix} --fresh\` to replace it.`,
       );
     }
     killTree(existing.pid);
@@ -331,13 +386,13 @@ export async function start(opts: StartOptions = {}): Promise<void> {
   // dir (isolated, safe). --data-dir / --live: the user's REAL campaigns.
   const usingRealData = opts.dataDir != null || opts.live === true;
   const dataRoot = opts.dataDir != null ? resolve(opts.dataDir) : machineDataRoot();
-  const campaignsDir = usingRealData ? join(dataRoot, "campaigns") : CAMPAIGNS_DIR;
+  const campaignsDir = usingRealData ? join(dataRoot, "campaigns") : paths.campaignsDir;
 
-  mkdirSync(SESSION_DIR, { recursive: true });
+  mkdirSync(paths.dir, { recursive: true });
   // Only create the temp campaigns dir. Never conjure the user's real data dir
   // — if --live/--data-dir points somewhere that doesn't exist, surface an
   // empty menu rather than silently creating a stray tree.
-  if (!usingRealData) mkdirSync(CAMPAIGNS_DIR, { recursive: true });
+  if (!usingRealData) mkdirSync(paths.campaignsDir, { recursive: true });
 
   const serverPort = pickEphemeralPort();
   let agentPort = pickEphemeralPort();
@@ -360,7 +415,7 @@ export async function start(opts: StartOptions = {}): Promise<void> {
   // Detached: the child must outlive THIS cli process. Its stdout/stderr go
   // to a log file (we have no live pipe to read once we exit). stdin is
   // ignored — the sidecar injects keystrokes via a mock TTY, not our stdin.
-  const logFd = openSync(LAUNCHER_LOG, "w");
+  const logFd = openSync(paths.log, "w");
   const child = spawn(process.execPath, [...LAUNCHER_NODE_ARGS], {
     env,
     cwd,
@@ -380,7 +435,7 @@ export async function start(opts: StartOptions = {}): Promise<void> {
     serverPort,
     agentPort,
     campaignsDir,
-    launcherLog: LAUNCHER_LOG,
+    launcherLog: paths.log,
     player,
     launchedAt,
     readCursor: 0,
@@ -397,7 +452,7 @@ export async function start(opts: StartOptions = {}): Promise<void> {
   let ready = false;
   while (Date.now() < deadline) {
     if (!isAlive(child.pid)) {
-      const tail = tailFile(LAUNCHER_LOG, 30);
+      const tail = tailFile(paths.log, 30);
       throw new Error(
         `Launcher exited before the sidecar came up. Recent log:\n${tail}`,
       );
@@ -412,13 +467,17 @@ export async function start(opts: StartOptions = {}): Promise<void> {
     killTree(child.pid);
     throw new Error(
       `Sidecar did not become reachable on port ${agentPort} within ${timeoutMs}ms. ` +
-      `Log tail:\n${tailFile(LAUNCHER_LOG, 30)}`,
+      `Log tail:\n${tailFile(paths.log, 30)}`,
     );
   }
 
-  writeSession(session);
+  writeSession(paths, session);
 
-  process.stdout.write(`✔ session started (pid ${child.pid}, sidecar :${agentPort})\n`);
+  const idTag = paths.id === DEFAULT_SESSION_ID ? "" : ` [${paths.id}]`;
+  process.stdout.write(`✔ session started${idTag} (pid ${child.pid}, sidecar :${agentPort})\n`);
+  if (paths.id !== DEFAULT_SESSION_ID) {
+    process.stdout.write(`  target it with \`--session ${paths.id}\` (or MVPLAY_SESSION=${paths.id}).\n`);
+  }
   if (usingRealData) {
     process.stdout.write(
       `\n⚠️  LIVE DATA — playing against the user's REAL campaigns dir:\n` +
@@ -443,15 +502,15 @@ export async function start(opts: StartOptions = {}): Promise<void> {
 }
 
 /** Print the rendered screen. */
-export async function screen(ansi = false): Promise<void> {
-  const s = requireSession();
+export async function screen(ansi = false, sessionId?: string): Promise<void> {
+  const s = requireSession(sessionPaths(resolveSessionId(sessionId)));
   const out = await getScreen(s, ansi);
   process.stdout.write(out.replace(/\n+$/, "") + "\n");
 }
 
 /** Print a compact state summary. */
-export async function state(): Promise<void> {
-  const s = requireSession();
+export async function state(sessionId?: string): Promise<void> {
+  const s = requireSession(sessionPaths(resolveSessionId(sessionId)));
   const snap = await getState(s);
   process.stdout.write(summarizeState(snap, s.readCursor) + "\n");
 }
@@ -460,8 +519,9 @@ export async function state(): Promise<void> {
  * Print narrative lines. By default shows only what's new since the read
  * cursor and advances it; `--all` shows everything (also advancing).
  */
-export async function narrative(opts: { all?: boolean } = {}): Promise<void> {
-  const s = requireSession();
+export async function narrative(opts: { all?: boolean } = {}, sessionId?: string): Promise<void> {
+  const paths = sessionPaths(resolveSessionId(sessionId));
+  const s = requireSession(paths);
   const snap = await getState(s);
   const from = opts.all ? 0 : s.readCursor;
   const body = formatNarrative(snap.narrativeLines, from);
@@ -470,7 +530,7 @@ export async function narrative(opts: { all?: boolean } = {}): Promise<void> {
     process.stdout.write("\nchoices:\n" + formatChoices(snap.activeChoices) + "\n");
   }
   s.readCursor = snap.narrativeLines.length;
-  writeSession(s);
+  writeSession(paths, s);
 }
 
 /**
@@ -480,8 +540,9 @@ export async function narrative(opts: { all?: boolean } = {}): Promise<void> {
  * so a subsequent `wait` won't mistake a lingering stale overlay for a new
  * beat.
  */
-export async function say(text: string): Promise<void> {
-  const s = requireSession();
+export async function say(text: string, sessionId?: string): Promise<void> {
+  const paths = sessionPaths(resolveSessionId(sessionId));
+  const s = requireSession(paths);
   const snap = await getState(s);
   const baseline = snap.narrativeLines.length;
   const hadChoices = !!snap.activeChoices;
@@ -509,7 +570,7 @@ export async function say(text: string): Promise<void> {
     ok = await inputAccepted(s, baseline, 4000);
   }
   if (ok && s.recording) (s.inputs ??= []).push({ kind: "say", text });
-  writeSession(s);
+  writeSession(paths, s);
 
   if (ok) {
     process.stdout.write(`✔ submitted: ${JSON.stringify(text)}\n`);
@@ -523,10 +584,11 @@ export async function say(text: string): Promise<void> {
 }
 
 /** Send a single named key (return, up, down, escape, tab, ...). */
-export async function key(name: string): Promise<void> {
-  const s = requireSession();
+export async function key(name: string, sessionId?: string): Promise<void> {
+  const paths = sessionPaths(resolveSessionId(sessionId));
+  const s = requireSession(paths);
   await postKey(s, name);
-  if (s.recording) { (s.inputs ??= []).push({ kind: "key", name }); writeSession(s); }
+  if (s.recording) { (s.inputs ??= []).push({ kind: "key", name }); writeSession(paths, s); }
   process.stdout.write(`✔ key: ${name}\n`);
 }
 
@@ -538,8 +600,9 @@ export async function key(name: string): Promise<void> {
  * overlay's initial selection or whether the short-list custom input was
  * auto-focused.
  */
-export async function pick(query: string): Promise<void> {
-  const s = requireSession();
+export async function pick(query: string, sessionId?: string): Promise<void> {
+  const paths = sessionPaths(resolveSessionId(sessionId));
+  const s = requireSession(paths);
   const snap = await getState(s);
   if (!snap.activeChoices) {
     throw new Error("No choice overlay is currently presented. Use `mvplay state` to check.");
@@ -584,7 +647,7 @@ export async function pick(query: string): Promise<void> {
     ok = await inputAccepted(s, baseline, 4000);
   }
   if (ok && s.recording) (s.inputs ??= []).push({ kind: "pick", index, label: labels[index] });
-  writeSession(s);
+  writeSession(paths, s);
 
   if (ok) {
     process.stdout.write(`✔ picked #${index + 1}: ${JSON.stringify(labels[index])}\n`);
@@ -620,8 +683,9 @@ export interface WaitOptions {
  * Exits 0 on settle, 1 on timeout (printing the current state + log tail so
  * the agent can diagnose without re-running).
  */
-export async function wait(opts: WaitOptions = {}): Promise<void> {
-  const s = requireSession();
+export async function wait(opts: WaitOptions = {}, sessionId?: string): Promise<void> {
+  const paths = sessionPaths(resolveSessionId(sessionId));
+  const s = requireSession(paths);
   const forWhat = opts.for ?? "beat";
   // Guard against NaN/Infinity/<=0 sneaking in from CLI parsing — any of those
   // would make the deadline NaN and trip an immediate bogus timeout.
@@ -707,13 +771,14 @@ export async function wait(opts: WaitOptions = {}): Promise<void> {
   s.lastChoiceFp = settledSnap.activeChoices ? choiceFp(settledSnap.activeChoices) : s.lastChoiceFp;
   s.lastTurnSeq = settledSnap.currentTurn?.seq ?? s.lastTurnSeq;
   s.lastCampaignId = settledSnap.currentTurn?.campaignId ?? s.lastCampaignId;
-  writeSession(s);
+  writeSession(paths, s);
 }
 
 /** Tail the detached launcher's log file (crash diagnostics). */
-export async function log(tailLines = 40): Promise<void> {
-  const s = readSession();
-  const path = s?.launcherLog ?? LAUNCHER_LOG;
+export async function log(tailLines = 40, sessionId?: string): Promise<void> {
+  const paths = sessionPaths(resolveSessionId(sessionId));
+  const s = readSession(paths);
+  const path = s?.launcherLog ?? paths.log;
   if (!existsSync(path)) {
     process.stdout.write("(no launcher log yet)\n");
     return;
@@ -722,8 +787,8 @@ export async function log(tailLines = 40): Promise<void> {
 }
 
 /** Report whether a session is alive and its vitals. */
-export async function status(): Promise<void> {
-  const s = readSession();
+export async function status(sessionId?: string): Promise<void> {
+  const s = readSession(sessionPaths(resolveSessionId(sessionId)));
   if (!s) { process.stdout.write("no session\n"); return; }
   const alive = isAlive(s.pid);
   process.stdout.write(
@@ -751,8 +816,8 @@ export async function status(): Promise<void> {
  * `mvplay record <scenario>`; pull the tape BEFORE `mvplay stop`, since teardown
  * force-kills the engine and its in-memory tape with it.
  */
-export async function saveTape(outPath: string): Promise<void> {
-  const s = requireSession();
+export async function saveTape(outPath: string, sessionId?: string): Promise<void> {
+  const s = requireSession(sessionPaths(resolveSessionId(sessionId)));
   if (!s.recording) {
     throw new Error(
       "This session is not recording. Start it with `mvplay record <scenario>` to capture a tape.",
@@ -799,13 +864,42 @@ export async function saveTape(outPath: string): Promise<void> {
   );
 }
 
-/** Kill the session process tree and remove the session file. */
-export async function stop(): Promise<void> {
-  const s = readSession();
+/** Kill the session process tree and remove the session dir. */
+export async function stop(sessionId?: string): Promise<void> {
+  const paths = sessionPaths(resolveSessionId(sessionId));
+  const s = readSession(paths);
   if (!s) { process.stdout.write("no session to stop\n"); return; }
   if (isAlive(s.pid)) killTree(s.pid);
-  try { rmSync(SESSION_FILE); } catch { /* ignore */ }
-  process.stdout.write(`✔ stopped session (pid ${s.pid})\n`);
+  // Remove the whole session dir (state file, launcher log, temp campaigns) so
+  // a stopped session leaves nothing behind for `list` to show as stale.
+  try { rmSync(paths.dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  const idTag = paths.id === DEFAULT_SESSION_ID ? "" : ` [${paths.id}]`;
+  process.stdout.write(`✔ stopped session${idTag} (pid ${s.pid})\n`);
+}
+
+/**
+ * List every session dir under the sessions root with liveness/vitals. The
+ * point of parallel sessions is you can't remember them all — this is how you
+ * find the one you want (or reap dead ones). (#696)
+ */
+export async function list(): Promise<void> {
+  if (!existsSync(SESSIONS_ROOT)) { process.stdout.write("(no sessions)\n"); return; }
+  const ids = readdirSync(SESSIONS_ROOT, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+  const rows: string[] = [];
+  for (const id of ids) {
+    const s = readSession(sessionPaths(id));
+    if (!s) continue;
+    const alive = isAlive(s.pid);
+    rows.push(
+      `${alive ? "●" : "○"} ${id.padEnd(20)} pid=${String(s.pid).padEnd(7)} ` +
+      `:${s.agentPort} ${alive ? "alive" : "dead "}` +
+      (s.recording ? `  ● recording "${s.recording}"` : ""),
+    );
+  }
+  process.stdout.write((rows.length ? rows.join("\n") : "(no sessions)") + "\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/test-harness/src/session-driver.ts
+++ b/packages/test-harness/src/session-driver.ts
@@ -84,6 +84,20 @@ export function resolveSessionId(explicit?: string): string {
   return sanitizeSessionId(explicit || process.env.MVPLAY_SESSION || DEFAULT_SESSION_ID);
 }
 
+/**
+ * Assign a session's engine + sidecar ports. A `portBase` pins them
+ * deterministically (base / base+1) so a bulk dispatcher can hand out disjoint,
+ * collision-free ports; without one they're random-picked and only guaranteed
+ * distinct from each other (fine for a single ad-hoc session).
+ */
+export function resolvePorts(portBase?: number): { serverPort: number; agentPort: number } {
+  if (portBase != null) return { serverPort: portBase, agentPort: portBase + 1 };
+  const serverPort = pickEphemeralPort();
+  let agentPort = pickEphemeralPort();
+  while (agentPort === serverPort) agentPort = pickEphemeralPort();
+  return { serverPort, agentPort };
+}
+
 /** Compute a session's paths from its id (pure — no I/O). */
 export function sessionPaths(id: string): SessionPaths {
   const dir = join(SESSIONS_ROOT, id);
@@ -358,6 +372,14 @@ export interface StartOptions {
    * settable via the MVPLAY_SESSION env var. (#696)
    */
   session?: string;
+  /**
+   * Assign this session's ports deterministically instead of picking at random:
+   * engine on `portBase`, sidecar on `portBase + 1`. For BULK concurrent starts
+   * (a dispatcher fanning out playtests), hand each session a disjoint base
+   * (e.g. 30000, 30002, 30004, …) so ports can't collide — the default random
+   * pick has no free-port probe and a loser just fails to launch. (#696)
+   */
+  portBase?: number;
 }
 
 /**
@@ -394,11 +416,7 @@ export async function start(opts: StartOptions = {}): Promise<void> {
   // empty menu rather than silently creating a stray tree.
   if (!usingRealData) mkdirSync(paths.campaignsDir, { recursive: true });
 
-  const serverPort = pickEphemeralPort();
-  let agentPort = pickEphemeralPort();
-  // Distinct ports — a collision would make the second listener fail to bind
-  // (or the sidecar check attach to the engine). 1-in-10000, but cheap to rule out.
-  while (agentPort === serverPort) agentPort = pickEphemeralPort();
+  const { serverPort, agentPort } = resolvePorts(opts.portBase);
   const player = opts.player ?? "Player";
   const launchedAt = Date.now();
 

--- a/packages/test-harness/vitest.config.ts
+++ b/packages/test-harness/vitest.config.ts
@@ -1,0 +1,22 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+/**
+ * test-harness unit tests (co-located `src/**​/*.test.ts`). Kept lightweight —
+ * the harness's heavy work is the live/replay e2e runners driven by npm scripts,
+ * not vitest; this project covers the pure logic (session id/path resolution,
+ * golden shaping, …). Mirrors the shared-source alias the sibling projects use so
+ * imports that reach @machine-violet/shared resolve to .ts without a dist build.
+ */
+export default defineConfig({
+  resolve: {
+    conditions: ["source"],
+    alias: {
+      "@machine-violet/shared": resolve(__dirname, "../../packages/shared/src"),
+    },
+  },
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     projects: [
       "packages/engine",
       "packages/client-ink",
+      "packages/test-harness",
       "tools/campaign-explorer",
     ],
   },


### PR DESCRIPTION
Makes `mvplay` parallelizable so multiple live playtests / golden recordings run at once, and adds the dispatcher tooling to fan them out. Closes #696.

The issue undersold how much was already done: **ports were already ephemeral**, and **per-session `CODEX_HOME`** shipped with #699. The only real blocker was the single fixed `SESSION_DIR`.

## 1. Per-session isolation + selection (`1be4924`)
Each session now lives under `tmpdir()/mvplay/<id>`, fully isolated (state file, launcher log, temp campaigns). Selection: `--session <id>` → `MVPLAY_SESSION` env → `"default"` (existing single-session usage is byte-for-byte unchanged). `sanitizeSessionId` strips unsafe chars and maps `.`/`..` to default so an id can't escape the root. New **`mvplay list`** (id/pid/port/liveness); `stop` removes the whole session dir.

Also: the **first co-located test-harness test** (`session-driver.test.ts`), which required wiring `packages/test-harness` into the vitest workspace — so harness unit tests finally gate in CI.

## 2. Atomic `connections.json` write (`dbdaa9f`) — shipped-app hardening
Tracing the issue's "write-protection on shared config" surfaced a real race: the codex provider persists **refreshed OAuth tokens to `connections.json` during play** (`token-store.ts`), so two concurrent codex sessions can write it at once — and a bare `writeFileSync` isn't atomic, so an interleaved or crash-truncated write corrupts the file holding every connection's API keys. Fixed with write-temp-then-`rename` (atomic), Windows EPERM/EBUSY retries, temp cleanup on failure. **Benefits the shipped app too** (crash-during-save no longer corrupts). Note: this is shipped engine code, not harness-only — the real hazard lives there.

## 3. `--port-base` + `playtest-sweep` skill (`1537c3d`)
`pickEphemeralPort` is `30000 + random*10000` with **no free-port probe** — fine for one session, but at fan-out two starts can grab the same port and the loser fails to launch. **`--port-base <N>`** pins engine `N` / sidecar `N+1` so a dispatcher hands out disjoint bases (30000, 30002, …) — collision-free by construction. New **`playtest-sweep` skill**: the dispatcher playbook (isolation contract, quota-aware concurrency cap, a lean subagent prompt since subagents are Opus and know mvplay, mandatory cleanup).

## Verification
- `npm run check` green (203 files, 3688 tests — +1 file is the new harness project).
- Unit: session-id precedence/sanitization/path-disjointness, `resolvePorts` pairing, atomic-write no-litter + valid-JSON-across-many-saves.
- **Live**: two concurrent `--live` sessions resumed two *different* real campaigns (The Aurelia + Inkblot), played 2 concurrent rounds each — both codex DMs streamed simultaneously, every turn coherent to its own campaign, **zero cross-contamination**; `connections.json` stayed valid (0 temp litter) after 4 concurrent codex turns; `--port-base 34500` → sidecar `:34501`; all sessions reaped clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)