### PR TITLE
feat(tui): default main-menu caret to API Keys in no-connection mode (#713)

### DIFF
--- a/docs/game-initialization.md
+++ b/docs/game-initialization.md
@@ -60,6 +60,8 @@ The main menu uses the full themed frame (same border components as the playing 
 
 "Continue Campaign" only appears in the main menu when at least one campaign exists.
 
+**No-connection mode.** When no valid API connection exists, an **API Keys** item appears in the menu (colored yellow, linking to Settings → API Keys) and the API-dependent items ("New Campaign", "Continue Campaign", "Add Content") are disabled with a "Requires a valid API key" hint. In this mode the default caret opens on **API Keys** rather than the disabled "New Campaign" — it points the player straight at the one required next step. Once a connection is valid the API Keys item disappears and the caret defaults to "New Campaign" as usual.
+
 Returning from a game via "Save & Exit" or "End Session" runs teardown (graceful shutdown + cache reset) and transitions back to this menu.
 
 #### Campaign sub-list columns

--- a/packages/client-ink/src/phases/MainMenuPhase.test.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.test.tsx
@@ -180,6 +180,42 @@ describe("MainMenuPhase", () => {
     expect(lastFrame()).not.toContain("Requires a valid API key");
   });
 
+  it("defaults the caret to API Keys in no-connection mode (#713)", () => {
+    // The disabled "New Campaign" is a dead first stop; the caret should land
+    // on the one actionable item instead.
+    const { lastFrame } = render(<MainMenuPhase {...defaultProps({ apiKeyValid: false })} />);
+    const selected = (lastFrame() ?? "").split("\n").find((l) => l.includes("◆")) ?? "";
+    expect(selected).toContain("API Keys");
+  });
+
+  it("defaults the caret to API Keys past Continue Campaign / Add Content (#713)", () => {
+    // The initial index must track the menu build order — with campaigns and
+    // dev mode both present, API Keys sits below those extra items.
+    const props = defaultProps({
+      apiKeyValid: false,
+      campaigns: [{ name: "X", path: "/x" }],
+      devModeEnabled: true,
+    });
+    const { lastFrame } = render(<MainMenuPhase {...props} />);
+    const selected = (lastFrame() ?? "").split("\n").find((l) => l.includes("◆")) ?? "";
+    expect(selected).toContain("API Keys");
+  });
+
+  it("keeps the default caret on New Campaign when the API key is valid (#713)", () => {
+    const { lastFrame } = render(<MainMenuPhase {...defaultProps({ apiKeyValid: true })} />);
+    const selected = (lastFrame() ?? "").split("\n").find((l) => l.includes("◆")) ?? "";
+    expect(selected).toContain("New Campaign");
+  });
+
+  it("selects API Keys with Enter on the default caret in no-connection mode (#713)", () => {
+    const onSettingsApiKeys = vi.fn();
+    const { stdin } = render(
+      <MainMenuPhase {...defaultProps({ apiKeyValid: false, onSettingsApiKeys })} />,
+    );
+    stdin.write("\r"); // Enter on the default (API Keys) item
+    expect(onSettingsApiKeys).toHaveBeenCalled();
+  });
+
   it("collapses the campaign list and advances to the next menu item when scrolling past the end", async () => {
     // Mirror of the up-arrow collapse at the top: down-arrow on the last
     // campaign should close the sub-list and land on the main-menu item

--- a/packages/client-ink/src/phases/MainMenuPhase.test.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.test.tsx
@@ -216,6 +216,59 @@ describe("MainMenuPhase", () => {
     expect(onSettingsApiKeys).toHaveBeenCalled();
   });
 
+  it("moves the caret to API Keys when apiKeyValid flips false after mount (#713)", async () => {
+    // The real launch path mounts the menu with apiKeyValid=true (optimistic
+    // default) and only flips it false once the async connection health check
+    // resolves. The caret must follow the mode change, not stay stranded on
+    // the now-disabled New Campaign.
+    const { rerender, lastFrame } = render(
+      <MainMenuPhase {...defaultProps({ apiKeyValid: true })} />,
+    );
+    const selected = () => (lastFrame() ?? "").split("\n").find((l) => l.includes("◆")) ?? "";
+    expect(selected()).toContain("New Campaign");
+    rerender(<MainMenuPhase {...defaultProps({ apiKeyValid: false })} />);
+    await vi.waitFor(() => expect(selected()).toContain("API Keys"));
+  });
+
+  it("tracks the shifting API Keys index when devModeEnabled loads late (#713)", async () => {
+    // devModeEnabled also arrives async (getMachineSettings), inserting
+    // "Add Content" above API Keys. The default caret must re-resolve to the
+    // new API Keys position, not point one row off.
+    const { rerender, lastFrame } = render(
+      <MainMenuPhase {...defaultProps({ apiKeyValid: false, devModeEnabled: false })} />,
+    );
+    const selected = () => (lastFrame() ?? "").split("\n").find((l) => l.includes("◆")) ?? "";
+    await vi.waitFor(() => expect(selected()).toContain("API Keys"));
+    rerender(<MainMenuPhase {...defaultProps({ apiKeyValid: false, devModeEnabled: true })} />);
+    await vi.waitFor(() => {
+      expect(selected()).toContain("API Keys");
+      expect(selected()).not.toContain("Add Content");
+    });
+  });
+
+  it("does not yank the caret away once the player has navigated (#713)", async () => {
+    // If the player has already moved the caret, a late apiKeyValid flip must
+    // respect their choice rather than snapping back to API Keys.
+    const props = defaultProps({ apiKeyValid: true, campaigns: [{ name: "X", path: "/x" }] });
+    const { stdin, rerender, lastFrame } = render(<MainMenuPhase {...props} />);
+    const frame = () => lastFrame() ?? "";
+    const selected = () => frame().split("\n").find((l) => l.includes("◆")) ?? "";
+    const DOWN = "[B";
+    // Move down to Continue Campaign — a deliberate caret move.
+    await vi.waitFor(() => {
+      if (selected().includes("New Campaign")) stdin.write(DOWN);
+      expect(selected()).toContain("Continue Campaign");
+    });
+    // Health check resolves invalid — the caret stays where the player left it.
+    rerender(
+      <MainMenuPhase {...defaultProps({ apiKeyValid: false, campaigns: [{ name: "X", path: "/x" }] })} />,
+    );
+    await vi.waitFor(() => {
+      expect(frame()).toContain("API Keys"); // item now present…
+      expect(selected()).toContain("Continue Campaign"); // …but caret unmoved
+    });
+  });
+
   it("collapses the campaign list and advances to the next menu item when scrolling past the end", async () => {
     // Mirror of the up-arrow collapse at the top: down-arrow on the last
     // campaign should close the sub-list and land on the main-menu item

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -77,7 +77,14 @@ export function MainMenuPhase({
   onQuit,
 }: MainMenuPhaseProps) {
   const { columns: cols, rows: termRows } = useWindowSize();
-  const [mainMenuIndex, setMainMenuIndex] = useState(0);
+  // In no-connection mode ("API Keys" is shown because the key is invalid),
+  // start the caret on that item — it's the one actionable next step, and the
+  // default "New Campaign" is disabled until a key exists (#713). The initial
+  // API Keys index mirrors the mainMenuItems build order below:
+  // New Campaign, [Continue Campaign], [Add Content], API Keys.
+  const [mainMenuIndex, setMainMenuIndex] = useState(() =>
+    apiKeyValid ? 0 : 1 + (campaigns.length > 0 ? 1 : 0) + (devModeEnabled ? 1 : 0),
+  );
   const [expandedCampaigns, setExpandedCampaigns] = useState(false);
   const [campaignSelectIndex, setCampaignSelectIndex] = useState(0);
   /** Which column is active: 0=name (resume), 1=archive, 2=delete */

--- a/packages/client-ink/src/phases/MainMenuPhase.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useInput, Text, Box, useWindowSize } from "ink";
 import type { ResolvedTheme } from "../tui/themes/types.js";
 import { TerminalTooSmall, FullScreenFrame } from "../tui/components/index.js";
@@ -81,10 +81,14 @@ export function MainMenuPhase({
   // start the caret on that item — it's the one actionable next step, and the
   // default "New Campaign" is disabled until a key exists (#713). The initial
   // API Keys index mirrors the mainMenuItems build order below:
-  // New Campaign, [Continue Campaign], [Add Content], API Keys.
+  // New Campaign, [Continue Campaign], [Add Content], API Keys. An effect
+  // below keeps this in sync when the mode flips after mount.
   const [mainMenuIndex, setMainMenuIndex] = useState(() =>
     apiKeyValid ? 0 : 1 + (campaigns.length > 0 ? 1 : 0) + (devModeEnabled ? 1 : 0),
   );
+  // Once the player moves the caret themselves, stop auto-positioning it —
+  // their choice stands. Until then, the default tracks the current mode.
+  const userMovedCaret = useRef(false);
   const [expandedCampaigns, setExpandedCampaigns] = useState(false);
   const [campaignSelectIndex, setCampaignSelectIndex] = useState(0);
   /** Which column is active: 0=name (resume), 1=archive, 2=delete */
@@ -102,6 +106,23 @@ export function MainMenuPhase({
   useEffect(() => {
     setMainMenuIndex((i) => Math.min(i, mainMenuItems.length - 1));
   }, [mainMenuItems.length]);
+
+  // Keep the default caret on the actionable "API Keys" item in no-connection
+  // mode. The lazy initializer above only captures the state at mount, but
+  // `apiKeyValid` flips false asynchronously (the connection health check
+  // resolves after the menu is already showing) and `devModeEnabled` loads
+  // late too — both change where "API Keys" sits — so the default has to react
+  // to those prop changes, not just run once. Guarded by `userMovedCaret` so a
+  // late flip never yanks the caret out from under a player who has already
+  // navigated. (#713)
+  useEffect(() => {
+    if (userMovedCaret.current) return;
+    // Index derives from apiKeyValid + the item count; recompute when either
+    // shifts (both deps below). mainMenuItems itself is rebuilt every render,
+    // so we key on its length rather than the array identity.
+    const apiKeysIndex = mainMenuItems.indexOf("API Keys");
+    setMainMenuIndex(apiKeysIndex >= 0 ? apiKeysIndex : 0);
+  }, [apiKeyValid, mainMenuItems.length]);
 
   // The campaign sub-list stays expanded through an archive so the inline
   // "Archiving…" state is visible; when the archive lands the entry drops out
@@ -191,10 +212,12 @@ export function MainMenuPhase({
     }
 
     if (key.upArrow) {
+      userMovedCaret.current = true;
       setMainMenuIndex((i) => Math.max(0, i - 1));
       return;
     }
     if (key.downArrow) {
+      userMovedCaret.current = true;
       setMainMenuIndex((i) => Math.min(mainMenuItems.length - 1, i + 1));
       return;
     }


### PR DESCRIPTION
## Summary
Fixes #713. When the main menu opens without a valid API connection, the caret used to land on the disabled **New Campaign** item — a dead first stop, since it can't be selected until an API connection exists. This defaults the caret to the actionable **API Keys** item instead, pointing the player straight at the one required next step.

## Changes
- `MainMenuPhase.tsx`: `mainMenuIndex` now uses a lazy `useState` initializer. In no-connection mode (`!apiKeyValid`) it computes the API Keys index (mirroring the `mainMenuItems` build order: New Campaign → optional Continue Campaign → optional Add Content → API Keys); in normal mode it stays `0` (New Campaign), unchanged.
- Added 4 tests: default caret on API Keys (simple + with Continue Campaign / Add Content present), caret unchanged in normal mode, and Enter-on-default selecting API Keys.
- Documented no-connection mode and the default-caret behavior in `docs/game-initialization.md` (previously the API Keys item wasn't mentioned there at all).

## Testing
- `npx vitest related --run packages/client-ink/src/phases/MainMenuPhase.tsx` — 35 passed
- eslint + tsc clean (pre-commit hook green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)