### PR TITLE
fix(diagnostics): allow export before sign-in

### DIFF
--- a/docs/error-recovery.md
+++ b/docs/error-recovery.md
@@ -95,15 +95,21 @@ The `/retry` command retries the last DM turn at any time — useful for recover
 - Otherwise, it pops the last exchange from conversation history and replays the original player input (with `skipTranscript: true`).
 - Both paths log a `dev` narrative line (visible when verbose display is enabled in Settings).
 
-### `/diagnostics` slash command
+### Diagnostics export
 
-The `/diagnostics` command bundles the current campaign folder together with the top-level `.debug/` (engine.jsonl, context dumps) into a single zip and reveals it in the OS file explorer:
+Use **Settings → Export Diagnostics** to create a support bundle at any time,
+including when no API connection is configured or sign-in has failed. During
+gameplay, the `/diagnostics` slash command provides the same export.
 
-- Output path: `<homeDir>/diagnostics/<campaign-name>-<timestamp>.mvdiag` (a zip with a Machine Violet-specific extension — any zip tool can still read it).
-- The bundle includes a `manifest.json` at the root with the collection timestamp, campaign name, platform, and Node version.
+When a campaign is active, the bundle contains the current campaign folder
+together with the top-level `.debug/` (engine.jsonl, context dumps). Before a
+campaign is active, it contains the top-level `.debug/` data only:
+
+- Output path: `<homeDir>/diagnostics/<campaign-name>-<timestamp>.mvdiag`, or `machine-violet-<timestamp>.mvdiag` outside a campaign (a zip with a Machine Violet-specific extension — any zip tool can still read it).
+- The bundle includes a `manifest.json` at the root with the collection timestamp, scope, platform, and Node version, plus campaign name/slug when applicable.
 - Per-campaign `.debug/` is captured as part of the campaign walk; the top-level `.debug/` is added under a `.debug/` prefix in the archive.
 - The top-level `.debug/server.log` (mirrored stdout/stderr) is excluded — it's noisy and rarely useful for triage compared with `engine.jsonl`.
-- Reveal-in-folder uses platform-specific commands (`explorer /select,` on Windows, `open -R` on macOS, `xdg-open <parent>` on Linux). The system message in the chat always prints the absolute path as a fallback when reveal is unavailable or silently fails.
+- Reveal-in-folder uses platform-specific commands (`explorer /select,` on Windows, `open -R` on macOS, `xdg-open <parent>` on Linux). The UI always prints the absolute path as a fallback when reveal is unavailable or silently fails.
 
 Use this when sending a triage bundle for a bug report.
 

--- a/packages/client-ink/src/api-client.ts
+++ b/packages/client-ink/src/api-client.ts
@@ -192,7 +192,7 @@ export class ApiClient {
   }
 
   async diagnostics(): Promise<{ ok: boolean; path: string }> {
-    return this.fetch("/session/diagnostics", { method: "PUT" });
+    return this.fetch("/manage/diagnostics", { method: "PUT" });
   }
 
   async getSettings(): Promise<{ config: unknown }> {

--- a/packages/client-ink/src/app.tsx
+++ b/packages/client-ink/src/app.tsx
@@ -34,6 +34,7 @@ import type {
 import type { ArchivedCampaignEntry, CampaignDeleteInfo } from "./config/campaign-archive.js";
 import { setAgentClientState } from "./agent-state-ref.js";
 import { loadClientSettings, saveClientSettings } from "./config/client-settings.js";
+import { revealInExplorer } from "./commands/open-path.js";
 import {
   loadThemeDefinition,
   resolveTheme,
@@ -604,6 +605,11 @@ export function App({ serverUrl, playerId, campaignId, hasKittyProtocol, stdinFi
         onArchivedCampaigns={() => {
           apiClientRef.current.listArchivedCampaigns().then((resp) => setArchivedCampaigns(resp.archives)).catch(() => { /* ignore */ });
           setPhase("archived_campaigns");
+        }}
+        onExportDiagnostics={async () => {
+          const { path } = await apiClientRef.current.diagnostics();
+          revealInExplorer(path);
+          return path;
         }}
         onBack={() => setPhase("menu")}
       />

--- a/packages/client-ink/src/phases/SettingsPhase.test.tsx
+++ b/packages/client-ink/src/phases/SettingsPhase.test.tsx
@@ -21,9 +21,17 @@ function defaultProps(overrides?: Partial<SettingsPhaseProps>): SettingsPhasePro
     onApiKeys: vi.fn(),
     onDiscord: vi.fn(),
     onArchivedCampaigns: vi.fn(),
+    onExportDiagnostics: vi.fn(async () => "/home/diagnostics/machine-violet.mvdiag"),
     onBack: vi.fn(),
     ...overrides,
   };
+}
+
+async function moveToExportDiagnostics(stdin: { write: (data: string) => void }): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    stdin.write("\u001B[B");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 describe("SettingsPhase", () => {
@@ -35,6 +43,11 @@ describe("SettingsPhase", () => {
   it("renders API Keys menu item", () => {
     const { lastFrame } = render(<SettingsPhase {...defaultProps()} />);
     expect(lastFrame()).toContain("API Keys");
+  });
+
+  it("renders an Export Diagnostics menu item", () => {
+    const { lastFrame } = render(<SettingsPhase {...defaultProps()} />);
+    expect(lastFrame()).toContain("Export Diagnostics");
   });
 
   it("calls onBack on ESC", async () => {
@@ -49,7 +62,7 @@ describe("SettingsPhase", () => {
   it("calls onApiKeys when API Keys selected", () => {
     const onApiKeys = vi.fn();
     const { stdin } = render(<SettingsPhase {...defaultProps({ onApiKeys })} />);
-    stdin.write("\r"); // Enter on first (and only) item
+    stdin.write("\r"); // Enter on the first item
     expect(onApiKeys).toHaveBeenCalled();
   });
 
@@ -59,6 +72,54 @@ describe("SettingsPhase", () => {
     // setTimeout(0) is used for the deep-link, so wait a tick
     await new Promise((r) => setTimeout(r, 10));
     expect(onApiKeys).toHaveBeenCalled();
+  });
+
+  it("exports diagnostics and displays the saved path", async () => {
+    const onExportDiagnostics = vi.fn(async () => "/home/diagnostics/machine-violet.mvdiag");
+    const { stdin, lastFrame } = render(
+      <SettingsPhase {...defaultProps({ onExportDiagnostics })} />,
+    );
+    await moveToExportDiagnostics(stdin);
+    stdin.write("\r");
+
+    await vi.waitFor(() => {
+      expect(onExportDiagnostics).toHaveBeenCalledTimes(1);
+      expect(lastFrame()).toContain("Diagnostics saved: /home/diagnostics/machine-violet.mvdiag");
+    });
+  });
+
+  it("displays a diagnostics export failure", async () => {
+    const onExportDiagnostics = vi.fn(async () => {
+      throw new Error("debug folder unavailable");
+    });
+    const { stdin, lastFrame } = render(
+      <SettingsPhase {...defaultProps({ onExportDiagnostics })} />,
+    );
+    await moveToExportDiagnostics(stdin);
+    stdin.write("\r");
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("Diagnostics failed: debug folder unavailable");
+    });
+  });
+
+  it("ignores repeated export input while a bundle is in progress", async () => {
+    let resolveExport!: (path: string) => void;
+    const onExportDiagnostics = vi.fn(() => new Promise<string>((resolve) => {
+      resolveExport = resolve;
+    }));
+    const { stdin, lastFrame } = render(
+      <SettingsPhase {...defaultProps({ onExportDiagnostics })} />,
+    );
+    await moveToExportDiagnostics(stdin);
+    stdin.write("\r");
+    stdin.write("\r");
+
+    expect(onExportDiagnostics).toHaveBeenCalledTimes(1);
+    resolveExport("/home/diagnostics/machine-violet.mvdiag");
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("Diagnostics saved");
+    });
   });
 
   it("renders a version label pinned to the bottom-left", () => {

--- a/packages/client-ink/src/phases/SettingsPhase.tsx
+++ b/packages/client-ink/src/phases/SettingsPhase.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useInput, Text, useWindowSize } from "ink";
 import type { ResolvedTheme } from "../tui/themes/types.js";
 import { TerminalTooSmall, FullScreenFrame } from "../tui/components/index.js";
@@ -19,6 +19,8 @@ export interface SettingsPhaseProps {
   onApiKeys: () => void;
   onDiscord: () => void;
   onArchivedCampaigns: () => void;
+  /** Export diagnostics and resolve with the saved bundle's absolute path. */
+  onExportDiagnostics: () => Promise<string>;
   onBack: () => void;
 }
 
@@ -39,19 +41,47 @@ export function SettingsPhase({
   onApiKeys,
   onDiscord,
   onArchivedCampaigns,
+  onExportDiagnostics,
   onBack,
 }: SettingsPhaseProps) {
   const { columns: cols, rows: termRows } = useWindowSize();
   const [menuIndex, setMenuIndex] = useState(0);
+  const [diagnosticsStatus, setDiagnosticsStatus] = useState<{
+    text: string;
+    error: boolean;
+  } | null>(null);
+  const diagnosticsBusyRef = useRef(false);
   const navigatedRef = useRef(false);
+
+  const exportDiagnostics = useCallback(() => {
+    // The ref is the synchronous guard: repeated Enter events can arrive
+    // before React commits state, so state alone would allow duplicate bundles.
+    if (diagnosticsBusyRef.current) return;
+    diagnosticsBusyRef.current = true;
+    setDiagnosticsStatus({ text: "Saving diagnostics…", error: false });
+    void onExportDiagnostics()
+      .then((path) => {
+        setDiagnosticsStatus({ text: `Diagnostics saved: ${path}`, error: false });
+      })
+      .catch((err: unknown) => {
+        const raw = err instanceof Error ? err.message : String(err);
+        const message = raw.replace(/\s+/g, " ").trim();
+        setDiagnosticsStatus({ text: `Diagnostics failed: ${message}`, error: true });
+      })
+      .finally(() => { diagnosticsBusyRef.current = false; });
+  }, [onExportDiagnostics]);
 
   const items: MenuItem[] = useMemo(() => [
     { label: "API Keys", action: onApiKeys },
     { label: "Discord", action: onDiscord },
     { label: "Archived Campaigns", action: onArchivedCampaigns },
+    { label: "Export Diagnostics", action: exportDiagnostics },
     { label: "Enable Dev Mode", toggle: devModeEnabled ?? false, action: onToggleDevMode ?? noop },
     { label: "Show Debug Info", toggle: showVerbose ?? false, action: onToggleVerbose ?? noop },
-  ], [onApiKeys, onDiscord, onArchivedCampaigns, devModeEnabled, onToggleDevMode, showVerbose, onToggleVerbose]);
+  ], [
+    onApiKeys, onDiscord, onArchivedCampaigns, exportDiagnostics,
+    devModeEnabled, onToggleDevMode, showVerbose, onToggleVerbose,
+  ]);
 
   // Deep-link: if initialView is set, navigate once on mount
   useEffect(() => {
@@ -102,6 +132,14 @@ export function SettingsPhase({
         <Text color={markerColor}>{marker}</Text>
         <Text color={isSelected ? accentColor : undefined} bold={isSelected}>{` ${item.label}`}</Text>
         {suffix && <Text color={item.toggle ? "#66cc66" : dimColor} bold={item.toggle}>{suffix}</Text>}
+      </Text>,
+    );
+  }
+  if (diagnosticsStatus) {
+    menuLines.push(<Text key="diagnostics-spacer"> </Text>);
+    menuLines.push(
+      <Text key="diagnostics-status" color={diagnosticsStatus.error ? "red" : dimColor}>
+        {diagnosticsStatus.text}
       </Text>,
     );
   }

--- a/packages/engine/src/server/diagnostics.test.ts
+++ b/packages/engine/src/server/diagnostics.test.ts
@@ -124,6 +124,7 @@ describe("collectDiagnostics", () => {
     const manifest = JSON.parse(new TextDecoder().decode(entries!["manifest.json"]));
     expect(manifest.campaignName).toBe("Test Quest");
     expect(manifest.campaignSlug).toBe("my-campaign");
+    expect(manifest.scope).toBe("campaign");
     expect(typeof manifest.collectedAt).toBe("string");
     expect(manifest.platform).toBe(process.platform);
     // Absolute paths must NOT leak into the bundle.
@@ -177,6 +178,37 @@ describe("collectDiagnostics", () => {
     expect(keys.some((k) => k.startsWith(".debug/"))).toBe(false);
     expect(keys).toContain("campaign/config.json");
     expect(keys).toContain("manifest.json");
+  });
+
+  it("collects machine-level diagnostics without an active campaign", async () => {
+    const fs = makeMemFs({
+      "/home/.debug/engine.jsonl": "{\"event\":\"oauth:error\"}\n",
+      "/home/.debug/server.log": "noisy terminal output",
+      "/home/.debug/context/login.txt": "login context",
+    });
+    const result = await collectDiagnostics(undefined, "/home", fs.io);
+
+    expect(result.ok).toBe(true);
+    expect(result.path!).toMatch(/\/home\/diagnostics\/machine-violet-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.mvdiag$/);
+
+    const entries = unzipBinaryFiles(fs.files.get(norm(result.path!))!)!;
+    expect(Object.keys(entries)).toContain(".debug/engine.jsonl");
+    expect(Object.keys(entries)).toContain(".debug/context/login.txt");
+    expect(Object.keys(entries)).not.toContain(".debug/server.log");
+    expect(Object.keys(entries).some((key) => key.startsWith("campaign/"))).toBe(false);
+
+    const manifest = JSON.parse(new TextDecoder().decode(entries["manifest.json"]));
+    expect(manifest.scope).toBe("application");
+    expect(manifest.campaignName).toBeUndefined();
+    expect(manifest.campaignSlug).toBeUndefined();
+    expect(manifest.homeDir).toBeUndefined();
+  });
+
+  it("returns an error when no campaign or machine-level debug data exists", async () => {
+    const fs = makeMemFs({});
+    const result = await collectDiagnostics(undefined, "/home", fs.io);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/empty|unreadable|nothing/i);
   });
 
   it("returns an error when nothing can be collected", async () => {

--- a/packages/engine/src/server/diagnostics.ts
+++ b/packages/engine/src/server/diagnostics.ts
@@ -9,7 +9,7 @@
  * `server.log` (mirrored stdout/stderr) is intentionally excluded — it's
  * noisy and rarely useful for triage compared with `engine.jsonl`.
  *
- * Output: `<homeDir>/diagnostics/<campaignSlug>-<timestamp>.mvdiag`, or
+ * Output: `<homeDir>/diagnostics/<campaign-name>-<timestamp>.mvdiag`, or
  * `machine-violet-<timestamp>.mvdiag` when collected outside a campaign.
  * (a zip file with a Machine Violet-specific extension for easy
  * recognition in support inboxes — any zip tool can still read it).
@@ -118,7 +118,7 @@ function buildManifest(args: {
  *    top-level context dumps. `server.log` is excluded.
  *  - A `manifest.json` at the root of the archive.
  *
- * The bundle is written to `<homeDir>/diagnostics/<campaignSlug>-<ts>.mvdiag`,
+ * The bundle is written to `<homeDir>/diagnostics/<campaign-name>-<ts>.mvdiag`,
  * or `machine-violet-<ts>.mvdiag` when no campaign is active.
  * If a file with that exact name already exists, the timestamp ensures
  * uniqueness; on collision (sub-second), an extra suffix is appended.

--- a/packages/engine/src/server/diagnostics.ts
+++ b/packages/engine/src/server/diagnostics.ts
@@ -1,15 +1,16 @@
 /**
  * Diagnostic bundle collection.
  *
- * Zips the active campaign folder together with the top-level `.debug/`
- * folder (engine.jsonl, context dumps) into a single archive for triage.
- * The campaign's own per-campaign `.debug/` is captured as part of the
- * campaign walk.
+ * Zips the active campaign folder (when one exists) together with the
+ * top-level `.debug/` folder (engine.jsonl, context dumps) into a single
+ * archive for triage. The campaign's own per-campaign `.debug/` is captured
+ * as part of the campaign walk.
  *
  * `server.log` (mirrored stdout/stderr) is intentionally excluded — it's
  * noisy and rarely useful for triage compared with `engine.jsonl`.
  *
- * Output: `<homeDir>/diagnostics/<campaignSlug>-<timestamp>.mvdiag`
+ * Output: `<homeDir>/diagnostics/<campaignSlug>-<timestamp>.mvdiag`, or
+ * `machine-violet-<timestamp>.mvdiag` when collected outside a campaign.
  * (a zip file with a Machine Violet-specific extension for easy
  * recognition in support inboxes — any zip tool can still read it).
  *
@@ -94,13 +95,14 @@ async function walkForDiagnostics(
  * username).
  */
 function buildManifest(args: {
-  campaignName: string;
-  campaignSlug: string;
+  campaignName?: string;
+  campaignSlug?: string;
 }): string {
   const manifest = {
     collectedAt: new Date().toISOString(),
-    campaignName: args.campaignName,
-    campaignSlug: args.campaignSlug,
+    scope: args.campaignSlug ? "campaign" : "application",
+    ...(args.campaignName ? { campaignName: args.campaignName } : {}),
+    ...(args.campaignSlug ? { campaignSlug: args.campaignSlug } : {}),
     platform: process.platform,
     nodeVersion: process.version,
   };
@@ -109,28 +111,32 @@ function buildManifest(args: {
 
 /**
  * Collect a diagnostics bundle. Includes:
- *  - The current campaign folder (under `campaign/`) — captures per-campaign
- *    `.debug/`, state, config, characters. The campaign's `.git/` is skipped.
+ *  - The current campaign folder (under `campaign/`) when one is active —
+ *    captures per-campaign `.debug/`, state, config, characters. The
+ *    campaign's `.git/` is skipped.
  *  - The top-level `.debug/` folder (under `.debug/`) — engine.jsonl,
  *    top-level context dumps. `server.log` is excluded.
  *  - A `manifest.json` at the root of the archive.
  *
- * The bundle is written to `<homeDir>/diagnostics/<campaignSlug>-<ts>.mvdiag`.
+ * The bundle is written to `<homeDir>/diagnostics/<campaignSlug>-<ts>.mvdiag`,
+ * or `machine-violet-<ts>.mvdiag` when no campaign is active.
  * If a file with that exact name already exists, the timestamp ensures
  * uniqueness; on collision (sub-second), an extra suffix is appended.
  */
 export async function collectDiagnostics(
-  campaignRoot: string,
+  campaignRoot: string | undefined,
   homeDir: string,
   io: ArchiveFileIO,
 ): Promise<DiagnosticsResult> {
   try {
     const fileMap: BinaryFileMap = {};
 
-    // 1. Walk the campaign folder (skips .git).
-    const campaignFiles = await walkForDiagnostics(io, norm(campaignRoot), "");
-    for (const f of campaignFiles) {
-      fileMap[`campaign/${f.relativePath}`] = f.content;
+    // 1. Walk the campaign folder (skips .git) when a session is active.
+    if (campaignRoot) {
+      const campaignFiles = await walkForDiagnostics(io, norm(campaignRoot), "");
+      for (const f of campaignFiles) {
+        fileMap[`campaign/${f.relativePath}`] = f.content;
+      }
     }
 
     // 2. Walk the top-level .debug folder (may not exist in test envs).
@@ -149,10 +155,13 @@ export async function collectDiagnostics(
     }
 
     // 3. Add manifest. Only safe-to-share metadata — no absolute paths.
-    const campaignName = await readCampaignName(norm(campaignRoot), io);
+    const campaignName = campaignRoot
+      ? await readCampaignName(norm(campaignRoot), io)
+      : undefined;
+    const campaignSlug = campaignRoot ? basename(norm(campaignRoot)) : undefined;
     fileMap["manifest.json"] = new TextEncoder().encode(buildManifest({
       campaignName,
-      campaignSlug: basename(norm(campaignRoot)),
+      campaignSlug,
     }));
 
     // 4. Zip.
@@ -166,7 +175,7 @@ export async function collectDiagnostics(
     await io.mkdir(outDir);
 
     const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-    const safeName = sanitizeFilename(campaignName);
+    const safeName = sanitizeFilename(campaignName ?? "machine-violet");
     let zipPath = norm(join(outDir, `${safeName}-${ts}.${BUNDLE_EXT}`));
 
     // Sub-second collision guard.

--- a/packages/engine/src/server/routes/management.test.ts
+++ b/packages/engine/src/server/routes/management.test.ts
@@ -61,12 +61,13 @@ const ARCHIVE_URL = "/campaigns/test-campaign/archive";
 async function buildApp(opts: {
   isBusy?: boolean;
   gameState?: { campaignRoot: string; homeDir: string } | null;
+  campaignsDir?: string;
 } = {}): Promise<FastifyInstance> {
   const app = Fastify();
   app.decorate("configDir", "/tmp/config");
   app.decorate("sessionManager", {
     isBusy: opts.isBusy ?? false,
-    getCampaignsDir: () => "/tmp/campaigns",
+    getCampaignsDir: () => opts.campaignsDir ?? "/tmp/campaigns",
     getGameState: () => opts.gameState ?? null,
   } as never);
   await app.register(managementRoutes);
@@ -118,6 +119,18 @@ describe("PUT /diagnostics — pre-session export", () => {
     expect(collectDiagnosticsMock).toHaveBeenCalledWith(
       "/home/campaigns/test",
       "/home",
+      expect.any(Object),
+    );
+  });
+
+  it("uses SessionManager's canonical home derivation for a trailing slash", async () => {
+    app = await buildApp({ campaignsDir: "/tmp/campaigns/" });
+    const res = await app.inject({ method: "PUT", url: "/diagnostics" });
+
+    expect(res.statusCode).toBe(200);
+    expect(collectDiagnosticsMock).toHaveBeenCalledWith(
+      undefined,
+      norm("/tmp"),
       expect.any(Object),
     );
   });

--- a/packages/engine/src/server/routes/management.test.ts
+++ b/packages/engine/src/server/routes/management.test.ts
@@ -13,12 +13,25 @@ interface ArchiveResult { ok: boolean; zipPath?: string; error?: string }
 // Created via vi.hoisted so they exist before vi.mock's factory (hoisted to the
 // top of the module) references them. Both archive and restore are replaced with
 // controllable deferreds so a concurrent overlap is deterministic.
-const { archiveCampaignMock, pending, unarchiveCampaignMock, pendingRestore } = vi.hoisted(() => {
+const {
+  archiveCampaignMock,
+  pending,
+  unarchiveCampaignMock,
+  pendingRestore,
+  collectDiagnosticsMock,
+} = vi.hoisted(() => {
   const pending: ((v: ArchiveResult) => void)[] = [];
   const archiveCampaignMock = vi.fn(() => new Promise<ArchiveResult>((res) => { pending.push(res); }));
   const pendingRestore: ((v: ArchiveResult) => void)[] = [];
   const unarchiveCampaignMock = vi.fn(() => new Promise<ArchiveResult>((res) => { pendingRestore.push(res); }));
-  return { archiveCampaignMock, pending, unarchiveCampaignMock, pendingRestore };
+  const collectDiagnosticsMock = vi.fn();
+  return {
+    archiveCampaignMock,
+    pending,
+    unarchiveCampaignMock,
+    pendingRestore,
+    collectDiagnosticsMock,
+  };
 });
 
 // Keep the real module (the route relies on the real `archiveDir` for path
@@ -33,6 +46,10 @@ vi.mock("../../config/campaign-archive.js", async (importActual) => {
   };
 });
 
+vi.mock("../diagnostics.js", () => ({
+  collectDiagnostics: collectDiagnosticsMock,
+}));
+
 import { managementRoutes } from "./management.js";
 
 // In-process Fastify inject (no network) but boot can blow the 5s default
@@ -41,17 +58,82 @@ vi.setConfig({ testTimeout: 30_000 });
 
 const ARCHIVE_URL = "/campaigns/test-campaign/archive";
 
-async function buildApp(opts: { isBusy?: boolean } = {}): Promise<FastifyInstance> {
+async function buildApp(opts: {
+  isBusy?: boolean;
+  gameState?: { campaignRoot: string; homeDir: string } | null;
+} = {}): Promise<FastifyInstance> {
   const app = Fastify();
   app.decorate("configDir", "/tmp/config");
   app.decorate("sessionManager", {
     isBusy: opts.isBusy ?? false,
     getCampaignsDir: () => "/tmp/campaigns",
+    getGameState: () => opts.gameState ?? null,
   } as never);
   await app.register(managementRoutes);
   await app.ready();
   return app;
 }
+
+describe("PUT /diagnostics — pre-session export", () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    collectDiagnosticsMock.mockReset();
+    collectDiagnosticsMock.mockResolvedValue({
+      ok: true,
+      path: "/tmp/diagnostics/machine-violet.mvdiag",
+    });
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it("collects machine-level diagnostics when no game state exists", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "PUT", url: "/diagnostics" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      ok: true,
+      path: "/tmp/diagnostics/machine-violet.mvdiag",
+    });
+    expect(collectDiagnosticsMock).toHaveBeenCalledWith(
+      undefined,
+      norm("/tmp"),
+      expect.any(Object),
+    );
+  });
+
+  it("includes the active campaign when a game state exists", async () => {
+    app = await buildApp({
+      gameState: {
+        campaignRoot: "/home/campaigns/test",
+        homeDir: "/home",
+      },
+    });
+    const res = await app.inject({ method: "PUT", url: "/diagnostics" });
+
+    expect(res.statusCode).toBe(200);
+    expect(collectDiagnosticsMock).toHaveBeenCalledWith(
+      "/home/campaigns/test",
+      "/home",
+      expect.any(Object),
+    );
+  });
+
+  it("returns a useful error when collection fails", async () => {
+    collectDiagnosticsMock.mockResolvedValue({
+      ok: false,
+      error: "Nothing to collect",
+    });
+    app = await buildApp();
+    const res = await app.inject({ method: "PUT", url: "/diagnostics" });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().error).toBe("Nothing to collect");
+  });
+});
 
 describe("POST /campaigns/:id/archive — concurrency guard", () => {
   let app: FastifyInstance;

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -6,7 +6,7 @@
  *
  * Prefix: /manage
  */
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { mkdir, rm } from "node:fs/promises";
 import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 import { randomBytes } from "node:crypto";
@@ -32,6 +32,7 @@ import { norm } from "../../utils/paths.js";
 import { loadDiscordSettings, saveDiscordSettings } from "../../config/discord.js";
 import { loadMachineSettings, saveMachineSettings } from "../../config/machine-settings.js";
 import { createArchiveFileIO } from "../fileio.js";
+import { collectDiagnostics } from "../diagnostics.js";
 import {
   IdParams, NameParams, LoginIdParams,
   AddConnectionRequest, ConnectionsListResponse, HealthCheckResponse,
@@ -39,7 +40,7 @@ import {
   ModelsResponse, ArchiveResponse, ArchivedListResponse, RestoreRequest,
   DiscordSettings, MachineSettingsResponse, DeleteInfoResponse, ErrorResponse,
   ChatGptLoginStartResponse, ChatGptLoginStatusResponse,
-  UsageResponse,
+  UsageResponse, DiagnosticsResponse,
 } from "@machine-violet/shared";
 
 export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstance) => {
@@ -553,6 +554,34 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
   // -----------------------------------------------------------------------
 
   const campaignsDir = () => server.sessionManager.getCampaignsDir();
+
+  // -----------------------------------------------------------------------
+  // Diagnostics
+  // -----------------------------------------------------------------------
+
+  /**
+   * Collect diagnostics whether or not a campaign session is active.
+   *
+   * This lives under /manage rather than /session so a player blocked at API
+   * setup or sign-in can still export engine logs. When a session is active,
+   * include that campaign exactly as the gameplay command historically did.
+   */
+  server.put("/diagnostics", {
+    schema: {
+      tags: ["Management"],
+      response: { 200: DiagnosticsResponse, 500: ErrorResponse },
+    },
+  }, async (_request, reply) => {
+    const gs = server.sessionManager.getGameState();
+    const homeDir = gs?.homeDir ?? dirname(campaignsDir());
+    const io = createArchiveFileIO();
+    const result = await collectDiagnostics(gs?.campaignRoot, homeDir, io);
+
+    if (!result.ok || !result.path) {
+      return reply.status(500).send({ error: result.error ?? "Diagnostics collection failed." });
+    }
+    return { ok: true, path: result.path };
+  });
 
   /** Get info for delete confirmation dialog. */
   server.get("/campaigns/:id/delete-info", {

--- a/packages/engine/src/server/routes/management.ts
+++ b/packages/engine/src/server/routes/management.ts
@@ -6,7 +6,7 @@
  *
  * Prefix: /manage
  */
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { mkdir, rm } from "node:fs/promises";
 import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 import { randomBytes } from "node:crypto";
@@ -573,7 +573,9 @@ export const managementRoutes: FastifyPluginAsync = async (server: FastifyInstan
     },
   }, async (_request, reply) => {
     const gs = server.sessionManager.getGameState();
-    const homeDir = gs?.homeDir ?? dirname(campaignsDir());
+    // Match SessionManager's canonical derivation exactly. `dirname()` differs
+    // when campaignsDir has a trailing slash or uses a non-standard layout.
+    const homeDir = gs?.homeDir ?? campaignsDir().replace(/[/\\]campaigns\/?$/, "");
     const io = createArchiveFileIO();
     const result = await collectDiagnostics(gs?.campaignRoot, homeDir, io);
 


### PR DESCRIPTION
## Summary

- add an always-available management diagnostics endpoint
- export machine-level debug logs when no campaign session exists
- expose **Settings -> Export Diagnostics** with progress, success, and error feedback
- route the existing gameplay `/diagnostics` command through the same endpoint
- document and test application-scoped and campaign-scoped bundles

## Root cause

The diagnostics action existed only inside `PlayingPhase`, its REST endpoint rejected requests without an active `GameState`, and the bundle collector required a campaign root. Players blocked during API setup or OAuth sign-in therefore had no in-app path to export the engine logs needed to diagnose that blocker.

## User impact

Diagnostics can now be exported before a provider connection or campaign exists. Pre-session bundles contain only machine-level `.debug` data and never include the configuration directory or credentials. Active-session exports continue to include the current campaign. The intentionally noisy `.debug/server.log` remains excluded.

## Validation

- `npm run typecheck`
- `npm run check` - 207 test files passed; 3,795 tests passed; 14 skipped
- pre-push token stamp and catalog documentation checks

Fixes #720
