### PR TITLE
docs(install): name the portable launcher correctly (Machine Violet.exe)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ Download [**`MachineViolet-nightly-Setup.exe`**](https://github.com/octopollux/m
 
 ### Portable
 
-Download [**`MachineViolet-nightly-Portable.zip`**](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Portable.zip), unzip anywhere, and run `MachineViolet.exe`. The portable build does not auto-update — re-download to upgrade.
+Download [**`MachineViolet-nightly-Portable.zip`**](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Portable.zip), unzip anywhere, and run `Machine Violet.exe`. The portable build does not auto-update — re-download to upgrade.
 
 ### Terminal requirements
 


### PR DESCRIPTION
The Portable section tells users to *"unzip anywhere, and run `MachineViolet.exe`"* — but the zip has no such file at its root. Velopack names the portable stub **with a space**:

```
.portable
Machine Violet.exe        ← the launcher
Update.exe
current/MachineViolet.exe ← not what you launch
```

`MachineViolet.exe` exists only nested under `current/`. So the first instruction a portable user follows points at a file they can't find, while the real launcher sits right next to it under a slightly different name.

Verified against the shipped artifact rather than the extracted folder:

```console
$ unzip -Z1 MachineViolet-nightly-Portable.zip | grep -iE '^[^/]+\.exe$'
Machine Violet.exe
Update.exe
```

Found while smoke-testing the Windows install methods for 1.1. Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)