### PR TITLE
fix(tui): stop PlayingPhase crashing when the terminal shrinks below minimum

### DIFF
--- a/packages/client-ink/src/phases/PlayingPhase.tsx
+++ b/packages/client-ink/src/phases/PlayingPhase.tsx
@@ -458,16 +458,19 @@ export function PlayingPhase() {
     }
   });
 
+  const keyHints: KeyHint[] = useMemo(() => [
+    { label: "\u21E5", active: characterPaneOpen },
+  ], [characterPaneOpen]);
+
   // --- Render ---
+  // NB: keep every hook above this early return. Shrinking the terminal flips
+  // `tooSmall`, and any hook rendered only on the non-tiny path would change the
+  // hook count between renders ("Rendered fewer hooks than expected").
   if (tooSmall) {
     return <TerminalTooSmall columns={cols} rows={rows} />;
   }
 
   const conversationPaneTop = visibleElements.topFrame ? theme.asset.height : 0;
-
-  const keyHints: KeyHint[] = useMemo(() => [
-    { label: "\u21E5", active: characterPaneOpen },
-  ], [characterPaneOpen]);
 
   // Active client-driven modal data (character sheet, compendium, notes, swatch)
   const am = activeModal as Record<string, unknown> | null;


### PR DESCRIPTION
## The bug

Resizing the terminal window smaller crashed the client with:

> Error: Rendered fewer hooks than expected. This may be caused by an accidental early return statement.

## Cause

In `PlayingPhase.tsx`, the "terminal too small" guard —

```tsx
if (tooSmall) {
  return <TerminalTooSmall columns={cols} rows={rows} />;
}
...
const keyHints = useMemo(() => [...], [characterPaneOpen]); // ← hook AFTER the return
```

— sat *above* the `keyHints` `useMemo`. React requires a stable hook count per render. Once the terminal shrank below `MIN_COLUMNS`/`MIN_ROWS`, `tooSmall` flipped true, the component returned early, and that `useMemo` was skipped — one fewer hook than the prior render, so React threw and took the client down.

## Fix

Hoist the `keyHints` `useMemo` above the early return (it only depends on `characterPaneOpen`, so this is safe) and add a note that every hook must stay above the guard.

Audited the five sibling phases that render `TerminalTooSmall` (`MainMenu`, `Settings`, `Connections`, `AddContent`, `ArchivedCampaigns`, `DiscordSettings`) — all already keep every hook before the early return. PlayingPhase was the only offender, which is why the crash only reproduced during gameplay.

## Follow-up (not in this PR)

This class of bug is caught statically by `eslint-plugin-react-hooks`' `rules-of-hooks`, which isn't installed here. Wiring up just that rule would prevent recurrence.

## Testing

- `npm run check` green (3689 passed, lint clean)
- Typecheck + targeted vitest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)