### PR TITLE
feat(windows): default Windows Terminal config (100x60 + Ottosson theme)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,6 +86,11 @@ jobs:
           # Enable portable mode (settings stored next to exe, not in %APPDATA%)
           touch dist/terminal/.portable
 
+          # Seed MV's default terminal config (window size + Ottosson theme).
+          # Portable mode reads settings/ next to WindowsTerminal.exe.
+          mkdir -p dist/terminal/settings
+          cp assets/windows-terminal/settings.json dist/terminal/settings/settings.json
+
           # Include Windows Terminal's MIT license (third-party notice)
           if [ -f dist/terminal/LICENSE ]; then
             mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,11 @@ jobs:
           # Enable portable mode (settings stored next to exe, not in %APPDATA%)
           touch dist/terminal/.portable
 
+          # Seed MV's default terminal config (window size + Ottosson theme).
+          # Portable mode reads settings/ next to WindowsTerminal.exe.
+          mkdir -p dist/terminal/settings
+          cp assets/windows-terminal/settings.json dist/terminal/settings/settings.json
+
           # Include Windows Terminal's MIT license (third-party notice)
           if [ -f dist/terminal/LICENSE ]; then
             mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -62,6 +62,10 @@ jobs:
           mkdir -p dist/terminal
           unzip -q wt-portable.zip -d dist/terminal
           touch dist/terminal/.portable
+          # Seed MV's default terminal config (window size + Ottosson theme).
+          # Portable mode reads settings/ next to WindowsTerminal.exe.
+          mkdir -p dist/terminal/settings
+          cp assets/windows-terminal/settings.json dist/terminal/settings/settings.json
           if [ -f dist/terminal/LICENSE ]; then
             mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt
           fi

--- a/assets/windows-terminal/settings.json
+++ b/assets/windows-terminal/settings.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+    "$help": "Default config for the Windows Terminal that Machine Violet bundles (portable mode). Copied to terminal/settings/settings.json at build time; see .github/workflows and docs/installation.md. Only applies when MV auto-relaunches into its bundled terminal — a user's own terminal is never touched.",
+    "initialCols": 100,
+    "initialRows": 60,
+    "profiles": {
+        "defaults": {
+            "colorScheme": "Ottosson"
+        }
+    },
+    "schemes": [
+        {
+            "name": "Ottosson",
+            "background": "#000000",
+            "foreground": "#BEBEBE",
+            "cursorColor": "#FFFFFF",
+            "selectionBackground": "#92A4FD",
+            "black": "#000000",
+            "red": "#BE2C21",
+            "green": "#3FAE3A",
+            "yellow": "#BE9A4A",
+            "blue": "#204DBE",
+            "purple": "#BB54BE",
+            "cyan": "#00A7B2",
+            "white": "#BEBEBE",
+            "brightBlack": "#808080",
+            "brightRed": "#FF3E30",
+            "brightGreen": "#58EA51",
+            "brightYellow": "#FFC944",
+            "brightBlue": "#2F6AFF",
+            "brightPurple": "#FC74FF",
+            "brightCyan": "#00E1F0",
+            "brightWhite": "#FFFFFF"
+        }
+    ]
+}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,9 @@ Download [**`MachineViolet-nightly-Portable.zip`**](https://github.com/octopollu
 
 ### Terminal requirements
 
-Use **Windows Terminal (Preview 1.25+)** for the best experience. PowerShell ISE is not supported. If Machine Violet is launched from bare `cmd.exe` or by double-click, it auto-relaunches inside Windows Terminal when one is available. The portable zip bundles a copy of Windows Terminal so it works out of the box.
+Use **Windows Terminal (Preview 1.25+)** for the best experience. PowerShell ISE is not supported. If Machine Violet is launched from bare `cmd.exe` or by double-click, it auto-relaunches inside Windows Terminal when one is available. Both the installer and the portable zip bundle a copy of Windows Terminal so it works out of the box.
+
+When it auto-relaunches, Machine Violet uses its **own bundled terminal** (configured with a 100×60 window and the *Ottosson* color scheme — see `assets/windows-terminal/settings.json`) in preference to a system-installed Windows Terminal, so the game looks the same on every machine. If you instead run `MachineViolet.exe` from a terminal you already have open, it stays there and leaves your terminal's own configuration untouched.
 
 ## macOS (Apple Silicon) / Linux (x64)
 

--- a/packages/engine/src/config/terminal-check.ts
+++ b/packages/engine/src/config/terminal-check.ts
@@ -98,10 +98,26 @@ function shouldUpgradeTerminal(): boolean {
 
 /**
  * Find the best available Windows Terminal binary.
- * Returns the path to wt.exe / WindowsTerminal.exe, or null.
+ * Returns the path to WindowsTerminal.exe / wt.exe, or null.
  */
 export function findWindowsTerminal(): string | null {
-  // 1. System-installed wt.exe (Store, winget, MSIX)
+  // 1. Bundled portable Windows Terminal (next to our exe). Preferred over a
+  //    system install for two reasons:
+  //      - It's the only WT we can pre-configure. wt.exe has no "use this
+  //        settings file" flag, so our default config (terminal/settings/
+  //        settings.json — window size + Ottosson color scheme) only takes
+  //        effect when the launched terminal is our own portable copy.
+  //      - It's the pinned Preview 1.25 build with the Kitty-keyboard input
+  //        fix, so every packaged user gets it regardless of what (possibly
+  //        older) WT they have installed.
+  //    Only present in packaged builds; dev falls through to the system WT.
+  if (isCompiled()) {
+    const bundled = join(dirname(process.execPath), "terminal", "WindowsTerminal.exe");
+    if (existsSync(bundled)) return bundled;
+  }
+
+  // 2. System-installed wt.exe (Store, winget, MSIX) — dev runs, or a fallback
+  //    if the bundled terminal is somehow missing.
   try {
     const result = execFileSync("where.exe", ["wt.exe"], {
       encoding: "utf-8",
@@ -111,12 +127,6 @@ export function findWindowsTerminal(): string | null {
     const firstLine = result.trim().split(/\r?\n/)[0];
     if (firstLine) return firstLine;
   } catch { /* not found */ }
-
-  // 2. Bundled portable Windows Terminal (next to our exe)
-  if (isCompiled()) {
-    const bundled = join(dirname(process.execPath), "terminal", "WindowsTerminal.exe");
-    if (existsSync(bundled)) return bundled;
-  }
 
   return null;
 }


### PR DESCRIPTION
## What

When Machine Violet auto-relaunches into its bundled Windows Terminal (the bare-`cmd.exe` / double-click path), it now opens with sane defaults for the majority of players who don't run their own terminal:

- **Window size:** 100 columns × 60 rows
- **Color scheme:** Ottosson (Oklab-based, a WT built-in — inlined so it's guaranteed present)
- **Tab title:** "Machine Violet" (already handled by the existing `--title` flag)

Players who launch from a terminal they already have open are **untouched**, exactly as before.

## How

- **`assets/windows-terminal/settings.json`** — the bundled portable-mode config.
- **`terminal-check.ts`** — `findWindowsTerminal()` now prefers the **bundled** portable WT over a system `wt.exe`. This is load-bearing: `wt.exe` has no "use this settings file" flag, so the config only applies when our own portable terminal is the one launched. Bonus: it guarantees the pinned Preview 1.25 build (Kitty-keyboard input fix) for every packaged user.
- **nightly / release / test-build workflows** — copy the config into `dist/terminal/settings/` (where portable mode reads it) right after the `.portable` marker.
- **`docs/installation.md`** — documents the bundled defaults.

## Behavior-change note

Preferring the bundled WT over an installed system WT is a deliberate change: it's the only way the config can apply on a machine that already has Windows Terminal. It only affects the auto-relaunch path (which fires precisely when the user *wasn't* already in a good terminal), so it aligns with "trust users who run their own terminal, set sane defaults otherwise."

## Validation

- JSON parses, `tsc -b` clean, ESLint clean, all three workflow YAMLs parse.
- Real Windows packaging (the relaunch + portable-mode read) is exercised by a `test-build.yml` Windows run / the nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)