### PR TITLE
fix(resume): drop yellow "Welcome back" banner on game load

### DIFF
--- a/packages/engine/src/server/session-manager.ts
+++ b/packages/engine/src/server/session-manager.ts
@@ -1191,12 +1191,6 @@ export class SessionManager {
       this.broadcast({ type: "narrative:complete", data: { text: "" } });
     }
 
-    // Welcome message
-    this.broadcast({
-      type: "narrative:chunk",
-      data: { text: `Welcome back to ${config.name}.`, kind: "system" },
-    });
-
     // Session recap is delivered via sessionRecap in the state:snapshot above;
     // the client renders it as SessionRecapModal, not narrative text.
 


### PR DESCRIPTION
## What

Removes the yellow `Welcome back to <campaign>.` system message broadcast on game resume, right before the first turn opens.

## Why

The banner cluttered launch and made the game harder to screenshot cleanly. It was redundant: the session recap already conveys where you left off, delivered via `sessionRecap` in the state snapshot and rendered as the `SessionRecapModal` — not as narrative text.

## Notes

- One `broadcast` block removed in `session-manager.ts`; no behavior change beyond the banner.
- No golden tapes or tests captured this line, and no docs reference it, so nothing to re-record or document.
- Typecheck, lint, and pre-commit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)