### PR TITLE
fix(release): split stable and nightly Homebrew formulas

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -456,7 +456,7 @@ jobs:
           |---|---|
           | Tarball | [`machine-violet-nightly-linux-x64.tar.gz`](https://github.com/REPO_PLACEHOLDER/releases/download/nightly/machine-violet-nightly-linux-x64.tar.gz) |
 
-          Also available via Homebrew: `brew install octopollux/mv-tap/machine-violet`
+          Also available via Homebrew: `brew install octopollux/mv-tap/machine-violet-nightly`
           BODYEOF
           sed -i 's/^          //' nightly-body.md
           sed -i "s|REPO_PLACEHOLDER|${REPO}|g" nightly-body.md
@@ -527,10 +527,12 @@ jobs:
             fi
           done
 
-  update-homebrew:
+  update-homebrew-nightly:
     needs: [prepare, release]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - name: Update Homebrew formula
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -543,58 +545,18 @@ jobs:
           LINUX_SHA=$(curl -fsSL "$LINUX_URL" | sha256sum | cut -d' ' -f1)
 
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/octopollux/homebrew-mv-tap.git" tap
+
+          bash scripts/ci/render-homebrew-formula.sh \
+            nightly \
+            "$NIGHTLY_VERSION" \
+            "$DARWIN_URL" \
+            "$DARWIN_SHA" \
+            "$LINUX_URL" \
+            "$LINUX_SHA" \
+            tap/Formula/machine-violet-nightly.rb
+
           cd tap
-
-          cat > Formula/machine-violet.rb << 'FORMULA'
-          class MachineViolet < Formula
-            desc "AI Dungeon Master for tabletop RPGs"
-            homepage "https://github.com/octopollux/machine-violet"
-            version "NIGHTLY_VERSION_PLACEHOLDER"
-            license "MIT"
-
-            on_macos do
-              on_arm do
-                url "https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-darwin-arm64.tar.gz"
-                sha256 "DARWIN_SHA_PLACEHOLDER"
-              end
-            end
-
-            on_linux do
-              on_intel do
-                url "https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-linux-x64.tar.gz"
-                sha256 "LINUX_SHA_PLACEHOLDER"
-              end
-            end
-
-            def install
-              # Install the whole extracted tree. The binary resolves prompts/,
-              # themes/, systems/, worlds/, personalities/, config/, assets/,
-              # the vendored codex/ runtime and node_modules/ (sharp) relative
-              # to its own location, and reads version.json for --version.
-              # Cherry-picking a subset silently breaks those at runtime —
-              # notably ChatGPT sign-in, which spawns codex/vendor/.../bin/codex.
-              libexec.install Dir["*"]
-
-              chmod 0755, libexec/"MachineViolet"
-              # Expose as lowercase `machine-violet` for CLI convention.
-              # A symlink (not write_env_script) keeps process.execPath pointing
-              # into libexec, which is what the colocated asset + codex lookups
-              # resolve against.
-              bin.install_symlink libexec/"MachineViolet" => "machine-violet"
-            end
-
-            test do
-              assert_match "MachineViolet", shell_output("#{bin}/machine-violet --version")
-            end
-          end
-          FORMULA
-
-          sed -i "s/NIGHTLY_VERSION_PLACEHOLDER/${NIGHTLY_VERSION}/g" Formula/machine-violet.rb
-          sed -i "s/DARWIN_SHA_PLACEHOLDER/${DARWIN_SHA}/g" Formula/machine-violet.rb
-          sed -i "s/LINUX_SHA_PLACEHOLDER/${LINUX_SHA}/g" Formula/machine-violet.rb
-          sed -i 's/^          //' Formula/machine-violet.rb
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/machine-violet.rb
-          git diff --cached --quiet && echo "No changes" || (git commit -m "Update machine-violet nightly ($(date -u +%Y-%m-%d))" && git push)
+          git add Formula/machine-violet-nightly.rb
+          git diff --cached --quiet && echo "No changes" || (git commit -m "Update machine-violet-nightly ($(date -u +%Y-%m-%d))" && git push)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -562,3 +562,41 @@ jobs:
             -H "Content-Type: application/json" \
             -d @discord-payload.json \
             "$DISCORD_WEBHOOK"
+
+  update-homebrew-stable:
+    needs: [prep, release]
+    if: needs.prep.outputs.channel == 'stable'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prep.outputs.tag }}
+
+      - name: Update Homebrew formula
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ needs.prep.outputs.tag }}
+          VERSION: ${{ needs.prep.outputs.version }}
+        run: |
+          DARWIN_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/machine-violet-${VERSION}-darwin-arm64.tar.gz"
+          LINUX_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/machine-violet-${VERSION}-linux-x64.tar.gz"
+
+          DARWIN_SHA=$(curl -fsSL "$DARWIN_URL" | sha256sum | cut -d' ' -f1)
+          LINUX_SHA=$(curl -fsSL "$LINUX_URL" | sha256sum | cut -d' ' -f1)
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/octopollux/homebrew-mv-tap.git" tap
+
+          bash scripts/ci/render-homebrew-formula.sh \
+            stable \
+            "$VERSION" \
+            "$DARWIN_URL" \
+            "$DARWIN_SHA" \
+            "$LINUX_URL" \
+            "$LINUX_SHA" \
+            tap/Formula/machine-violet.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/machine-violet.rb
+          git diff --cached --quiet && echo "No changes" || (git commit -m "Update machine-violet stable (${VERSION})" && git push)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Self-contained binary — no runtime, no dependencies. Add an AI provider from t
 | Platform | Recommended | Alternatives |
 |---|---|---|
 | **Windows** | [**Setup.exe**](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Setup.exe) — installs, auto-updates, code-signed | [Portable.zip](https://github.com/octopollux/machine-violet/releases/download/nightly/MachineViolet-nightly-Portable.zip) |
-| **macOS** (Apple Silicon) | `brew install octopollux/mv-tap/machine-violet` | [install script](docs/installation.md#install-script) · [tarball](https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-darwin-arm64.tar.gz) |
-| **Linux** (x64) | `brew install octopollux/mv-tap/machine-violet` | [install script](docs/installation.md#install-script) · [tarball](https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-linux-x64.tar.gz) |
+| **macOS** (Apple Silicon) | `brew install octopollux/mv-tap/machine-violet` (stable) | [nightly formula](docs/installation.md#nightly-channel) · [install script](docs/installation.md#install-script) · [tarball](https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-darwin-arm64.tar.gz) |
+| **Linux** (x64) | `brew install octopollux/mv-tap/machine-violet` (stable) | [nightly formula](docs/installation.md#nightly-channel) · [install script](docs/installation.md#install-script) · [tarball](https://github.com/octopollux/machine-violet/releases/download/nightly/machine-violet-nightly-linux-x64.tar.gz) |
 
 [**Nightlies**](https://github.com/octopollux/machine-violet/releases/tag/nightly) are also available.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,11 +37,39 @@ When it auto-relaunches, Machine Violet uses its **own bundled terminal** (confi
 
 The easiest install. Requires [Homebrew](https://brew.sh/).
 
+#### Stable channel
+
 ```bash
 brew install octopollux/mv-tap/machine-violet
 ```
 
 Then run `machine-violet` in your terminal. Upgrade later with `brew upgrade machine-violet`.
+
+#### Nightly channel
+
+Nightlies track the latest successful build from `main`:
+
+```bash
+brew install octopollux/mv-tap/machine-violet-nightly
+```
+
+Both formulas install the `machine-violet` command and cannot be installed at
+the same time. To switch channels, uninstall the current formula first:
+
+```bash
+# Stable → nightly
+brew uninstall machine-violet
+brew install octopollux/mv-tap/machine-violet-nightly
+
+# Nightly → stable
+brew uninstall machine-violet-nightly
+brew install octopollux/mv-tap/machine-violet
+```
+
+If you installed `machine-violet` before the channels were split, that formula
+tracked nightlies. It now tracks stable; `brew upgrade machine-violet` moves the
+installation to the current stable release. Switch formulas as shown above to
+keep receiving nightlies.
 
 ### Install script
 
@@ -66,7 +94,8 @@ Extract it, then run `./MachineViolet` from the extracted directory.
 
 - **Windows installer** — updates automatically in the background; no action needed.
 - **Windows portable** — re-download the zip and replace your copy.
-- **Homebrew** — `brew upgrade machine-violet`.
+- **Homebrew (stable)** — `brew upgrade machine-violet`.
+- **Homebrew (nightly)** — `brew upgrade machine-violet-nightly`.
 - **Install script** — re-run the `curl … | bash` command.
 - **Tarball** — download the latest tarball and replace the extracted directory.
 
@@ -74,5 +103,6 @@ Extract it, then run `./MachineViolet` from the extracted directory.
 
 - **Windows installer** — remove via *Settings → Apps → Installed apps*, or the Start Menu uninstall shortcut.
 - **Windows portable** — delete the unzipped folder.
-- **Homebrew** — `brew uninstall machine-violet`.
+- **Homebrew (stable)** — `brew uninstall machine-violet`.
+- **Homebrew (nightly)** — `brew uninstall machine-violet-nightly`.
 - **Install script / tarball** — delete the `machine-violet` symlink from `~/.local/bin` and the extracted directory.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -118,4 +118,23 @@ The release UI is kept lean so humans can scan it:
 
 ## Homebrew
 
-The Homebrew tap (`octopollux/homebrew-mv-tap`) currently tracks **nightly** only — the formula is overwritten on each nightly build by [nightly.yml](../.github/workflows/nightly.yml). A stable formula split is planned post-1.0; until then, `brew install octopollux/mv-tap/machine-violet` gets nightlies despite the stable release body advertising it.
+The Homebrew tap (`octopollux/homebrew-mv-tap`) has separate formulas for the
+stable and nightly channels:
+
+| Channel | Formula | Updated by |
+|---|---|---|
+| Stable | `machine-violet` | [release.yml](../.github/workflows/release.yml), after each stable release is published |
+| Nightly | `machine-violet-nightly` | [nightly.yml](../.github/workflows/nightly.yml), after each nightly release is published |
+
+Both workflows render their formula through
+[`scripts/ci/render-homebrew-formula.sh`](../scripts/ci/render-homebrew-formula.sh)
+so their install behavior stays identical. Versions, immutable stable asset
+URLs, rolling nightly URLs, and checksums come from the release being
+published—no application version is hard-coded in the automation.
+
+Both formulas expose the `machine-violet` executable and therefore conflict;
+switching channels requires uninstalling one formula before installing the
+other. The stable formula carries `version_scheme 1` because the unsplit
+formula previously used nightly version strings. This one-time scheme change
+lets existing `machine-violet` installations move onto the stable version
+sequence with a normal `brew upgrade`.

--- a/scripts/ci/render-homebrew-formula.sh
+++ b/scripts/ci/render-homebrew-formula.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 7 ]; then
+  echo "Usage: $0 <stable|nightly> <version> <darwin-url> <darwin-sha> <linux-url> <linux-sha> <output>" >&2
+  exit 2
+fi
+
+CHANNEL="$1"
+VERSION="$2"
+DARWIN_URL="$3"
+DARWIN_SHA="$4"
+LINUX_URL="$5"
+LINUX_SHA="$6"
+OUTPUT="$7"
+
+case "$CHANNEL" in
+  stable)
+    CLASS_NAME="MachineViolet"
+    CONFLICT_NAME="machine-violet-nightly"
+    VERSION_SCHEME="  version_scheme 1"
+    ;;
+  nightly)
+    CLASS_NAME="MachineVioletNightly"
+    CONFLICT_NAME="machine-violet"
+    VERSION_SCHEME=""
+    ;;
+  *)
+    echo "Unknown Homebrew channel: $CHANNEL" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+cat > "$OUTPUT" <<FORMULA
+class ${CLASS_NAME} < Formula
+  desc "AI Dungeon Master for tabletop RPGs"
+  homepage "https://github.com/octopollux/machine-violet"
+  version "${VERSION}"
+${VERSION_SCHEME}
+  license "MIT"
+
+  conflicts_with "${CONFLICT_NAME}", because: "both install the machine-violet executable"
+
+  on_macos do
+    on_arm do
+      url "${DARWIN_URL}"
+      sha256 "${DARWIN_SHA}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "${LINUX_URL}"
+      sha256 "${LINUX_SHA}"
+    end
+  end
+
+  def install
+    # Install the whole extracted tree. The binary resolves prompts/,
+    # themes/, systems/, worlds/, personalities/, config/, assets/,
+    # the vendored codex/ runtime and node_modules/ (sharp) relative
+    # to its own location, and reads version.json for --version.
+    # Cherry-picking a subset silently breaks those at runtime —
+    # notably ChatGPT sign-in, which spawns codex/vendor/.../bin/codex.
+    libexec.install Dir["*"]
+
+    chmod 0755, libexec/"MachineViolet"
+    # Expose as lowercase \`machine-violet\` for CLI convention.
+    # A symlink (not write_env_script) keeps process.execPath pointing
+    # into libexec, which is what the colocated asset + codex lookups
+    # resolve against.
+    bin.install_symlink libexec/"MachineViolet" => "machine-violet"
+  end
+
+  test do
+    assert_match "MachineViolet", shell_output("#{bin}/machine-violet --version")
+  end
+end
+FORMULA


### PR DESCRIPTION
## Summary

- move rolling Homebrew builds to the explicit `machine-violet-nightly` formula
- add a stable-only tap update after stable releases, with versions and immutable asset URLs derived from each release
- render both formulas from one shared script so install behavior cannot drift
- document stable/nightly installation, upgrades, switching, and the one-time Homebrew version-scheme migration

## Why

`machine-violet` currently gets overwritten by every nightly, so the documented stable install path silently installs a rolling build. This change separates the channels while preserving normal upgrades for existing installations.

This is the `main`/nightly portion of #742. The tap bootstrap, `release` branch port, and website label change are prepared separately so the issue is not closed prematurely.

## Validation

- `npm run check` — 207 test files passed; 3,785 tests passed; 14 skipped; lint clean
- pre-push `token-stamp`, catalog docs, and full check passed
- both workflow files parse as YAML
- shared renderer passes `bash -n`
- rendered stable/nightly formulas exactly match the prepared tap bootstrap files
- v1.1.0 stable asset digests match the formula checksums