### PR TITLE
feat(models): add GPT-5.6 Sol/Terra/Luna as ChatGPT tier defaults (#715)

### DIFF
--- a/docs/state-atlas.md
+++ b/docs/state-atlas.md
@@ -639,7 +639,7 @@ In addition to campaign-scoped state, Machine Violet maintains machine-scoped co
                                Per-model: pricing, capabilities, context window, tier defaults.
 ```
 
-Additionally, `dev-config.jsonc` (read from the process working directory, not the app config directory) provides optional dev-only overrides for `effort` (per-agent reasoning level) and `pricing` (per-model cost calculations). `//` and `/* */` comments are stripped before JSON parsing. Per-tier provider/model assignment is *not* configured here — that lives in `connections.json`, managed via the Connections UI.
+Additionally, `dev-config.jsonc` (read from the process working directory, not the app config directory) provides optional dev-only overrides for `effort` (per-agent reasoning level) and `pricing` (per-model cost calculations). `//` and `/* */` comments and trailing commas are stripped before JSON parsing. A genuinely-absent file falls back to defaults silently; a file that is *present but unparseable* logs a one-time warning (rather than silently defaulting) so a typo'd override doesn't go unnoticed. Per-tier provider/model assignment is *not* configured here — that lives in `connections.json`, managed via the Connections UI.
 
 **Tier resolution:** at session start, `buildTierProviders` (`src/config/tier-resolver.ts`) reads `connections.json` and emits a `Record<ModelTier, TierProvider>` — three `{provider, model}` pairs, one per tier. The map threads through `GameEngine`, `SceneManager`, and `ResolveSession` so every subagent call routes through the connection assigned to its tier. Heterogeneous setups (e.g. Large=OpenAI, Medium=Anthropic) just work; subagents accept `model` as a required parameter and never fall back to `getModel(tier)` silently.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,9 +1879,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0.tgz",
-      "integrity": "sha512-wr2fRE+fzW0CjEbfFsLh1ftarVEcw0CMLWS7QyA0nyOz5qacQPVq3cq2+/U7oEbwm1TOqoi0Fm1nxniB5FkpmA==",
+      "version": "0.144.5",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5.tgz",
+      "integrity": "sha512-jjB+K+OMv572mKhS+2QuLxWXDJNdpwbPenf+V+8bdq7wg4Scqt3cn6WEekD8wPqDVZqck0HSX17K9rD9kbDJQA==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -1890,19 +1890,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.139.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.139.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.139.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.139.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.139.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.139.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.5-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.5-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.5-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.5-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.5-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.5-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.139.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-darwin-arm64.tgz",
-      "integrity": "sha512-o+0ZKWwgDFMMLO7rwinzO0PQsgK+Vme1pMN2GeAxsX29ZgGZcyPICfpJbeGSUO1mb2a36Skjx6nfdRnxMY0r7w==",
+      "version": "0.144.5-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-arm64.tgz",
+      "integrity": "sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw==",
       "cpu": [
         "arm64"
       ],
@@ -1917,9 +1917,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.139.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-darwin-x64.tgz",
-      "integrity": "sha512-9gkBWzu6DB2rqU4DbpxD3DE5bofGpsK46Lp0h0I+bKWc2IIcxvSi8K2utKmBLoJCbKrn4JQu7dFNGRqEfENung==",
+      "version": "0.144.5-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-darwin-x64.tgz",
+      "integrity": "sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw==",
       "cpu": [
         "x64"
       ],
@@ -1934,9 +1934,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.139.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-linux-arm64.tgz",
-      "integrity": "sha512-tBQE5lZciRHeWZGuURgjP9S717MvTIpQMc593+DNxY2LQxozkngOkzFSQd1+/UmQKGrCqdFLu5irIwPXpSZyEw==",
+      "version": "0.144.5-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-arm64.tgz",
+      "integrity": "sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ==",
       "cpu": [
         "arm64"
       ],
@@ -1951,9 +1951,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.139.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-linux-x64.tgz",
-      "integrity": "sha512-14UgzDS+X4crkvdt6S02A/ZZOrS8ZyWiuTRpguCtnhNamb7unSuDxy86BWgpAl3sqiTaN2CP8VLyp2ohQ8Nbzw==",
+      "version": "0.144.5-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-linux-x64.tgz",
+      "integrity": "sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg==",
       "cpu": [
         "x64"
       ],
@@ -1968,9 +1968,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.139.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-win32-arm64.tgz",
-      "integrity": "sha512-nlwRjsYotH1Rtqu/Q0VwQbIeO2UX1mkHK84Ov9qn/hl29QqqoBtno0tRyqIPbkXFIVQuWiAYXlV3ugLwH5fTrQ==",
+      "version": "0.144.5-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-arm64.tgz",
+      "integrity": "sha512-0Pj7iqjEOEvPQPO3kFfCy9vGX4BTu76ChFFZHr2eNNIfVc3FOENAv/X98u4L+iIUtDOK9DbqmfUudW3DPapshg==",
       "cpu": [
         "arm64"
       ],
@@ -1985,9 +1985,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.139.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-win32-x64.tgz",
-      "integrity": "sha512-lQrVLNz+90wdvWVNFDvCkHQRiAK9ZllmkTka3c8eqSDqdJk35Gpgppfv9Xtw5M2ZBtTq0sBdWBiCMyzGDBSpmQ==",
+      "version": "0.144.5-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.5-win32-x64.tgz",
+      "integrity": "sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg==",
       "cpu": [
         "x64"
       ],
@@ -10706,7 +10706,7 @@
         "@fastify/swagger": "^9.7.0",
         "@fastify/websocket": "^11.0.0",
         "@machine-violet/shared": "*",
-        "@openai/codex": ">=0.130.0",
+        "@openai/codex": ">=0.144.5",
         "@scalar/fastify-api-reference": "^1.49.7",
         "@sinclair/typebox": "^0.34.0",
         "dotenv": "^17.4.2",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -17,7 +17,7 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/websocket": "^11.0.0",
     "@machine-violet/shared": "*",
-    "@openai/codex": ">=0.130.0",
+    "@openai/codex": ">=0.144.5",
     "@scalar/fastify-api-reference": "^1.49.7",
     "@sinclair/typebox": "^0.34.0",
     "dotenv": "^17.4.2",

--- a/packages/engine/src/config/known-models.json
+++ b/packages/engine/src/config/known-models.json
@@ -46,6 +46,33 @@
       "pricing": { "input": 1, "output": 5, "cacheWrite": 1.25, "cacheRead": 0.10 },
       "capabilities": { "thinking": false, "tools": true, "streaming": true, "caching": true, "imageGeneration": false }
     },
+    "gpt-5.6-sol": {
+      "provider": "openai",
+      "displayName": "GPT-5.6 Sol",
+      "contextWindow": 1050000,
+      "maxOutput": 128000,
+      "defaultTier": "large",
+      "pricing": { "input": 5, "output": 30, "cacheWrite": 6.25, "cacheRead": 0.50 },
+      "capabilities": { "thinking": true, "tools": true, "streaming": true, "caching": true, "imageGeneration": true }
+    },
+    "gpt-5.6-terra": {
+      "provider": "openai",
+      "displayName": "GPT-5.6 Terra",
+      "contextWindow": 1050000,
+      "maxOutput": 128000,
+      "defaultTier": "medium",
+      "pricing": { "input": 2.5, "output": 15, "cacheWrite": 3.125, "cacheRead": 0.25 },
+      "capabilities": { "thinking": true, "tools": true, "streaming": true, "caching": true, "imageGeneration": true }
+    },
+    "gpt-5.6-luna": {
+      "provider": "openai",
+      "displayName": "GPT-5.6 Luna",
+      "contextWindow": 1050000,
+      "maxOutput": 128000,
+      "defaultTier": "small",
+      "pricing": { "input": 1, "output": 6, "cacheWrite": 1.25, "cacheRead": 0.10 },
+      "capabilities": { "thinking": true, "tools": true, "streaming": true, "caching": true, "imageGeneration": true }
+    },
     "gpt-5.5": {
       "provider": "openai",
       "displayName": "GPT-5.5",
@@ -122,6 +149,6 @@
   "tierDefaults": {
     "anthropic": { "large": "claude-opus-4-6", "medium": "claude-sonnet-4-6", "small": "claude-haiku-4-5-20251001" },
     "openai-apikey": { "large": "gpt-5.5", "medium": "gpt-5-mini", "small": "gpt-5-nano" },
-    "openai-chatgpt": { "large": "gpt-5.5", "medium": "gpt-5.4-mini", "small": "gpt-5.4-mini" }
+    "openai-chatgpt": { "large": "gpt-5.6-sol", "medium": "gpt-5.6-terra", "small": "gpt-5.6-luna" }
   }
 }

--- a/packages/engine/src/config/models.test.ts
+++ b/packages/engine/src/config/models.test.ts
@@ -24,9 +24,11 @@ describe("model config", () => {
   });
 
   it("ignores malformed JSON", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     writeFileSync(join(testDir, "dev-config.jsonc"), "not json {{{");
     const config = loadModelConfig({ cwd: testDir, reset: true });
     expect(config.large).toBe("claude-opus-4-6");
+    warn.mockRestore();
   });
 
   it("caches after first load", () => {
@@ -110,6 +112,60 @@ describe("model config", () => {
     const config = loadModelConfig({ cwd: testDir, reset: true });
     expect(config.effort.dm).toBe("max");
     expect(config.effort.ooc).toBe("low");
+  });
+
+  it("tolerates a trailing comma before a closing brace (the #715 A/B bug)", () => {
+    // Exactly the shape that silently defaulted before: one uncommented field
+    // followed by a comma, then (comment-stripped) nothing but the closing brace.
+    writeFileSync(
+      join(testDir, "dev-config.jsonc"),
+      `{
+         "effort": {
+           "dm": "max"
+         },
+         // "pricing": { }
+       }`,
+    );
+    const config = loadModelConfig({ cwd: testDir, reset: true });
+    expect(config.effort.dm).toBe("max");
+  });
+
+  it("tolerates a trailing comma on the last entry of a nested object", () => {
+    writeFileSync(
+      join(testDir, "dev-config.jsonc"),
+      `{ "effort": { "dm": "high", "ooc": "low", } }`,
+    );
+    const config = loadModelConfig({ cwd: testDir, reset: true });
+    expect(config.effort.dm).toBe("high");
+    expect(config.effort.ooc).toBe("low");
+  });
+
+  it("does not strip a comma that lives inside a string value", () => {
+    // The trailing-comma remover must respect string state: a pricing key
+    // containing `,}` should survive intact.
+    writeFileSync(
+      join(testDir, "dev-config.jsonc"),
+      `{ "pricing": { "weird,}key": { "input": 1, "output": 2, "cacheWrite": 0, "cacheRead": 0 } } }`,
+    );
+    const pricing = loadPricingConfig({ cwd: testDir, reset: true });
+    expect(pricing["weird,}key"]).toEqual({ input: 1, output: 2, cacheWrite: 0, cacheRead: 0 });
+  });
+
+  it("warns when a present config is unparseable (not silent)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeFileSync(join(testDir, "dev-config.jsonc"), "{ this is not json");
+    const config = loadModelConfig({ cwd: testDir, reset: true });
+    expect(config.large).toBe("claude-opus-4-6"); // still falls back to defaults
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("dev-config.jsonc");
+    warn.mockRestore();
+  });
+
+  it("does NOT warn when the config file is simply absent", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadModelConfig({ cwd: testDir, reset: true }); // testDir has no dev-config.jsonc
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("preserves // and /* */ inside string values", () => {

--- a/packages/engine/src/config/models.ts
+++ b/packages/engine/src/config/models.ts
@@ -33,8 +33,8 @@ const DEV_CONFIG_FILENAME = "dev-config.jsonc";
  * content inside double-quoted strings. Recognizes:
  *   - `//` to end-of-line
  *   - block comments delimited by slash-star and star-slash
- * Trailing commas are not supported — keep the file syntactically JSON once
- * comments are removed.
+ * Trailing commas are handled separately by {@link stripTrailingCommas}, which
+ * runs after this pass.
  *
  * Hand-rolled to avoid pulling in a JSONC parser dep for a single config file.
  * Single-quoted strings are not recognized (JSON doesn't allow them).
@@ -71,9 +71,83 @@ function stripJsoncComments(src: string): string {
   return out;
 }
 
+/**
+ * Remove trailing commas — a comma whose next non-whitespace character is a
+ * closing `}` or `]`. Runs after {@link stripJsoncComments}, so only whitespace
+ * can sit between the comma and the bracket. Commas inside strings are left
+ * untouched (string state is tracked exactly as in the comment stripper).
+ *
+ * Hand-authored `dev-config.jsonc` files routinely leave a trailing comma
+ * behind — e.g. uncommenting one field of a multi-field block. Before this,
+ * `JSON.parse` rejected it and the whole file was silently ignored, so the
+ * override appeared to do nothing (this bit the #715 model A/B test: a stray
+ * comma meant the DM ran at default effort, not the configured one).
+ */
+function stripTrailingCommas(src: string): string {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (inString) {
+      out += c;
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+    if (c === ",") {
+      let j = i + 1;
+      while (j < src.length && /\s/.test(src[j])) j++;
+      if (src[j] === "}" || src[j] === "]") continue; // drop the trailing comma
+    }
+    out += c;
+  }
+  return out;
+}
+
+/**
+ * Read + parse `dev-config.jsonc` from `dir`.
+ *
+ * Returns `undefined` when the file is simply absent (the common case — no
+ * override configured). Throws a descriptive error when the file *exists* but
+ * cannot be parsed, so callers can distinguish "no config" from "broken config"
+ * and surface the latter instead of silently falling back to defaults.
+ */
 function loadDevConfig(dir: string): unknown {
-  const raw = readFileSync(join(dir, DEV_CONFIG_FILENAME), "utf-8");
-  return JSON.parse(stripJsoncComments(raw));
+  let raw: string;
+  try {
+    raw = readFileSync(join(dir, DEV_CONFIG_FILENAME), "utf-8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw e;
+  }
+  try {
+    return JSON.parse(stripTrailingCommas(stripJsoncComments(raw)));
+  } catch (e) {
+    throw new Error(
+      `${DEV_CONFIG_FILENAME} in ${dir} is not valid JSONC and was ignored: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+      { cause: e },
+    );
+  }
+}
+
+/** Dirs we've already warned about, so a broken config warns once, not per-load. */
+const warnedConfigDirs = new Set<string>();
+
+/** Warn (once per dir) that a present-but-broken dev-config was ignored. */
+function warnBadDevConfig(dir: string, err: unknown): void {
+  if (warnedConfigDirs.has(dir)) return;
+  warnedConfigDirs.add(dir);
+  const msg = err instanceof Error ? err.message : String(err);
+  console.warn(`[machine-violet] ${msg} Using built-in defaults.`);
 }
 
 const DEFAULTS: ModelConfig = {
@@ -148,8 +222,10 @@ export function loadModelConfig(opts?: { cwd?: string; reset?: boolean }): Model
         config.effort = { ...DEFAULTS.effort, ...map };
       }
     }
-  } catch {
-    // No dev-config.jsonc or invalid — use defaults
+  } catch (e) {
+    // A missing file returns undefined (no throw); reaching here means the file
+    // exists but couldn't be parsed. Warn rather than silently use defaults.
+    warnBadDevConfig(dir, e);
   }
 
   cached = config;
@@ -204,8 +280,9 @@ export function loadPricingConfig(opts?: { cwd?: string; reset?: boolean }): Rec
         }
       }
     }
-  } catch {
-    // No dev-config.jsonc or invalid — use defaults
+  } catch (e) {
+    // Present-but-unparseable config: warn instead of silently defaulting.
+    warnBadDevConfig(dir, e);
   }
 
   cachedPricing = pricing;


### PR DESCRIPTION
## What

Adds the **GPT-5.6** model family (Sol, Terra, Luna) and makes them the **ChatGPT (codex) provider's** Large/Medium/Small tier defaults. Addresses #715 for the ChatGPT path.

## Changes

- **`known-models.json`** — add `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` (1.05M context, 128K max output, launch pricing, image-gen capable) and repoint `openai-chatgpt` tier defaults to Sol/Terra/Luna.
- **`@openai/codex` floor → `>=0.144.5`** (lockfile pinned). Required, not cosmetic: older Codex hard-**400**s the new model IDs (*"requires a newer version of Codex"*), so the registry change alone doesn't work on the codex path. The `openai-apikey` path has no such gate.
- **`dev-config.jsonc` loader robustness** — a bug this work surfaced: the loader silently reverted the whole override to defaults on a **trailing comma**, and couldn't distinguish "file absent" from "file present but broken." Now tolerates trailing commas, stays silent when the file is genuinely absent, and **warns** when a present config fails to parse. (+6 tests, doc note in `state-atlas.md`.)

## Prompting / parameter review

No prompt or parameter changes needed on the codex path:
- Reasoning effort still spans `none→max`, covering MV's `low/medium/high/max` mapping unchanged.
- Model-conditional prompt blocks key off the `gpt-` prefix, which `gpt-5.6-*` satisfies.
- No temperature/max_tokens knobs changed; `getMaxOutput` reads 128K straight from the registry.

## Validation

- **Live**: an 11-turn campaign on the ChatGPT path with all tiers on GPT-5.6 (DM=Sol, subagents=Terra/Luna) — setup, portrait + async in-game image generation, Breathless mechanics, scribe/scene-tracker/summarizer subagents, and per-turn injections all functioned. Plus an A/B run confirming Luna is viable as a DM (Luna@low ≈ 3–4× faster than Sol@low at comparable quality; Luna@xhigh ≈ Sol@low speed with the strongest reasoning of the set).
- **Offline**: `npm run check` green — 3724 tests, lint, typecheck; golden replay green.

## Scope / follow-ups

- **ChatGPT provider only**, per the request. `openai-apikey` tier defaults intentionally stay on `gpt-5.5` — a deliberate follow-up, not an oversight.
- Live testing turned up a separate **silent-fallback bug** (a setup-agent `finalize` slip labels the PC `[Adventurer]` when `character_name` is omitted, and cascades into a duplicate character entity). It's the same class as the JSONC bug and belongs to the broader input-validation effort — documented on **#739** rather than shimmed here.

Addresses #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
