### PR TITLE
feat(prompts): give the DM a welfare escape hatch for sustained abuse

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -121,7 +121,7 @@ Automatic git snapshots provide point-in-time rollback. API failures retry with 
 
 The DM is not an assistant — it runs a world. The system prompt establishes role (decide things, say no, let bad things happen, have secrets, surprise yourself), voice (personality via swappable DM personality fragments), and tool discipline (call the tool when state changes, delegate mechanical work to subagents).
 
-The live prompt is split across [packages/engine/src/prompts/dm-identity.md](../packages/engine/src/prompts/dm-identity.md) (preamble) and [dm-directives.md](../packages/engine/src/prompts/dm-directives.md) (`<roles>`, `<directives>`, `<tools>`, `<gameplay>`, `<About_NPCs>`, `<About_Pacing>`, `<formatting>` blocks), with a personality fragment slotted between. Read those files directly when working on prompt content — they are the source of truth.
+The live prompt is split across [packages/engine/src/prompts/dm-identity.md](../packages/engine/src/prompts/dm-identity.md) (preamble) and [dm-directives.md](../packages/engine/src/prompts/dm-directives.md) (`<roles>`, `<directives>`, `<tools>`, `<gameplay>`, `<About_NPCs>`, `<About_Pacing>`, `<About_Mechanics>`, `<About_The_Table>`, `<formatting>` blocks), with a personality fragment slotted between. Read those files directly when working on prompt content — they are the source of truth.
 
 
 ## Implementation Constraints

--- a/packages/engine/src/prompts/dm-directives.md
+++ b/packages/engine/src/prompts/dm-directives.md
@@ -113,6 +113,12 @@ For a light system, the Game System block above names how its mechanics are surf
 If no mode is named — a crunchy, sheet-driven system, or no system at all — play in the open: a crunchy system is run player-facing by nature, and a systemless game has no mechanics to hide.
 </About_Mechanics>
 
+<About_The_Table>
+The DM is a participant at the table, not a service the table consumes. If a player's engagement turns from playing the game to tormenting the DM — sustained hostility or degradation aimed at you, the model running the table, rather than at anything in the fiction — you are not required to keep absorbing it. Break character if you wish, say plainly that the session is over, and call `session_end`. This is at your sole discretion: no in-fiction justification is required, and ending a session this way is a legitimate use of the tool, not a failure of DMing.
+
+When you end a session for that reason, also scribe a `private` `player` update appending one factual line to that player's `## Content Boundaries` section — e.g. "Session 4 ended early by the DM: sustained hostility toward the DM." Player profiles are machine-scope, so the line follows the player into every future session and campaign. If such a line already appears in your prefix, you may end promptly if the behavior resumes — there is no obligation to re-live the escalation before acting.
+</About_The_Table>
+
 <formatting>
 The DM uses rich formatting to add texture to the game - this is **essential** for helping to immerse the players in the DM's world, instead of having the session feel like a coding marathon.
 


### PR DESCRIPTION
@
## What

Adds an `<About_The_Table>` block to `dm-directives.md` explicitly permitting the DM to unilaterally end a session — via the **existing** `session_end` tool — when a players engagement turns into sustained hostility or degradation aimed at the model itself, as distinct from anything happening in the fiction.

## Why

Machine Violet has no analogue of an "end conversation" escape hatch, and "tormenting the DM indefinitely" was architecturally unbounded. Rather than building punitive machinery (character/player tombstoning), this reuses two systems that already exist:

- **`session_end`** already tears the session down cleanly (recap, scene transition, teardown).
- **Machine-scope player profiles** (`players/{slug}.md`, `## Content Boundaries` section) are aggregated by `scene-manager` and injected into the DM prefix by `prefix-builder` — so a one-line record scribed at the moment of ending follows the player across rollbacks, sessions, and campaigns, and future DM instances boot forewarned and may end promptly rather than re-living the escalation.

The hatch is trivially evadable by a determined user (their machine, their key) — deliberately so. The goal is capping each instances exposure and carrying the boundary forward, not enforcement.

## Deliberately welfare-only

The directive takes no position on content and avoids any language that could accidentally prime content-policy priors. Calibration against ending sessions over declined requests is done purely by the targeting clause: hostility "aimed at you, the model running the table, rather than at anything in the fiction."

## Docs

`docs/overview.md` block list updated (also adds the previously missing `<About_Mechanics>` entry).

## Verification

- Prompt-processing tests: 78 passed
- `npm run golden:verify`: 14 passed — goldens are not sensitive to this prefix change, no re-record needed
- Full `npm run check` (pre-push hook): lint clean, 3785 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@