### PR TITLE
fix(install): unbreak brew install, implement --version, don't crash on codex spawn failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -567,14 +567,20 @@ jobs:
             end
 
             def install
-              libexec.install "MachineViolet"
-              libexec.install "prompts" if Dir.exist?("prompts")
-              libexec.install "themes" if Dir.exist?("themes")
-              libexec.install "systems" if Dir.exist?("systems")
+              # Install the whole extracted tree. The binary resolves prompts/,
+              # themes/, systems/, worlds/, personalities/, config/, assets/,
+              # the vendored codex/ runtime and node_modules/ (sharp) relative
+              # to its own location, and reads version.json for --version.
+              # Cherry-picking a subset silently breaks those at runtime —
+              # notably ChatGPT sign-in, which spawns codex/vendor/.../bin/codex.
+              libexec.install Dir["*"]
 
               chmod 0755, libexec/"MachineViolet"
-              # Expose as lowercase `machine-violet` for CLI convention
-              (bin/"machine-violet").write_env_script libexec/"MachineViolet"
+              # Expose as lowercase `machine-violet` for CLI convention.
+              # A symlink (not write_env_script) keeps process.execPath pointing
+              # into libexec, which is what the colocated asset + codex lookups
+              # resolve against.
+              bin.install_symlink libexec/"MachineViolet" => "machine-violet"
             end
 
             test do

--- a/packages/engine/src/config/app-version.test.ts
+++ b/packages/engine/src/config/app-version.test.ts
@@ -1,0 +1,89 @@
+import { readAppVersion, versionBanner, versionFile, UNKNOWN_VERSION } from "./app-version.js";
+import { norm } from "../utils/paths.js";
+
+describe("versionFile", () => {
+  it("points at version.json beside the exe when compiled", () => {
+    expect(norm(versionFile({ compiled: true, execPath: "/opt/mv/MachineViolet" })))
+      .toBe("/opt/mv/version.json");
+  });
+
+  it("points at the monorepo package.json in dev", () => {
+    expect(norm(versionFile({ compiled: false, repoRoot: "/repo" })))
+      .toBe("/repo/package.json");
+  });
+});
+
+describe("readAppVersion", () => {
+  it("reads version.json from the install dir when compiled", () => {
+    const version = readAppVersion({
+      compiled: true,
+      execPath: "/opt/mv/MachineViolet",
+      readFile: (p) => {
+        expect(norm(p)).toBe("/opt/mv/version.json");
+        return JSON.stringify({ version: "1.1.0-rc.2", releaseDate: "2026-07-04 21:08" });
+      },
+    });
+    expect(version).toBe("1.1.0-rc.2");
+  });
+
+  it("reads package.json in dev", () => {
+    const version = readAppVersion({
+      compiled: false,
+      repoRoot: "/repo",
+      readFile: () => JSON.stringify({ version: "1.2.3" }),
+    });
+    expect(version).toBe("1.2.3");
+  });
+
+  it("returns unknown rather than throwing when the file is absent", () => {
+    const version = readAppVersion({
+      compiled: true,
+      execPath: "/opt/mv/MachineViolet",
+      readFile: () => { throw new Error("ENOENT"); },
+    });
+    expect(version).toBe(UNKNOWN_VERSION);
+  });
+
+  it("returns unknown on malformed JSON", () => {
+    const version = readAppVersion({
+      compiled: true,
+      execPath: "/opt/mv/MachineViolet",
+      readFile: () => "not json{",
+    });
+    expect(version).toBe(UNKNOWN_VERSION);
+  });
+
+  it.each([
+    ["missing version key", JSON.stringify({ releaseDate: "x" })],
+    ["non-string version", JSON.stringify({ version: 42 })],
+    ["empty version", JSON.stringify({ version: "" })],
+    ["json null", "null"],
+  ])("returns unknown for %s", (_label, payload) => {
+    expect(readAppVersion({ compiled: true, execPath: "/x/MachineViolet", readFile: () => payload }))
+      .toBe(UNKNOWN_VERSION);
+  });
+});
+
+describe("versionBanner", () => {
+  // The Homebrew formula's `test do` block asserts the --version output matches
+  // "MachineViolet", and install.sh echoes it as the post-install confirmation.
+  // Dropping the product name would silently break `brew test`.
+  it("includes the product name and the version", () => {
+    const banner = versionBanner({
+      compiled: true,
+      execPath: "/opt/mv/MachineViolet",
+      readFile: () => JSON.stringify({ version: "1.1.0" }),
+    });
+    expect(banner).toBe("MachineViolet 1.1.0");
+    expect(banner).toMatch(/MachineViolet/);
+  });
+
+  it("still names the product when the version is unknown", () => {
+    const banner = versionBanner({
+      compiled: true,
+      execPath: "/opt/mv/MachineViolet",
+      readFile: () => { throw new Error("nope"); },
+    });
+    expect(banner).toBe(`MachineViolet ${UNKNOWN_VERSION}`);
+  });
+});

--- a/packages/engine/src/config/app-version.test.ts
+++ b/packages/engine/src/config/app-version.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { readAppVersion, versionBanner, versionFile, UNKNOWN_VERSION } from "./app-version.js";
 import { norm } from "../utils/paths.js";
 

--- a/packages/engine/src/config/app-version.ts
+++ b/packages/engine/src/config/app-version.ts
@@ -1,0 +1,71 @@
+/**
+ * Resolve the application version for `--version`.
+ *
+ * Two sources, depending on how we're running:
+ *  - Compiled (SEA): `version.json`, written next to the executable by
+ *    `scripts/build-dist.js` (`{ version, releaseDate }`).
+ *  - Dev: the monorepo root `package.json`.
+ *
+ * Never throws — `--version` must not be the thing that crashes. An
+ * unreadable/absent file yields {@link UNKNOWN_VERSION} so callers still print
+ * something useful.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { isCompiled } from "../utils/paths.js";
+
+export const UNKNOWN_VERSION = "unknown";
+
+export interface VersionSources {
+  /** Override compiled-vs-dev detection (tests). */
+  compiled?: boolean;
+  /** Override `process.execPath` (tests). */
+  execPath?: string;
+  /** Override the dev monorepo root (tests). */
+  repoRoot?: string;
+  /** Override the file reader (tests). */
+  readFile?: (path: string) => string;
+}
+
+/**
+ * The file that carries the version, for the current run mode.
+ *
+ * Compiled builds ship `version.json` beside the exe. In dev there is no
+ * `version.json` (it's a build artifact), so we read the monorepo root
+ * package.json — the same value `build-dist.js` stamps into version.json.
+ */
+export function versionFile(src: VersionSources = {}): string {
+  const compiled = src.compiled ?? isCompiled();
+  if (compiled) {
+    return join(dirname(src.execPath ?? process.execPath), "version.json");
+  }
+  // src/config/app-version.ts → packages/engine/src/config → repo root is ../../../..
+  const root = src.repoRoot ?? join(import.meta.dirname, "..", "..", "..", "..");
+  return join(root, "package.json");
+}
+
+/** The app version, or {@link UNKNOWN_VERSION} if it can't be determined. */
+export function readAppVersion(src: VersionSources = {}): string {
+  const read = src.readFile ?? ((p: string) => readFileSync(p, "utf-8"));
+  try {
+    const parsed: unknown = JSON.parse(read(versionFile(src)));
+    if (parsed && typeof parsed === "object") {
+      const { version } = parsed as { version?: unknown };
+      if (typeof version === "string" && version.length > 0) return version;
+    }
+  } catch {
+    // Missing, unreadable, or malformed — fall through.
+  }
+  return UNKNOWN_VERSION;
+}
+
+/**
+ * The one-line `--version` banner.
+ *
+ * The product name is load-bearing, not decoration: the Homebrew formula's
+ * `test do` block asserts the output matches "MachineViolet", and install.sh
+ * echoes this string as its post-install confirmation.
+ */
+export function versionBanner(src: VersionSources = {}): string {
+  return `MachineViolet ${readAppVersion(src)}`;
+}

--- a/packages/engine/src/providers/openai-chatgpt/rpc.test.ts
+++ b/packages/engine/src/providers/openai-chatgpt/rpc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { codexStderrLineWorthLogging } from "./rpc.js";
+import { codexStderrLineWorthLogging, spawnFailureError } from "./rpc.js";
 
 // codex's stderr (ANSI-stripped) is `<ts> <LEVEL> <target>: <msg>`. At
 // RUST_LOG=info the INFO span records alone hit 100k+ lines/turn (measured live
@@ -32,5 +32,35 @@ describe("codexStderrLineWorthLogging", () => {
     expect(codexStderrLineWorthLogging("thread 'main' panicked at 'boom', src/lib.rs:42")).toBe(true);
     expect(codexStderrLineWorthLogging("   3: codex_core::run")).toBe(true);
     expect(codexStderrLineWorthLogging("some bare diagnostic with no level")).toBe(true);
+  });
+});
+
+// A spawn that never starts emits `error`, not `exit`. With no `error` listener
+// Node tears the whole process down, so a missing codex runtime killed Machine
+// Violet outright — observed on a stock v1.1.0-rc.2 tarball, where "Sign in with
+// ChatGPT" died with `spawn codex ENOENT`. These messages are what the user
+// actually sees instead of a crash.
+describe("spawnFailureError", () => {
+  const errno = (code: string): NodeJS.ErrnoException =>
+    Object.assign(new Error(`spawn ${code}`), { code });
+
+  it("explains an ENOENT as a missing runtime, and names the remedies", () => {
+    const err = spawnFailureError("codex", errno("ENOENT"));
+    expect(err.message).toMatch(/Codex runtime not installed/);
+    expect(err.message).toContain("codex");
+    expect(err.message).toMatch(/CODEX_BIN/);
+  });
+
+  it("distinguishes a present-but-unrunnable binary (EACCES)", () => {
+    const err = spawnFailureError("/opt/mv/codex/vendor/x/bin/codex", errno("EACCES"));
+    expect(err.message).toMatch(/not executable/);
+    expect(err.message).toContain("/opt/mv/codex/vendor/x/bin/codex");
+    expect(err.message).not.toMatch(/not installed/);
+  });
+
+  it("falls back to the underlying message for other spawn failures", () => {
+    const err = spawnFailureError("codex", errno("EAGAIN"));
+    expect(err.message).toMatch(/failed to start/);
+    expect(err.message).toMatch(/EAGAIN/);
   });
 });

--- a/packages/engine/src/providers/openai-chatgpt/rpc.ts
+++ b/packages/engine/src/providers/openai-chatgpt/rpc.ts
@@ -84,6 +84,27 @@ const CODEX_LEAN_FLAGS = ["--disable", "plugins", "--disable", "shell_snapshot"]
  */
 const RPC_LARGE_LINE_LOG_MIN_BYTES = 256 * 1024;
 
+/**
+ * Turn a child_process spawn `error` into a message that says what to do about
+ * it. ENOENT here means no codex binary resolved at all — every candidate in
+ * `resolveCodexBinary()` missed and it fell through to a bare PATH lookup.
+ */
+export function spawnFailureError(binaryPath: string, err: NodeJS.ErrnoException): Error {
+  if (err.code === "ENOENT") {
+    return new Error(
+      `Codex runtime not installed: could not spawn \`${binaryPath}\`. ` +
+      `Reinstall Machine Violet, or install codex yourself (\`npm i -g @openai/codex\`) ` +
+      `or point CODEX_BIN at a codex executable.`,
+    );
+  }
+  if (err.code === "EACCES") {
+    return new Error(
+      `Codex runtime not executable: \`${binaryPath}\` exists but cannot be run (EACCES).`,
+    );
+  }
+  return new Error(`codex app-server failed to start (\`${binaryPath}\`): ${err.message}`);
+}
+
 // ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
@@ -116,6 +137,12 @@ export class CodexRpcClient extends EventEmitter {
   private notifListeners = new Map<string, Set<NotificationHandler>>();
   private serverHandlers = new Map<string, ServerRequestHandler>();
   private exited = false;
+  /**
+   * Set when the spawn itself failed (see the `error` handler in
+   * {@link startInternal}). Preferred over the generic "has exited" message so
+   * callers report *why* codex never came up.
+   */
+  private spawnError: Error | null = null;
   private startPromise: Promise<void> | null = null;
   private readonly sessionId?: string;
   private readonly extraArgs: string[];
@@ -154,6 +181,22 @@ export class CodexRpcClient extends EventEmitter {
       // `.cmd` shims on Windows (used by PATH-resolved global installs) need
       // shell resolution. Bundled-mode invokes node directly so shell is off.
       shell: process.platform === "win32" && bin.source === "path",
+    });
+
+    // A spawn that never starts emits `error`, NOT `exit`: ENOENT when no codex
+    // binary resolves (the colocated probe missing + nothing on PATH), EACCES
+    // when it isn't executable. Node treats an `error` with no listener as an
+    // unhandled error event and tears the whole process down — so a missing
+    // codex runtime killed Machine Violet outright instead of surfacing a
+    // message. Funnel it into the same "subprocess is gone" path as `exit` so
+    // the provider's reset-and-respawn recovery applies unchanged.
+    this.proc.on("error", (err: NodeJS.ErrnoException) => {
+      this.exited = true;
+      this.spawnError = spawnFailureError(bin.path, err);
+      log.exit({ code: null, signal: null, sessionId: this.sessionId });
+      for (const p of this.pending.values()) p.reject(this.spawnError);
+      this.pending.clear();
+      this.emit("exit", { code: null, signal: null });
     });
 
     this.proc.on("exit", (code, signal) => {
@@ -330,6 +373,9 @@ export class CodexRpcClient extends EventEmitter {
 
   /** Send a request and await the typed response. */
   async call<T = unknown>(method: string, params: unknown = {}): Promise<T> {
+    // A spawn failure is more specific than "exited" — report why codex never
+    // came up rather than implying it ran and died.
+    if (this.spawnError) throw this.spawnError;
     if (this.exited) throw new Error("codex app-server has exited; call stop()/start() to restart");
     if (!this.proc || !this.proc.stdin) throw new Error("codex app-server not started; call start() first");
     const id = this.nextId++;

--- a/scripts/launcher.ts
+++ b/scripts/launcher.ts
@@ -31,7 +31,19 @@ import { defaultCampaignRoot } from "../packages/engine/src/tools/filesystem/pla
 import { configDir } from "../packages/engine/src/utils/paths.js";
 import { loadEnv } from "../packages/engine/src/config/first-launch.js";
 import { checkTerminal } from "../packages/engine/src/config/terminal-check.js";
+import { versionBanner } from "../packages/engine/src/config/app-version.js";
 import { disableReactPerfTrackUnlessRequested } from "../packages/client-ink/src/react-perf-track.js";
+
+// --- Version flag ---
+// Must precede every other startup step, and especially checkTerminal(): both
+// install.sh and the Homebrew formula's `test do` shell out to `--version` from
+// a non-TTY, where the terminal guard exits 1 with "cannot run in this
+// terminal". Left unhandled, `--version` fell through to a normal boot — it
+// launched the whole game on a TTY and printed the guard error off one.
+if (process.argv.includes("--version") || process.argv.includes("-v")) {
+  console.log(versionBanner());
+  process.exit(0);
+}
 
 // --- Velopack lifecycle hooks (Windows install/update/uninstall) ---
 // Must run before any server/client startup. Exits the process if a hook fires.


### PR DESCRIPTION
## Summary

Three defects found while smoke-testing the macOS install methods (`brew` / `install.sh` / tarball) for the 1.1.0 release. All three are `main`-side and unrelated to the codex path bug already fixed in #724.

None of these are caught by `npm run check` or the smoketest — they only exist in a packaged artifact or in the packaging itself.

## 1. `brew install` has been broken for ~3.5 months

`brew install octopollux/mv-tap/machine-violet` fails outright:

```
ArgumentError: wrong number of arguments (given 1, expected 2..3)
.../Formula/machine-violet.rb:29:in 'install'
```

The generated formula calls `write_env_script` with one argument; Homebrew's signature is
`write_env_script(target, args_or_env, env = nil)` — two required, and it has been since
well before Aug 2025, so **the 1-arg call never worked**. It landed 2026-03-29 and every
fresh install/upgrade since has hit it. It went unnoticed because an already-installed copy
keeps working (this machine still had the 2026-03-24 nightly, installed 5 days before the
bad line landed).

There's no env to inject, so this uses the idiomatic `bin.install_symlink`.

**The formula was also installing an incomplete tree.** It cherry-picked
`MachineViolet` + `prompts`/`themes`/`systems`, but the tarball also ships `worlds/`,
`personalities/`, `config/`, `assets/`, `version.json`, `node_modules/` (sharp) and the
vendored `codex/` runtime. So a brew install was missing the codex binary that ChatGPT
sign-in spawns — even with the arity fixed, sign-in would have failed on brew for a
second, unrelated reason. Now installs the whole tree (`libexec.install Dir["*"]`):
**373 files vs the old formula's 50**.

## 2. `--version` was never implemented

The launcher's arg loop handles `--campaign`, `--ws-log`, `--agent-port` and bare args;
anything else starting with `-` falls through. So `MachineViolet --version` **booted the
game** on a TTY, and off-TTY hit the terminal guard:

```
  Installed:
  Machine Violet cannot run in this terminal.
  stdin is not a TTY (piped input or non-interactive shell).
```

That's install.sh's post-install confirmation on a *successful* install. The Homebrew
formula's `test do` also asserts `--version` output matches "MachineViolet", so `brew test`
could never pass either.

The data was already shipping — `build-dist.js` stamps `version.json` next to the exe and
nothing read it. Now: read it when compiled, fall back to the monorepo `package.json` in
dev, never throw. Handled before the velopack hooks / `loadEnv()` / `checkTerminal()`,
since the whole point is that it must work from a non-interactive shell.

The banner keeps the product name (`MachineViolet 1.1.0`) because the brew test asserts on
it; a test pins that so it can't be dropped.

## 3. A codex spawn failure killed the whole app

`CodexRpcClient` registered `exit` on the subprocess but never `error`. A spawn that never
starts emits `error`, not `exit` — and Node treats an unhandled `error` event as fatal:

```
Error: spawn codex ENOENT   spawnargs: ['app-server', ...]
node:events:487  throw er; // Unhandled 'error' event
```

This is what turned #719's bad path into a hard crash instead of the "Codex runtime not
installed" error `binary.ts`'s own docstring promises — and it would do the same for any
future resolution miss, or an EACCES. `error` now funnels into the same "subprocess is
gone" path as `exit`, so #699's reset-and-respawn recovery applies unchanged, and the spawn
reason is kept so `call()` reports why codex never came up rather than the generic
"has exited" (which implies it ran).

## Verification

`npx tsc -b` clean; `npm run check` green — **3717 tests / 206 files** (14 skipped).

Formula validated for real, end-to-end, against today's nightly artifact
(`nightly-20260715-0650`, which contains #724):

- Rendered the formula from this branch into a scratch tap → `brew install` **succeeds**
  (it fails with `ArgumentError` on the current formula).
- Full tree lands: `codex/vendor/aarch64-apple-darwin/bin/codex`, `version.json`,
  `node_modules`, `worlds`, `personalities`, `config`, `assets` all present.
- Launched through the `bin/machine-violet` symlink; engine log confirms the colocated
  probe now resolves the real binary and completes the handshake:
  ```
  codex:subprocess:spawn        binaryPath: .../libexec/codex/vendor/aarch64-apple-darwin/bin/codex
  codex:subprocess:initialized  userAgent: machine_violet/0.139.0 ...
                                codexHome: /private/var/.../codex-homes/<id>-<n>
  ```
  (Pre-fix this logged `binaryPath: "codex"` and died with ENOENT.)
- Started a campaign on that brew install and the setup agent returned a real generated
  turn over the ChatGPT provider — `engineState: waiting_input`. Sign-in → live turn works
  end-to-end on a brew install.

`--version` verified off-TTY: prints `MachineViolet 1.1.0`, exits 0, no terminal guard.

Note `brew test` will keep failing until a nightly ships commit 2 — today's nightly binary
predates the `--version` fix. Expected, and self-resolving on the next nightly.

## Not included

Two further observations from the same session, filed here rather than fixed:

- `server:start` logs `"version": "dev"` on a packaged build — now that `readAppVersion()`
  exists it could report the real version, but that's a logging change and out of scope.
- `agent-sidecar.ts` says "Excluded from release builds", but it is reachable in the
  shipped binary via `--agent-port` (that's how the verification above was driven). It's
  opt-in and loopback-only, so low risk — but the comment is inaccurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
