### PR TITLE
fix(anthropic): route non-streaming subagent calls through the streaming transport (#712)

### DIFF
--- a/packages/engine/src/providers/anthropic.long-request.test.ts
+++ b/packages/engine/src/providers/anthropic.long-request.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Regression for issue #712: on the Anthropic path, non-streaming subagent
+ * calls (scribe, style_scene, …) failed with
+ *
+ *   "Streaming is required for operations that may take longer than 10 minutes."
+ *
+ * The SDK throws that from `calculateNonstreamingTimeout` — a purely
+ * client-side guard on `messages.create()` — whenever `max_tokens` is large
+ * enough that the request *could* exceed the 10-minute ceiling. Thinking bumps
+ * `max_tokens` to the model max (128000 on Opus), so heavy subagent calls trip
+ * it and throw before any HTTP request. The fix routes every call — streaming
+ * or not — through `client.messages.stream(...).finalMessage()`, which has no
+ * such ceiling.
+ *
+ * These tests mock the SDK so `messages.create()` faithfully reproduces the
+ * guard (throws on large max_tokens) and `messages.stream()` succeeds, then
+ * assert that `provider.chat()` (the non-streaming entry subagents use) never
+ * touches `create()` and resolves cleanly.
+ */
+
+const hoisted = vi.hoisted(() => {
+  function makeMessage(body: { model: string }) {
+    return {
+      id: "msg_test",
+      model: body.model,
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+  }
+  // Rate-limit headers ride on this; return null for all so captureRateLimits
+  // no-ops (parseAnthropicRateLimits → null).
+  const httpResponse = { headers: { get: () => null } };
+
+  // Faithful stand-in for the SDK's client-side non-streaming guard
+  // (client.js `_calculateNonstreamingTimeout`): expectedTime =
+  // 60min * max_tokens / 128000; if that exceeds 10min, throw. This is the
+  // exact error text and threshold the real SDK uses — reproduced here so the
+  // test fails loudly if the provider ever regresses to the create() path.
+  const createSpy = vi.fn((body: { model: string; max_tokens: number }) => {
+    const expectedTimeMs = (60 * 60 * 1000 * body.max_tokens) / 128000;
+    if (expectedTimeMs > 10 * 60 * 1000) {
+      throw new Error(
+        "Streaming is required for operations that may take longer than 10 minutes. " +
+          "See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details",
+      );
+    }
+    return { withResponse: async () => ({ data: makeMessage(body), response: httpResponse }) };
+  });
+
+  const streamSpy = vi.fn((body: { model: string }) => ({
+    on: () => {},
+    finalMessage: async () => makeMessage(body),
+    get response() {
+      return httpResponse;
+    },
+  }));
+
+  return { createSpy, streamSpy };
+});
+
+vi.mock("@anthropic-ai/sdk", () => {
+  class MockAnthropic {
+    messages = { create: hoisted.createSpy, stream: hoisted.streamSpy };
+  }
+  return { default: MockAnthropic };
+});
+
+import { createAnthropicProvider } from "./anthropic.js";
+import type { ChatParams } from "./types.js";
+
+function params(overrides?: Partial<ChatParams>): ChatParams {
+  return {
+    model: "claude-opus-4-6",
+    systemPrompt: "You are the scribe.",
+    messages: [{ role: "user", content: "persist this" }],
+    maxTokens: 1024,
+    ...overrides,
+  };
+}
+
+describe("createAnthropicProvider: non-streaming calls avoid the 10-min guard (issue #712)", () => {
+  beforeEach(() => {
+    hoisted.createSpy.mockClear();
+    hoisted.streamSpy.mockClear();
+  });
+
+  it("does not throw when max_tokens is large — routes through stream, never create", async () => {
+    const provider = createAnthropicProvider("test-key");
+    // Above the SDK's ~21k non-streaming ceiling; the old create() path threw here.
+    const result = await provider.chat(params({ maxTokens: 64000 }));
+
+    expect(result.text).toBe("ok");
+    expect(hoisted.streamSpy).toHaveBeenCalledTimes(1);
+    expect(hoisted.createSpy).not.toHaveBeenCalled();
+
+    // Guard the guard: the mocked create() really would have thrown on these
+    // tokens, so a regression to the create() path can't pass silently.
+    expect(() => hoisted.createSpy({ model: "claude-opus-4-6", max_tokens: 64000 })).toThrow(
+      /Streaming is required/,
+    );
+  });
+
+  it("survives the thinking-driven max_tokens bump (128000 on Opus) that first surfaced the bug", async () => {
+    // Reproduces the reported repro shape: an Opus subagent with thinking
+    // enabled. toAnthropicParams bumps max_tokens to the model max (128000),
+    // which is far above the guard threshold.
+    const provider = createAnthropicProvider("test-key");
+    const result = await provider.chat(params({ thinking: { effort: "medium" } }));
+
+    expect(result.text).toBe("ok");
+    expect(hoisted.streamSpy).toHaveBeenCalledTimes(1);
+    expect(hoisted.streamSpy.mock.calls[0][0]).toMatchObject({ max_tokens: 128000 });
+    expect(hoisted.createSpy).not.toHaveBeenCalled();
+  });
+
+  it("streaming callers (onDelta) also go through stream", async () => {
+    const provider = createAnthropicProvider("test-key");
+    const deltas: string[] = [];
+    const result = await provider.stream(params({ maxTokens: 64000 }), (t) => deltas.push(t));
+
+    expect(result.text).toBe("ok");
+    expect(hoisted.streamSpy).toHaveBeenCalledTimes(1);
+    expect(hoisted.createSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/providers/anthropic.ts
+++ b/packages/engine/src/providers/anthropic.ts
@@ -103,8 +103,13 @@ async function anthropicChat(
   // attach them via an unknown cast that resolves to the same shape the
   // typed methods accept. `as unknown as ...` keeps the overload resolution
   // correctly disambiguating Message vs Stream return types.
+  //
+  // Every call — streaming or not — goes over `client.messages.stream`. Even
+  // non-streaming callers (subagents with no onDelta) buffer the streamed
+  // result rather than calling the non-streaming create(): the SDK refuses a
+  // non-streaming request whose max_tokens could exceed the 10-minute ceiling,
+  // which thinking-enabled subagent calls routinely trip. See the else branch.
   const streamParams = { ...apiParams, ...diagnosticsParams } as unknown as Anthropic.MessageStreamParams;
-  const createParams = { ...apiParams, ...diagnosticsParams, stream: false } as unknown as Anthropic.MessageCreateParamsNonStreaming;
 
   if (streaming && onDelta) {
     const stream = client.messages.stream(streamParams, requestOptions);
@@ -115,14 +120,18 @@ async function anthropicChat(
     // resolves.
     captureRateLimits(stream.response?.headers, rateLimitState);
   } else {
-    // withResponse() surfaces the raw HTTP response alongside the parsed
-    // Message so we can read the `anthropic-ratelimit-*` headers; awaiting it
-    // is otherwise identical to awaiting create() directly.
-    const { data, response: httpResponse } = await client.messages
-      .create(createParams, requestOptions)
-      .withResponse();
-    response = data;
-    captureRateLimits(httpResponse.headers, rateLimitState);
+    // Non-streaming callers (subagents, which pass no onDelta) still go over
+    // the streaming transport internally, then buffer the final message. A
+    // *non-streaming* create() is refused by the SDK when max_tokens is large
+    // enough that the request could exceed the 10-minute ceiling — and thinking
+    // bumps max_tokens to the model max (see toAnthropicParams), so heavy
+    // subagent calls trip that guard and throw before any HTTP request. The
+    // streaming endpoint has no such ceiling; finalMessage() returns the
+    // identical Message shape and `stream.response` still carries the
+    // `anthropic-ratelimit-*` headers, so nothing downstream changes. (#712)
+    const stream = client.messages.stream(streamParams, requestOptions);
+    response = await stream.finalMessage();
+    captureRateLimits(stream.response?.headers, rateLimitState);
   }
 
   // Cursor advances on success only — a thrown error leaves the prior id in

--- a/packages/engine/src/providers/anthropic.usage.test.ts
+++ b/packages/engine/src/providers/anthropic.usage.test.ts
@@ -13,8 +13,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Anthropic from "@anthropic-ai/sdk";
 import type { ChatParams } from "./types.js";
 
-// Mock the SDK so createAnthropicProvider builds against a fake client whose
-// messages.create(...).withResponse() returns headers we control.
+// Mock the SDK so createAnthropicProvider builds against a fake client. The
+// provider routes every call — streaming or not — through messages.stream()
+// (issue #712), so the rate-limit headers we control ride on the stream's
+// `.response.headers`.
 vi.mock("@anthropic-ai/sdk", () => {
   const messages = { create: vi.fn(), stream: vi.fn() };
   class MockAnthropic {
@@ -29,7 +31,7 @@ vi.mock("@anthropic-ai/sdk", () => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const anthropicMod = await import("@anthropic-ai/sdk") as any;
-const mockCreate: ReturnType<typeof vi.fn> = anthropicMod.__mockMessages.create;
+const mockStream: ReturnType<typeof vi.fn> = anthropicMod.__mockMessages.stream;
 
 const {
   createAnthropicProvider,
@@ -53,14 +55,12 @@ function fakeMessage(): Anthropic.Message {
   } as unknown as Anthropic.Message;
 }
 
-/** Make create() return the SDK's withResponse() shape with the given headers. */
+/** Make stream() return a fake MessageStream whose response carries the headers. */
 function mockResponseHeaders(headers: Headers): void {
-  mockCreate.mockReturnValue({
-    withResponse: () => Promise.resolve({
-      data: fakeMessage(),
-      response: { headers },
-      request_id: "req_test",
-    }),
+  mockStream.mockReturnValue({
+    on: () => {},
+    finalMessage: () => Promise.resolve(fakeMessage()),
+    response: { headers },
   });
 }
 
@@ -85,7 +85,7 @@ function baseParams(): ChatParams {
 }
 
 beforeEach(() => {
-  mockCreate.mockReset();
+  mockStream.mockReset();
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/providers/preserves-thinking.contract.test.ts
+++ b/packages/engine/src/providers/preserves-thinking.contract.test.ts
@@ -90,26 +90,24 @@ const anthropicMod = await import("@anthropic-ai/sdk") as any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const openaiMod = await import("openai") as any;
 
-const mockAnthropicCreate: ReturnType<typeof vi.fn> = anthropicMod.__mockMessages.create;
+const mockAnthropicStream: ReturnType<typeof vi.fn> = anthropicMod.__mockMessages.stream;
 const mockResponsesCreate: ReturnType<typeof vi.fn> = openaiMod.__mockResponses.create;
 
 const { createAnthropicProvider } = await import("./anthropic.js");
 const { createOpenAIProvider } = await import("./openai.js");
 
 /**
- * Shape the Anthropic `messages.create` mock to mirror the real SDK: the
- * provider consumes the call via `.withResponse()` (to read rate-limit
- * headers), so the mock returns an object exposing that method rather than a
- * bare resolved Message. Headers are empty here — header capture is exercised
- * in anthropic.usage.test.ts.
+ * Shape the Anthropic `messages.stream` mock to mirror the real SDK: the
+ * provider routes every call — streaming or not — through the streaming
+ * transport (issue #712) and reads the final buffered message via
+ * `finalMessage()`, with rate-limit headers on `.response`. Headers are empty
+ * here — header capture is exercised in anthropic.usage.test.ts.
  */
 function mockAnthropicResponse(message: unknown): void {
-  mockAnthropicCreate.mockReturnValue({
-    withResponse: () => Promise.resolve({
-      data: message,
-      response: { headers: new Headers() },
-      request_id: "req_test",
-    }),
+  mockAnthropicStream.mockReturnValue({
+    on: () => {},
+    finalMessage: () => Promise.resolve(message),
+    response: { headers: new Headers() },
   });
 }
 
@@ -163,7 +161,7 @@ anthropicEntry.encodeTurn2 = async (turn1Content) => {
       { role: "user", content: "and 3+3?" },
     ],
   }));
-  return mockAnthropicCreate.mock.calls.at(-1)?.[0];
+  return mockAnthropicStream.mock.calls.at(-1)?.[0];
 };
 anthropicEntry.assertReplayed = (encoded) => {
   // The assistant message (index 1) must contain a native Anthropic


### PR DESCRIPTION
## Problem

On the Anthropic/Claude provider path, auxiliary subagents failed **every time** they ran, with:

> Streaming is required for operations that may take longer than 10 minutes.

Observed live during a 10-turn playthrough pinned to `env-anthropic` (opus-4-6 / sonnet-4-6 / haiku-4-5). Affected subagents:

- **`scribe`** (world-state persistence) — failed on essentially every turn, so entities/inventory/notes were **not persisted**; player resources degraded to a bare `HP=▢▢▢▢` instead of full Breathless state.
- **`style_scene`** (theme-styler at handoff) — failed, so scenes never got themed (no `key_color`).
- `scene-tracker` (smaller `max_tokens`) ran fine.

The OpenAI path had none of these failures on the same scenario.

## Root cause

The SDK's `messages.create()` runs a **client-side** `calculateNonstreamingTimeout` guard ([`client.js`](https://github.com/anthropics/anthropic-sdk-typescript)) that *throws before any HTTP request* whenever `max_tokens` implies a request that could exceed the 10-minute ceiling (≈ `max_tokens > 21333`). Thinking bumps `max_tokens` to the model max (128000 on Opus, in `toAnthropicParams`), so heavy subagent calls tripped it. Subagents call the model **non-streaming** (no `onDelta`), so they hit the guard; the DM narration streams and was unaffected — exactly matching the observed pattern.

## Fix

The non-streaming branch of `anthropicChat` now uses `client.messages.stream(...).finalMessage()` internally and buffers the result (no `onDelta`) — suggested option 1. The streaming endpoint has no 10-minute ceiling, `finalMessage()` returns the identical `Message` shape, and `stream.response` still carries the `anthropic-ratelimit-*` headers, so nothing downstream changes.

## Tests

- New `anthropic.long-request.test.ts` faithfully reproduces the SDK guard (exact threshold + error text) and asserts `chat()` with a large `max_tokens` — including the thinking-driven 128000 bump that first surfaced the bug — routes through `stream()` and never touches `create()`.
- Updated the two existing tests that mocked the non-streaming `create()` path (`anthropic.usage.test.ts`, `preserves-thinking.contract.test.ts`) to drive through `stream()`.

Full provider suite (261 tests), targeted related suite, and the offline golden replay all pass; lint + typecheck clean.

## Not yet done

No live API run (the `mvplay` + temp `MV_CONFIG_DIR` repro that spends metered credit). Another Claude is standing by to test that live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)