### PR TITLE
fix(ui): hide OpenRouter and Custom from the provider picker until validated (#712)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ If you want this to change, you should ask Anthropic (nicely) to add support for
 <details>
 <summary>Will Machine Violet work with Ollama/local models/GLM 5.x/etc?</summary>
 
-You can try! We only test using OpenAI and Anthropic frontier models. It may work with the largest open-source models via an OpenAI-compatible API connection (the "Custom" provider) — untested, so playtesting reports are welcome!
+Not in this release. Machine Violet currently supports Anthropic and OpenAI (including the ChatGPT-subscription sign-in) — those are the only connection options we've validated and ship. Support for OpenAI-compatible / local endpoints is planned once we can test it end to end.
 
-Local models probably won't work, or won't work well. Machine Violet requires reliable tool use and about ~300k tokens of context window. Additionally, "big model smell" leads to a *much* better gameplay experience.
+Even then, local models probably won't work well: Machine Violet requires reliable tool use and about ~300k tokens of context window, and "big model smell" leads to a *much* better gameplay experience.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ If you want this to change, you should ask Anthropic (nicely) to add support for
 </details>
 
 <details>
-<summary>Will Machine Violet work with Ollama/OpenRouter/local models/GLM 5.x/etc?</summary>
+<summary>Will Machine Violet work with Ollama/local models/GLM 5.x/etc?</summary>
 
-You can try! We only test using OpenAI and Anthropic frontier models. It may work with the largest open-source models via OpenRouter or an OpenAI-compatible API connection. Playtesting reports are welcome!
+You can try! We only test using OpenAI and Anthropic frontier models. It may work with the largest open-source models via an OpenAI-compatible API connection (the "Custom" provider) — untested, so playtesting reports are welcome!
 
 Local models probably won't work, or won't work well. Machine Violet requires reliable tool use and about ~300k tokens of context window. Additionally, "big model smell" leads to a *much* better gameplay experience.
 </details>

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you want this to change, you should ask Anthropic (nicely) to add support for
 <details>
 <summary>Will Machine Violet work with Ollama/local models/GLM 5.x/etc?</summary>
 
-Not in this release. Machine Violet currently supports Anthropic and OpenAI (including the ChatGPT-subscription sign-in) — those are the only connection options we've validated and ship. Support for OpenAI-compatible / local endpoints is planned once we can test it end to end.
+Not offered in this release. The app's connection picker only lets you add Anthropic and OpenAI (including the ChatGPT-subscription sign-in) — those are the connection types we've validated. Adding OpenAI-compatible / local endpoints through the UI is planned once we can test it end to end. (If you carried over a custom endpoint from an earlier build it still loads; it's just no longer offered as a new option.)
 
 Even then, local models probably won't work well: Machine Violet requires reliable tool use and about ~300k tokens of context window, and "big model smell" leads to a *much* better gameplay experience.
 </details>

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -794,7 +794,7 @@ A full-screen out-of-game wizard (root title: "AI Connections") for managing LLM
 **Model Assignments** — shows the three model tiers (Large: DM narration, Medium: OOC / AI players, Small: mechanical tasks). Each tier displays the currently assigned model and connection label. Enter on a tier enters the model picker, which lists all models from all connections; Enter there assigns the selected model + connection to that tier.
 
 **Add Connection wizard** — a multi-step flow:
-1. Provider selection: Anthropic, OpenAI (API key), OpenRouter, Custom (OpenAI-compatible). `openai-chatgpt` is intentionally absent — it uses the dedicated "Sign in with ChatGPT" entry.
+1. Provider selection: Anthropic, OpenAI (API key), Custom (OpenAI-compatible, untested). `openai-chatgpt` is intentionally absent — it uses the dedicated "Sign in with ChatGPT" entry. `openrouter` is also absent from the picker: the adapter still exists engine-side, but OpenRouter is hidden pending an end-to-end validation playtest (issue #712) so we don't imply support we can't stand behind. Re-add the row once it's validated.
 2. API key entry (text input, Enter to advance).
 3. Label entry (optional friendly name, Enter to advance).
 4. Base URL entry — only shown for the `custom` provider. Escape backs up one step at each stage.

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -794,7 +794,7 @@ A full-screen out-of-game wizard (root title: "AI Connections") for managing LLM
 **Model Assignments** — shows the three model tiers (Large: DM narration, Medium: OOC / AI players, Small: mechanical tasks). Each tier displays the currently assigned model and connection label. Enter on a tier enters the model picker, which lists all models from all connections; Enter there assigns the selected model + connection to that tier.
 
 **Add Connection wizard** — a multi-step flow:
-1. Provider selection: Anthropic, OpenAI (API key), Custom (OpenAI-compatible, untested). `openai-chatgpt` is intentionally absent — it uses the dedicated "Sign in with ChatGPT" entry. `openrouter` is also absent from the picker: the adapter still exists engine-side, but OpenRouter is hidden pending an end-to-end validation playtest (issue #712) so we don't imply support we can't stand behind. Re-add the row once it's validated.
+1. Provider selection: Anthropic, OpenAI (API key). `openai-chatgpt` is intentionally absent — it uses the dedicated "Sign in with ChatGPT" entry. `openrouter` and `custom` are also absent from the picker: both adapters still exist engine-side, but neither is validated end-to-end, so they're hidden for 1.1 pending a validation playtest (issue #712) rather than shipping untested top-level connection options. The `needsBaseUrl` step (base-URL entry, step 4 below) is currently unreachable as a result but kept for the re-enable. Re-add the rows once validated.
 2. API key entry (text input, Enter to advance).
 3. Label entry (optional friendly name, Enter to advance).
 4. Base URL entry — only shown for the `custom` provider. Escape backs up one step at each stage.

--- a/packages/client-ink/src/phases/ConnectionsPhase.test.tsx
+++ b/packages/client-ink/src/phases/ConnectionsPhase.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "ink-testing-library";
+import { ConnectionsPhase } from "./ConnectionsPhase.js";
+import type { ConnectionsPhaseProps } from "./ConnectionsPhase.js";
+import type { TierAssignmentsResponse } from "../api-client.js";
+import { resetThemeCache, resolveTheme, BUILTIN_DEFINITIONS } from "../tui/themes/index.js";
+
+const DOWN = "[B";
+const ENTER = "\r";
+
+beforeEach(() => {
+  resetThemeCache();
+});
+
+function makeTheme() {
+  const def = BUILTIN_DEFINITIONS["gothic"] ?? Object.values(BUILTIN_DEFINITIONS)[0];
+  return resolveTheme(def, "exploration", "#8888aa");
+}
+
+function defaultProps(overrides?: Partial<ConnectionsPhaseProps>): ConnectionsPhaseProps {
+  const tierAssignments: TierAssignmentsResponse = { large: null, medium: null, small: null };
+  return {
+    theme: makeTheme(),
+    connections: [],
+    tierAssignments,
+    healthResults: {},
+    knownModels: {},
+    onAddConnection: vi.fn(),
+    onRemoveConnection: vi.fn(),
+    onCheckHealth: vi.fn(),
+    onSetTier: vi.fn(),
+    onBack: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Navigate menu → "Add Connection" (index 2) → provider-selection screen. */
+async function openProviderPicker(props?: Partial<ConnectionsPhaseProps>) {
+  const rendered = render(<ConnectionsPhase {...defaultProps(props)} />);
+  // Menu starts at "Connections" (index 0); "Add Connection" is index 2.
+  // Space the keystrokes so each stdin data event is parsed and re-rendered
+  // independently rather than arriving as one batched chunk.
+  const press = async (key: string) => {
+    rendered.stdin.write(key);
+    await new Promise((r) => setTimeout(r, 20));
+  };
+  await press(DOWN);
+  await press(DOWN);
+  await press(ENTER);
+  await vi.waitFor(() => {
+    expect(rendered.lastFrame()).toContain("Choose provider type");
+  });
+  return rendered;
+}
+
+describe("ConnectionsPhase provider picker", () => {
+  it("offers only the validated providers (Anthropic, OpenAI API key)", async () => {
+    const { lastFrame } = await openProviderPicker();
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Anthropic");
+    expect(frame).toContain("OpenAI (API key)");
+  });
+
+  // Regression guard for #712: OpenRouter and Custom (OpenAI-compatible) were
+  // pulled from the picker for 1.1 because neither is validated end-to-end.
+  // The engine-side adapters still exist, so it's easy to accidentally
+  // re-surface them here — this test fails if either row comes back before
+  // the post-1.1 validation playtest re-enables it deliberately.
+  it("does not offer the unvalidated OpenRouter or Custom providers", async () => {
+    const { lastFrame } = await openProviderPicker();
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("OpenRouter");
+    expect(frame).not.toContain("Custom");
+  });
+});

--- a/packages/client-ink/src/phases/ConnectionsPhase.tsx
+++ b/packages/client-ink/src/phases/ConnectionsPhase.tsx
@@ -47,21 +47,22 @@ const MENU_ITEMS = ["Connections", "Model Assignments", "Add Connection", "Sign 
  * dedicated "Sign in with ChatGPT" entry in the Connections menu (no API
  * key paste; OAuth via the codex app-server).
  *
- * `openrouter` is intentionally absent too: the provider adapter still
- * exists engine-side (`createProviderFromConnection`), but OpenRouter has
- * never been validated end-to-end for the things MV depends on (reliable
- * tool use, subagents, ~300k-token context). Offering it here would imply
- * support we can't stand behind, so it's hidden for 1.1 pending a real
- * playtest. Re-add the row once that validation passes (issue #712).
+ * `openrouter` and `custom` are intentionally absent too. Both adapters
+ * still exist engine-side (`createProviderFromConnection`), but neither has
+ * been validated end-to-end for the things MV depends on (reliable tool use,
+ * subagents, ~300k-token context) — OpenRouter never, and `custom`
+ * OpenAI-compatible endpoints only as a best-effort escape hatch. Rather
+ * than ship untested top-level connection options in 1.1, both are hidden
+ * from the picker pending a real validation playtest. Re-add the rows once
+ * that validation passes (issue #712). The `needsBaseUrl` wizard step and
+ * both adapters are left intact so re-enabling is a one-row revert.
  *
- * The tested/supported providers are Anthropic and OpenAI (incl. the
- * ChatGPT-subscription path). "Custom" is offered but flagged untested —
- * an explicit "you can try" escape hatch for OpenAI-compatible endpoints.
+ * The tested/supported providers that remain are Anthropic and OpenAI
+ * (incl. the ChatGPT-subscription path via "Sign in with ChatGPT").
  */
 const PROVIDER_OPTIONS = [
   { id: "anthropic", label: "Anthropic", needsBaseUrl: false },
   { id: "openai-apikey", label: "OpenAI (API key)", needsBaseUrl: false },
-  { id: "custom", label: "Custom (OpenAI-compatible, untested)", needsBaseUrl: true },
 ] as const;
 
 const TIER_LABELS: Record<string, string> = {

--- a/packages/client-ink/src/phases/ConnectionsPhase.tsx
+++ b/packages/client-ink/src/phases/ConnectionsPhase.tsx
@@ -46,12 +46,22 @@ const MENU_ITEMS = ["Connections", "Model Assignments", "Add Connection", "Sign 
  * Note `openai-chatgpt` is intentionally absent here — it goes through a
  * dedicated "Sign in with ChatGPT" entry in the Connections menu (no API
  * key paste; OAuth via the codex app-server).
+ *
+ * `openrouter` is intentionally absent too: the provider adapter still
+ * exists engine-side (`createProviderFromConnection`), but OpenRouter has
+ * never been validated end-to-end for the things MV depends on (reliable
+ * tool use, subagents, ~300k-token context). Offering it here would imply
+ * support we can't stand behind, so it's hidden for 1.1 pending a real
+ * playtest. Re-add the row once that validation passes (issue #712).
+ *
+ * The tested/supported providers are Anthropic and OpenAI (incl. the
+ * ChatGPT-subscription path). "Custom" is offered but flagged untested —
+ * an explicit "you can try" escape hatch for OpenAI-compatible endpoints.
  */
 const PROVIDER_OPTIONS = [
   { id: "anthropic", label: "Anthropic", needsBaseUrl: false },
   { id: "openai-apikey", label: "OpenAI (API key)", needsBaseUrl: false },
-  { id: "openrouter", label: "OpenRouter", needsBaseUrl: false },
-  { id: "custom", label: "Custom (OpenAI-compatible)", needsBaseUrl: true },
+  { id: "custom", label: "Custom (OpenAI-compatible, untested)", needsBaseUrl: true },
 ] as const;
 
 const TIER_LABELS: Record<string, string> = {


### PR DESCRIPTION
Closes the "Now (before 1.1)" tasks in #712.

## Problem
OpenRouter is selectable in the Add-Connection picker but has never been validated for what Machine Violet depends on (reliable tool use, subagents, ~300k-token context). Offering it implies a level of support we can't stand behind. The `custom` OpenAI-compatible option is in the same boat — a best-effort escape hatch, never validated end-to-end — and we'd rather not ship untested top-level connection options for 1.1.

## Change
Provider picker is now **Anthropic** + **OpenAI (API key)**, plus the dedicated ChatGPT-subscription sign-in — exactly the tested/supported set.

- `openrouter` and `custom` rows removed from `PROVIDER_OPTIONS` in `ConnectionsPhase.tsx`.
- **Backend left fully intact** — both adapters (`createProviderFromConnection`, `openai.ts`), the `ProviderType` union, and the base-URL wizard step all stay. Re-enabling after post-1.1 validation is a one-row revert, and any already-persisted OpenRouter/Custom connection still loads.
- Server `VALID_PROVIDERS` untouched: the picker is the gate, so persisted connections keep working.

## Docs synced (same commits)
- `docs/tui-design.md` — provider-selection list.
- `README.md` FAQ — dropped the OpenRouter mention; local / OpenAI-compatible endpoints now described as unsupported this release (planned once testable), matching the mv-website content pass.

## Note / deliberate divergence
#712 wanted the local / OpenAI-compatible "you can try, untested" escape hatch to *stay*. We pulled `custom` too as a ship-time call to avoid exposing untested top-level functions in 1.1. The post-1.1 follow-up (re-enable + validate) now covers **both** OpenRouter and Custom.

## Verification
`tsc -b` clean, eslint clean, pre-commit + push `check` gate green. No behavioral test exists for the picker options (no co-located test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)