### PR TITLE
fix(windows): flatten the bundled Windows Terminal so the app launches at all

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,57 +63,7 @@ jobs:
       - name: Bundle Windows Terminal portable
         if: matrix.os == 'windows-latest'
         shell: bash
-        run: |
-          # Download Windows Terminal Preview portable ZIP from GitHub releases.
-          # Preview 1.25+ adds Kitty keyboard protocol support, which fixes
-          # Backspace/Home/End input corruption on Windows (ConPTY bug).
-          WT_VERSION="1.25.622.0"
-          WT_TAG="v${WT_VERSION}"
-          WT_ZIP="Microsoft.WindowsTerminalPreview_${WT_VERSION}_x64.zip"
-          WT_URL="https://github.com/microsoft/terminal/releases/download/${WT_TAG}/${WT_ZIP}"
-
-          echo "Downloading Windows Terminal portable ${WT_VERSION}..."
-          curl -fSL -o wt-portable.zip "$WT_URL"
-
-          # Verify integrity (update hash when bumping WT_VERSION)
-          WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
-          echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
-
-          # Extract into dist/terminal/. The zip wraps its payload in a single
-          # top-level `terminal-<version>/` directory, so extracting straight
-          # into dist/terminal/ buries the exe one level too deep. Flatten it:
-          # findWindowsTerminal() probes exactly `<exeDir>/terminal/
-          # WindowsTerminal.exe`, and portable mode only reads `.portable` and
-          # `settings/` when they sit next to the exe.
-          rm -rf wt-extract
-          mkdir -p wt-extract dist/terminal
-          unzip -q wt-portable.zip -d wt-extract
-          WT_SRC="$(dirname "$(find wt-extract -name WindowsTerminal.exe | head -1)")"
-          mv "$WT_SRC"/* dist/terminal/
-          rm -rf wt-extract
-
-          # Enable portable mode (settings stored next to exe, not in %APPDATA%)
-          touch dist/terminal/.portable
-
-          # Seed MV's default terminal config (window size + Ottosson theme).
-          # Portable mode reads settings/ next to WindowsTerminal.exe.
-          mkdir -p dist/terminal/settings
-          cp assets/windows-terminal/settings.json dist/terminal/settings/settings.json
-
-          # Include Windows Terminal's MIT license (third-party notice)
-          if [ -f dist/terminal/LICENSE ]; then
-            mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt
-          fi
-
-          # Fail the build if the layout drifts. findWindowsTerminal() probes
-          # these paths with existsSync and SILENTLY falls back to a system
-          # Windows Terminal when they're missing, so a wrong layout ships as
-          # "the app won't launch from the Start Menu" instead of a build error.
-          for f in dist/terminal/WindowsTerminal.exe dist/terminal/settings/settings.json dist/terminal/.portable; do
-            test -f "$f" || { echo "::error::bundled Windows Terminal layout wrong: missing $f"; exit 1; }
-          done
-
-          echo "Bundled Windows Terminal ${WT_VERSION} ($(du -sh dist/terminal | cut -f1))"
+        run: bash scripts/ci/bundle-windows-terminal.sh
 
       - name: Azure login (OIDC)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,9 +79,18 @@ jobs:
           WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
           echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
 
-          # Extract into dist/terminal/
-          mkdir -p dist/terminal
-          unzip -q wt-portable.zip -d dist/terminal
+          # Extract into dist/terminal/. The zip wraps its payload in a single
+          # top-level `terminal-<version>/` directory, so extracting straight
+          # into dist/terminal/ buries the exe one level too deep. Flatten it:
+          # findWindowsTerminal() probes exactly `<exeDir>/terminal/
+          # WindowsTerminal.exe`, and portable mode only reads `.portable` and
+          # `settings/` when they sit next to the exe.
+          rm -rf wt-extract
+          mkdir -p wt-extract dist/terminal
+          unzip -q wt-portable.zip -d wt-extract
+          WT_SRC="$(dirname "$(find wt-extract -name WindowsTerminal.exe | head -1)")"
+          mv "$WT_SRC"/* dist/terminal/
+          rm -rf wt-extract
 
           # Enable portable mode (settings stored next to exe, not in %APPDATA%)
           touch dist/terminal/.portable
@@ -95,6 +104,14 @@ jobs:
           if [ -f dist/terminal/LICENSE ]; then
             mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt
           fi
+
+          # Fail the build if the layout drifts. findWindowsTerminal() probes
+          # these paths with existsSync and SILENTLY falls back to a system
+          # Windows Terminal when they're missing, so a wrong layout ships as
+          # "the app won't launch from the Start Menu" instead of a build error.
+          for f in dist/terminal/WindowsTerminal.exe dist/terminal/settings/settings.json dist/terminal/.portable; do
+            test -f "$f" || { echo "::error::bundled Windows Terminal layout wrong: missing $f"; exit 1; }
+          done
 
           echo "Bundled Windows Terminal ${WT_VERSION} ($(du -sh dist/terminal | cut -f1))"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,18 @@ jobs:
           WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
           echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
 
-          # Extract into dist/terminal/
-          mkdir -p dist/terminal
-          unzip -q wt-portable.zip -d dist/terminal
+          # Extract into dist/terminal/. The zip wraps its payload in a single
+          # top-level `terminal-<version>/` directory, so extracting straight
+          # into dist/terminal/ buries the exe one level too deep. Flatten it:
+          # findWindowsTerminal() probes exactly `<exeDir>/terminal/
+          # WindowsTerminal.exe`, and portable mode only reads `.portable` and
+          # `settings/` when they sit next to the exe.
+          rm -rf wt-extract
+          mkdir -p wt-extract dist/terminal
+          unzip -q wt-portable.zip -d wt-extract
+          WT_SRC="$(dirname "$(find wt-extract -name WindowsTerminal.exe | head -1)")"
+          mv "$WT_SRC"/* dist/terminal/
+          rm -rf wt-extract
 
           # Enable portable mode (settings stored next to exe, not in %APPDATA%)
           touch dist/terminal/.portable
@@ -122,6 +131,14 @@ jobs:
           if [ -f dist/terminal/LICENSE ]; then
             mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt
           fi
+
+          # Fail the build if the layout drifts. findWindowsTerminal() probes
+          # these paths with existsSync and SILENTLY falls back to a system
+          # Windows Terminal when they're missing, so a wrong layout ships as
+          # "the app won't launch from the Start Menu" instead of a build error.
+          for f in dist/terminal/WindowsTerminal.exe dist/terminal/settings/settings.json dist/terminal/.portable; do
+            test -f "$f" || { echo "::error::bundled Windows Terminal layout wrong: missing $f"; exit 1; }
+          done
 
           echo "Bundled Windows Terminal ${WT_VERSION} ($(du -sh dist/terminal | cut -f1))"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,57 +90,7 @@ jobs:
       - name: Bundle Windows Terminal portable
         if: matrix.os == 'windows-latest'
         shell: bash
-        run: |
-          # Download Windows Terminal Preview portable ZIP from GitHub releases.
-          # Preview 1.25+ adds Kitty keyboard protocol support, which fixes
-          # Backspace/Home/End input corruption on Windows (ConPTY bug).
-          WT_VERSION="1.25.622.0"
-          WT_TAG="v${WT_VERSION}"
-          WT_ZIP="Microsoft.WindowsTerminalPreview_${WT_VERSION}_x64.zip"
-          WT_URL="https://github.com/microsoft/terminal/releases/download/${WT_TAG}/${WT_ZIP}"
-
-          echo "Downloading Windows Terminal portable ${WT_VERSION}..."
-          curl -fSL -o wt-portable.zip "$WT_URL"
-
-          # Verify integrity (update hash when bumping WT_VERSION)
-          WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
-          echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
-
-          # Extract into dist/terminal/. The zip wraps its payload in a single
-          # top-level `terminal-<version>/` directory, so extracting straight
-          # into dist/terminal/ buries the exe one level too deep. Flatten it:
-          # findWindowsTerminal() probes exactly `<exeDir>/terminal/
-          # WindowsTerminal.exe`, and portable mode only reads `.portable` and
-          # `settings/` when they sit next to the exe.
-          rm -rf wt-extract
-          mkdir -p wt-extract dist/terminal
-          unzip -q wt-portable.zip -d wt-extract
-          WT_SRC="$(dirname "$(find wt-extract -name WindowsTerminal.exe | head -1)")"
-          mv "$WT_SRC"/* dist/terminal/
-          rm -rf wt-extract
-
-          # Enable portable mode (settings stored next to exe, not in %APPDATA%)
-          touch dist/terminal/.portable
-
-          # Seed MV's default terminal config (window size + Ottosson theme).
-          # Portable mode reads settings/ next to WindowsTerminal.exe.
-          mkdir -p dist/terminal/settings
-          cp assets/windows-terminal/settings.json dist/terminal/settings/settings.json
-
-          # Include Windows Terminal's MIT license (third-party notice)
-          if [ -f dist/terminal/LICENSE ]; then
-            mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt
-          fi
-
-          # Fail the build if the layout drifts. findWindowsTerminal() probes
-          # these paths with existsSync and SILENTLY falls back to a system
-          # Windows Terminal when they're missing, so a wrong layout ships as
-          # "the app won't launch from the Start Menu" instead of a build error.
-          for f in dist/terminal/WindowsTerminal.exe dist/terminal/settings/settings.json dist/terminal/.portable; do
-            test -f "$f" || { echo "::error::bundled Windows Terminal layout wrong: missing $f"; exit 1; }
-          done
-
-          echo "Bundled Windows Terminal ${WT_VERSION} ($(du -sh dist/terminal | cut -f1))"
+        run: bash scripts/ci/bundle-windows-terminal.sh
 
       - name: Azure login (OIDC)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -50,25 +50,7 @@ jobs:
 
       - name: Bundle Windows Terminal portable
         shell: bash
-        run: |
-          WT_VERSION="1.25.622.0"
-          WT_TAG="v${WT_VERSION}"
-          WT_ZIP="Microsoft.WindowsTerminalPreview_${WT_VERSION}_x64.zip"
-          WT_URL="https://github.com/microsoft/terminal/releases/download/${WT_TAG}/${WT_ZIP}"
-          curl -fSL -o wt-portable.zip "$WT_URL"
-          # Verify integrity (update hash when bumping WT_VERSION)
-          WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
-          echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
-          mkdir -p dist/terminal
-          unzip -q wt-portable.zip -d dist/terminal
-          touch dist/terminal/.portable
-          # Seed MV's default terminal config (window size + Ottosson theme).
-          # Portable mode reads settings/ next to WindowsTerminal.exe.
-          mkdir -p dist/terminal/settings
-          cp assets/windows-terminal/settings.json dist/terminal/settings/settings.json
-          if [ -f dist/terminal/LICENSE ]; then
-            mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt
-          fi
+        run: bash scripts/ci/bundle-windows-terminal.sh
 
       - name: Azure login (OIDC)
         if: inputs.sign

--- a/docs/e2e-harness.md
+++ b/docs/e2e-harness.md
@@ -303,6 +303,25 @@ Both accept the same flags:
 - `--keep` skips cleanup of the temporary campaigns directory. The path
   is logged at shutdown so you can poke around the resulting campaign
   files.
+- `--binary <path>` drives a **packaged binary** (an installed or portable
+  build) instead of the from-source launcher:
+
+  ```bash
+  npm run smoketest -- --binary "$LOCALAPPDATA/MachineViolet/current/MachineViolet.exe"
+  ```
+
+  The exe is compiled, so `isCompiled()` is true and it resolves its config
+  dir the real way (`%APPDATA%\MachineViolet`) using your actual saved
+  connections — that's the point: it proves the *shipped artifact* works,
+  not just the source tree. Campaigns still go to a temp dir, so it won't
+  touch real saves. Close any interactive instance first; two builds sharing
+  the config dir will contend over codex.
+
+  Reach for this when validating a release candidate by hand. The packaged
+  binary is otherwise only exercised by offline golden replay
+  (`replay-golden --binary`), which invokes it directly and never touches the
+  launch path or a live provider — the gap that let the bundled-Windows-Terminal
+  bug (#729) ship an app that couldn't start from the Start Menu.
 
 On success: exit 0, single-line `✔ OK <probe> (<n>s)` summary.
 
@@ -482,8 +501,9 @@ await runProbe({
 });
 ```
 
-`runProbe` handles argv parsing (`--stdio`, `--keep`), the launch, the
-error dump on failure, and clean shutdown.
+`runProbe` handles argv parsing (`--stdio`, `--keep`, `--binary`), the launch,
+the error dump on failure, and clean shutdown. Every probe gets `--binary` for
+free — no probe-side code needed to target a packaged build.
 
 Conventions:
 - **No naive sleeps.** Reach for `waitForState` family helpers. If you find

--- a/packages/client-ink/src/phases/MainMenuPhase.test.tsx
+++ b/packages/client-ink/src/phases/MainMenuPhase.test.tsx
@@ -14,6 +14,19 @@ function makeTheme() {
   return resolveTheme(def, "exploration", "#8888aa");
 }
 
+/**
+ * Wait budget for assertions about where the caret SETTLES (#713).
+ *
+ * Settling takes a React effect plus an ink repaint, and ink throttles its
+ * writes — so the frame the assertion reads is always a few async hops behind
+ * the prop change. Under the full suite's file parallelism the process gets
+ * starved enough to blow vi.waitFor's 1s default, which surfaced as a flake
+ * that failed in the 204-file run but passed the file in isolation. These
+ * assertions are about where the caret LANDS, never how fast it gets there,
+ * so give them room. Same pattern as CampaignSettingsModal.test.tsx.
+ */
+const CARET_SETTLE = { timeout: 5000, interval: 20 } as const;
+
 function defaultProps(overrides?: Partial<MainMenuPhaseProps>): MainMenuPhaseProps {
   return {
     theme: makeTheme(),
@@ -227,7 +240,7 @@ describe("MainMenuPhase", () => {
     const selected = () => (lastFrame() ?? "").split("\n").find((l) => l.includes("◆")) ?? "";
     expect(selected()).toContain("New Campaign");
     rerender(<MainMenuPhase {...defaultProps({ apiKeyValid: false })} />);
-    await vi.waitFor(() => expect(selected()).toContain("API Keys"));
+    await vi.waitFor(() => expect(selected()).toContain("API Keys"), CARET_SETTLE);
   });
 
   it("tracks the shifting API Keys index when devModeEnabled loads late (#713)", async () => {
@@ -238,12 +251,12 @@ describe("MainMenuPhase", () => {
       <MainMenuPhase {...defaultProps({ apiKeyValid: false, devModeEnabled: false })} />,
     );
     const selected = () => (lastFrame() ?? "").split("\n").find((l) => l.includes("◆")) ?? "";
-    await vi.waitFor(() => expect(selected()).toContain("API Keys"));
+    await vi.waitFor(() => expect(selected()).toContain("API Keys"), CARET_SETTLE);
     rerender(<MainMenuPhase {...defaultProps({ apiKeyValid: false, devModeEnabled: true })} />);
     await vi.waitFor(() => {
       expect(selected()).toContain("API Keys");
       expect(selected()).not.toContain("Add Content");
-    });
+    }, CARET_SETTLE);
   });
 
   it("does not yank the caret away once the player has navigated (#713)", async () => {
@@ -266,7 +279,7 @@ describe("MainMenuPhase", () => {
     await vi.waitFor(() => {
       expect(frame()).toContain("API Keys"); // item now present…
       expect(selected()).toContain("Continue Campaign"); // …but caret unmoved
-    });
+    }, CARET_SETTLE);
   });
 
   it("collapses the campaign list and advances to the next menu item when scrolling past the end", async () => {

--- a/packages/test-harness/src/run-probe.ts
+++ b/packages/test-harness/src/run-probe.ts
@@ -49,14 +49,20 @@ export interface RunProbeOptions {
 interface ParsedArgs {
   stdio: "inherit" | "buffer" | "ignore";
   keep: boolean;
+  binary?: string;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
   let stdio: "inherit" | "buffer" | "ignore" = "buffer";
   let keep = false;
-  for (const arg of argv) {
+  let binary: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
     if (arg === "--keep") keep = true;
-    else if (arg.startsWith("--stdio=")) {
+    else if (arg === "--binary") {
+      binary = argv[++i];
+      if (!binary) fail("--binary requires a path");
+    } else if (arg.startsWith("--stdio=")) {
       const v = arg.slice("--stdio=".length);
       if (v === "inherit" || v === "buffer" || v === "ignore") stdio = v;
       else fail(`Unknown --stdio value: ${v}`);
@@ -67,16 +73,22 @@ function parseArgs(argv: string[]): ParsedArgs {
       fail(`Unknown arg: ${arg}`);
     }
   }
-  return { stdio, keep };
+  return { stdio, keep, binary };
 }
 
 function printUsage(): void {
   process.stderr.write(
-    "Usage: <probe-script> [--stdio=inherit|buffer|ignore] [--keep]\n\n" +
+    "Usage: <probe-script> [--stdio=inherit|buffer|ignore] [--keep] [--binary <path>]\n\n" +
     "  --stdio=inherit  forward launcher stdout/stderr live (debugging)\n" +
     "  --stdio=buffer   capture to memory (default; dump on failure)\n" +
     "  --stdio=ignore   drop launcher output entirely\n" +
-    "  --keep           don't clean up the tmp campaigns dir on exit\n",
+    "  --keep           don't clean up the tmp campaigns dir on exit\n" +
+    "  --binary <path>  drive the PACKAGED binary (the installed/portable exe)\n" +
+    "                   instead of the from-source launcher. The exe is compiled,\n" +
+    "                   so it resolves its config dir the real way (%APPDATA%\\\n" +
+    "                   MachineViolet) and uses your actual saved connections —\n" +
+    "                   which is the point: it proves the shipped artifact works,\n" +
+    "                   not just the source tree. Campaigns still go to a temp dir.\n",
   );
 }
 
@@ -97,7 +109,10 @@ export async function runProbe(opts: RunProbeOptions): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   process.stderr.write(`▶ ${opts.title}\n  (${opts.name})\n`);
 
-  const harness = await Harness.launch({ stdio: args.stdio });
+  const harness = await Harness.launch({
+    stdio: args.stdio,
+    ...(args.binary ? { executable: { command: args.binary } } : {}),
+  });
   const log = (msg: string) => process.stderr.write(`  ${msg}\n`);
   const ctx: ProbeContext = { harness, log };
 

--- a/scripts/ci/bundle-windows-terminal.sh
+++ b/scripts/ci/bundle-windows-terminal.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Stage the portable Windows Terminal that ships inside the Windows build.
+#
+# Shared by release.yml, nightly.yml, and test-build.yml. It lived inline in all
+# three, drifted, and shipped a layout the app couldn't use: the exe ended up at
+# dist/terminal/terminal-<version>/WindowsTerminal.exe while findWindowsTerminal()
+# (packages/engine/src/config/terminal-check.ts) probes dist/terminal/
+# WindowsTerminal.exe. That probe is an existsSync with a silent fallback to a
+# system wt.exe, so the mistake shipped as "the installed app won't launch from
+# the Start Menu" rather than as a build failure. One copy now, asserted below.
+#
+# Run from the repo root, after build-dist.js has populated dist/.
+set -euo pipefail
+
+# Preview 1.25+ adds Kitty keyboard protocol support, which fixes
+# Backspace/Home/End input corruption on Windows (ConPTY bug).
+WT_VERSION="1.25.622.0"
+WT_ZIP="Microsoft.WindowsTerminalPreview_${WT_VERSION}_x64.zip"
+WT_URL="https://github.com/microsoft/terminal/releases/download/v${WT_VERSION}/${WT_ZIP}"
+# Update this hash when bumping WT_VERSION.
+WT_SHA256="ba5b75eb769e99221e68fe4bfb3580ed1ade81f24b70334de4cb4742edf1b017"
+
+echo "Downloading Windows Terminal portable ${WT_VERSION}..."
+curl -fSL -o wt-portable.zip "$WT_URL"
+echo "$WT_SHA256  wt-portable.zip" | sha256sum -c -
+
+# The zip wraps its payload in a single top-level `terminal-<version>/`
+# directory, so unzipping straight into dist/terminal/ buries the exe one level
+# too deep. Extract aside, then flatten: the exe, `.portable`, and `settings/`
+# must be siblings — portable mode only reads the latter two next to the exe.
+rm -rf wt-extract
+mkdir -p wt-extract dist/terminal
+unzip -q wt-portable.zip -d wt-extract
+
+# Locate the exe rather than hardcoding the wrapper name, but bail if it's
+# absent: `dirname ""` is `.`, which would turn the mv below into
+# `mv ./* dist/terminal/` and sweep up the whole workspace.
+WT_EXE="$(find wt-extract -name WindowsTerminal.exe -print -quit)"
+test -n "$WT_EXE" || { echo "::error::WindowsTerminal.exe not found in ${WT_ZIP} — layout changed?"; exit 1; }
+mv "$(dirname "$WT_EXE")"/* dist/terminal/
+rm -rf wt-extract wt-portable.zip
+
+# Enable portable mode (settings stored next to exe, not in %APPDATA%).
+touch dist/terminal/.portable
+
+# Seed MV's default terminal config (window size + Ottosson theme).
+mkdir -p dist/terminal/settings
+cp assets/windows-terminal/settings.json dist/terminal/settings/settings.json
+
+# Include Windows Terminal's MIT license (third-party notice).
+if [ -f dist/terminal/LICENSE ]; then
+  mv dist/terminal/LICENSE dist/terminal/LICENSE-windows-terminal.txt
+fi
+
+# Assert the layout. This is the point of the script: the consuming code fails
+# silently, so the packaging step has to be the thing that shouts.
+for f in dist/terminal/WindowsTerminal.exe dist/terminal/settings/settings.json dist/terminal/.portable; do
+  test -f "$f" || { echo "::error::bundled Windows Terminal layout wrong: missing $f"; exit 1; }
+done
+
+echo "Bundled Windows Terminal ${WT_VERSION} ($(du -sh dist/terminal | cut -f1))"


### PR DESCRIPTION
## The bug

**The installed app cannot be launched from the Start Menu or Explorer.** It exits within ~0.5s and no game process ever starts. Found during the 1.1 pre-release smoke test on a clean Windows 11 machine (fresh install of today's nightly, `1.1.0-nightly.20260715-0650`).

Microsoft's `WindowsTerminalPreview_1.25.622.0_x64.zip` wraps its payload in a single top-level `terminal-<version>/` directory. `unzip -q wt-portable.zip -d dist/terminal` therefore ships:

```
current/terminal/terminal-1.25.622.0/WindowsTerminal.exe   ← actual
current/terminal/WindowsTerminal.exe                       ← what everything expects
```

Three things break at once, **all silently**:

1. `findWindowsTerminal()` ([terminal-check.ts:115](packages/engine/src/config/terminal-check.ts)) probes `<exeDir>/terminal/WindowsTerminal.exe` with `existsSync`. Always false → quietly falls back to a system-installed `wt.exe`.
2. `.portable` and `settings/` land one level *above* the exe, so portable mode never engages and the shipped Ottosson/100×60 config never applies — **#728 has been inert since it merged**.
3. On a machine whose system WT is older (1.24 here), that forced fallback fails outright with `0x80070002` and the app never starts. The bundled 1.25 launches it fine — **the fallback is precisely the path that doesn't work**.

Not a #728 regression: the `unzip` line and the `existsSync` probe are both present in `v1.1.0-rc.2` too. #728 only added `settings.json` into the already-orphaned directory.

## The fix

Flatten the extraction so the exe, `.portable`, and `settings/` are siblings, and **assert the layout at build time**. The assertion is the important half — the failure mode is a false `existsSync`, which turns a packaging slip into "the app won't launch" instead of a build error.

## Why CI missed it

`scripts/ci/velopack-install-smoke.ps1` replays goldens by invoking the binary directly via `--binary`, which bypasses `checkTerminal()` entirely. The one path every real user takes is the one path no automated test exercises. The build-time assertion closes that gap without needing a GUI-driving test.

## Verification

Against the real artifact (sha256 matches the workflow's pinned `ba5b75eb…`):

| | old logic | new logic |
|---|---|---|
| `terminal/WindowsTerminal.exe` | ✗ buried | ✓ |
| `settings/settings.json` next to exe | ✗ | ✓ |
| `.portable` next to exe | ✗ | ✓ |
| leftover wrapper dir | — | 0 |

Patching a live install to the fixed layout makes a plain double-click of the installed stub work, relaunching into the **bundled** terminal with the game as its child:

```
WindowsTerminal.exe  (current/terminal/WindowsTerminal.exe)   ← bundled 1.25
└── MachineViolet.exe (current/MachineViolet.exe)             ← engine on :7200
```

Before the fix: no process at all.

Full `npm run check` green (3,699 tests). `test-build.yml` dispatched on this branch per the build-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)