### PR TITLE
docs: playtest-sweep isolation via per-session --data-dir (#696 follow-up)

### DIFF
--- a/.claude/skills/play/SKILL.md
+++ b/.claude/skills/play/SKILL.md
@@ -78,12 +78,14 @@ mvplay start --live          # menu now lists the user's real campaigns
 The startup banner prints the resolved dir and this warning whenever real data
 is in play — read it and confirm it's the dir you meant.
 
-> **Concurrent sessions share nothing only if their campaigns dirs differ.** Setup
-> writes to a shared `__setup__` scratch dir *inside* the campaigns dir, so two
-> concurrent sessions must not share one `--data-dir` while running setup — give
-> each its own (`--data-dir <root>/<id>`) or use the per-session temp default.
-> Resuming *distinct existing* campaigns from a shared dir is fine. See the
-> `playtest-sweep` skill for bulk dispatch.
+> **Concurrent sessions isolate their *campaign files* only if their campaigns
+> dirs differ.** (They still share the engine config dir — `connections.json` —
+> but that write is made atomic, so it's concurrency-safe.) Setup writes to a
+> shared `__setup__` scratch dir *inside* the campaigns dir, so two concurrent
+> sessions must not share one `--data-dir` while running setup — give each its own
+> (`--data-dir <root>/<id>`) or use the per-session temp default. Resuming
+> *distinct existing* campaigns from a shared dir is fine. See the `playtest-sweep`
+> skill for bulk dispatch.
 
 ## The turn loop
 

--- a/.claude/skills/play/SKILL.md
+++ b/.claude/skills/play/SKILL.md
@@ -78,6 +78,13 @@ mvplay start --live          # menu now lists the user's real campaigns
 The startup banner prints the resolved dir and this warning whenever real data
 is in play — read it and confirm it's the dir you meant.
 
+> **Concurrent sessions share nothing only if their campaigns dirs differ.** Setup
+> writes to a shared `__setup__` scratch dir *inside* the campaigns dir, so two
+> concurrent sessions must not share one `--data-dir` while running setup — give
+> each its own (`--data-dir <root>/<id>`) or use the per-session temp default.
+> Resuming *distinct existing* campaigns from a shared dir is fine. See the
+> `playtest-sweep` skill for bulk dispatch.
+
 ## The turn loop
 
 ```bash

--- a/.claude/skills/playtest-sweep/SKILL.md
+++ b/.claude/skills/playtest-sweep/SKILL.md
@@ -28,18 +28,36 @@ Every subagent MUST receive three things, and must pass the first two on *every*
    the part you can't skip:** the default port pick is random with *no* free-port
    probe, so at fan-out two sessions can grab the same port and the loser just
    fails to launch. A handed-out base is collision-free by construction.
-3. **A distinct target.** In `--live`, **never point two subagents at the same
-   campaign** — they'd race one save. (Different campaigns are fine; the engine
-   isolates per campaign.) For fresh-seed sweeps in the temp dir, distinct seeds.
+3. **Its own campaigns dir.** The setup agent writes to a *shared* `__setup__`
+   scratch dir *inside* the campaigns dir, so two sessions that share one
+   campaigns dir and both run setup will **clobber each other's setup**. Each
+   session needs an isolated campaigns dir — see *Where results land* below. (The
+   one exception: sessions that only *resume distinct existing* campaigns from a
+   shared dir are fine — no setup, separate per-campaign subdirs.)
 
 Example assignment for 4 targets:
 
-| i | target | `--session` | `--port-base` |
-|---|--------|-------------|---------------|
-| 0 | seed A | `pt-a` | 30000 |
-| 1 | seed B | `pt-b` | 30002 |
-| 2 | seed C | `pt-c` | 30004 |
-| 3 | seed D | `pt-d` | 30006 |
+| i | target | `--session` | `--port-base` | `--data-dir` |
+|---|--------|-------------|---------------|--------------|
+| 0 | seed A | `pt-a` | 30000 | `<root>/pt-a` |
+| 1 | seed B | `pt-b` | 30002 | `<root>/pt-b` |
+| 2 | seed C | `pt-c` | 30004 | `<root>/pt-c` |
+| 3 | seed D | `pt-d` | 30006 | `<root>/pt-d` |
+
+### Where results land (data dir)
+
+You almost never want `--live` for a sweep — that's machine-scope real saves.
+Pick by whether you keep the output:
+
+- **Throwaway** → default (no data flag): each session auto-gets its own
+  `tmpdir()/mvplay/<id>/campaigns`. Isolated, but gone after.
+- **Keep it in a playtest directory** (the usual case) → give each session its
+  **own** subdir under one root: `--data-dir <playtest-root>/<id>`. Every run
+  collects under the one known root (per-session subdirs), and `__setup__` stays
+  isolated. **Never point multiple concurrent sessions at a single shared
+  `--data-dir` for fresh sweeps** — they collide on `__setup__`.
+- **Resume real machine saves** → `--live`, one subagent per campaign, only the
+  campaigns the user named. Mutates real data — last resort, not the default.
 
 ## Concurrency & quota
 
@@ -53,7 +71,9 @@ so a straggler from batch 1 can't collide with batch 2.
 ## Dispatch loop
 
 1. **Build the target list** — the seeds to sweep, or the campaigns to resume.
-2. **Assign** each a session id + `port-base = 30000 + 2*i` (i over the whole list).
+2. **Assign** each a session id, `port-base = 30000 + 2*i` (i over the whole
+   list), and its own `--data-dir <root>/<id>` (for kept results) or nothing
+   (throwaway temp). One `--data-dir` per session — never shared for fresh sweeps.
 3. **Spawn a batch** of subagents (Agent tool — multiple in one message run
    concurrently). Cap the batch at your concurrency limit.
 4. **Collect** each batch's reports; spawn the next batch as slots free.
@@ -64,13 +84,14 @@ so a straggler from batch 1 can't collide with batch 2.
 Give each subagent only its assignment and the report shape — not a command
 reference. Template:
 
-> You're running one **live playtest**. Pass **`--session <id> --port-base <N>`**
-> on *every* `mvplay` command (this isolates you from the other concurrent
-> playtests — never omit them).
+> You're running one **live playtest**. Pass **`--session <id>`** on *every*
+> `mvplay` command (it selects your isolated session — never omit it). On your
+> **`start`**, also pass **`--port-base <N>`** and **`--data-dir <dir>`** so your
+> ports and campaigns can't collide with the other concurrent playtests.
 > **Target:** _<seed name, or "resume campaign X">_.
-> **Do:** boot (`start [--live] --session <id> --port-base <N> [--fresh]`), then
-> _<goal: e.g. "drive setup + play 5 turns" / "resume + play 3 turns">_, watching
-> for _<criteria: crashes, DM naming tics, incoherence, image failures, pacing>_.
+> **Do:** boot (`start --session <id> --port-base <N> --data-dir <dir> [--fresh]`),
+> then _<goal: e.g. "drive setup + play 5 turns" / "resume + play 3 turns">_,
+> watching for _<criteria: crashes, DM naming tics, incoherence, image failures>_.
 > **Waits are 1–5 min** — run `mvplay wait` in the background.
 > When done, **`stop --session <id>`** and return ONLY a compact report:
 > `{ target, turnsPlayed, crashed, findings: [...], verdict: "clean" | "issues" }`.
@@ -88,9 +109,14 @@ node --import tsx/esm packages/test-harness/bin/mvplay.ts stop --session <id>   
 
 ## Safety
 
-- **`--live` MUTATES real saves** (narration, saves, images written). Only sweep
-  live campaigns the user explicitly named. Default a sweep to the **temp dir**
-  (fresh seeds, `start` without `--live`) so nothing real is touched.
+- **`--live` MUTATES real saves** (narration, saves, images written) and is the
+  *last* resort — only for resuming campaigns the user explicitly named. Default a
+  sweep to a **per-session `--data-dir <root>/<id>`** (kept, collected under one
+  playtest root) or the **temp dir** (throwaway) — never machine-scope just to
+  persist output. See *Where results land*.
+- **One campaigns dir per concurrent session during setup.** A shared campaigns
+  dir means a shared `__setup__` scratch → concurrent fresh setups corrupt each
+  other. Per-session `--data-dir` (or the temp default) keeps them apart.
 - **One subagent per `--live` campaign.** Two on the same save corrupt it.
 - Prefer `--fresh` per session only if you intend to replace a same-named session;
   with unique ids you never need it.

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -166,8 +166,13 @@ so multiple run concurrently (parallel playtests / recordings, #696): pass
 ports and `CODEX_HOME`, so concurrent codex sessions don't contend. Ports are
 random-picked (no free-port probe), which is fine for one session; for **bulk
 concurrent dispatch** hand each session a disjoint `--port-base <N>` (engine `N`,
-sidecar `N+1`) so starts can't collide. The `playtest-sweep` skill is the
-dispatcher playbook for fanning out N live playtests across subagents this way.
+sidecar `N+1`) so starts can't collide. One more isolation axis: **campaigns.**
+The default temp dir is already per-session, but a shared `--data-dir` is *not* —
+and setup writes to a shared `__setup__` scratch dir inside it, so concurrent
+fresh setups in one `--data-dir` corrupt each other. Give each session its own
+(`--data-dir <root>/<id>`) unless they only resume distinct existing campaigns.
+The `playtest-sweep` skill is the dispatcher playbook for fanning out N live
+playtests across subagents this way.
 
 This exists because `runProbe` kills the process the moment its scripted body
 returns; nothing survives between an agent's tool calls, so there's no session


### PR DESCRIPTION
Doc-only follow-up to #702. Corrects the `playtest-sweep` skill's data-directory guidance and closes a real corruption trap it didn't warn about.

## Why
The skill defaulted toward `--live`/temp and never covered the common workflow — sweeps into a **playtest-specific data directory** (`--data-dir`). More importantly, it missed the concurrency trap: the setup agent writes to a **shared `__setup__` scratch dir inside the campaigns dir**, so two concurrent sessions that share one campaigns dir and both run setup **clobber each other**. (The live demo in #702 dodged this only because it *resumed* two distinct existing campaigns — no setup, separate subdirs.)

## What
No code change — `--data-dir` already supports this; the gap was pure guidance:
- **`playtest-sweep` skill**: per-session `--data-dir <root>/<id>` is now the recommended mode (kept results under one playtest root, isolated `__setup__`), temp for throwaway, `--live` a last resort. New "Where results land" section, a `--data-dir` column in the assignment table, a hard "never share one `--data-dir` for fresh sweeps" rule, and updated subagent prompt + dispatch loop.
- **`/play` skill + `docs/e2e-harness.md`**: the same `__setup__`/shared-dir caveat for discoverability.

Mechanically verified: `start --data-dir <p>` resolves campaigns to `<p>/campaigns` (session-driver.ts:411), so a per-session path isolates `__setup__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)