### PR TITLE
fix(replay): quiesce narrative before next input (nightly install-smoke flake)

### DIFF
--- a/packages/test-harness/src/replay-runner.ts
+++ b/packages/test-harness/src/replay-runner.ts
@@ -262,10 +262,13 @@ async function workStarted(
  * narrative flush can push `dmCount` past that stale-low baseline in the brief
  * waiting_input gap BEFORE this turn renders, tripping the beat one turn early.
  * Left unguarded the final capture then misses the last turn's whole response
- * (nightly #697: install-smoke replay diverged, 59 vs 77 dm lines). So after the
- * beat we wait for the dm-line count to HOLD STEADY across a quiet window with
- * the engine idle: the turn is fully rendered before we return, which also keeps
- * the next turn's `baseDm` accurate.
+ * (the install-smoke replay diverged, 59 vs 77 dm lines). So after the beat we
+ * wait for the dm-line count to HOLD STEADY across a quiet window with the engine
+ * idle: the turn is fully rendered before we return, which also keeps the next
+ * turn's `baseDm` accurate.
+ *
+ * Beat wait and quiesce share one `timeoutMs` deadline, so a slow turn can't
+ * spend the full budget twice.
  */
 async function settle(
   h: Harness,
@@ -273,6 +276,7 @@ async function settle(
   baselineFp: string | null,
   timeoutMs: number,
 ): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   await h.waitForState(
     (s) => {
       const dmAdvanced = s.engineState === "waiting_input" && dmCount(s) > baseDm;
@@ -282,7 +286,7 @@ async function settle(
     },
     { timeoutMs, pollMs: 250, description: "beat after input" },
   );
-  await quiesce(h, timeoutMs);
+  await quiesce(h, Math.max(0, deadline - Date.now()));
 }
 
 /** How long the dm-line count must hold steady (engine idle) to count as done. */

--- a/packages/test-harness/src/replay-runner.ts
+++ b/packages/test-harness/src/replay-runner.ts
@@ -255,6 +255,17 @@ async function workStarted(
  * `dm` lines specifically: the previous turn's detached scribe keeps appending
  * `dev` breadcrumbs after the turn settles, and counting those as "the beat"
  * would let the next input fire before its DM response actually lands.
+ *
+ * The beat predicate fires on the FIRST qualifying poll, but the narrative may
+ * still be streaming — and `baseDm` is snapshotted BEFORE submit, so on a slow
+ * cold boot (the packaged install-smoke path) the PREVIOUS turn's trailing
+ * narrative flush can push `dmCount` past that stale-low baseline in the brief
+ * waiting_input gap BEFORE this turn renders, tripping the beat one turn early.
+ * Left unguarded the final capture then misses the last turn's whole response
+ * (nightly #697: install-smoke replay diverged, 59 vs 77 dm lines). So after the
+ * beat we wait for the dm-line count to HOLD STEADY across a quiet window with
+ * the engine idle: the turn is fully rendered before we return, which also keeps
+ * the next turn's `baseDm` accurate.
  */
 async function settle(
   h: Harness,
@@ -271,6 +282,35 @@ async function settle(
     },
     { timeoutMs, pollMs: 250, description: "beat after input" },
   );
+  await quiesce(h, timeoutMs);
+}
+
+/** How long the dm-line count must hold steady (engine idle) to count as done. */
+const QUIESCE_QUIET_MS = 1_000;
+
+/**
+ * Block until the DM narrative stops growing — `dm`-line count unchanged across
+ * a quiet window while the engine is back at waiting_input. Best-effort: on
+ * exhausting the budget it returns rather than throwing, since `settle`'s beat
+ * wait has already proven the turn happened; the divergence check that follows
+ * surfaces any genuinely-missing narrative.
+ */
+async function quiesce(h: Harness, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastDm = -1;
+  let steadySince = Date.now();
+  while (Date.now() < deadline) {
+    let s: ClientStateSnapshot;
+    try { s = await h.getState(); } catch { await delay(150); continue; }
+    const n = dmCount(s);
+    if (s.engineState === "waiting_input" && n === lastDm) {
+      if (Date.now() - steadySince >= QUIESCE_QUIET_MS) return;
+    } else {
+      lastDm = n;
+      steadySince = Date.now();
+    }
+    await delay(200);
+  }
 }
 
 function firstCharDiff(a: string, b: string): number {


### PR DESCRIPTION
## What

Fixes the flaky **`verify-package (windows-latest)` → Velopack install/uninstall smoke** step that failed [nightly run #28923661601](https://github.com/octopollux/machine-violet/actions/runs/28923661601).

The golden replay against the *installed* binary diverged (`59 vs 77 dm lines`) while the *packaged*-binary replay in the same job — and every from-source replay — stayed green. The actual narrative was a clean truncated prefix, missing the entire final turn's 17 lines.

## Root cause (test harness, not the product)

In `packages/test-harness/src/replay-runner.ts`, `settle` returned on the first poll where `engineState === "waiting_input" && dmCount > baseDm`. But `baseDm` is snapshotted *before* submit. On a slow cold boot (the packaged-install path), the previous turn's still-in-flight narrative flush pushes `dmCount` past that stale-low baseline during the brief `waiting_input` gap *before* the new turn renders — so `settle` fires one turn early, and the immediate final capture misses the last turn entirely. Warm runs (source, packaged) never hit the window; the cold installed-binary first-run widened it. Same class of race that #654 previously fixed for this step.

## Fix

Add a `quiesce` step after the beat fires: wait for the dm-line count to hold steady across a 1s quiet window with the engine idle before returning. The turn is fully rendered before we proceed, which also keeps the next turn's `baseDm` accurate. Best-effort (returns on the outer budget rather than throwing) since the beat wait already proved the turn happened.

Harness-only change — no engine or tape edits, so no golden re-record.

## Validation

- Typecheck + lint clean; full `npm test` green (3689 passed).
- From-source replay 3/3 green; full-corpus binary replay + `golden:verify` green.
- Windows `test-build.yml` gate (pack → replay → **install-smoke**) dispatched on this branch to exercise the exact failing step: [run #28980405904](https://github.com/octopollux/machine-violet/actions/runs/28980405904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)