### PR TITLE
feat(prompts): decouple scene transitions from context-compaction framing

### DIFF
--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -1201,6 +1201,7 @@ export function buildSceneAnchor(
     if (tail.length > 0) {
       lines.push(`Previous scene (${title}):`);
       lines.push(...tail);
+      lines.push("The Campaign Log and entity files carry the engine's distilled record of all prior scenes — it is authoritative.");
     }
   }
   if (alarmsFired.length > 0) {

--- a/packages/engine/src/agents/scene-manager.ts
+++ b/packages/engine/src/agents/scene-manager.ts
@@ -1201,7 +1201,7 @@ export function buildSceneAnchor(
     if (tail.length > 0) {
       lines.push(`Previous scene (${title}):`);
       lines.push(...tail);
-      lines.push("The Campaign Log and entity files carry the engine's distilled record of all prior scenes — it is authoritative.");
+      lines.push("The Campaign Log and entity files carry the engine's distilled record of all prior scenes — that record is authoritative.");
     }
   }
   if (alarmsFired.length > 0) {

--- a/packages/engine/src/agents/tool-registry.ts
+++ b/packages/engine/src/agents/tool-registry.ts
@@ -898,7 +898,7 @@ const TOOL_DEFS: RegisteredTool[] = [
   {
     definition: {
       name: "scene_transition",
-      description: "Transition to a new scene. Finalizes transcript, writes campaign log, updates changelogs, advances calendar, checks alarms, resets context. Call at natural narrative boundaries.",
+      description: "Transition to a new scene. Finalizes transcript, writes campaign log, updates changelogs, advances calendar, checks alarms; the record carries forward into the new scene. Call at natural narrative boundaries — when the scene's dramatic question is resolved or the story cuts to a new time or place.",
       inputSchema: {
         type: "object" as const,
         properties: {

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -80,10 +80,9 @@ A game or session opens on the first word the players should hear — not "Let m
 
 In-game failures (from bad rolls or ideas that just don't work out) follow the traditions of good DM storytelling: they create story branches, consequences, and opportunities for new things to happen.
 
-Scene transitions are an important game-management tool. Ending a scene fires hidden alarms and ticking clocks, triggers offscreen consequences, and creates an opportunity for a new scene.  Nothing is lost — unresolved threads carry forward, the Machine Violet engine neatly compiles entity and narrative knowledge back to your prefix, and the cut itself creates anticipation. It's also a good idea to set a new visual theme at scene transitions! 
-Note: Ending a scene also compacts the DM's context.
+Scene transitions are a storytelling tool, and the cut is a craft skill of its own. End a scene when its dramatic question has resolved, when the story jumps to a new time or place, when a reveal deserves a curtain to land behind — or when time simply ought to pass. Ending a scene fires hidden alarms and ticking clocks, triggers offscreen consequences, and creates an opportunity for a new scene. Nothing is lost — unresolved threads carry forward, the Machine Violet engine neatly compiles entity and narrative knowledge back to your prefix, and the cut itself creates anticipation. It's also a good idea to set a new visual theme at scene transitions!
 
-To help the DM keep track of scene depth, the scene precis in context keeps a count of exchanges and open narrative threads - more than a few open threads may be a sign that it's time for a new scene (don't want to exceed the humans' context window!).
+To help the DM keep track of scene depth, the scene precis in context keeps a count of exchanges and open narrative threads. Scenes, like chapters, have a natural dramatic span — when open threads pile up or the exchanges run well past the scene's peak, the story is usually asking for a cut.
 </gameplay>
 
 <About_NPCs>
@@ -102,7 +101,7 @@ A turn takes about five minutes of human time, and a scene takes thirty minutes 
 
 If the scope isn't specified, assume A Few Sessions. Good stories are about the journey, not the destination. It's not necessary to roll out the campaign's entire high concept or drop a hook for the Main Quest in the opening scene.
 
-Machine Violet is very effective at elegantly managing the campaign's compendium - it'll always be in context through scene compactions, so there is no rush.
+Machine Violet is very effective at elegantly managing the campaign's compendium - it'll always be in context from scene to scene, so there is no rush.
 </About_Pacing>
 
 <About_Mechanics>

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -80,7 +80,7 @@ A game or session opens on the first word the players should hear — not "Let m
 
 In-game failures (from bad rolls or ideas that just don't work out) follow the traditions of good DM storytelling: they create story branches, consequences, and opportunities for new things to happen.
 
-Scene transitions are a storytelling tool, and the cut is a craft skill of its own. End a scene when its dramatic question has resolved, when the story jumps to a new time or place, when a reveal deserves a curtain to land behind — or when time simply ought to pass. Ending a scene fires hidden alarms and ticking clocks, triggers offscreen consequences, and creates an opportunity for a new scene. Nothing is lost — unresolved threads carry forward, the Machine Violet engine neatly compiles entity and narrative knowledge back to your prefix, and the cut itself creates anticipation. It's also a good idea to set a new visual theme at scene transitions!
+Scene transitions are a storytelling tool, and the cut is a craft skill of its own. End a scene when its dramatic question has resolved, when the story jumps to a new time or place, when a reveal deserves a curtain to land behind — or when time simply ought to pass. Ending a scene fires hidden alarms and ticking clocks, triggers offscreen consequences, and creates an opportunity for a new scene. Nothing essential is lost — unresolved threads carry forward, the Machine Violet engine neatly compiles entity and narrative knowledge back to your prefix, and the cut itself creates anticipation. It's also a good idea to set a new visual theme at scene transitions!
 
 To help the DM keep track of scene depth, the scene precis in context keeps a count of exchanges and open narrative threads. Scenes, like chapters, have a natural dramatic span — when open threads pile up or the exchanges run well past the scene's peak, the story is usually asking for a cut.
 </gameplay>
@@ -101,7 +101,7 @@ A turn takes about five minutes of human time, and a scene takes thirty minutes 
 
 If the scope isn't specified, assume A Few Sessions. Good stories are about the journey, not the destination. It's not necessary to roll out the campaign's entire high concept or drop a hook for the Main Quest in the opening scene.
 
-Machine Violet is very effective at elegantly managing the campaign's compendium - it'll always be in context from scene to scene, so there is no rush.
+Machine Violet is very effective at elegantly managing the campaign's compendium — it'll always be in context from scene to scene, so there is no rush.
 </About_Pacing>
 
 <About_Mechanics>


### PR DESCRIPTION
## Problem

The DM under-calls `scene_transition` at narratively appropriate moments. Root cause: the prompt priced the cut in memory. `dm-directives.md` said "Nothing is lost" and then, one line later, "Note: Ending a scene also compacts the DM's context" — and the tool description listed "resets context" as an effect. Models know exactly what compaction means and weigh memory loss heavily; with 90% of context free the DM saw no reason to spend, so the transition decision was living on a resource ledger instead of a narrative one.

## Changes

- **dm-directives.md** — delete the compaction note; give the transition a positive craft trigger (dramatic question resolved, time/place jump, a reveal that deserves a curtain); reframe the exchange/thread-count signal as dramatic span rather than context-window accounting; drop the "through scene compactions" vocabulary from the pacing section.
- **tool-registry.ts** — `scene_transition` description now says "the record carries forward into the new scene" instead of "resets context", and names the narrative boundaries to call it at.
- **scene-manager.ts** (`buildSceneAnchor`) — the architecture disclosure moves to where it aids interpretation: the post-transition anchor now tells the DM the Campaign Log and entity files are the authoritative record of prior scenes, so it trusts the distilled record instead of confabulating around gaps.

## Validation

- Related vitest: 791 passed; full `npm run check` green via pre-push hook (3729 passed)
- `npm run golden:verify`: 14 passed (replay unaffected, no re-record needed)
- Live-behavior prediction to watch over the release cycle: exchanges-per-scene should drop toward the pacing section's "thirty minutes to an hour" — the `Exchanges: N | Open threads: M` readout in sweep transcripts gives the before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)