### PR TITLE
fix(tui): keep the full-screen frame's right edge on Windows Terminal (autowrap guard)

### DIFF
--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -366,6 +366,22 @@ Below 80×25, the game replaces the entire UI with a fullscreen `TerminalTooSmal
 1. **Top frame** (resource display) — resources still available via character sheet
 2. **Activity line** — degrades to single glyph in modeline
 
+### Full-frame invariant: autowrap stays OFF
+
+The layout fills the **entire** terminal (`height={rows}`, `width={cols}`), so it
+paints the bottom-right cell — the one cell most Ink apps never touch. With
+terminal autowrap (DECAWM) enabled, that last-cell write leaves the terminal in a
+deferred-wrap state that, on Windows Terminal, scrolls the alt-screen buffer by one
+line; the resulting overflow surfaces an auto-hidden scrollbar painted over the last
+column, eating the right frame edge. So the client turns autowrap **off** for the
+duration of the full-screen session (restored on exit) — the same technique
+ncurses/vim use to draw a bottom-right corner safely. Ink never relies on terminal
+autowrap (it wraps text per-box and moves the cursor explicitly), so this affects
+only the last-cell scroll, not layout. **Don't re-enable autowrap mid-session or
+leave the last cell unpainted to "work around" a scrollbar** — the guard is the fix.
+
+**Code:** `src/tui/hooks/autowrap.ts`, wired in `src/start-client.ts` (gated on `alternateScreen`)
+
 
 ## Modals
 

--- a/packages/client-ink/src/start-client.ts
+++ b/packages/client-ink/src/start-client.ts
@@ -20,6 +20,7 @@ import {
   kittyKeyToLegacy,
 } from "./tui/hooks/kittyProtocol.js";
 import { installStdinFilterChain } from "./tui/hooks/stdinFilterChain.js";
+import { disableAutowrap, restoreAutowrap } from "./tui/hooks/autowrap.js";
 import { compositePainters, setIncrementalRendering } from "./tui/image/painterRegistry.js";
 import { detectGraphicsCapabilities } from "./tui/image/capabilities.js";
 import { getAgentClientState } from "./agent-state-ref.js";
@@ -173,6 +174,14 @@ export async function startClient(opts: StartClientOptions = {}): Promise<Client
     renderOpts,
   );
 
+  // Disable autowrap while the full-screen frame owns the terminal so painting
+  // the bottom-right cell can't scroll the alt-screen buffer (which on Windows
+  // Terminal surfaces an auto-hidden scrollbar over the last column, eating the
+  // right frame edge). Sequenced AFTER render() so it lands inside the alt
+  // buffer Ink just entered. Gated on alternateScreen so the mode change never
+  // leaks into redirected output, pipes, or CI logs. See tui/hooks/autowrap.ts.
+  if (alternateScreen) disableAutowrap(process.stdout);
+
   // Graceful shutdown on SIGINT
   const onSigInt = () => {
     unmount();
@@ -187,6 +196,7 @@ export async function startClient(opts: StartClientOptions = {}): Promise<Client
       process.removeListener("SIGINT", onSigInt);
       if (sidecarClose) await sidecarClose();
     } finally {
+      if (alternateScreen) restoreAutowrap(process.stdout);
       if (hasKitty) disableKittyProtocol(process.stdout);
       filterChain.teardown();
       unlockRawMode();

--- a/packages/client-ink/src/tui/hooks/autowrap.test.ts
+++ b/packages/client-ink/src/tui/hooks/autowrap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { disableAutowrap, restoreAutowrap } from "./autowrap.js";
+
+function fakeStdout() {
+  const writes: string[] = [];
+  return { writes, write: (s: string) => (writes.push(s), true) };
+}
+
+describe("autowrap guard", () => {
+  beforeEach(() => {
+    // Ensure a clean module state between tests (restore removes the exit net).
+    restoreAutowrap(fakeStdout());
+  });
+  afterEach(() => {
+    restoreAutowrap(fakeStdout());
+    vi.restoreAllMocks();
+  });
+
+  it("disables autowrap with DECAWM off (CSI ?7l)", () => {
+    const out = fakeStdout();
+    disableAutowrap(out);
+    expect(out.writes).toEqual(["\x1b[?7l"]);
+  });
+
+  it("is idempotent — a second disable does not re-emit", () => {
+    const out = fakeStdout();
+    disableAutowrap(out);
+    disableAutowrap(out);
+    expect(out.writes).toEqual(["\x1b[?7l"]);
+  });
+
+  it("restores autowrap with DECAWM on (CSI ?7h)", () => {
+    disableAutowrap(fakeStdout());
+    const out = fakeStdout();
+    restoreAutowrap(out);
+    expect(out.writes).toEqual(["\x1b[?7h"]);
+  });
+
+  it("restore is a no-op when never disabled", () => {
+    const out = fakeStdout();
+    restoreAutowrap(out);
+    expect(out.writes).toEqual([]);
+  });
+
+  it("registers an exit safety-net that restores autowrap", () => {
+    const onSpy = vi.spyOn(process, "on");
+    const out = fakeStdout();
+    disableAutowrap(out);
+
+    const call = onSpy.mock.calls.find(([evt]) => evt === "exit");
+    expect(call).toBeDefined();
+
+    // Fire the registered exit handler and confirm it re-enables autowrap.
+    const handler = call![1] as () => void;
+    handler();
+    expect(out.writes).toContain("\x1b[?7h");
+  });
+
+  it("re-disable works after a restore cycle", () => {
+    disableAutowrap(fakeStdout());
+    restoreAutowrap(fakeStdout());
+    const out = fakeStdout();
+    disableAutowrap(out);
+    expect(out.writes).toEqual(["\x1b[?7l"]);
+  });
+});

--- a/packages/client-ink/src/tui/hooks/autowrap.ts
+++ b/packages/client-ink/src/tui/hooks/autowrap.ts
@@ -1,0 +1,63 @@
+/**
+ * Autowrap (DECAWM) guard for the full-screen TUI.
+ *
+ * MV is unusual among Ink apps: it draws a frame that fills the *entire*
+ * terminal (`height={rows}`, `width={cols}`), so it writes the terminal's
+ * bottom-right cell — the one cell most Ink apps never touch. With autowrap
+ * (DECAWM, private mode 7) enabled, writing a glyph to that last cell leaves
+ * the terminal in a "deferred wrap" state; on Windows Terminal this nudges the
+ * alternate-screen buffer to scroll by a single line. That one-line overflow is
+ * enough for Windows Terminal to show its (auto-hidden) vertical scrollbar,
+ * which is painted over the last column and visually eats the right frame edge.
+ * A horizontal resize forces a full repaint that looks correct for a frame,
+ * then the next paint re-triggers the scroll — the classic "right edge keeps
+ * disappearing" report.
+ *
+ * The fix is the same one ncurses and vim use to draw the bottom-right corner
+ * safely: turn autowrap OFF while the full-screen UI owns the terminal, then
+ * restore it on teardown. Ink never relies on terminal autowrap — it wraps text
+ * to each box width itself and moves the cursor explicitly — so disabling it has
+ * no effect on layout, only on the last-cell scroll behavior.
+ *
+ * DECAWM is a terminal-wide mode (not saved/restored across the alt-screen
+ * switch), so we must always restore it, including via an `exit` safety-net.
+ */
+
+/** Disable autowrap (DECAWM off). */
+const DISABLE_AUTOWRAP = "\x1b[?7l";
+/** Enable autowrap (DECAWM on) — the terminal default. */
+const ENABLE_AUTOWRAP = "\x1b[?7h";
+
+let _exitCleanup: (() => void) | null = null;
+
+/**
+ * Disable terminal autowrap so the full-screen frame can paint its bottom-right
+ * cell without scrolling the alt-screen buffer. Registers an `exit` safety-net
+ * so autowrap is restored even on SIGINT / uncaught exceptions. Idempotent.
+ *
+ * Call this AFTER Ink has entered the alternate screen so the mode change lands
+ * while the TUI owns the terminal.
+ */
+export function disableAutowrap(stdout: { write(s: string): boolean }): void {
+  if (_exitCleanup) return; // already active
+
+  stdout.write(DISABLE_AUTOWRAP);
+
+  const onExit = () => { stdout.write(ENABLE_AUTOWRAP); };
+  process.on("exit", onExit);
+
+  _exitCleanup = () => {
+    process.removeListener("exit", onExit);
+  };
+}
+
+/**
+ * Restore terminal autowrap to its default (on) and remove the exit safety-net.
+ * Safe to call when autowrap was never disabled.
+ */
+export function restoreAutowrap(stdout: { write(s: string): boolean }): void {
+  if (!_exitCleanup) return;
+  stdout.write(ENABLE_AUTOWRAP);
+  _exitCleanup();
+  _exitCleanup = null;
+}


### PR DESCRIPTION
## Problem

On Windows Terminal, the **right edge of the whole game frame goes missing**, and briefly reappears when you resize the window horizontally.

## Root cause

MV is unusual among Ink apps: it draws a frame that fills the **entire** terminal (`height={rows}`, `width={cols}`), so it paints the terminal's bottom-right cell — the one cell most Ink apps never touch. With terminal autowrap (DECAWM) enabled, writing a glyph to that last cell leaves the terminal in a deferred-wrap state that, on Windows Terminal, nudges the **alt-screen buffer to scroll by one line**. That single line of overflow makes Windows Terminal surface its auto-hidden vertical scrollbar, which is painted **over the last column** — visually eating the right frame edge. A horizontal resize forces a clean repaint (briefly correct), then the next frame re-triggers it.

Offline row/height audits confirmed the React tree is **always exactly `cols` wide and `rows` tall** (delta 0 across themes × heights × player counts × extra-height), so this is not a layout math bug — it's the terminal's last-cell scroll behavior.

## Fix

Turn autowrap **off** while the full-screen UI owns the terminal and restore it on teardown — the same technique ncurses/vim use to draw a bottom-right corner safely. Ink never relies on terminal autowrap (it wraps text per-box and moves the cursor explicitly), so this changes nothing about layout, only the last-cell scroll.

- New `tui/hooks/autowrap.ts` (`CSI ?7l` off / `CSI ?7h` restore, with an `exit` safety-net, mirroring the kitty-protocol escape/teardown pattern)
- Wired into `start-client.ts`: disabled right after `render()` (so it lands in the alt buffer), gated on `alternateScreen` (never leaks into pipes/CI), restored in the teardown `finally`
- `autowrap.test.ts` covering the escapes, idempotency, restore-when-never-disabled, and the exit safety-net
- `docs/tui-design.md`: documents the full-frame autowrap-off invariant so it isn't "fixed" back

## Verification

- Offline layout audit: every rendered row exactly `cols` wide and the tree exactly `rows` tall.
- `npm run check` green (lint + full suite); golden replay green; new unit tests pass.
- **Live-confirmed by the reporter on Windows Terminal**: right edge now holds through scrolling and resizing; the scrollbar, when present, no longer covers the right frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)