### PR TITLE
fix(codex): find the vendored binary on packaged builds + isolate the OAuth CODEX_HOME (#719)

### DIFF
--- a/packages/engine/src/providers/openai-chatgpt/binary.test.ts
+++ b/packages/engine/src/providers/openai-chatgpt/binary.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
 import { resolveCodexBinary, resetCodexBinaryCache } from "./binary.js";
 import { norm } from "../../utils/paths.js";
 
@@ -51,23 +52,27 @@ describe("resolveCodexBinary", () => {
   });
 
   it("resolves colocated native binary when SEA-style layout sits next to execPath", () => {
-    // Simulate the production SEA layout that build-dist.js produces:
+    // Simulate the production SEA layout that build-dist.js produces, mirroring
+    // the real `@openai/codex` vendor tree (see the node_modules guard below):
     //   <exeDir>/MachineViolet[.exe]
-    //   <exeDir>/codex/vendor/<triple>/codex/codex[.exe]
-    //   <exeDir>/codex/vendor/<triple>/path/             (for bundled rg)
-    // The resolver should pick the native binary directly (no script
-    // wrapper, prefixArgs empty) and prepend the path/ dir to PATH so
-    // the bundled `rg` is discoverable.
+    //   <exeDir>/codex/vendor/<triple>/bin/codex[.exe]
+    //   <exeDir>/codex/vendor/<triple>/codex-path/          (for bundled rg)
+    // The resolver should pick the native binary directly (no script wrapper,
+    // prefixArgs empty), point CODEX_MANAGED_PACKAGE_ROOT at the colocated
+    // codex/ root, and prepend the codex-path/ dir to PATH. Getting the subdir
+    // names wrong is exactly the #719 crash: resolution silently misses and
+    // falls through to the bare-`codex` PATH lookup.
     const root = mkdtempSync(join(tmpdir(), "mv-codex-test-"));
     try {
       const triple = "x86_64-pc-windows-msvc";
       const exeName = process.platform === "win32" ? "codex.exe" : "codex";
-      const archDir = join(root, "codex", "vendor", triple);
-      const codexDir = join(archDir, "codex");
-      const pathDir = join(archDir, "path");
-      mkdirSync(codexDir, { recursive: true });
+      const codexRoot = join(root, "codex");
+      const archDir = join(codexRoot, "vendor", triple);
+      const binDir = join(archDir, "bin");
+      const pathDir = join(archDir, "codex-path");
+      mkdirSync(binDir, { recursive: true });
       mkdirSync(pathDir, { recursive: true });
-      writeFileSync(join(codexDir, exeName), "");
+      writeFileSync(join(binDir, exeName), "");
 
       process.execPath = join(root, process.platform === "win32" ? "MachineViolet.exe" : "MachineViolet");
       resetCodexBinaryCache();
@@ -75,7 +80,8 @@ describe("resolveCodexBinary", () => {
       const r = resolveCodexBinary();
       expect(r.source).toBe("colocated");
       expect(r.prefixArgs).toEqual([]);
-      expect(norm(r.path)).toBe(norm(join(codexDir, exeName)));
+      expect(norm(r.path)).toBe(norm(join(binDir, exeName)));
+      expect(norm(r.extraEnv?.CODEX_MANAGED_PACKAGE_ROOT ?? "")).toBe(norm(codexRoot));
       expect(r.extraEnv?.PATH).toBeDefined();
       expect(r.extraEnv!.PATH.split(delimiter)[0]).toBe(pathDir);
     } finally {
@@ -83,16 +89,18 @@ describe("resolveCodexBinary", () => {
     }
   });
 
-  it("omits PATH augmentation when colocated layout has no sibling path/ dir", () => {
+  it("omits PATH augmentation when colocated layout has no sibling codex-path/ dir", () => {
     // Defensive: an upstream codex release that ever drops the ripgrep
     // sidecar would still resolve, just without PATH augmentation.
+    // CODEX_MANAGED_PACKAGE_ROOT is still set so the native binary can find
+    // whatever else lives under the package root.
     const root = mkdtempSync(join(tmpdir(), "mv-codex-test-"));
     try {
       const triple = "x86_64-pc-windows-msvc";
       const exeName = process.platform === "win32" ? "codex.exe" : "codex";
-      const codexDir = join(root, "codex", "vendor", triple, "codex");
-      mkdirSync(codexDir, { recursive: true });
-      writeFileSync(join(codexDir, exeName), "");
+      const binDir = join(root, "codex", "vendor", triple, "bin");
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(join(binDir, exeName), "");
 
       process.execPath = join(root, process.platform === "win32" ? "MachineViolet.exe" : "MachineViolet");
       resetCodexBinaryCache();
@@ -100,8 +108,53 @@ describe("resolveCodexBinary", () => {
       const r = resolveCodexBinary();
       expect(r.source).toBe("colocated");
       expect(r.extraEnv?.PATH).toBeUndefined();
+      expect(r.extraEnv?.CODEX_MANAGED_PACKAGE_ROOT).toBeDefined();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("colocated subdir names match the real @openai/codex vendor layout", () => {
+    // Regression guard for #719: the fixtures above (and binary.ts's colocated
+    // resolution) hardcode the `bin/` + `codex-path/` subdir names. The
+    // colocated path has NO live CI coverage — the packaged-artifact replay
+    // gate runs against recorded tapes, never spawning a real codex — so if a
+    // future `@openai/codex` bump renames those dirs, nothing else catches it
+    // until a user's install crashes with `'codex' is not recognized`. Assert
+    // the names against the actual installed package so the drift fails here,
+    // at build time, instead of in the field.
+    const require_ = createRequire(import.meta.url);
+    let platformRoot: string;
+    try {
+      // The platform binary package the wrapper depends on for this host.
+      const map: Record<string, string> = {
+        "win32:x64": "@openai/codex-win32-x64",
+        "win32:arm64": "@openai/codex-win32-arm64",
+        "darwin:x64": "@openai/codex-darwin-x64",
+        "darwin:arm64": "@openai/codex-darwin-arm64",
+        "linux:x64": "@openai/codex-linux-x64",
+        "linux:arm64": "@openai/codex-linux-arm64",
+      };
+      const pkg = map[`${process.platform}:${process.arch}`];
+      if (!pkg) return; // unsupported host — nothing to assert
+      platformRoot = dirname(require_.resolve(`${pkg}/package.json`));
+    } catch {
+      return; // optional platform dep not installed in this env — skip
+    }
+
+    const tripleMap: Record<string, string> = {
+      "win32:x64": "x86_64-pc-windows-msvc",
+      "win32:arm64": "aarch64-pc-windows-msvc",
+      "darwin:x64": "x86_64-apple-darwin",
+      "darwin:arm64": "aarch64-apple-darwin",
+      "linux:x64": "x86_64-unknown-linux-musl",
+      "linux:arm64": "aarch64-unknown-linux-musl",
+    };
+    const triple = tripleMap[`${process.platform}:${process.arch}`];
+    const exeName = process.platform === "win32" ? "codex.exe" : "codex";
+    const archDir = join(platformRoot, "vendor", triple);
+    // The two subdir names binary.ts depends on must exist in the real tree.
+    expect(existsSync(join(archDir, "bin", exeName))).toBe(true);
+    expect(existsSync(join(archDir, "codex-path"))).toBe(true);
   });
 });

--- a/packages/engine/src/providers/openai-chatgpt/binary.ts
+++ b/packages/engine/src/providers/openai-chatgpt/binary.ts
@@ -2,7 +2,7 @@
  * Resolve the `codex` binary path.
  *
  * Look up order:
- *   1. Colocated with the running executable: `<exeDir>/codex/vendor/{triple}/codex/codex[.exe]`,
+ *   1. Colocated with the running executable: `<exeDir>/codex/vendor/{triple}/bin/codex[.exe]`,
  *      vendored next to the SEA binary by `scripts/build-dist.js`. We spawn
  *      the native Rust binary directly — NOT the `codex.js` wrapper —
  *      because `process.execPath` in a Node SEA build is the SEA exe itself
@@ -10,8 +10,15 @@
  *      binary ignores its first script-path argv and always runs its
  *      embedded main, so `MachineViolet.exe codex/bin/codex.js app-server`
  *      would relaunch Machine Violet instead of running Codex.
- *      We also prepend `vendor/{triple}/path` to PATH so the bundled
- *      `rg.exe` is discoverable — that's what codex.js does too.
+ *      The subdir names (`bin/`, `codex-path/`) mirror the `@openai/codex`
+ *      platform package's own `vendor/{triple}/` tree — they must match what
+ *      `codex/bin/codex.js` resolves (`path.join(vendorRoot, triple, "bin",
+ *      "codex[.exe]")`), because that wrapper is the layout's source of truth.
+ *      We reproduce `codex.js`'s spawn environment for the direct native
+ *      invocation: set `CODEX_MANAGED_PACKAGE_ROOT` to the colocated `codex/`
+ *      dir (so the native binary finds its `codex-path/rg` + `codex-resources/`
+ *      helper exes), and also prepend `vendor/{triple}/codex-path` to PATH so
+ *      the bundled `rg.exe` is discoverable.
  *   2. The `@openai/codex` npm package resolved via `createRequire` —
  *      this is the path for `npm run dev` and tests, where node_modules
  *      lives next to the source and `process.execPath` IS real Node, so
@@ -68,12 +75,23 @@ export function resolveCodexBinary(): CodexBinaryResolution {
       if (triples.length > 0) {
         const triple = triples[0];
         const exeName = process.platform === "win32" ? "codex.exe" : "codex";
-        const nativeBin = join(vendorDir, triple, "codex", exeName);
+        // The native binary lives under `bin/` in the `@openai/codex` vendor
+        // tree — NOT `codex/`. This is exactly the path `codex/bin/codex.js`
+        // resolves; keep them in lockstep or a colocated SEA build silently
+        // falls through to the bare-`codex` PATH lookup and dies with
+        // `'codex' is not recognized` on the first spawn (#719).
+        const nativeBin = join(vendorDir, triple, "bin", exeName);
         if (existsSync(nativeBin)) {
-          // Prepend the sibling `path/` dir to PATH so codex can find its
-          // bundled ripgrep, matching what codex.js does itself.
-          const pathDir = join(vendorDir, triple, "path");
-          const extraEnv: Record<string, string> = {};
+          // Reproduce codex.js's spawn env for the direct native invocation.
+          // codex.js sets CODEX_MANAGED_PACKAGE_ROOT to the codex package root
+          // so the native binary can locate its `codex-path/rg` and
+          // `codex-resources/` helper exes; we spawn the binary directly, so
+          // we must set it ourselves. We also prepend the `codex-path/` dir to
+          // PATH as a belt-and-suspenders route to the bundled ripgrep.
+          const extraEnv: Record<string, string> = {
+            CODEX_MANAGED_PACKAGE_ROOT: codexRoot,
+          };
+          const pathDir = join(vendorDir, triple, "codex-path");
           if (existsSync(pathDir)) {
             extraEnv.PATH = pathDir + delimiter + (process.env.PATH ?? "");
           }

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -301,9 +301,15 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
       // the normal case.
       sweepStaleCodexHomesOnce(Date.now());
       const codexHome = allocateCodexHome("oauth");
-      await mkdir(codexHome, { recursive: true }).catch(() => { /* codex will retry/create; non-fatal */ });
       const codex = new CodexRpcClient({ sessionId: `oauth-${randomBytes(4).toString("hex")}`, codexHome });
       try {
+        // `mkdir` sits INSIDE the try (not before it) for two reasons: the
+        // `finally` then always reaps the home even on an early bail, and this
+        // await honors the same cancellation contract as every boundary below
+        // — a cancel here returns before we spawn codex. `codex.stop()` in the
+        // `finally` is a safe no-op when start() never ran.
+        await mkdir(codexHome, { recursive: true }).catch(() => { /* codex will retry/create; non-fatal */ });
+        if (entry.status !== "pending") return;
         await codex.start();
         if (entry.status !== "pending") return;
         await codex.call("initialize", {

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -7,6 +7,7 @@
  * Prefix: /manage
  */
 import { join } from "node:path";
+import { mkdir, rm } from "node:fs/promises";
 import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 import { randomBytes } from "node:crypto";
 import {
@@ -20,7 +21,7 @@ import { createProviderFromConnection } from "../../providers/index.js";
 import { loadModelRegistry, getModelsForProvider, modelFamilyFor } from "../../config/model-registry.js";
 import {
   CodexRpcClient, startChatGptThirdPartyOAuth, pushChatGptAuthTokens, getAccount,
-  listModels, getCodexClientInfo,
+  listModels, getCodexClientInfo, allocateCodexHome, sweepStaleCodexHomesOnce,
 } from "../../providers/openai-chatgpt/index.js";
 import type { OAuthFlow } from "../../providers/openai-chatgpt/index.js";
 import {
@@ -289,7 +290,19 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
       // each await boundary and bail before persisting the connection.
       // The `finally` block always stops the codex subprocess so the
       // partial work doesn't leak the loopback port either way.
-      const codex = new CodexRpcClient({ sessionId: `oauth-${randomBytes(4).toString("hex")}` });
+      // Isolate this short-lived codex in its own CODEX_HOME, exactly as
+      // session providers do (providers/index.ts). Without it this subprocess
+      // shares the default `~/.codex` SQLite state runtime, so a re-sign-in
+      // while a game session is live — or two overlapping model-discovery
+      // spawns — can contend and crash the loser with `code=1`
+      // `(code: 1546) disk I/O error` on Windows (see codex-home.ts / #699).
+      // The date-sweep backstop reaps any home a crash-skipped `finally` leaked
+      // (idempotent + fire-and-forget); the `finally` below removes this one in
+      // the normal case.
+      sweepStaleCodexHomesOnce(Date.now());
+      const codexHome = allocateCodexHome("oauth");
+      await mkdir(codexHome, { recursive: true }).catch(() => { /* codex will retry/create; non-fatal */ });
+      const codex = new CodexRpcClient({ sessionId: `oauth-${randomBytes(4).toString("hex")}`, codexHome });
       try {
         await codex.start();
         if (entry.status !== "pending") return;
@@ -368,6 +381,11 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
         entry.error = err instanceof Error ? err.message : String(err);
       } finally {
         await codex.stop().catch(() => { /* ignore */ });
+        // Remove this subprocess's isolated home. Retry on Windows: a home
+        // whose codex was just SIGKILLed can hold briefly-locked SQLite
+        // handles as the OS tears the process down (mirrors provider dispose).
+        await rm(codexHome, { recursive: true, force: true, maxRetries: 6, retryDelay: 150 })
+          .catch(() => { /* best-effort; the date-sweep backstop reaps leftovers */ });
       }
     }).catch((err: unknown) => {
       if (entry.status === "cancelled") return;

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -260,11 +260,14 @@ for (const { src, dest, filter, exclude } of assets) {
 // there first (see its colocated-path resolution).
 //
 // Layout matches what codex.js expects when its `require.resolve` of the
-// optional-dep package fails (bin/codex.js:92):
+// optional-dep package fails (bin/codex.js falls back to __dirname/../vendor):
 //   dist/codex/bin/codex.js
 //   dist/codex/package.json
-//   dist/codex/vendor/{triple}/codex/codex[.exe]
-//   dist/codex/vendor/{triple}/path/rg[.exe]
+//   dist/codex/vendor/{triple}/bin/codex[.exe]
+//   dist/codex/vendor/{triple}/codex-path/rg[.exe]
+//   dist/codex/vendor/{triple}/codex-resources/   (helper exes)
+// binary.ts resolves the native binary from this same tree — the subdir
+// names must stay in lockstep with the `@openai/codex` package (see #719).
 //
 // Each build runs on its own platform's runner (windows-latest,
 // macos-latest, ubuntu-latest), so `npm ci` only installs the matching
@@ -311,7 +314,7 @@ console.log(`  Version: ${version}`);
  *       next to the wrapper. Inside our SEA build, no such node_modules
  *       exists, so this branch always fails at runtime.
  *   (b) Falls back to `path.join(__dirname, "..", "vendor", triple,
- *       "codex", "codex[.exe]")` — works if we colocate the vendor tree
+ *       "bin", "codex[.exe]")` — works if we colocate the vendor tree
  *       with the wrapper. This is the path we feed.
  *
  * Per-platform mapping mirrors `bin/codex.js` PLATFORM_PACKAGE_BY_TARGET.


### PR DESCRIPTION
Fixes #719.

## The crash

On the Windows installable build, "Sign in with ChatGPT" crashed the codex app-server with `code=1 signal=null` the instant the OAuth flow spawned its first codex subprocess. The reporter's `engine.jsonl` shows the smoking gun:

```
binaryPath:"codex"
'codex' is not recognized as an internal or external command
code:1 signal:null
```

## Root cause

`resolveCodexBinary()`'s colocated probe looked for the native binary at `<exeDir>/codex/vendor/{triple}/codex/codex[.exe]` and ripgrep at `.../path/`. But `@openai/codex` (0.139.0) vendors them under **`bin/`** and **`codex-path/`** — the exact subdirs `codex/bin/codex.js` itself resolves. Confirmed three ways: the codex.js wrapper source, the repo's `node_modules`, and the actual installed nightly on disk (`current/codex/vendor/x86_64-pc-windows-msvc/bin/codex.exe`).

The probe missed on **every** packaged build, fell through the bundled (#2) and env (#3) cases, and landed on the bare-`codex` PATH lookup (#4) — which isn't on PATH in an installed app. The first codex spawn on a fresh install is the OAuth login subprocess, so sign-in was simply the first thing to hit it → 100% repro.

**Why it slipped through:** dev resolves via case #2 (`codex.js`, which computes the right path itself), and the packaged-artifact replay gate drives recorded **tapes** — it never spawns a real codex. The old colocated tests even baked in the wrong `codex/`+`path/` layout, so they stayed green.

## Changes

**`fix(codex): correct colocated vendor subdir so packaged builds find codex`**
- `binary.ts` — resolve the native binary from `bin/` and ripgrep from `codex-path/`. Also set `CODEX_MANAGED_PACKAGE_ROOT` on the direct native spawn (as `codex.js` does) so the binary can locate its `codex-path/rg` + `codex-resources/` helpers.
- `build-dist.js` — corrected the stale layout comments (packaging already copies the whole tree, so it was fine — only the doc was wrong).
- `binary.test.ts` — fixed the fixtures to the real layout, assert `CODEX_MANAGED_PACKAGE_ROOT`, and added a guard that reads the actual installed `@openai/codex-*` package and fails if `bin/codex[.exe]` / `codex-path/` ever move again (the colocated path has no live-spawn CI coverage).

**`fix(codex): isolate the OAuth login subprocess in its own CODEX_HOME`**
- The short-lived codex spawned during sign-in was the last subprocess still running against the default `~/.codex` — every session provider moved to a per-session home in #699, but this one was missed. Applies the same pattern (sweep backstop → `allocateCodexHome` → `mkdir` before spawn → `rm` in `finally` with the Windows SQLite-handle retry). Prevents the #699-style `(code: 1546) disk I/O error` on a re-sign-in mid-session or overlapping model-discovery spawns.

## Verification

- Spawned the **real** vendored `vendor/{triple}/bin/codex.exe app-server` and completed an `initialize` handshake (`machine_violet/0.139.0`), clean exit — proves the fixed path resolves and the native binary boots on Windows.
- Full lint + test suite green; negative-control confirmed the corrected fixtures fail if the path regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)