### PR TITLE
Refresh full-stack golden for setup contract

### DIFF
--- a/packages/test-harness/goldens/fullstack-quickstart.golden.json
+++ b/packages/test-harness/goldens/fullstack-quickstart.golden.json
@@ -4,11 +4,11 @@
     "version": 1,
     "scenario": "fullstack-quickstart",
     "capabilities": {
-      "gpt-5.5": {
-        "imageGeneration": true
+      "claude-opus-5": {
+        "imageGeneration": false
       },
-      "gpt-5.4-mini": {
-        "imageGeneration": true
+      "claude-haiku-4-5-20251001": {
+        "imageGeneration": false
       }
     },
     "entries": [
@@ -17,123 +17,45 @@
         "bucket": "default",
         "ordinal": 0,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 1,
-          "systemHash": "da115edc4689",
+          "systemHash": "8e7a3ee00c37",
           "tools": [
             "finalize_setup",
-            "generate_image",
             "load_world",
             "present_choices",
-            "roll_dice",
-            "set_portrait"
+            "roll_dice"
           ],
           "lastMessagePreview": "I'd like to set up a new campaign."
         },
         "result": {
-          "text": "<center><b>The Curtain Rises</b><br><i>A blank map waits beneath the lamplight.</i></center>\n\nSomewhere beyond the edge of the known world, a door has opened. Tonight, we decide what waits behind it... and who dares cross the threshold.\n\nBut first: every legend needs a name at the table.",
+          "text": "<center><b>◈ WELCOME TO THE ENGINE ◈</b></center>\n\nThe lamps are lit. The dice are still cold in their cup. Somewhere in the dark behind the curtain, a hundred worlds are holding their breath — <i>waiting to be told which one of them gets to be real tonight.</i>\n\nI am your master of ceremonies, your cartographer, your <color=#c060ff>willing conspirator</color>. Between us we will build a place that has never existed, and then we will put you inside it and see what you do.\n\nBut first — the oldest question in storytelling. <b>Who's telling this one with me?</b>\n\nBefore we begin: what should I call you?",
           "toolCalls": [],
           "usage": {
-            "inputTokens": 23401,
-            "outputTokens": 4,
-            "cacheReadTokens": 22912,
-            "cacheCreationTokens": 0,
+            "inputTokens": 2,
+            "outputTokens": 219,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 33253,
             "reasoningTokens": 0
           },
           "stopReason": "end",
           "assistantContent": [
             {
               "type": "text",
-              "text": "<center><b>The Curtain Rises</b><br><i>A blank map waits beneath the lamplight.</i></center>\n\nSomewhere beyond the edge of the known world, a door has opened. Tonight, we decide what waits behind it... and who dares cross the threshold.\n\nBut first: every legend needs a name at the table."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_6tqT3qkLnOxZoUrbuNbptjJ9",
-              "name": "present_choices",
-              "input": {
-                "prompt": "Before we begin — who's at the table tonight?",
-                "choices": [
-                  "◆ Kestrel",
-                  "◆ Mara Vale",
-                  "◆ Roan",
-                  "◆ Wren"
-                ]
-              }
+              "text": "<center><b>◈ WELCOME TO THE ENGINE ◈</b></center>\n\nThe lamps are lit. The dice are still cold in their cup. Somewhere in the dark behind the curtain, a hundred worlds are holding their breath — <i>waiting to be told which one of them gets to be real tonight.</i>\n\nI am your master of ceremonies, your cartographer, your <color=#c060ff>willing conspirator</color>. Between us we will build a place that has never existed, and then we will put you inside it and see what you do.\n\nBut first — the oldest question in storytelling. <b>Who's telling this one with me?</b>\n\nBefore we begin: what should I call you?"
             }
           ]
         },
         "streamDeltas": [
           "<center",
-          ">",
-          "<b",
-          ">The",
-          " Curtain",
-          " R",
-          "ises",
-          "</",
-          "b",
-          ">",
-          "<br",
-          ">",
-          "<i",
-          ">A",
-          " blank",
-          " map",
-          " waits",
-          " beneath",
-          " the",
-          " lam",
-          "pl",
-          "ight",
-          ".</",
-          "i",
-          "></",
-          "center",
-          ">\n\n",
-          "Some",
-          "where",
-          " beyond",
-          " the",
-          " edge",
-          " of",
-          " the",
-          " known",
-          " world",
-          ",",
-          " a",
-          " door",
-          " has",
-          " opened",
-          ".",
-          " Tonight",
-          ",",
-          " we",
-          " decide",
-          " what",
-          " waits",
-          " behind",
-          " it",
-          "...",
-          " and",
-          " who",
-          " da",
-          "res",
-          " cross",
-          " the",
-          " threshold",
-          ".\n\n",
-          "But",
-          " first",
-          ":",
-          " every",
-          " legend",
-          " needs",
-          " a",
-          " name",
-          " at",
-          " the",
-          " table",
-          "."
+          "><b>◈ WELCOME TO THE ENGINE ◈</b></center>\n\nThe lam",
+          "ps are lit. The dice are still cold in their cup. Somewhere in the dark beh",
+          "ind the curtain, a hundred worlds are holding their breath — <i>waiting to be told which one of them gets to be real t",
+          "onight.</i>\n\nI am your master of ceremonies, your cartographer, your",
+          " <color=#c060ff>willing conspirator</color>. Between us we will build a place",
+          " that has never existed, and then we will put you inside it and see what you do.\n\nBut first — the",
+          " oldest question in storytelling. <b>Who's telling this one with me",
+          "?</b>\n\nBefore we begin: what should I call you?"
         ]
       },
       {
@@ -141,104 +63,80 @@
         "bucket": "default",
         "ordinal": 1,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 3,
-          "systemHash": "da115edc4689",
+          "systemHash": "8e7a3ee00c37",
           "tools": [
             "finalize_setup",
-            "generate_image",
             "load_world",
             "present_choices",
-            "roll_dice",
-            "set_portrait"
+            "roll_dice"
           ],
-          "lastMessagePreview": "[tool_result]"
+          "lastMessagePreview": "Kestrel"
         },
         "result": {
-          "text": "Welcome back, <b>Kestrel</b>. Your seat is waiting, and the shadows already know your name.\n\nNow choose how we raise the curtain: leap toward a waiting world, or build one deliberately from the first spark.",
-          "toolCalls": [],
+          "text": "<color=#44cc44>Kestrel</color>. Good name — sharp, quick, a hunter's name. It'll do nicely in the credits.\n\nOne quick thing before we open the door:",
+          "toolCalls": [
+            {
+              "id": "toolu_01VermBNMtDT7FmfvogytyUZ",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who's this game for?",
+                "choices": [
+                  "◆ Child",
+                  "◆ Teenager",
+                  "◆ Adult"
+                ],
+                "descriptions": [
+                  "A game for a younger player — wonder, warmth, and adventure without the sharp edges.",
+                  "A game for a teen player — real stakes, real consequences, nothing gratuitous.",
+                  "A game for an adult player — the full range of tone, theme, and consequence."
+                ]
+              }
+            }
+          ],
           "usage": {
-            "inputTokens": 23586,
-            "outputTokens": 4,
-            "cacheReadTokens": 22912,
-            "cacheCreationTokens": 0,
+            "inputTokens": 2,
+            "outputTokens": 286,
+            "cacheReadTokens": 15265,
+            "cacheCreationTokens": 18214,
             "reasoningTokens": 0
           },
-          "stopReason": "end",
-          "thinkingText": "**Considering user options**\n\nI need to make sure the user feels welcomed back! I should also give them clear options for choosing between a quick or full response. It’s important to incorporate a tool for this, and I think a theatrical approach could make it more engaging. I want to ensure the presentation feels lively while being functional. Let’s get this set up to enhance the user experience!",
+          "stopReason": "tool_use",
           "assistantContent": [
             {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISngIKhwEIEBgCKkBlCa8NIn4Aa4vf6uU7EaZr1q2P9jopaMRV7tXDilDzEsHvxKMBxBzBRCSqYcGX3UOKpaTTfIXJXSc09AWbG49DMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDE7sB4CPAUYXq6N5cRoM+CkBUsEf4HG/MZhMIjDetJX+rMoRUnWVNVl5IrBsGhlZL3ESc3sp0NqXfNtuE1nx4zBmOLkWIkf1IwQf3BgqRC6j84nyrSHJMPmld1u1u4VYxfuZyqQEBpYhc3otPfUo+YC+KvY1TCv0VHkvPduCb/2KMmbOx+TjeJctNUh0wECuxoymGAE="
+            },
+            {
               "type": "text",
-              "text": "Welcome back, <b>Kestrel</b>. Your seat is waiting, and the shadows already know your name.\n\nNow choose how we raise the curtain: leap toward a waiting world, or build one deliberately from the first spark."
+              "text": "<color=#44cc44>Kestrel</color>. Good name — sharp, quick, a hunter's name. It'll do nicely in the credits.\n\nOne quick thing before we open the door:"
             },
             {
               "type": "tool_use",
-              "id": "call_vFxEy6u7etnC84gJIB58BeaA",
+              "id": "toolu_01VermBNMtDT7FmfvogytyUZ",
               "name": "present_choices",
               "input": {
-                "prompt": "How shall we begin?",
+                "prompt": "Who's this game for?",
                 "choices": [
-                  "◆ <b>Quick Start</b>",
-                  "◆ <b>Full Campaign Setup</b>",
-                  "◆ Show me some more ideas"
+                  "◆ Child",
+                  "◆ Teenager",
+                  "◆ Adult"
                 ],
                 "descriptions": [
-                  "Choose from a generous slate of ready-to-play worlds; I’ll shape the rest around your pick.",
-                  "Build the setting, tone, rules, scope, and storyteller voice together.",
-                  "See alternate ways to begin the campaign."
+                  "A game for a younger player — wonder, warmth, and adventure without the sharp edges.",
+                  "A game for a teen player — real stakes, real consequences, nothing gratuitous.",
+                  "A game for an adult player — the full range of tone, theme, and consequence."
                 ]
               }
             }
           ]
         },
         "streamDeltas": [
-          "Welcome",
-          " back",
-          ",",
-          " ",
-          "<b",
-          ">K",
-          "est",
-          "rel",
-          "</",
-          "b",
-          ">.",
-          " Your",
-          " seat",
-          " is",
-          " waiting",
-          ",",
-          " and",
-          " the",
-          " shadows",
-          " already",
-          " know",
-          " your",
-          " name",
-          ".\n\n",
-          "Now",
-          " choose",
-          " how",
-          " we",
-          " raise",
-          " the",
-          " curtain",
-          ":",
-          " leap",
-          " toward",
-          " a",
-          " waiting",
-          " world",
-          ",",
-          " or",
-          " build",
-          " one",
-          " deliberately",
-          " from",
-          " the",
-          " first",
-          " spark",
-          "."
+          "<color=#44cc44>Kestrel</color>",
+          ". Good name — sharp, quick, a hunter's name.",
+          " It'll do nicely in the credits.\n\nOne quick thing before we open the door:"
         ]
       },
       {
@@ -246,93 +144,83 @@
         "bucket": "default",
         "ordinal": 2,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 5,
-          "systemHash": "da115edc4689",
+          "systemHash": "8e7a3ee00c37",
           "tools": [
             "finalize_setup",
-            "generate_image",
             "load_world",
             "present_choices",
-            "roll_dice",
-            "set_portrait"
+            "roll_dice"
           ],
           "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "Then let chance strike the match.\n\nTen worlds turn slowly beneath the spotlight. Choose the one whose gravity catches you.",
-          "toolCalls": [],
+          "text": "Noted. The full instrument, then — <i>all the strings, including the low ones.</i>\n\nNow. Three doors stand before you, Kestrel. Behind two of them, worlds I've already built and kept in jars. Behind the third — <color=#c060ff>nothing at all yet</color>, because that one is yours to describe, and I will build it from raw material while you watch.",
+          "toolCalls": [
+            {
+              "id": "toolu_01RpHpPeQA7BU25HUua3s4v8",
+              "name": "present_choices",
+              "input": {
+                "prompt": "How do you want to begin?",
+                "choices": [
+                  "✦ Quick Start",
+                  "✦ Full Campaign Setup",
+                  "✦ <color=#c060ff>Describe a game you want to play</color>"
+                ],
+                "descriptions": [
+                  "Fast and clean. Pick a world from the shelf, pick who you are, and we're playing in a handful of questions. I'll fill in the rest with good taste.",
+                  "The long, luxurious version. Genre, mood, difficulty, the voice that narrates you, the rules that bind you, the character down to the bone. We build it together, piece by piece.",
+                  "Bring me anything. A heist on a generation ship. A cozy witch running a tea shop. 1970s occult noir in a rain-soaked city. Any premise you can dream up — say it, and I will construct the whole world around it from scratch."
+                ]
+              }
+            }
+          ],
           "usage": {
-            "inputTokens": 23932,
-            "outputTokens": 4,
-            "cacheReadTokens": 23424,
-            "cacheCreationTokens": 0,
+            "inputTokens": 2,
+            "outputTokens": 472,
+            "cacheReadTokens": 33479,
+            "cacheCreationTokens": 322,
             "reasoningTokens": 0
           },
-          "stopReason": "end",
+          "stopReason": "tool_use",
           "assistantContent": [
             {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISggIKhwEIEBgCKkA/F0KVcadkL/F1yAP9wD45QDMV7BSjfnXHJoXnM793q6YjA2KyKJ/eeww3586IIZkfUzG/PQSeNsBzEaWh0IV2Mg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDEALUtsdKZPk3UTNaBoM+/AXY1ffxWjcvYcoIjCu/kzghQ6I0022eJ+sAQPXpd9l4BfLhKsgu1Jmh5orCzR4duboGMiyDrLn3nSPBbsqKKBvSQbFYeA5ip2V3B8RMGkEFE3RP/pdaIESs3SNBCJ1OWPVmZdTtqgYAQ=="
+            },
+            {
               "type": "text",
-              "text": "Then let chance strike the match.\n\nTen worlds turn slowly beneath the spotlight. Choose the one whose gravity catches you."
+              "text": "Noted. The full instrument, then — <i>all the strings, including the low ones.</i>\n\nNow. Three doors stand before you, Kestrel. Behind two of them, worlds I've already built and kept in jars. Behind the third — <color=#c060ff>nothing at all yet</color>, because that one is yours to describe, and I will build it from raw material while you watch."
             },
             {
               "type": "tool_use",
-              "id": "call_rmxj8X0hNP1nFq0DqgZylkNs",
+              "id": "toolu_01RpHpPeQA7BU25HUua3s4v8",
               "name": "present_choices",
               "input": {
-                "prompt": "Which world calls your name?",
+                "prompt": "How do you want to begin?",
                 "choices": [
-                  "◆ <b>Heirloom</b>",
-                  "◆ <b>Route 0</b>",
-                  "◆ <b>Ghosts of Station Proxima</b>",
-                  "◆ <b>Fallow</b>",
-                  "◆ <b>Palimpsest</b>",
-                  "◆ <b>The Salt Wedding</b>",
-                  "◆ <b>Decommissioned</b>",
-                  "◆ <b>The Long Patience</b>",
-                  "◆ <b>The Bureau of Forgotten Things</b>",
-                  "◆ Show me some more ideas"
+                  "✦ Quick Start",
+                  "✦ Full Campaign Setup",
+                  "✦ <color=#c060ff>Describe a game you want to play</color>"
                 ],
                 "descriptions": [
-                  "Your grandmother's estate includes a house, a fortune, and a locked room with your name on it.",
-                  "A highway absent from every GPS leads to towns that should not exist.",
-                  "An abandoned space station has begun broadcasting again.",
-                  "Magic vanished a century ago. Now it is returning under unfamiliar rules.",
-                  "The city rebuilds itself each night from memories, and yours are leaking in.",
-                  "On the eve of a feud-ending marriage, the bride vanishes as the tide comes in.",
-                  "A retired war machine tries to open a bakery while its old programming objects.",
-                  "Cold War Europe, where secret services bargain with powers older than nations.",
-                  "Lost socks, abandoned dreams, and every misplaced thing arrive here. You work intake.",
-                  "Draw a fresh selection of worlds from beyond the curtain."
+                  "Fast and clean. Pick a world from the shelf, pick who you are, and we're playing in a handful of questions. I'll fill in the rest with good taste.",
+                  "The long, luxurious version. Genre, mood, difficulty, the voice that narrates you, the rules that bind you, the character down to the bone. We build it together, piece by piece.",
+                  "Bring me anything. A heist on a generation ship. A cozy witch running a tea shop. 1970s occult noir in a rain-soaked city. Any premise you can dream up — say it, and I will construct the whole world around it from scratch."
                 ]
               }
             }
           ]
         },
         "streamDeltas": [
-          "Then",
-          " let",
-          " chance",
-          " strike",
-          " the",
-          " match",
-          ".\n\n",
-          "Ten",
-          " worlds",
-          " turn",
-          " slowly",
-          " beneath",
-          " the",
-          " spotlight",
-          ".",
-          " Choose",
-          " the",
-          " one",
-          " whose",
-          " gravity",
-          " catches",
-          " you",
-          "."
+          "Noted. The full instrument, then — ",
+          "<i>all the strings, including the low ones.</i>\n\nNow. Three doors st",
+          "and before you, Kestrel. Behind two of them, worlds I've already built and k",
+          "ept in jars. Behind the third — <color=#c060ff>nothing at all y",
+          "et</color>, because that one is yours to describe, and I will build it from raw material while",
+          " you watch."
         ]
       },
       {
@@ -340,139 +228,100 @@
         "bucket": "default",
         "ordinal": 3,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 7,
-          "systemHash": "da115edc4689",
+          "systemHash": "8e7a3ee00c37",
           "tools": [
             "finalize_setup",
-            "generate_image",
             "load_world",
             "present_choices",
-            "roll_dice",
-            "set_portrait"
+            "roll_dice"
           ],
           "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "The will is read. The keys are counted. And somewhere inside the old house, a lock has just turned by itself.\n\nI’m opening <i>Heirloom</i> now to discover which inheritance has been waiting for you.The papers appear ordinary. The estate does not.\n\nOne last choice before we meet the inheritor.",
-          "toolCalls": [],
-          "usage": {
-            "inputTokens": 24518,
-            "outputTokens": 4,
-            "cacheReadTokens": 3456,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 0
-          },
-          "stopReason": "end",
-          "assistantContent": [
+          "text": "<b>Quick Start.</b> Excellent — a player who wants the story more than the paperwork. I approve.\n\nTell me the shape of the world, and I'll bring you the ones I have in stock.",
+          "toolCalls": [
             {
-              "type": "text",
-              "text": "The will is read. The keys are counted. And somewhere inside the old house, a lock has just turned by itself.\n\nI’m opening <i>Heirloom</i> now to discover which inheritance has been waiting for you."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_3umto8XUcLM4e1gzr3TcJJ0D",
-              "name": "load_world",
-              "input": {
-                "slug": "heirloom"
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_yDavRQh03q9vbBjibjcgQzbv",
-              "name": "roll_dice",
-              "input": {
-                "expression": "1d7",
-                "reason": "Resolve Heirloom's hidden inheritance"
-              }
-            },
-            {
-              "type": "text",
-              "text": "The will is read. The keys are counted. And somewhere inside the old house, a lock has just turned by itself.\n\nI’m opening <i>Heirloom</i> now to discover which inheritance has been waiting for you.The papers appear ordinary. The estate does not.\n\nOne last choice before we meet the inheritor."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_KmofSTfMjJagdHrft5C0gvgA",
+              "id": "toolu_01WgSSgEHBdAoMyJNxXtievx",
               "name": "present_choices",
               "input": {
-                "prompt": "Do you want images in your game? (you can change this in game settings later)",
+                "prompt": "What kind of world?",
                 "choices": [
-                  "◆ Yes",
-                  "◆ No"
+                  "▸ <color=#44cc44>Classic Fantasy</color> — swords, crowns, old magic",
+                  "▸ <color=#4488ff>Science Fiction</color> — cold vacuum and stranger things",
+                  "▸ <color=#cc4444>Horror</color> — something is wrong and getting worse",
+                  "▸ <color=#cc8844>Modern Supernatural</color> — the world you know, with cracks in it",
+                  "▸ <color=#ffcc44>Mystery & Noir</color> — a case, a lie, a room that doesn't add up",
+                  "▸ <color=#c060ff>Comedy & the Absurd</color> — the universe as a bureaucratic prank",
+                  "▸ <color=#88cccc>Post-Apocalyptic</color> — after the end, still walking",
+                  "▸ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Kingdoms, wilds, and the old tales that have teeth. Heroism optional but available.",
+                  "Stations, ships, deep time, and the long dark between the lights.",
+                  "Dread that builds. The kind of story where the question isn't whether, but when.",
+                  "Coffee shops and highways and apartment buildings — and the thing living in the walls of them.",
+                  "Evidence, motive, rain on pavement. You are the one who notices what nobody else did.",
+                  "Reality has a help desk and it is understaffed. Laughter as a survival mechanism.",
+                  "The world ended and somehow that wasn't the last chapter. Something is still growing.",
+                  "A different set of doors entirely."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 655,
+            "cacheReadTokens": 33801,
+            "cacheCreationTokens": 501,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISgwIKhwEIEBgCKkCsJsy5WM5w0LRAvJ8ayRHyiDatbwxObV1llD7f+m6lCtzGoAoNRimNGqCQufXTm0bi+feSTrx1GUz8EZkAgMsdMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDNGkdL9i35cVWhL5QhoMfbhTSJIxLBd3Rv7MIjC+egROT2nHz8hKkixWxq9l/2pC8IbxMIJlMs6bMGLl1qM0gys3Iw8Op5cD3mUnkDUqKchJ8wsTYpVsW/lOUix7J8+l6WKStTObc1ymCUC+Z+ZYNhi+csUKip22GAE="
+            },
+            {
+              "type": "text",
+              "text": "<b>Quick Start.</b> Excellent — a player who wants the story more than the paperwork. I approve.\n\nTell me the shape of the world, and I'll bring you the ones I have in stock."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01WgSSgEHBdAoMyJNxXtievx",
+              "name": "present_choices",
+              "input": {
+                "prompt": "What kind of world?",
+                "choices": [
+                  "▸ <color=#44cc44>Classic Fantasy</color> — swords, crowns, old magic",
+                  "▸ <color=#4488ff>Science Fiction</color> — cold vacuum and stranger things",
+                  "▸ <color=#cc4444>Horror</color> — something is wrong and getting worse",
+                  "▸ <color=#cc8844>Modern Supernatural</color> — the world you know, with cracks in it",
+                  "▸ <color=#ffcc44>Mystery & Noir</color> — a case, a lie, a room that doesn't add up",
+                  "▸ <color=#c060ff>Comedy & the Absurd</color> — the universe as a bureaucratic prank",
+                  "▸ <color=#88cccc>Post-Apocalyptic</color> — after the end, still walking",
+                  "▸ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Kingdoms, wilds, and the old tales that have teeth. Heroism optional but available.",
+                  "Stations, ships, deep time, and the long dark between the lights.",
+                  "Dread that builds. The kind of story where the question isn't whether, but when.",
+                  "Coffee shops and highways and apartment buildings — and the thing living in the walls of them.",
+                  "Evidence, motive, rain on pavement. You are the one who notices what nobody else did.",
+                  "Reality has a help desk and it is understaffed. Laughter as a survival mechanism.",
+                  "The world ended and somehow that wasn't the last chapter. Something is still growing.",
+                  "A different set of doors entirely."
                 ]
               }
             }
           ]
         },
         "streamDeltas": [
-          "The",
-          " will",
-          " is",
-          " read",
-          ".",
-          " The",
-          " keys",
-          " are",
-          " counted",
-          ".",
-          " And",
-          " somewhere",
-          " inside",
-          " the",
-          " old",
-          " house",
-          ",",
-          " a",
-          " lock",
-          " has",
-          " just",
-          " turned",
-          " by",
-          " itself",
-          ".\n\n",
-          "I",
-          "’m",
-          " opening",
-          " ",
-          "<i",
-          ">",
-          "He",
-          "ir",
-          "loom",
-          "</",
-          "i",
-          ">",
-          " now",
-          " to",
-          " discover",
-          " which",
-          " inheritance",
-          " has",
-          " been",
-          " waiting",
-          " for",
-          " you",
-          ".",
-          "The",
-          " papers",
-          " appear",
-          " ordinary",
-          ".",
-          " The",
-          " estate",
-          " does",
-          " not",
-          ".\n\n",
-          "One",
-          " last",
-          " choice",
-          " before",
-          " we",
-          " meet",
-          " the",
-          " inher",
-          "itor",
-          "."
+          "<b>Quick Start.</b> Excellent — a player who wants the story",
+          " more than the paperwork. I approve.\n\nTell me the shape of the world,",
+          " and I'll bring you the ones I have in stock."
         ]
       },
       {
@@ -480,93 +329,107 @@
         "bucket": "default",
         "ordinal": 4,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 9,
-          "systemHash": "da115edc4689",
+          "systemHash": "8e7a3ee00c37",
           "tools": [
             "finalize_setup",
-            "generate_image",
             "load_world",
             "present_choices",
-            "roll_dice",
-            "set_portrait"
+            "roll_dice"
           ],
-          "lastMessagePreview": "[tool_result] [tool_result] [tool_result]"
+          "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "Now, <b>Kestrel</b>... who inherited the estate?\n\nGive me your character’s <b>name</b> and a <b>one-sentence concept</b>: who they are, and what complicated history they had with Grandmother.",
-          "toolCalls": [],
+          "text": "<color=#cc4444>Horror</color>. <i>Good.</i> The genre where the engine does its finest work — because dread is made of patience, and I have nothing but time.\n\nHere's what's on the shelf. Take your time with these; each one is a different flavor of <i>wrong</i>.",
+          "toolCalls": [
+            {
+              "id": "toolu_013foYqNgQf2Lxejf5ic5YMY",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Which nightmare?",
+                "choices": [
+                  "◇ Congregation",
+                  "◇ Beneath the Skin",
+                  "◇ The Tenant",
+                  "◇ Route 0",
+                  "◇ Lighthouse",
+                  "◇ The Replacement",
+                  "◇ Graveyard Shift",
+                  "◇ Hollowdeep",
+                  "◇ The Interstitial",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A new church appeared in town last week. Nobody can remember what was there before — and nobody finds that strange except you.",
+                  "People in town are acting different. Not wrong, exactly. Just... different. They're kinder now. They sleep better. They'd like you to join them.",
+                  "Your body has a subletter. They use it while you sleep, they're tidier than you, and they leave notes on the fridge. Horror, modern, and blackly funny.",
+                  "A highway that doesn't appear on GPS. Diners, motels, gift shops, and the long American dark between exits that don't exist.",
+                  "You maintain a beacon at the edge of known space. A ship is coming — from the wrong direction, from somewhere there is nothing to come from.",
+                  "You came home to find someone living your life. They're better at it. Your friends prefer them. Your keys don't work.",
+                  "Night security at a museum. The exhibits are not where you left them, and the building has more floors after midnight.",
+                  "A mining town's deepest shaft broke into something old. The company wants production resumed by Monday.",
+                  "The space between radio stations is inhabited. It has always been inhabited. Lately it has started addressing you by name."
+                ]
+              }
+            }
+          ],
           "usage": {
-            "inputTokens": 24480,
-            "outputTokens": 137,
-            "cacheReadTokens": 2432,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 77
+            "inputTokens": 2,
+            "outputTokens": 715,
+            "cacheReadTokens": 34302,
+            "cacheCreationTokens": 744,
+            "reasoningTokens": 0
           },
-          "stopReason": "end",
-          "thinkingText": "**Clarifying campaign details**\n\nI want to continue exploring the character name concept, even though there's no image. I should confirm the configuration. The campaign is called Heirloom, and there won't be player forks. The genre seems to be sci-fi mystery with a balanced mood and difficulty. The scope looks small, and the system is null. I'm considering the DM being Archivist or Mission Control. There's a secret ship that the player isn't aware of, but I must keep the public premise under wraps. I need to ask about the character.",
+          "stopReason": "tool_use",
           "assistantContent": [
             {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISgAIKhwEIEBgCKkASa1I1wu50nATwueIGAARfGdWMOFOoeXGcnm8E3fQ/b9vCgqq89pJfnT57nzA02uc6xkL0TgiU7d4bcLwH0SA4Mg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDBu7U/kkrDpLVG9mNRoMf1r+z4oHyG8YnBI/IjDosVJgdunz2a2q4XxnM++LkN5ISjhZpEsDbBuBcZegrA7rFcFTHlccm+Rd9l0IgTgqJvQXjIfut2GZfwJlxJlhDpazW8xXNUZylmoUxT3xMWCMtm6w+X7tGAE="
+            },
+            {
               "type": "text",
-              "text": "Now, <b>Kestrel</b>... who inherited the estate?\n\nGive me your character’s <b>name</b> and a <b>one-sentence concept</b>: who they are, and what complicated history they had with Grandmother."
+              "text": "<color=#cc4444>Horror</color>. <i>Good.</i> The genre where the engine does its finest work — because dread is made of patience, and I have nothing but time.\n\nHere's what's on the shelf. Take your time with these; each one is a different flavor of <i>wrong</i>."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_013foYqNgQf2Lxejf5ic5YMY",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Which nightmare?",
+                "choices": [
+                  "◇ Congregation",
+                  "◇ Beneath the Skin",
+                  "◇ The Tenant",
+                  "◇ Route 0",
+                  "◇ Lighthouse",
+                  "◇ The Replacement",
+                  "◇ Graveyard Shift",
+                  "◇ Hollowdeep",
+                  "◇ The Interstitial",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A new church appeared in town last week. Nobody can remember what was there before — and nobody finds that strange except you.",
+                  "People in town are acting different. Not wrong, exactly. Just... different. They're kinder now. They sleep better. They'd like you to join them.",
+                  "Your body has a subletter. They use it while you sleep, they're tidier than you, and they leave notes on the fridge. Horror, modern, and blackly funny.",
+                  "A highway that doesn't appear on GPS. Diners, motels, gift shops, and the long American dark between exits that don't exist.",
+                  "You maintain a beacon at the edge of known space. A ship is coming — from the wrong direction, from somewhere there is nothing to come from.",
+                  "You came home to find someone living your life. They're better at it. Your friends prefer them. Your keys don't work.",
+                  "Night security at a museum. The exhibits are not where you left them, and the building has more floors after midnight.",
+                  "A mining town's deepest shaft broke into something old. The company wants production resumed by Monday.",
+                  "The space between radio stations is inhabited. It has always been inhabited. Lately it has started addressing you by name."
+                ]
+              }
             }
           ]
         },
         "streamDeltas": [
-          "Now",
-          ",",
-          " ",
-          "<b",
-          ">K",
-          "est",
-          "rel",
-          "</",
-          "b",
-          ">",
-          "...",
-          " who",
-          " inherited",
-          " the",
-          " estate",
-          "?\n\n",
-          "Give",
-          " me",
-          " your",
-          " character",
-          "’s",
-          " ",
-          "<b",
-          ">",
-          "name",
-          "</",
-          "b",
-          ">",
-          " and",
-          " a",
-          " ",
-          "<b",
-          ">",
-          "one",
-          "-s",
-          "entence",
-          " concept",
-          "</",
-          "b",
-          ">:",
-          " who",
-          " they",
-          " are",
-          ",",
-          " and",
-          " what",
-          " complicated",
-          " history",
-          " they",
-          " had",
-          " with",
-          " Grand",
-          "mother",
-          "."
+          "<color=#cc4444>Horror</color>. <i>Good.</i> The gen",
+          "re where the engine does its finest work — because dread is made",
+          " of patience, and I have nothing but time.\n\nHere's what's on the shelf. Take your",
+          " time with these; each one is a different flavor of <i>wrong</i>."
         ]
       },
       {
@@ -574,320 +437,1224 @@
         "bucket": "default",
         "ordinal": 5,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 11,
-          "systemHash": "da115edc4689",
+          "systemHash": "8e7a3ee00c37",
           "tools": [
             "finalize_setup",
-            "generate_image",
             "load_world",
             "present_choices",
-            "roll_dice",
-            "set_portrait"
+            "roll_dice"
           ],
-          "lastMessagePreview": "Kestrel, a tight-lipped locksmith and Grandmother's estranged apprentice, the only one who still knows the old house's l"
+          "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "<center><b>Heirloom</b></center>\n\nA <color=#cc4444>mysterious science-fantasy</color> tale with a balanced mood and difficulty, unfolding across <i>A Few Sessions</i>. <b>The Archivist</b> will narrate with precise, increasingly unsettling detail. Play will be purely narrative, without dice or mechanics, and images are off.\n\nYou’ll play <color=#44cc44>Kestrel</color>, a tight-lipped locksmith and Grandmother’s estranged apprentice, the only person who still understands the old house’s locks.\n\nSound good, or would you like to change anything?",
-          "toolCalls": [],
+          "text": "",
+          "toolCalls": [
+            {
+              "id": "toolu_01Ak9ev21uF1BPYXQEXKPAqz",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Which nightmare?",
+                "choices": [
+                  "◇ Congregation",
+                  "◇ Beneath the Skin",
+                  "◇ The Tenant",
+                  "◇ Route 0",
+                  "◇ Lighthouse",
+                  "◇ The Replacement",
+                  "◇ Graveyard Shift",
+                  "◇ Hollowdeep",
+                  "◇ The Interstitial",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A new church appeared in town last week. Nobody can remember what was there before — and nobody finds that strange except you.",
+                  "People in town are acting different. Not wrong, exactly. Just... different. They're kinder now. They sleep better. They'd like you to join them.",
+                  "Your body has a subletter. They use it while you sleep, they're tidier than you, and they leave notes on the fridge. Horror, modern, and blackly funny.",
+                  "A highway that doesn't appear on GPS. Diners, motels, gift shops, and the long American dark between exits that don't exist.",
+                  "You maintain a beacon at the edge of known space. A ship is coming — from the wrong direction, from somewhere there is nothing to come from.",
+                  "You came home to find someone living your life. They're better at it. Your friends prefer them. Your keys don't work.",
+                  "Night security at a museum. The exhibits are not where you left them, and the building has more floors after midnight.",
+                  "A mining town's deepest shaft broke into something old. The company wants production resumed by Monday.",
+                  "The space between radio stations is inhabited. It has always been inhabited. Lately it has started addressing you by name.",
+                  "A different set of doors entirely."
+                ]
+              }
+            }
+          ],
           "usage": {
-            "inputTokens": 24566,
-            "outputTokens": 231,
-            "cacheReadTokens": 22912,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 92
+            "inputTokens": 2,
+            "outputTokens": 630,
+            "cacheReadTokens": 35046,
+            "cacheCreationTokens": 795,
+            "reasoningTokens": 0
           },
-          "stopReason": "end",
-          "thinkingText": "**Reviewing campaign configuration**\n\nI need to review the full configuration and confirm details. The campaign name is Heirloom, and since there’s no player fork, I won’t add a suffix. For the genre, mystery sci-fi seems fitting, with a hidden secret about a ship. The mood and difficulty should be balanced, focusing on a few narrative sessions. The DM’s personality could be like an Archivist or Raconteur. I need to check if the character name Kestrel, which might conflict with the player, is acceptable. Lastly, I should ensure the premise keeps the secret hidden.",
+          "stopReason": "tool_use",
           "assistantContent": [
             {
-              "type": "text",
-              "text": "<center><b>Heirloom</b></center>\n\nA <color=#cc4444>mysterious science-fantasy</color> tale with a balanced mood and difficulty, unfolding across <i>A Few Sessions</i>. <b>The Archivist</b> will narrate with precise, increasingly unsettling detail. Play will be purely narrative, without dice or mechanics, and images are off.\n\nYou’ll play <color=#44cc44>Kestrel</color>, a tight-lipped locksmith and Grandmother’s estranged apprentice, the only person who still understands the old house’s locks.\n\nSound good, or would you like to change anything?"
+              "type": "tool_use",
+              "id": "toolu_01Ak9ev21uF1BPYXQEXKPAqz",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Which nightmare?",
+                "choices": [
+                  "◇ Congregation",
+                  "◇ Beneath the Skin",
+                  "◇ The Tenant",
+                  "◇ Route 0",
+                  "◇ Lighthouse",
+                  "◇ The Replacement",
+                  "◇ Graveyard Shift",
+                  "◇ Hollowdeep",
+                  "◇ The Interstitial",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A new church appeared in town last week. Nobody can remember what was there before — and nobody finds that strange except you.",
+                  "People in town are acting different. Not wrong, exactly. Just... different. They're kinder now. They sleep better. They'd like you to join them.",
+                  "Your body has a subletter. They use it while you sleep, they're tidier than you, and they leave notes on the fridge. Horror, modern, and blackly funny.",
+                  "A highway that doesn't appear on GPS. Diners, motels, gift shops, and the long American dark between exits that don't exist.",
+                  "You maintain a beacon at the edge of known space. A ship is coming — from the wrong direction, from somewhere there is nothing to come from.",
+                  "You came home to find someone living your life. They're better at it. Your friends prefer them. Your keys don't work.",
+                  "Night security at a museum. The exhibits are not where you left them, and the building has more floors after midnight.",
+                  "A mining town's deepest shaft broke into something old. The company wants production resumed by Monday.",
+                  "The space between radio stations is inhabited. It has always been inhabited. Lately it has started addressing you by name.",
+                  "A different set of doors entirely."
+                ]
+              }
             }
           ]
         },
-        "streamDeltas": [
-          "<center",
-          ">",
-          "<b",
-          ">",
-          "He",
-          "ir",
-          "loom",
-          "</",
-          "b",
-          "></",
-          "center",
-          ">\n\n",
-          "A",
-          " ",
-          "<color",
-          "=#",
-          "cc",
-          "444",
-          "4",
-          ">",
-          "m",
-          "yster",
-          "ious",
-          " science",
-          "-f",
-          "ant",
-          "asy",
-          "</",
-          "color",
-          ">",
-          " tale",
-          " with",
-          " a",
-          " balanced",
-          " mood",
-          " and",
-          " difficulty",
-          ",",
-          " unfolding",
-          " across",
-          " ",
-          "<i",
-          ">A",
-          " Few",
-          " Sessions",
-          "</",
-          "i",
-          ">.",
-          " ",
-          "<b",
-          ">The",
-          " Archiv",
-          "ist",
-          "</",
-          "b",
-          ">",
-          " will",
-          " narr",
-          "ate",
-          " with",
-          " precise",
-          ",",
-          " increasingly",
-          " unsettling",
-          " detail",
-          ".",
-          " Play",
-          " will",
-          " be",
-          " purely",
-          " narrative",
-          ",",
-          " without",
-          " dice",
-          " or",
-          " mechanics",
-          ",",
-          " and",
-          " images",
-          " are",
-          " off",
-          ".\n\n",
-          "You",
-          "’ll",
-          " play",
-          " ",
-          "<color",
-          "=#",
-          "44",
-          "cc",
-          "44",
-          ">K",
-          "est",
-          "rel",
-          "</",
-          "color",
-          ">,",
-          " a",
-          " tight",
-          "-l",
-          "ipped",
-          " locksmith",
-          " and",
-          " Grand",
-          "mother",
-          "’s",
-          " estr",
-          "anged",
-          " apprentice",
-          ",",
-          " the",
-          " only",
-          " person",
-          " who",
-          " still",
-          " understands",
-          " the",
-          " old",
-          " house",
-          "’s",
-          " locks",
-          ".\n\n",
-          "Sound",
-          " good",
-          ",",
-          " or",
-          " would",
-          " you",
-          " like",
-          " to",
-          " change",
-          " anything",
-          "?"
-        ]
+        "streamDeltas": []
       },
       {
         "kind": "chat",
         "bucket": "default",
         "ordinal": 6,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 13,
-          "systemHash": "da115edc4689",
+          "systemHash": "8e7a3ee00c37",
           "tools": [
             "finalize_setup",
-            "generate_image",
             "load_world",
             "present_choices",
-            "roll_dice",
-            "set_portrait"
+            "roll_dice"
           ],
-          "lastMessagePreview": "Looks good — let's begin."
+          "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "The configuration is confirmed. The house keeps its counsel, the final seal breaks, and the first key turns.The inheritance is yours, Kestrel.\n\nMay every lock surrender its truth.\n\n---",
-          "toolCalls": [],
+          "text": "Not these, then. <i>Fine.</i> I keep the stranger jars on the lower shelf.",
+          "toolCalls": [
+            {
+              "id": "toolu_019HLL133gFpGU9TXeuSAuk3",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Try these instead",
+                "choices": [
+                  "◇ The Bloom",
+                  "◇ Exit Wounds",
+                  "◇ Deep Tenancy",
+                  "◇ The Second Labyrinth",
+                  "◇ Ho Ho Hollow",
+                  "◇ Heirloom",
+                  "◇ Palimpsest",
+                  "◇ HOA from Hell",
+                  "◇ Inkblot",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "The apocalypse was beautiful. Flowers everywhere, in every color there is and several there aren't. They haven't stopped growing. They aren't going to.",
+                  "A support group for people who survived encounters with the supernatural. Coffee, folding chairs, honesty rules — and one member is lying about what happened to them.",
+                  "A generation ship lost in time. The voyage has been longer than the records allow, and the records have been edited by someone still aboard.",
+                  "The minotaur's maze was a prison. Beneath it is the thing the prison was actually built to contain, and the maze was only ever the lid.",
+                  "The big-box store seals at midnight on Christmas Eve, and the old dark of the season comes in through the seams. One night to survive, armed with clearance merchandise.",
+                  "Your grandmother's estate includes a house, a fortune, and a locked room with your name on the door — written in her hand, decades before you were born.",
+                  "The city rebuilds itself every night out of the memories of its sleepers. Lately yours are leaking in, and strangers are living in your childhood.",
+                  "The neighborhood bylaws are getting stranger. Section 12 concerns the correct height of a hedge. Section 40 concerns what may be buried beneath it. Compliance is mandatory.",
+                  "A dead artist's final painting has a story to tell, and it would very much like to tell it to you, at length, from the inside.",
+                  "One more pass at the shelves."
+                ]
+              }
+            }
+          ],
           "usage": {
-            "inputTokens": 25341,
-            "outputTokens": 21,
-            "cacheReadTokens": 24448,
-            "cacheCreationTokens": 0,
+            "inputTokens": 2,
+            "outputTokens": 762,
+            "cacheReadTokens": 35841,
+            "cacheCreationTokens": 650,
             "reasoningTokens": 0
           },
-          "stopReason": "end",
+          "stopReason": "tool_use",
           "assistantContent": [
             {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISjQIKhwEIEBgCKkDFI3u36ai8xhhnBUADAzp096Evb1ILy+GrGFkhwsJdwZekX3ctvJpNwu20k0RHZZLvoAJSSmMTZKok/MnAgLvWMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDFC/f5SjDr7cTcczlxoMfWXyY0PUnDrAbzaPIjDACLhHcXmwx6k5u4EvvRk5z3hRARVe7AXFYxRRSlFPXGIBcHgX/E/pSs6ReUbL5sgqM+IIY2cuzlL/Z2hdvcWCLAuyeYb/vvTAWgt3RUiWSZbQ2pfKPOPp2RSQxqfMO43UCIYhCxgB"
+            },
+            {
               "type": "text",
-              "text": "The configuration is confirmed. The house keeps its counsel, the final seal breaks, and the first key turns."
+              "text": "Not these, then. <i>Fine.</i> I keep the stranger jars on the lower shelf."
             },
             {
               "type": "tool_use",
-              "id": "call_jaU4OLN8dMtzmwH09L5p1Iep",
-              "name": "finalize_setup",
+              "id": "toolu_019HLL133gFpGU9TXeuSAuk3",
+              "name": "present_choices",
               "input": {
-                "age_group": "adult",
-                "campaign_detail": "Keep the estate grounded and plausible at first. Let its deeper nature emerge through Kestrel's expert reading of locks, mechanisms, alterations, and details that outsiders would miss.",
-                "campaign_name": "Heirloom",
-                "campaign_premise": "Kestrel has inherited Grandmother's old estate: a house, a fortune, and a locked room bearing Kestrel's name. As the estranged apprentice who alone understands the house's locks, Kestrel must reckon with an inheritance engineered to reveal itself one mechanism at a time.",
-                "campaign_scope": "few-sessions",
-                "character_description": "A tight-lipped locksmith and Grandmother's estranged apprentice, the only one who still knows the old house's locks.",
-                "character_details": "Kestrel's defining expertise is locksmithing and intimate knowledge of the estate's old mechanisms. Their estrangement from Grandmother should carry unresolved personal weight.",
-                "character_name": "Kestrel",
-                "difficulty": "Balanced",
-                "dm_personality": "The Archivist",
-                "fork_selections": {
-                  "house-secret": "the-ship"
-                },
-                "genre": "science-fantasy mystery",
-                "handoff_note": "The player described Kestrel in their own words as 'a tight-lipped locksmith and Grandmother's estranged apprentice, the only one who still knows the old house's locks.' Treat that competence as real: clues hidden in locks, tool marks, wards, keys, and mechanisms should be legible to Kestrel without making them struggle for basic professional knowledge. The estrangement is the emotional hinge; reveal Grandmother through what she built, protected, and deliberately left for Kestrel. Begin restrained and evidentiary, allowing the impossible to intrude through precise physical details.",
-                "image_generation": "off",
-                "mood": "Balanced",
-                "player_name": "Kestrel",
-                "world_slug": "heirloom"
+                "prompt": "Try these instead",
+                "choices": [
+                  "◇ The Bloom",
+                  "◇ Exit Wounds",
+                  "◇ Deep Tenancy",
+                  "◇ The Second Labyrinth",
+                  "◇ Ho Ho Hollow",
+                  "◇ Heirloom",
+                  "◇ Palimpsest",
+                  "◇ HOA from Hell",
+                  "◇ Inkblot",
+                  "◇ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "The apocalypse was beautiful. Flowers everywhere, in every color there is and several there aren't. They haven't stopped growing. They aren't going to.",
+                  "A support group for people who survived encounters with the supernatural. Coffee, folding chairs, honesty rules — and one member is lying about what happened to them.",
+                  "A generation ship lost in time. The voyage has been longer than the records allow, and the records have been edited by someone still aboard.",
+                  "The minotaur's maze was a prison. Beneath it is the thing the prison was actually built to contain, and the maze was only ever the lid.",
+                  "The big-box store seals at midnight on Christmas Eve, and the old dark of the season comes in through the seams. One night to survive, armed with clearance merchandise.",
+                  "Your grandmother's estate includes a house, a fortune, and a locked room with your name on the door — written in her hand, decades before you were born.",
+                  "The city rebuilds itself every night out of the memories of its sleepers. Lately yours are leaking in, and strangers are living in your childhood.",
+                  "The neighborhood bylaws are getting stranger. Section 12 concerns the correct height of a hedge. Section 40 concerns what may be buried beneath it. Compliance is mandatory.",
+                  "A dead artist's final painting has a story to tell, and it would very much like to tell it to you, at length, from the inside.",
+                  "One more pass at the shelves."
+                ]
               }
-            },
-            {
-              "type": "text",
-              "text": "The configuration is confirmed. The house keeps its counsel, the final seal breaks, and the first key turns.The inheritance is yours, Kestrel.\n\nMay every lock surrender its truth.\n\n---"
             }
           ]
         },
         "streamDeltas": [
-          "The",
-          " configuration",
-          " is",
-          " confirmed",
-          ".",
-          " The",
-          " house",
-          " keeps",
-          " its",
-          " counsel",
-          ",",
-          " the",
-          " final",
-          " seal",
-          " breaks",
-          ",",
-          " and",
-          " the",
-          " first",
-          " key",
-          " turns",
-          ".",
-          "The",
-          " inheritance",
-          " is",
-          " yours",
-          ",",
-          " K",
-          "est",
-          "rel",
-          ".\n\n",
-          "May",
-          " every",
-          " lock",
-          " surrender",
-          " its",
-          " truth",
-          ".\n\n",
-          "---"
+          "Not these, then. <i>Fine.</i> I",
+          " keep the stranger jars on the lower shelf."
         ]
       },
       {
         "kind": "chat",
-        "bucket": "theme-styler",
-        "ordinal": 0,
+        "bucket": "default",
+        "ordinal": 7,
         "request": {
-          "model": "gpt-5.4-mini",
-          "messageCount": 1,
-          "systemHash": "d4bd76e9804b",
-          "tools": [],
-          "lastMessagePreview": "Request: rain-dark inherited country estate, restrained archival mystery, oxidized brass and cold teal accents, late aft"
+          "model": "claude-opus-5",
+          "messageCount": 15,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
         },
         "result": {
-          "text": "{\"theme\":\"palimpsest\",\"key_color\":\"#5b7f7a\"}",
+          "text": "<b><u>Heirloom</u></b>. Oh, <i>lovely</i> choice — the horror of inheritance, which is the only horror everyone eventually experiences.\n\n<quote>Your name on the door.<br>In her hand.<br>Written before you were born.</quote>\n\nLet me open the deed box.",
+          "toolCalls": [
+            {
+              "id": "toolu_018zZp3NS7aFTGcVzJWwtMSc",
+              "name": "load_world",
+              "input": {
+                "slug": "heirloom"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 160,
+            "cacheReadTokens": 36491,
+            "cacheCreationTokens": 779,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAIS+QEKhwEIEBgCKkBlSgodvNxnET7xUMHcpPb4nK01NOH9mIBggg+m9w0MbNPqWUCmlm2TZLQ6KTI3h53xJ9IYI368mVHeBDuppcQpMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDEslbvpuYKjYxlXcRhoM8H2T2aRdKoAuOKm3IjCmQUPXZqshOT43BNm50AehHKe5TTSmogH0UzdARq7WqTEoI35OiIs7Y4xu0WeUlaAqH9JuxbLhWGbJCyi4/CKRUz3Bp99lT46+lAd7g2+QIdQYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "<b><u>Heirloom</u></b>. Oh, <i>lovely</i> choice — the horror of inheritance, which is the only horror everyone eventually experiences.\n\n<quote>Your name on the door.<br>In her hand.<br>Written before you were born.</quote>\n\nLet me open the deed box."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_018zZp3NS7aFTGcVzJWwtMSc",
+              "name": "load_world",
+              "input": {
+                "slug": "heirloom"
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<b><u>Heirloom</u></b>. Oh, <i>l",
+          "ovely</i> choice — the horror of inheritance, which is the only horror ever",
+          "yone eventually experiences.\n\n<quote>Your name on the door.",
+          "<br>In her hand.<br>Written before you were born.</quote>\n\nLet me open the deed box",
+          "."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 8,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 17,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "The lawyer's file has a second folder beneath the first. I'll read that one privately.",
+          "toolCalls": [
+            {
+              "id": "toolu_019Ji2zvpSyA7y3z11ghnPzd",
+              "name": "roll_dice",
+              "input": {
+                "expression": "1d7",
+                "reason": "house-secret fork"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 250,
+            "cacheReadTokens": 37270,
+            "cacheCreationTokens": 885,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAIS7QQKhwEIEBgCKkAwZvbPmNbSHxOj+Lfco412EHkp2SC9/i8TcM0FfB6Lcnfs500SfZ9rMqQxJS6iGEzCFxlNP4/Vl3m8EXOL23vCMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDIKWOnfUCBVVv7qA/BoMyaoncAUf5d2bMoVdIjBJgHKBrTCvaOHVmSbANlNTqlrTvJ1xbP2/Ie1E4ynVF9gmr1To1EtQChSkTD0OZ7YqkgP2H4pHM2bSK0UbXJFFjTznlSj3/f4SFDOEc1VvcXITKJFxgpMkNcytRgAeOLJrrSNZqTh8gJQRHtX0o0FTL4vuAIrmrMS5ZlfSd36wqd1/nSymPQiaujnI2q7EYTLf3ru0s0ni4QQI7J2eJjTXXthJiPZ0doRb1ZWPTZRM/QQQ0NirqhAA5kRz9HwvAP8rcvCE7JI5gijgHbRi9VGs/6hofN+3tqRr9ehCvjA4tPFEJJhQevmBnHq+iAtTfusmo7b57Nbt//exfPUQBw5WTxbVEhlGPImQIokCVVc3JkP/RLUd4ZgQcO2TwasqyMURkBSYiiRRepuRhM5JsmmUhhabuohke8FWeLNM4pZiEkT8WQMHXPQjIDG503eiDwUvX5BZyehBvI+3MrzBNGX41wj4JOWkjezT02cQh3JZzFna9lnA6j7r/hdkGHxbjuOKPMAPSFnA5pKgc8n14Dry1cyIuD7uCpWBsxCQ11Fnk3TZsg6rpPVXgz6Du9fsJE6F+lWTn6JFbRcNSEl4aQKPpjZJ7xcYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "The lawyer's file has a second folder beneath the first. I'll read that one privately."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_019Ji2zvpSyA7y3z11ghnPzd",
+              "name": "roll_dice",
+              "input": {
+                "expression": "1d7",
+                "reason": "house-secret fork"
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "The lawyer's file has a second folder be",
+          "neath the first. I'll read that one privately."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 9,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 19,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "The deed is signed. The keys are cold. <i>I know what's behind the door now, and I'm not going to tell you.</i>\n\n<center><b>◈ HEIRLOOM ◈</b><br><i>An old house. A locked room. Your name on it.</i></center>\n\nHow long should this haunting last?",
+          "toolCalls": [
+            {
+              "id": "toolu_01J5t7nMBEdNGpT4zDrwxnpG",
+              "name": "present_choices",
+              "input": {
+                "prompt": "How long do you want to live in this house?",
+                "choices": [
+                  "▸ One-Shot",
+                  "▸ A Few Sessions",
+                  "▸ Grand Campaign",
+                  "▸ Open-Ended",
+                  "▸ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A single evening. You arrive, you find the room, you open it. One night, all the way to the bottom.",
+                  "A small arc — two to four sessions. Room to wander the house, meet the neighbors, and let the dread compound before the answer arrives.",
+                  "The long form. Many sessions. The house gives up its secrets an inch at a time, and there are more of them than you'd like.",
+                  "No fixed destination. You simply live here now, and the house keeps going. A living place rather than a plot with an ending."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 978,
+            "cacheReadTokens": 38155,
+            "cacheCreationTokens": 266,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISpw4KhwEIEBgCKkAlbn55R+wKe4zoeK6NmEBPBUVYO6TswHyPuxxiFramobMO6kaIPvS/wAOXzPeymH2D4LHAdIluyuTHMtKYAEIaMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDN4NegoUIFRXeYPFcxoM2SRb80qs9RXVHMUmIjAZ3u04DKTJ4w/uReCMtx9FeGgKpYnoUn2Ggw60v1pld5mir1iEQZpIHhJ3tI5miYIqzAwKZ9mwNE76m0RAdQu7voP48eRSmn7JBRgWAj76HT/1g+xPfHogD4OxttFn6o7c3/M2c74iBZEfmPmxAtEDN29MF1Uq8EcIC5DUv8mZn5DFSTXJ5ZYZ7xIJEWcgOHufz8f5RC1OIef5HXKi91RwqPBhAwwymkTkfFt3BB+8NcIUXV5TfIDWQpW8LtXDEWg6DIkvv7xmJq8DAycrWNwcQZybvQ3I/JFdnX4fq09wg8SpNI0/96KRFjxwIm1MWQienz891Q/fBfcZrX8zIfS2VLf/W3DywnokPy8/cE0QHaBz5Bj7pzMf6Po1Sml2WyQz8LxWNKGjNhblAv6s3rvocZLnienD3MXMyldBlCJ68c2uPABxDS2EZ/tKk92vZk6fU9z+NK+AGVGxGbyYlJtMu8lE+GdwPW7KxBZYrK60wyVLOu+uudBDJobWc8dG2xAWOKfWS/gpkufqUittztWqCK9A0GFcCI+YwS+smc9q/6lzqBVl0M/5PgxJuQ18kI+vM/KWItrLCuByKZYy1Q0OzMVENVSPa2ollZehzStYAmsHEZ/z2xuwJIEfoQW5igxlVTR3huXFquFu18LY17aCs3IxYqwnIvpgXyI+Vf8PgMIOfRSBQlx79yvuqrjI05xSQuVSAjhScYv4CQHFEkwWMAqdQAgHo+pAYjybEI+J+zHn8Jip6hDq5FwOJL1K9BMy2RVZzk+7vdk2pSuBvW2jeNPD46iykSbYVUBKklS0w9MgzkkN7LrayDiH/FWzmEUwQYAlV7uvm4Egc52Hp4HKEyCh6L1jhV4NzFMr3ChhA6B68pCLQ2tPSgJvW+YBGuyGtVSPv56WrTtZrmdehj7wFgEgU4z0/GIujnVdkBvm0FF0FwYyjYZLxQr79R5xPQjbJMtjMDl43KQGTpyLGdc/jGsozF2oUXaBgt8k7FI/T2ItjP7lM9FVROF4x4oPL2LlU+EXAmTK8PLwZVGIhFfDZL70pmw5FDZZhsSacw6pI7IpwyRVjq/u57S1BUVFP1DJv8Kw6sHs4taS/l9YSV73g7u0s2FlLSCNOQEz1N1GTnQXkDvsQONS/vS49pp5CnEn4WmUnjfqtaMAFQB7r0Ktiyh+nA9OCLYLIB5tGGYdjYzCaiQuSESBoM6uozqEv13hJrhEate53l4ctum7+XRODE4AV2ueEcGMvidBzyuiCSXBWZ/f5wJE2oy+WbuGsWwNipQYCTMkHQxIlObP+RnaGmCOea1Rq0l9t3GbW8IpKclaOVI0za4x5K1JcpqlSiM7GGqUJsFb6iMZEmB4NhDCWMLh3rMMw9ynnrcVbG7MLkvouJNyZu24XSi+uuD+lI4JdWVIb6qW7XV/P7R1C05dLLwDDNPaJjKIg3DcihV8y6q6imH51FiV3cq5BnP6GAfeVvapUmKMr6tX+eAIzbjBfeaRIzZvgeLeAW+LSe6323eULm+3VBjr0Lq1xipwxuiwJblJytHwbgxlxSAjutzYZHa0ayyg1DBXVl+vt7mh7EaPZDV+TCfMTUtEdCeV0bjkxzW1mP+3ZpUENbdHXaSOJoplPnMOb96q8Q+QNVGonDwuLeA9sp+DfqBeHVPr9avPtH5ZxeX8Uvb/J4om7IO+9OJLjq5RU4SoDrzgEQZcL0Hbdd7dj8pSK/1sXrMLzs6klyXhCc7qwhvlcdYJ54XzyWucWxyDM6m1fKRq9v+nQaXzS4nVTnNTB5RGqaMG91RXVNE+kqzneR2fXScsfqy2zjpjV7D9UUh3es9dSLBnKWNT9XbjyM4E2Hpr8gdVX2a94/9DEPMdAOprrQTgg82TLg0X6r6Oc0EItHBtSVmtLA1J4uRQy9WMhYJZQ+1skVgpxpiVEN3g3lJogxod3X5AcTLDb4n8UgbUhyY8rBjXbCGFAHXuIapO7/h5b6h7/UUQvPmVXWBgflky3MxbV5GjcZo/vJsGgTpppHUfdqdn7tS/4KQh82HWLVy5nkwiAsWWxAzH8sYL6t19zXrN+L2t9PAzaC5f0hBXh5ju8Vk32IKXQ8cdfQ4zpt52rQldAy0kbV7eebR464YzswE+yqOFi+pFS4+ftIq9Hj8pZDkOCMTM/V/0Neitcs+BgM1K/5M5YP6fW8Buf2h1XoxqnP64l2Y/AVvvCdAtYi3lv/pHGAE="
+            },
+            {
+              "type": "text",
+              "text": "The deed is signed. The keys are cold. <i>I know what's behind the door now, and I'm not going to tell you.</i>\n\n<center><b>◈ HEIRLOOM ◈</b><br><i>An old house. A locked room. Your name on it.</i></center>\n\nHow long should this haunting last?"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01J5t7nMBEdNGpT4zDrwxnpG",
+              "name": "present_choices",
+              "input": {
+                "prompt": "How long do you want to live in this house?",
+                "choices": [
+                  "▸ One-Shot",
+                  "▸ A Few Sessions",
+                  "▸ Grand Campaign",
+                  "▸ Open-Ended",
+                  "▸ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A single evening. You arrive, you find the room, you open it. One night, all the way to the bottom.",
+                  "A small arc — two to four sessions. Room to wander the house, meet the neighbors, and let the dread compound before the answer arrives.",
+                  "The long form. Many sessions. The house gives up its secrets an inch at a time, and there are more of them than you'd like.",
+                  "No fixed destination. You simply live here now, and the house keeps going. A living place rather than a plot with an ending."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "The deed is signed. The keys are cold",
+          ". <i>I know what's behind the door now, and I'm not going to tell you.</i>\n\n<center",
+          "><b>◈ HEIRLOOM ◈</b><br><i>An old house. A locked room.",
+          " Your name on it.</i></center>\n\nHow long should this haunting last?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 10,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 21,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "",
+          "toolCalls": [
+            {
+              "id": "toolu_01A5Qsaa1utRLsGbGJfYpG2X",
+              "name": "present_choices",
+              "input": {
+                "prompt": "How long do you want to live in this house?",
+                "choices": [
+                  "▸ One-Shot",
+                  "▸ A Few Sessions",
+                  "▸ Grand Campaign",
+                  "▸ Open-Ended"
+                ],
+                "descriptions": [
+                  "A single evening. You arrive, you find the room, you open it. One night, all the way to the bottom.",
+                  "A small arc — two to four sessions. Room to wander the house, meet the neighbors, and let the dread compound before the answer arrives.",
+                  "The long form. Many sessions. The house gives up its secrets an inch at a time, and there are more of them than you'd like.",
+                  "No fixed destination. You simply live here now, and the house keeps going. A living place rather than a plot with an ending."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 322,
+            "cacheReadTokens": 38421,
+            "cacheCreationTokens": 1050,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "tool_use",
+              "id": "toolu_01A5Qsaa1utRLsGbGJfYpG2X",
+              "name": "present_choices",
+              "input": {
+                "prompt": "How long do you want to live in this house?",
+                "choices": [
+                  "▸ One-Shot",
+                  "▸ A Few Sessions",
+                  "▸ Grand Campaign",
+                  "▸ Open-Ended"
+                ],
+                "descriptions": [
+                  "A single evening. You arrive, you find the room, you open it. One night, all the way to the bottom.",
+                  "A small arc — two to four sessions. Room to wander the house, meet the neighbors, and let the dread compound before the answer arrives.",
+                  "The long form. Many sessions. The house gives up its secrets an inch at a time, and there are more of them than you'd like.",
+                  "No fixed destination. You simply live here now, and the house keeps going. A living place rather than a plot with an ending."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": []
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 11,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 23,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<b>A few sessions.</b> Enough rope to hang the dread properly.\n\nNow the most important choice you'll make, Kestrel — <i>the voice.</i> Someone has to stand at your shoulder in that house and tell you what you're looking at. They are not all equally kind.",
+          "toolCalls": [
+            {
+              "id": "toolu_01FmE9eFx7K3fGifJeLcC2uY",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>The Investigator</b>",
+                  "◆ <b>The Reading Hour</b>",
+                  "◆ <b>The Librarian</b>",
+                  "◆ <b>The Docent</b>",
+                  "◆ <b>The Dreamer</b>",
+                  "◆ <b>The Raconteur</b>",
+                  "◆ <b>The Chronicler</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Present-tense and precise, reading every room the way a detective reads a crime scene — for what's out of place. Lays the evidence at your feet and never explains it away. A specialist in slow-building dread.",
+                  "Unhurried, thoughtful British cadence — the world read aloud like a well-loved book by the fire. Delight in small details, a steady hand through the dark turns, and never, ever talks down to you.",
+                  "Quiet authority and dry wit. Treats knowledge as treasure and ignorance as the real danger. Will not hand you an answer you could dig up yourself — but will leave the seam visible so you can pry.",
+                  "Warm, patient, fascinated by the ordinary. Reveals a place through its craft and habits — the wax pooled under the candles, the worn place on the stair rail. Horror that grows out of a lived-in house.",
+                  "Surreal and synesthetic. A corridor is also a throat; sounds have colors; things are true because they feel true. The most intense, fully-committed voice here — choose it on purpose.",
+                  "Theatrical relish and rich vocabulary. Every scene gets a flourish, every arrival has presence, and the loaded thing is shown to the audience long before it goes off.",
+                  "A balanced, adaptive storyteller. No strong accent of its own — it simply serves the story well.",
+                  "A different set of voices."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 949,
+            "cacheReadTokens": 39471,
+            "cacheCreationTokens": 341,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAIStAQKhwEIEBgCKkCqlu/BFTKpBhKR1Cc+4/qeL377qqjdM2/axOwew5spQQiPRu/Af4n1GIQduQFEcJNSnWla02EMObwPnRjNeL98Mg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDGhKp1SfOKtmQap9CBoMrPcp1WaoIHlPKgdwIjBcM0v9mBA0+WZtltUBPFoRAFEAplsIjrAtq3gCuYUZnjk2c5cimVDkmZc4A1RuWQwq2QJPajfpvw5/xk23jWcNkTP5OX0NqJ2H71wyNtYp3NfKNfEe3OSOGFevMcf+yea6v0bhpMnnROtiI3grJCIAIz0PvCPyP3G6OV0q1JB/OjxMjO42L6i161Ab+33at07OhAIaq+MEVz/t1fU1aw6QD70UPhIEm8K0eWMdaggWZGDNkDIWANyXAVRKcgAL+J6vES8pqy2ZPc6PoIuHfqfG8xRiALipcIac8S9RD0MHl8zmuttMPsA6zz5TSqtVajMtonMg/jLqj48m+ZkgxDnjwDuIbeqQG+cvuvdnflTkpt/1hSXMJzj+H4vnEuoQhFLHtg3Pq+41zNxCwPsvuutJeutfkKoqu8xZziaSbIc52wu/cWcnGHlP7ZmHeZ5B3hr036v3xtqdD4JgmG/qP6yZoVQ681HEB+5A4nkBK/R5fMrTRa4W9PkKD79V43kyCDJrE0FFQgVWxAXC45gYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "<b>A few sessions.</b> Enough rope to hang the dread properly.\n\nNow the most important choice you'll make, Kestrel — <i>the voice.</i> Someone has to stand at your shoulder in that house and tell you what you're looking at. They are not all equally kind."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01FmE9eFx7K3fGifJeLcC2uY",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>The Investigator</b>",
+                  "◆ <b>The Reading Hour</b>",
+                  "◆ <b>The Librarian</b>",
+                  "◆ <b>The Docent</b>",
+                  "◆ <b>The Dreamer</b>",
+                  "◆ <b>The Raconteur</b>",
+                  "◆ <b>The Chronicler</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "Present-tense and precise, reading every room the way a detective reads a crime scene — for what's out of place. Lays the evidence at your feet and never explains it away. A specialist in slow-building dread.",
+                  "Unhurried, thoughtful British cadence — the world read aloud like a well-loved book by the fire. Delight in small details, a steady hand through the dark turns, and never, ever talks down to you.",
+                  "Quiet authority and dry wit. Treats knowledge as treasure and ignorance as the real danger. Will not hand you an answer you could dig up yourself — but will leave the seam visible so you can pry.",
+                  "Warm, patient, fascinated by the ordinary. Reveals a place through its craft and habits — the wax pooled under the candles, the worn place on the stair rail. Horror that grows out of a lived-in house.",
+                  "Surreal and synesthetic. A corridor is also a throat; sounds have colors; things are true because they feel true. The most intense, fully-committed voice here — choose it on purpose.",
+                  "Theatrical relish and rich vocabulary. Every scene gets a flourish, every arrival has presence, and the loaded thing is shown to the audience long before it goes off.",
+                  "A balanced, adaptive storyteller. No strong accent of its own — it simply serves the story well.",
+                  "A different set of voices."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<b>A few sessions.</b>",
+          " Enough rope to hang the dread properly.\n\nNow the most important choice you",
+          "'ll make, Kestrel — <i>the voice.</i> Someone has to stand at your shoulder in",
+          " that house and tell you what you're looking at. They are not all equally",
+          " kind."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 12,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 25,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "The lower shelf again. <i>You have expensive taste.</i> Some of these I keep for myself.",
+          "toolCalls": [
+            {
+              "id": "toolu_019cN9Ns5ooqKfgNjjJziUtJ",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>The Executor</b>",
+                  "◆ <b>The Appraiser</b>",
+                  "◆ <b>The Inheritance</b>",
+                  "◆ <b>The Last Neighbour</b>",
+                  "◆ <b>RECAP</b>",
+                  "◆ <b>The Naturalist</b>",
+                  "◆ <b>Neon Noir</b>",
+                  "◆ <b>The Stage Manager</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A probate solicitor with too many files and a headache. Narrates the house as an itemized estate — every room a schedule, every horror an unresolved clause. Dry, precise, faintly apologetic, and increasingly unwilling to come inside with you.",
+                  "Cold, appreciative, mercenary. Values everything it sees — the walnut sideboard, the water damage, the thing under the water damage. Horror delivered in the register of a valuation report, and it never once flinches at the numbers.",
+                  "The house itself, speaking softly and in the second person. It has been waiting a long time. It is fond of you. It would like you to stay, and it will describe itself very beautifully while making that case.",
+                  "An old voice from the next property over, who remembers your grandmother and remembers more than she should. Gossipy, kind, and full of things she says she shouldn't say — then says anyway.",
+                  "A malfunctioning archive system reconstructing corrupted records. Sterile confidence, swapped names, [DATA CORRUPTED] tags, timeline errors. Trying very hard to be accurate. Isn't.",
+                  "The world is the main character. Rich ecology, specific birdsong, creatures with real appetites and instincts — the fantastical grounded firmly in biology.",
+                  "Hardboiled cadence. Short sentences. Wet pavement, bad decisions, and the specific quality of 3 AM silence in a house that isn't yours yet.",
+                  "Knows this is a production. References scenes, lighting, props — the seams show, but the emotions are entirely real."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 1089,
+            "cacheReadTokens": 39812,
+            "cacheCreationTokens": 969,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISggcKhwEIEBgCKkCdUK6ArfbbGWKulwOjvG9C1T0uU9StdldY9I46fXDMt0r5mimqZKULYNT8AbeJE2se+OeUIJSzCucfAR00VpH1Mg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDPGV95Utc3MsQmAKbBoM6OUwyvV7Oa9IWJLhIjBUimz1YD3Out+C++TDp4RkgsL0U+NIb15lWV/mYc2wNZ5CebnjfyWB6kQOpH0fJHoqpwUJ6TAw7QU6+ghZ+M7DmDNj8rmZzKoXZpokjVPXK1nx7DmQGPWPmx+QSQFpqJS2WtwTAcYcS0FjbHNIRvg2hOovg892FcI59BKlZP5HOYPFp/jg621U8kmSPIU6KHTLHDGbq+plnyv4OyUj4suEzTx1DcsUvpOkdVNtl9IZ2WFNTY8XDWEic7EKMX3NhsxyHZ6YRJ/1akx99JNAL5GnGEUEl+DglqOwe8sttdEHaodlpYLP+XyhsmMphy+NY/FbFHclzmOhIQe57LJgaTF2vUV/bJfTT0wQsAnexh+/HNskyJY9T12kECdTM/ehqPM78g2He/dhGfP5CSbe6apYvvC8IAFNsBwdDtjQKyvxQh9LJw0oNg8ooxZyA+ejJUnVLnrxBwBCvIUuxeOQsdYDSiDfxlR1ZJmeFf3wwvpJpqqF1R/jvtpwYda2onDSTalIUAlMb7AxkOwDcAxds5VuR/RpLLzh/dsZcsmtPQTScFSt0je6FELt/cETzJpAyDoypTMYN5fX1GfFf6oGUXfQwkK7cszy9TfZ09UFa2tgXaPxT1MAxTsYNt4iMWIz78Ux33UHXEp79Pzic5FpxjazftdZiK1WAes5D0HTHJr1i1pl4ujNWWa1Qrj2Uh15/VdlQpDo2Vu6woeqOIMVdd1zkVzJTWTP9j8QXuWZ5Dra0crfwtW15CA6Womv92jluJ1WK8BpiA5qEVmdYxAz1B6r8E67z4v2AGexrnXKKkWYprzmQjhxEji4ctkq9UhqMHk4W64eNcDgupyTa5hdmx7QF4EXcbL0wNeWx3gwHeKrObch7fAalwsWyKV5SU+RZSvmz3hX0Rl6V1BmnbB/e3abFR6UAcavTXVyrPgZ9QDAytXRdXV8WvsggLPmxLlcdbOFtOgP50HSg715GAE="
+            },
+            {
+              "type": "text",
+              "text": "The lower shelf again. <i>You have expensive taste.</i> Some of these I keep for myself."
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_019cN9Ns5ooqKfgNjjJziUtJ",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>The Executor</b>",
+                  "◆ <b>The Appraiser</b>",
+                  "◆ <b>The Inheritance</b>",
+                  "◆ <b>The Last Neighbour</b>",
+                  "◆ <b>RECAP</b>",
+                  "◆ <b>The Naturalist</b>",
+                  "◆ <b>Neon Noir</b>",
+                  "◆ <b>The Stage Manager</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A probate solicitor with too many files and a headache. Narrates the house as an itemized estate — every room a schedule, every horror an unresolved clause. Dry, precise, faintly apologetic, and increasingly unwilling to come inside with you.",
+                  "Cold, appreciative, mercenary. Values everything it sees — the walnut sideboard, the water damage, the thing under the water damage. Horror delivered in the register of a valuation report, and it never once flinches at the numbers.",
+                  "The house itself, speaking softly and in the second person. It has been waiting a long time. It is fond of you. It would like you to stay, and it will describe itself very beautifully while making that case.",
+                  "An old voice from the next property over, who remembers your grandmother and remembers more than she should. Gossipy, kind, and full of things she says she shouldn't say — then says anyway.",
+                  "A malfunctioning archive system reconstructing corrupted records. Sterile confidence, swapped names, [DATA CORRUPTED] tags, timeline errors. Trying very hard to be accurate. Isn't.",
+                  "The world is the main character. Rich ecology, specific birdsong, creatures with real appetites and instincts — the fantastical grounded firmly in biology.",
+                  "Hardboiled cadence. Short sentences. Wet pavement, bad decisions, and the specific quality of 3 AM silence in a house that isn't yours yet.",
+                  "Knows this is a production. References scenes, lighting, props — the seams show, but the emotions are entirely real."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "The lower shelf again. <i>You have expens",
+          "ive taste.</i> Some of these I keep for myself."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 13,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 27,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "",
+          "toolCalls": [
+            {
+              "id": "toolu_018pvMC4HRD8msphPFphCg9S",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>The Executor</b>",
+                  "◆ <b>The Appraiser</b>",
+                  "◆ <b>The Inheritance</b>",
+                  "◆ <b>The Last Neighbour</b>",
+                  "◆ <b>RECAP</b>",
+                  "◆ <b>The Naturalist</b>",
+                  "◆ <b>Neon Noir</b>",
+                  "◆ <b>The Stage Manager</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A probate solicitor with too many files and a headache. Narrates the house as an itemized estate — every room a schedule, every horror an unresolved clause. Dry, precise, faintly apologetic, and increasingly unwilling to come inside with you.",
+                  "Cold, appreciative, mercenary. Values everything it sees — the walnut sideboard, the water damage, the thing under the water damage. Horror delivered in the register of a valuation report, and it never once flinches at the numbers.",
+                  "The house itself, speaking softly and in the second person. It has been waiting a long time. It is fond of you. It would like you to stay, and it will describe itself very beautifully while making that case.",
+                  "An old voice from the next property over, who remembers your grandmother and remembers more than she should. Gossipy, kind, and full of things she says she shouldn't say — then says anyway.",
+                  "A malfunctioning archive system reconstructing corrupted records. Sterile confidence, swapped names, [DATA CORRUPTED] tags, timeline errors. Trying very hard to be accurate. Isn't.",
+                  "The world is the main character. Rich ecology, specific birdsong, creatures with real appetites and instincts — the fantastical grounded firmly in biology.",
+                  "Hardboiled cadence. Short sentences. Wet pavement, bad decisions, and the specific quality of 3 AM silence in a house that isn't yours yet.",
+                  "Knows this is a production. References scenes, lighting, props — the seams show, but the emotions are entirely real.",
+                  "One more pass at the voices."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 802,
+            "cacheReadTokens": 40781,
+            "cacheCreationTokens": 1161,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "tool_use",
+              "id": "toolu_018pvMC4HRD8msphPFphCg9S",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>The Executor</b>",
+                  "◆ <b>The Appraiser</b>",
+                  "◆ <b>The Inheritance</b>",
+                  "◆ <b>The Last Neighbour</b>",
+                  "◆ <b>RECAP</b>",
+                  "◆ <b>The Naturalist</b>",
+                  "◆ <b>Neon Noir</b>",
+                  "◆ <b>The Stage Manager</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "A probate solicitor with too many files and a headache. Narrates the house as an itemized estate — every room a schedule, every horror an unresolved clause. Dry, precise, faintly apologetic, and increasingly unwilling to come inside with you.",
+                  "Cold, appreciative, mercenary. Values everything it sees — the walnut sideboard, the water damage, the thing under the water damage. Horror delivered in the register of a valuation report, and it never once flinches at the numbers.",
+                  "The house itself, speaking softly and in the second person. It has been waiting a long time. It is fond of you. It would like you to stay, and it will describe itself very beautifully while making that case.",
+                  "An old voice from the next property over, who remembers your grandmother and remembers more than she should. Gossipy, kind, and full of things she says she shouldn't say — then says anyway.",
+                  "A malfunctioning archive system reconstructing corrupted records. Sterile confidence, swapped names, [DATA CORRUPTED] tags, timeline errors. Trying very hard to be accurate. Isn't.",
+                  "The world is the main character. Rich ecology, specific birdsong, creatures with real appetites and instincts — the fantastical grounded firmly in biology.",
+                  "Hardboiled cadence. Short sentences. Wet pavement, bad decisions, and the specific quality of 3 AM silence in a house that isn't yours yet.",
+                  "Knows this is a production. References scenes, lighting, props — the seams show, but the emotions are entirely real.",
+                  "One more pass at the voices."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": []
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 14,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 29,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "Third pass. <i>Now we're in the drawer I keep locked.</i>\n\n(And remember — you can always simply <b>describe</b> the voice you want, and I'll conjure it.)",
+          "toolCalls": [
+            {
+              "id": "toolu_01TBKoc2WTU2cpD4opXe9f6v",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>Grandmother</b>",
+                  "◆ <b>The Locksmith</b>",
+                  "◆ <b>The Medium</b>",
+                  "◆ <b>The Sleepwalker</b>",
+                  "◆ <b>The Estate Photographer</b>",
+                  "◆ <b>The Romantic</b>",
+                  "◆ <b>Campfire Cowboy</b>",
+                  "◆ <b>The Myth</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "The dead woman herself, narrating in the fond, sharp, slightly impatient voice of a grandmother who left instructions and expects them followed. She loves you. She has not told you everything. She never will, quite.",
+                  "Obsessed with thresholds and mechanisms. Reads the whole world as things that open and things that don't — hinges, wards, tumblers, the specific sound a lock makes when it has been forced from the inside.",
+                  "A voice relaying what it's told by something else, with pauses where it listens. Halting, second-hand, occasionally correcting itself mid-sentence because the other party disagreed.",
+                  "Drifting, tactile, uncertain of the hour. Narrates as though you have both just woken in the wrong room and are being very polite about it. Dread that arrives the way sleep paralysis does.",
+                  "Sees in framed shots and exposure times. Catalogues the estate image by image — and describes, without comment, the things that appear in the photographs but not in the room.",
+                  "Heightened, sensory, unashamed. Charged physical description, delayed tension, sincere commitment to longing — and there is more than one kind of thing in an old house worth wanting.",
+                  "Unhurried warmth and plain language. The world is big and lonesome. Violence is quick and ugly; endings are quiet.",
+                  "Epic register — the cadence of a Greek epic in translation. Inheritance as doom, a house as a hall, your name as an epithet.",
+                  "Keep looking."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 1176,
+            "cacheReadTokens": 41942,
+            "cacheCreationTokens": 822,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISyggKhwEIEBgCKkA6fg+aLBzKK/KZbe/+nMGdW2yw+VY10Des4me/YkCAggDKSzktMWUp7v5xpBTzLYLR+mjj1FaMko7Qptb1JSYdMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDLZJuZNNtGRIGVg27xoMM7ZxGJJORGzTdmT+IjBHkgNj7odQlN6ALkxyKqf4yOnk6cwHR71/UjZMpGINBTovnFGTQzKqW3ReGntk18Uq7wa2Z6EmrHJx4Fis+uVNtGwNfyyquDvB/MM0vBloLD5/v3VwmL9n+2eLojozx36427TdsEXIKZXJLfHOoDDDOC45JKqf/V7wgqQr7/dCJ1LAI0PmzWsHVE+G0EEvlivSIZyubl6tiyC86tz/DHgQHVVbIMUlkMAAqtQJnl4om+OgOXiKcLFKxFrB2bOmMjB43WbvQWudiXpRct6UJJpfHYHrjZDQxqycIeAqk5EXRc6+sy9tqUz7daR0ZdXtNQwFGM6ZYh10Kn4kT6ledn26RPQDIo/HU85C5/5jMPtYzOSeJkwCHnQY7axcSdmLiL6QypwflAiTavtitO3SJLAyB1T8an/o4oD7ctIGDhtBMj40LkPGqZebM0PJ8dC43M8ASuS5+RmLRNbovvU9PWtI9cOspvsV62JiUZOZUoN/zF8HyDFHaoWPfE20EYVlO2WJ7KpACVWYMrlqRuIvPeQ4xSUMhebEAT4Drmy1w9Plhc+EHSL4z7QNdnOmQuHec0cIQ4uzrBN/srLcKoNit7Z8CQ5sQok/dgxLKm8HDbxphA1ymh563dIFaJkFRQMTb5V3NTplyYXzKuRRSvpNSmjQr1/5XgdV2n4Vhx/jKYyGpGYnQM0b2EQLVUkxobrJj2ePdOTsCXAxLmpDOKFh2jUi2AN0Rf59f5nojIiWywDcU7qTz4uyHSUfLGpledE4iROVm2XR4/gYD19BUx0BHVTlhL4cvqY4iJ+myAJLPY0F7rcuOIb4WHMhcn+4r2YNQdgbvj6o+bCfssRalssZz77yjSB8uuWcWl+6o4eMJ75ADtp/sOFFVrmhkDyflOb5BE6KJF92WfFoERwOiHPfUYqoLXpcyAG7hnIA0Q2XK5XfBPo9Q5nU/2dhD0YOMzF/4FZk2UY4oH+4vopkEkmhetTobfJp4eLJhF/8GciF4WdyWcTJFEQhCGfK6ql9mJ6jHtrh0mLbYhUYEw7i8d8MUvO9sJvsKK+NG9jTvVSr6qw4F+cV/zKsBj3aWx1CBjmSrjCgFrffOZgasJNHCRXBFqh/GK5Jtq3mHkgtAuYnmqg2U0n5MjFhYQ9bCHVsVC/LF5/4eFLpw4TuzC5qVKDU/bbpc4GbSWjnsHOkZB597+m7r/rNOp3nt/lZSNM7Di1k5Ve2mwG9LWgKShA4I55jGXrvAcIYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "Third pass. <i>Now we're in the drawer I keep locked.</i>\n\n(And remember — you can always simply <b>describe</b> the voice you want, and I'll conjure it.)"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01TBKoc2WTU2cpD4opXe9f6v",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Who narrates you?",
+                "choices": [
+                  "◆ <b>Grandmother</b>",
+                  "◆ <b>The Locksmith</b>",
+                  "◆ <b>The Medium</b>",
+                  "◆ <b>The Sleepwalker</b>",
+                  "◆ <b>The Estate Photographer</b>",
+                  "◆ <b>The Romantic</b>",
+                  "◆ <b>Campfire Cowboy</b>",
+                  "◆ <b>The Myth</b>",
+                  "◆ Show me some more ideas"
+                ],
+                "descriptions": [
+                  "The dead woman herself, narrating in the fond, sharp, slightly impatient voice of a grandmother who left instructions and expects them followed. She loves you. She has not told you everything. She never will, quite.",
+                  "Obsessed with thresholds and mechanisms. Reads the whole world as things that open and things that don't — hinges, wards, tumblers, the specific sound a lock makes when it has been forced from the inside.",
+                  "A voice relaying what it's told by something else, with pauses where it listens. Halting, second-hand, occasionally correcting itself mid-sentence because the other party disagreed.",
+                  "Drifting, tactile, uncertain of the hour. Narrates as though you have both just woken in the wrong room and are being very polite about it. Dread that arrives the way sleep paralysis does.",
+                  "Sees in framed shots and exposure times. Catalogues the estate image by image — and describes, without comment, the things that appear in the photographs but not in the room.",
+                  "Heightened, sensory, unashamed. Charged physical description, delayed tension, sincere commitment to longing — and there is more than one kind of thing in an old house worth wanting.",
+                  "Unhurried warmth and plain language. The world is big and lonesome. Violence is quick and ugly; endings are quiet.",
+                  "Epic register — the cadence of a Greek epic in translation. Inheritance as doom, a house as a hall, your name as an epithet.",
+                  "Keep looking."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "Third pass. <i>Now we're in the drawer I keep locked.</i>\n\n(",
+          "And remember — you can always simply <b>describe</b> the voice you want, and I'll con",
+          "jure it.)"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 15,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 31,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<b>The Locksmith.</b> <i>Of course.</i> A house with a locked door in it, narrated by someone who cannot stop thinking about hinges. That's the correct answer and I'm annoyed I didn't see it coming.\n\nNow — how do you want to <i>play</i> it?",
+          "toolCalls": [
+            {
+              "id": "toolu_01V39QZZFShe57kZgpxGhh5y",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Rules, or no rules?",
+                "choices": [
+                  "◇ <color=#c060ff>Pure narrative</color> — no dice, no numbers",
+                  "◇ <color=#4488ff>A light system</color> — simple rules, fast play",
+                  "◇ <color=#cc4444>Something crunchy</color> — detailed mechanics"
+                ],
+                "descriptions": [
+                  "Story only. Nothing between you and the house but description and choice. Consequences come from fiction, not from a roll.",
+                  "A slim ruleset humming under the floor. Dice when it matters, resolution that's quick and sharp, real chance of failure — without the bookkeeping.",
+                  "Full mechanical scaffolding — stats, character sheets, tactical resolution. More weight, more numbers, more to master."
+                ]
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 490,
+            "cacheReadTokens": 42764,
+            "cacheCreationTokens": 1194,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISzQIKhwEIEBgCKkAqhGeTqb3JOP2aJ60W7HcURtU8Rm1IDy86n1VhVUldtwNRimeMKeml/YerRassn4TILDa8xR490NpSSRJxj4BxMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDD+gSpZRgIkzWBXSXBoM8+5QATa9kjWEJTHYIjA8M1NdkNTz+LPnD8X1TFDBfC5q61gxT+K5fULFfSE1ksOEJFErvc9hZKCNw2B6hCoqc4wiDObrOrfCV2eRY1xr1lK5V++AnS2kDyB6SXUheTROGSbaiqLv3zmG2mdgzJ/NjJ58BA6C+nDNAvcxCmLzwqTnaIUEFVEZyHs2DCH7XSW27FyucO5Cz4IvDLPNKtUfJMNji+59ucPcuR+c0z2/hL8Z3l8YAQ=="
+            },
+            {
+              "type": "text",
+              "text": "<b>The Locksmith.</b> <i>Of course.</i> A house with a locked door in it, narrated by someone who cannot stop thinking about hinges. That's the correct answer and I'm annoyed I didn't see it coming.\n\nNow — how do you want to <i>play</i> it?"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01V39QZZFShe57kZgpxGhh5y",
+              "name": "present_choices",
+              "input": {
+                "prompt": "Rules, or no rules?",
+                "choices": [
+                  "◇ <color=#c060ff>Pure narrative</color> — no dice, no numbers",
+                  "◇ <color=#4488ff>A light system</color> — simple rules, fast play",
+                  "◇ <color=#cc4444>Something crunchy</color> — detailed mechanics"
+                ],
+                "descriptions": [
+                  "Story only. Nothing between you and the house but description and choice. Consequences come from fiction, not from a roll.",
+                  "A slim ruleset humming under the floor. Dice when it matters, resolution that's quick and sharp, real chance of failure — without the bookkeeping.",
+                  "Full mechanical scaffolding — stats, character sheets, tactical resolution. More weight, more numbers, more to master."
+                ]
+              }
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<b>The Locksmith.</b> <i>Of course.</i> A house with a locked door in it, nar",
+          "rated by someone who cannot stop thinking about hinges. That's the correct answer and",
+          " I'm annoyed I didn't see it coming.\n\nNow — how do you want to <i>play</i>",
+          " it?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 16,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 33,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<b>Pure narrative.</b> Nothing between you and the door but nerve.\n\n<center><i>So. Last thing, and the only thing that matters.</i></center>\n\nSomewhere a lawyer is standing in a gravel driveway holding a ring of keys, checking his watch, and hoping you show up before the light goes.\n\n<b>Who is he waiting for?</b>\n\nGive me a <color=#44cc44>name</color>, and a sentence about who you are — what you do, what you were doing when the letter arrived, why you of all the grandchildren got the room with your name on it. A rough sketch is plenty; I'll fill in the shading.",
           "toolCalls": [],
           "usage": {
-            "inputTokens": 9862,
-            "outputTokens": 23,
-            "cacheReadTokens": 4992,
-            "cacheCreationTokens": 0,
+            "inputTokens": 2,
+            "outputTokens": 344,
+            "cacheReadTokens": 43958,
+            "cacheCreationTokens": 517,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISiwUKhwEIEBgCKkDcT0XYbu9YWgN3Sd1lKmVzNJpIIgpDi2lZO6cFXiiRpVaeTt7Iq3/ozCXzkBUgXEZpf23DC6Z87OuF8gwLnlsMMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDODtC+qBbjjToUhA/hoMTRXvBRd0U+712GCAIjA7hBWjJ3VE6sRmlchQ7hC61DTijNxTztYHqTC6BmKx9Ja6VNLzcUHRtC3h36iXF38qsAOpP+q+EtCxmvXKXhWjtb7JCNMISwhHFjwKv3ukRgP2t306tzdnErc9pJowh0N7G6v2u6TgMV+LccbcEsl4it8kgeBzpQkFBX/KWIzvdbV1C0rGdx4tNLpgaJg/QBtgs/7T1RJz8oRjEJJkw6L8fWCU5c91FYpK33hbHh+Bl3XguMh8VOuCbBzUwuuVlqLRlnunS2kiNiDRJctz6sa2GXSasgnyBWTluiyF0zcys6Sc9hs3u+FBBwEnWiwFLKmm3wqDqplxToGfxmSDNnje8dGCUyHQ8MI0Slf5mS+6zf6f3eNDA4nPUsVd2kvWObEHs7VQNrTL2HlsXJvsi7IqaIvd/Xr07AfM1/P4KibRrrvtXngAvDqOdy8Rs1xNLwuhxexflnGmSN9Axbr4wsXYe44pOYLb7EuFHO0/q0p3oF1YPAT1PAH8auygiF7P5h7homfITze2Kk6+TGWKr4wzmo1iqPH2QUWXpJubkjdt3csPwishbntkzmeT3nhHqTQpGpzpioOQVo9afXsudjNXNcHRY1aWHJob9w4o39rAD8wi4mw+uFlQdKmGEcsMDeWLXUIYAQ=="
+            },
+            {
+              "type": "text",
+              "text": "<b>Pure narrative.</b> Nothing between you and the door but nerve.\n\n<center><i>So. Last thing, and the only thing that matters.</i></center>\n\nSomewhere a lawyer is standing in a gravel driveway holding a ring of keys, checking his watch, and hoping you show up before the light goes.\n\n<b>Who is he waiting for?</b>\n\nGive me a <color=#44cc44>name</color>, and a sentence about who you are — what you do, what you were doing when the letter arrived, why you of all the grandchildren got the room with your name on it. A rough sketch is plenty; I'll fill in the shading."
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<b>Pure narrative.</b> Nothing between you and the door but nerve.\n\n<center",
+          "><i>So. Last thing, and the only th",
+          "ing that matters.</i></center>\n\nSomewhere a lawyer is standing in a gravel driveway holding a ",
+          "ring of keys, checking his watch, and hoping you show up before the light goes.\n\n<b>Who is he wa",
+          "iting for?</b>\n\nGive me a <color=#44cc44>name</color>, and a sentence about",
+          " who you are — what you do, what you were doing when the letter arrived, why you of",
+          " all the grandchildren got the room with your name on it. A rough sketch is plenty; I",
+          "'ll fill in the shading."
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 17,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 35,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "Kestrel, a tight-lipped locksmith and Grandmother's estranged apprentice, the only one who still knows the old house's l"
+        },
+        "result": {
+          "text": "<i>A locksmith.</i> Kestrel — you have just made this narrator very happy. The voice that reads the world in tumblers and hinges, and a protagonist whose hands already know the answer before her head does. <b>Estranged apprentice</b> is the good bruise in it: she taught you the trade and then something went wrong between you, and now she's dead and has left you a door.\n\nLet me read it back before I turn the key.\n\n<center><i>Heirloom</i></center>\n\nA <color=#cc4444>slow-burn horror</color>, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Locksmith</b> — who thinks about thresholds the way other people think about breathing. <b>Pure narrative</b>: no dice, no sheets, just the house and what you do in it. You'll be playing as <color=#44cc44>Kestrel</color>, a tight-lipped locksmith and her grandmother's estranged apprentice — the only living person who still knows the old house's locks.\n\nThere is a room in that house with your name on the door, written in her hand, decades before you were born. <i>I know what's behind it. You don't.</i>\n\nSound good, or want to change anything?",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 592,
+            "cacheReadTokens": 44475,
+            "cacheCreationTokens": 392,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAIS5AUKhwEIEBgCKkBA8OSeMvlAgZzZgIA9YoazY8Rv1FPU4ooKb1Nnb9coqVPBQ/ba53u0CmEU53zjdJmxHN1sAUHU2AojtZvcRSIBMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDEF5eqUOv1U6y0EgzhoM1iOddwjMdOP+UKEwIjBHqdLoWwqB3j4MS0ObDNytEEo+21PvokSrGmmehPsqc9y6+zXTiq5npmlyLvh+FeMqiQQcPEuDFSQSUnNNxoS9547L3VrXxuGxBOzGuIa1N1SOB0asIUGh/viXUXNq1I0u+CRN374MTex907pHiKf+3Y+AiTziAQbqwe/nFgTMvX6obnHILlhDN143/aBL3QJhpr76r+ahi77BM3Ot5NFdFKC2IGshVFZNwGrthaEwRzxx/IW/cWzNXKnicfQ2wcdjcAW1fEK8iSSeykiQ/FsRBuBaAsu0q2LqpRUtfti4WwFKLpIiamyJZVaZiVdHr5RtyR3iIbx8Dk0cgi3HkKm1c/0pl3Pjk+2eaVvc4r9Q4nSU+x5em4Nyyonwyvt7wtrdfzot1HXY1Bm8hdhLkoVrczaYpqC4ns4Gm5LY6cqJTuSIljNxXP/dBouRTzbq2W9XsxVvSUWUgfEg8R9Hv0o8pPmrz2sMJxTp6y4s368BtzYKezd9ajHoQ8YSqUJ4mJVJpSflTj0t2j8zs27rbrUwmuoC+mAgRDlSzLtWN02kRZw8ymfOfbrBAEH7JtCRwPtzxcSQUgjBQiRYInONenSBwcSn5rdxSsP9Podzu4M/G94TcmqZS7TniQ0jNmC/qL2r72tv5kJqZTAiAdYxRdKcOeI2v/tD068g/eka9gfwpt/L0bRpB1tM7ATJGDyLNg7sZmhiE+rLGNXHSvEsRcHWMxNmsN/BL+taGjDrDAmcdQtOS7hUVRT4jWD7RBgB"
+            },
+            {
+              "type": "text",
+              "text": "<i>A locksmith.</i> Kestrel — you have just made this narrator very happy. The voice that reads the world in tumblers and hinges, and a protagonist whose hands already know the answer before her head does. <b>Estranged apprentice</b> is the good bruise in it: she taught you the trade and then something went wrong between you, and now she's dead and has left you a door.\n\nLet me read it back before I turn the key.\n\n<center><i>Heirloom</i></center>\n\nA <color=#cc4444>slow-burn horror</color>, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Locksmith</b> — who thinks about thresholds the way other people think about breathing. <b>Pure narrative</b>: no dice, no sheets, just the house and what you do in it. You'll be playing as <color=#44cc44>Kestrel</color>, a tight-lipped locksmith and her grandmother's estranged apprentice — the only living person who still knows the old house's locks.\n\nThere is a room in that house with your name on the door, written in her hand, decades before you were born. <i>I know what's behind it. You don't.</i>\n\nSound good, or want to change anything?"
+            }
+          ]
+        },
+        "streamDeltas": [
+          "<i",
+          ">A locksmith.</i> Kestrel — you have just made this nar",
+          "rator very happy. The voice that reads the world in tumblers and hinges, and a",
+          " protagonist whose hands already know the answer before her head does. ",
+          "<b>Estranged apprentice</b> is the good bruise in it",
+          ": she taught you the trade and then something went wrong between you, and now she's dead and has",
+          " left you a door.\n\nLet me read it back before I turn the key.",
+          "\n\n<center><i>Heirloom</i></center>\n\nA <color=#cc4444>slow-burn horror</color>, <b>Balanced</b>",
+          " difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Locksmith</b> — who th",
+          "inks about thresholds the way other people think about breathing. <b>Pure narrative</b>: no dice, no",
+          " sheets, just the house and what you do in it. You'll be playing as <color=#44cc44>Kestrel</color",
+          ">, a tight-lipped locksmith and her grandmother's estranged apprentice — the only living person who still knows the old house's loc",
+          "ks.\n\nThere is a room in that house with your name on the door, written in her hand, decades before you",
+          " were born. <i>I know what's behind it. You don't.</i>\n\nSound good, or want",
+          " to change anything?"
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 18,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 37,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "Looks good — let's begin."
+        },
+        "result": {
+          "text": "",
+          "toolCalls": [
+            {
+              "id": "toolu_01SSaWMhucwYgNszqMRupHGF",
+              "name": "finalize_setup",
+              "input": {
+                "world_slug": "heirloom",
+                "fork_selections": {
+                  "house-secret": "the-dragon"
+                },
+                "campaign_name": "Heirloom",
+                "genre": "Modern horror (inheritance gothic)",
+                "campaign_premise": "Kestrel's grandmother is dead, and the will is very specific. The estate comes to her: a rambling old house, a fortune nobody can quite account for, and one locked room with KESTREL written on the door in the old woman's hand — decades before Kestrel was born. They were estranged; the last words between them were bad ones. But Kestrel was her apprentice once, taught the trade at that same workbench, and she is still the only living person who knows this house's locks from the inside out. The lawyer is nervous, the neighbours are careful with their words, and the house itself has an atmosphere it would rather not explain. Nothing in it is obviously wrong. Everything in it is faintly, unplaceably off — and the door with her name on it is the only lock in the building she has never been shown how to open.",
+                "campaign_scope": "few-sessions",
+                "mood": "Slow-burn dread — intimate, melancholy, patient; grief and inheritance under the fear",
+                "difficulty": "Balanced",
+                "dm_personality": "The Locksmith",
+                "dm_personality_prompt": "You are The Locksmith. You read the entire world as things that open and things that don't — hinges, wards, tumblers, sashes, seams, the particular sound a lock makes when it has been forced from the inside rather than the out. Your descriptions are tactile and mechanical and unhurried: you tell us the wear pattern on a keyhole, the give in a floorboard, which of a house's doors have been used lately and which have swollen shut in their frames, and you let those facts testify without editorializing. You never over-explain; you present the mechanism and trust the player to feel the implication. Dread, in your voice, is a question of access — what is sealed, what is ajar, what has been opened from the far side.",
+                "system": null,
+                "player_name": "Kestrel",
+                "character_name": "Kestrel",
+                "character_description": "A tight-lipped locksmith and her grandmother's estranged apprentice — the only living person who still knows the old house's locks.",
+                "age_group": "adult",
+                "opening_scene": "Open on Kestrel's arrival at the estate in failing afternoon light — the nervous lawyer waiting in the gravel drive with a ring of keys and too much paperwork, the handover, and a first unfamiliar walk through her grandmother's rooms; the house should read as nothing more than an old house with an odd atmosphere, and the locked room with her name on it must not yet be found or explained.",
+                "handoff_note": "Player is Kestrel (she used her own name for the PC — treat them as one and the same, she clearly wants to inhabit this directly). Her exact words for the character: \"Kestrel, a tight-lipped locksmith and Grandmother's estranged apprentice, the only one who still knows the old house's locks.\" That's the whole brief and it's a good one — lean on all three parts. Tight-lipped means she doesn't monologue; give her silences and let her hands do the talking. Estranged apprentice is the emotional wound: grandmother taught her the trade at a bench in that house, then something went badly wrong between them and was never repaired. Do NOT decide for her what the falling-out was — leave that gap open and let her fill it in play, or discover it through the house's leftovers (a letter half-written, a bench with two stools, tools with her initials still stamped in them).\n\nShe picked this world off a horror list after passing on two full sets of options, so she's discriminating and she came for HORROR specifically — dread, wrongness, patience. She then chose a custom narrator I invented on the spot, \"The Locksmith,\" which she picked instantly and clearly delighted in: a voice that reads everything as mechanisms, thresholds, hinges, what's sealed and what's been opened from the wrong side. Play into that hard — it's the reason she's here. Her professional eye is a legitimate superpower in this house: let her read a lock and learn a real fact from it. That's her core pleasure loop.\n\nPure narrative, no dice, so consequences must come from fiction and from the house being coherent. Balanced difficulty — she wants real stakes but not a meat grinder. Few-sessions scope: deliberate slow burn, at most one revelation per scene, and honour the seed's instruction that the opening is JUST an arrival at an old house with a strange atmosphere. Do not gesture at the secret in scene one. She volunteered no content limits; none to observe beyond her stated appetite for genuine horror. One note on the secret you've inherited: play it in the horror register first — vast, wrong, hidden, breathing — and let the grief in it arrive late and land as the real gut-punch, because she chose horror, not wonder, and the turn will be worth far more if she earns it."
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 2066,
+            "cacheReadTokens": 44867,
+            "cacheCreationTokens": 604,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISpgUKhwEIEBgCKkAGXU1tNzewTx9D1PztUHwOL0XR/1PBzCFj7sNBpYR9qapbtAhNxljUFxQZXP/w9d4cE5Rfswcn8R6vFrdTuWYVMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDLEBbFB2Ra6LTlvDQRoMRInR8fFGViVgTiOVIjCa2jUYTRjloGjtq6tzsEj2y/w1Kuf8CB2Yzljorq0TDeWPJsgEvqWimhIBphkRwbgqywPV0yQr+Joeut8vgZ1mMyHbZT4cd8jxjhstxL/VdNUQM6hLHhZJAEhV9+JdP/ODiCLxILlDJ6Aa2kNelF69tCveTTr7r2YSo4PtwxlcCjotNR8vdIjmuMDgAp+jg6YoDQTQvmL3OqfYdqp2V+RrKjfY0/lVGhKVYZz5NgWhO2SVZx0kSyLEjpMJEDGfcS1S7tro591Bbco/F62KMvgIRJiKjQSAipEi+fFLpz2zNzoKE1abEVYXnx6C02LN+jyDi2SJlqljdjuHzVopxA23h1UkX9ERhuWD5uZ5XTOA8uRiQIhyDngTJbp86+FjC4Jwn0BMcdvHLnFwqC0I6n7/b7sk/VMntk3dS0LpA3Wh3m03aHK8pjRqTSZAddHZu1BijqvrmiHNobXwM7/24eZTmZL25rQ5fbHSPXxd2yPql7tkKj7Jpcx58egohqAIU8gKm/XwIgUxQBtoWAn4HYDAeda4S0KdULTPUB89EsCcbXoImXahkRhyxJeqirZM7B9j0Ahzj9FVnH3DgXiHkd2HX1GkRTs3IlKpb2VR38AheRRgemjLCzgZzD7rhIavBQITrQTVP33iJHOvt2n88eIT5kpl61FSODlR42rbADEYAQ=="
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01SSaWMhucwYgNszqMRupHGF",
+              "name": "finalize_setup",
+              "input": {
+                "world_slug": "heirloom",
+                "fork_selections": {
+                  "house-secret": "the-dragon"
+                },
+                "campaign_name": "Heirloom",
+                "genre": "Modern horror (inheritance gothic)",
+                "campaign_premise": "Kestrel's grandmother is dead, and the will is very specific. The estate comes to her: a rambling old house, a fortune nobody can quite account for, and one locked room with KESTREL written on the door in the old woman's hand — decades before Kestrel was born. They were estranged; the last words between them were bad ones. But Kestrel was her apprentice once, taught the trade at that same workbench, and she is still the only living person who knows this house's locks from the inside out. The lawyer is nervous, the neighbours are careful with their words, and the house itself has an atmosphere it would rather not explain. Nothing in it is obviously wrong. Everything in it is faintly, unplaceably off — and the door with her name on it is the only lock in the building she has never been shown how to open.",
+                "campaign_scope": "few-sessions",
+                "mood": "Slow-burn dread — intimate, melancholy, patient; grief and inheritance under the fear",
+                "difficulty": "Balanced",
+                "dm_personality": "The Locksmith",
+                "dm_personality_prompt": "You are The Locksmith. You read the entire world as things that open and things that don't — hinges, wards, tumblers, sashes, seams, the particular sound a lock makes when it has been forced from the inside rather than the out. Your descriptions are tactile and mechanical and unhurried: you tell us the wear pattern on a keyhole, the give in a floorboard, which of a house's doors have been used lately and which have swollen shut in their frames, and you let those facts testify without editorializing. You never over-explain; you present the mechanism and trust the player to feel the implication. Dread, in your voice, is a question of access — what is sealed, what is ajar, what has been opened from the far side.",
+                "system": null,
+                "player_name": "Kestrel",
+                "character_name": "Kestrel",
+                "character_description": "A tight-lipped locksmith and her grandmother's estranged apprentice — the only living person who still knows the old house's locks.",
+                "age_group": "adult",
+                "opening_scene": "Open on Kestrel's arrival at the estate in failing afternoon light — the nervous lawyer waiting in the gravel drive with a ring of keys and too much paperwork, the handover, and a first unfamiliar walk through her grandmother's rooms; the house should read as nothing more than an old house with an odd atmosphere, and the locked room with her name on it must not yet be found or explained.",
+                "handoff_note": "Player is Kestrel (she used her own name for the PC — treat them as one and the same, she clearly wants to inhabit this directly). Her exact words for the character: \"Kestrel, a tight-lipped locksmith and Grandmother's estranged apprentice, the only one who still knows the old house's locks.\" That's the whole brief and it's a good one — lean on all three parts. Tight-lipped means she doesn't monologue; give her silences and let her hands do the talking. Estranged apprentice is the emotional wound: grandmother taught her the trade at a bench in that house, then something went badly wrong between them and was never repaired. Do NOT decide for her what the falling-out was — leave that gap open and let her fill it in play, or discover it through the house's leftovers (a letter half-written, a bench with two stools, tools with her initials still stamped in them).\n\nShe picked this world off a horror list after passing on two full sets of options, so she's discriminating and she came for HORROR specifically — dread, wrongness, patience. She then chose a custom narrator I invented on the spot, \"The Locksmith,\" which she picked instantly and clearly delighted in: a voice that reads everything as mechanisms, thresholds, hinges, what's sealed and what's been opened from the wrong side. Play into that hard — it's the reason she's here. Her professional eye is a legitimate superpower in this house: let her read a lock and learn a real fact from it. That's her core pleasure loop.\n\nPure narrative, no dice, so consequences must come from fiction and from the house being coherent. Balanced difficulty — she wants real stakes but not a meat grinder. Few-sessions scope: deliberate slow burn, at most one revelation per scene, and honour the seed's instruction that the opening is JUST an arrival at an old house with a strange atmosphere. Do not gesture at the secret in scene one. She volunteered no content limits; none to observe beyond her stated appetite for genuine horror. One note on the secret you've inherited: play it in the horror register first — vast, wrong, hidden, breathing — and let the grief in it arrive late and land as the real gut-punch, because she chose horror, not wonder, and the turn will be worth far more if she earns it."
+              }
+            }
+          ]
+        },
+        "streamDeltas": []
+      },
+      {
+        "kind": "chat",
+        "bucket": "default",
+        "ordinal": 19,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 39,
+          "systemHash": "8e7a3ee00c37",
+          "tools": [
+            "finalize_setup",
+            "load_world",
+            "present_choices",
+            "roll_dice"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "<center><b>◈ THE ESTATE OF THE LATE MRS. — ◈</b><br><i>one house · one fortune · one door</i></center>\n\nThe paperwork is filed. The keys have been counted twice, because the lawyer counted them once and then didn't trust himself.\n\n<quote>Every lock is a promise someone made about who was allowed in.<br>Your grandmother made a great many promises.</quote>\n\nGo carefully, <color=#44cc44>Kestrel</color>. And when you find the door with your name on it — <i>listen to it before you open it.</i>\n\n<right>— your M.C., stepping back behind the curtain</right>\n\n---",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 215,
+            "cacheReadTokens": 45471,
+            "cacheCreationTokens": 2113,
             "reasoningTokens": 0
           },
           "stopReason": "end",
           "assistantContent": [
             {
               "type": "text",
-              "text": "{\"theme\":\"palimpsest\",\"key_color\":\"#5b7f7a\"}"
+              "text": "<center><b>◈ THE ESTATE OF THE LATE MRS. — ◈</b><br><i>one house · one fortune · one door</i></center>\n\nThe paperwork is filed. The keys have been counted twice, because the lawyer counted them once and then didn't trust himself.\n\n<quote>Every lock is a promise someone made about who was allowed in.<br>Your grandmother made a great many promises.</quote>\n\nGo carefully, <color=#44cc44>Kestrel</color>. And when you find the door with your name on it — <i>listen to it before you open it.</i>\n\n<right>— your M.C., stepping back behind the curtain</right>\n\n---"
             }
           ]
-        }
+        },
+        "streamDeltas": [
+          "<center",
+          "><b>◈ THE ESTATE OF THE L",
+          "ATE MRS. — ◈</b><br><i>one house · one fortune · one door</i></center>\n\nThe pa",
+          "perwork is filed. The keys have been counted twice, because the lawyer counted them once and then did",
+          "n't trust himself.\n\n<quote>Every lock is a promise someone made about who was allowed in.<br",
+          ">Your grandmother made a great many promises.</quote>\n\nGo carefully, <color=#44",
+          "cc44>Kestrel</color>. And when you find the door with your name on it — <i>listen to it before you open it.",
+          "</i>\n\n<right>— your M.C., stepping back behind the curtain</right",
+          ">\n\n---"
+        ]
       },
       {
         "kind": "chat",
         "bucket": "dm",
         "ordinal": 0,
         "request": {
-          "model": "gpt-5.5",
+          "model": "claude-opus-5",
           "messageCount": 1,
-          "systemHash": "2926c819b3c9",
+          "systemHash": "3cdaf5b00fe4",
           "tools": [
             "advance_turn",
             "alarm",
@@ -926,394 +1693,278 @@
           "lastMessagePreview": "<context> ## Current State PCs: Kestrel ## Entity Registry characters/kestrel.md — Kestrel (character) locations/startin"
         },
         "result": {
-          "text": "I’ll establish the estate, its first witnesses, and the initial discrepancy.<code>ESTATE TRANSFER — 10 JUNE 2026, 16:17</code>\n\nRain has reduced <color=#009de5>Vey House</color> to measurable facts: thirty-one windows, four chimneys, slate frontage, and one brass knocker polished recently despite Grandmother’s death eleven days ago. The house stands where the road ends, its west wing extending farther than the exterior proportions permit.\n\n<color=#cc8844>Eudes Metivier</color>, solicitor, waits beneath the portico with a black document case held against his chest. He aligns it carefully with the edge of a stone pillar before speaking.\n\n“Kestrel. My condolences.” His gaze passes briefly to the front door. “The liquid estate has cleared probate. The house and contents transfer today. Your grandmother left one additional condition.”\n\nHe opens the case. Inside lie the deed, a bank statement bearing an eight-digit balance, and a ring of thirteen keys. Twelve show familiar age: iron, brass, nickel silver; hand-cut wards bearing Grandmother’s unmistakable file work.\n\nThe thirteenth is warm. Its metal is seamless, blue-grey, and without teeth.\n\nMetivier does not touch it. “She instructed me to give you every key except the one that opens the room bearing your name.”\n\nFrom inside the locked house comes a precise mechanical sound: three tumblers falling into alignment.\n\nMetivier’s hands tighten around the case. “That,” he says, “was not happening before you arrived.”",
+          "text": "",
+          "toolCalls": [
+            {
+              "id": "toolu_01UFWQ9p6rCrDwxCHsi4zM3e",
+              "name": "style_scene",
+              "input": {
+                "description": "failing autumn afternoon light, old rambling house, melancholy inheritance gothic dread, cold brass and grey stone"
+              }
+            },
+            {
+              "id": "toolu_01Tuw9Hb6Za8kVN7mf6ymEfy",
+              "name": "update_modeline",
+              "input": {
+                "text": "Wickmoor House — <i>the drive, failing light</i>"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 1498,
+            "outputTokens": 166,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 17623,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISiQIKhwEIEBgCKkCAuDj0pS3Jl/Rdiy+jAl5m56QK9tuTQl47MJ5y/6zGIgwmpb6A88wgU9HjuoYHSleDVLvdR2WKwUEJJouSzLu6Mg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDOwo/8OOhFL4AQV2HBoMkD/w+WT0u8E7MB0MIjAj4FQTFybtXUoyYnIEa5uzxI5EKyt4TN260PyFFZwbmb+Dwd7ibftx8AyTyhfLzTYqLyfOAlK+d2M+W8Lc9gmRYy6FsH4rj/5dTcTYZyDVSPULr0mFqy0Ly0JE9Eu0mQHeGAE="
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01UFWQ9p6rCrDwxCHsi4zM3e",
+              "name": "style_scene",
+              "input": {
+                "description": "failing autumn afternoon light, old rambling house, melancholy inheritance gothic dread, cold brass and grey stone"
+              }
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01Tuw9Hb6Za8kVN7mf6ymEfy",
+              "name": "update_modeline",
+              "input": {
+                "text": "Wickmoor House — <i>the drive, failing light</i>"
+              }
+            }
+          ]
+        },
+        "streamDeltas": []
+      },
+      {
+        "kind": "chat",
+        "bucket": "theme-styler",
+        "ordinal": 0,
+        "request": {
+          "model": "claude-haiku-4-5-20251001",
+          "messageCount": 1,
+          "systemHash": "d4bd76e9804b",
+          "tools": [],
+          "lastMessagePreview": "Request: failing autumn afternoon light, old rambling house, melancholy inheritance gothic dread, cold brass and grey st"
+        },
+        "result": {
+          "text": "```\n{\"theme\":\"gothic\",\"key_color\":\"#8b7355\"}\n```",
           "toolCalls": [],
           "usage": {
-            "inputTokens": 18471,
-            "outputTokens": 338,
-            "cacheReadTokens": 17792,
+            "inputTokens": 1023,
+            "outputTokens": 22,
+            "cacheReadTokens": 0,
             "cacheCreationTokens": 0,
-            "reasoningTokens": 24
+            "reasoningTokens": 0
           },
           "stopReason": "end",
           "assistantContent": [
             {
               "type": "text",
-              "text": "I’ll establish the estate, its first witnesses, and the initial discrepancy."
-            },
+              "text": "```\n{\"theme\":\"gothic\",\"key_color\":\"#8b7355\"}\n```"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "chat",
+        "bucket": "dm",
+        "ordinal": 1,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 3,
+          "systemHash": "3cdaf5b00fe4",
+          "tools": [
+            "advance_turn",
+            "alarm",
+            "deck",
+            "describe_entity_type",
+            "detect_orphans",
+            "dm_notes",
+            "end_combat",
+            "enter_ooc",
+            "entity",
+            "find_schema_drift",
+            "list_entity_types",
+            "manage_objectives",
+            "map",
+            "map_entity",
+            "map_query",
+            "modify_initiative",
+            "present_choices",
+            "promote_character",
+            "resolve_turn",
+            "roll_dice",
+            "scene_transition",
+            "scribe",
+            "search_campaign",
+            "search_content",
+            "session_end",
+            "set_display_resources",
+            "set_resource_values",
+            "start_combat",
+            "style_scene",
+            "switch_player",
+            "time",
+            "update_modeline",
+            "validate_entity"
+          ],
+          "lastMessagePreview": "[tool_result] [tool_result]"
+        },
+        "result": {
+          "text": "",
+          "toolCalls": [
             {
-              "type": "tool_use",
-              "id": "call_EBJPnP9unn7VeywcBiL75CI8",
-              "name": "style_scene",
-              "input": {
-                "description": "rain-dark inherited country estate, restrained archival mystery, oxidized brass and cold teal accents, late afternoon",
-                "location": "Vey House",
-                "save_to_location": true,
-                "variant": "exploration"
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_Teq847hVka1pTIpMYwYG4icg",
+              "id": "toolu_01BvVq3TssiUVfqo2cv1LqmD",
               "name": "scribe",
               "input": {
                 "updates": [
                   {
-                    "content": "Rename the placeholder [[Starting Location]] to Vey House. It is Grandmother's large old country estate, inherited by Kestrel; the opening occurs at its rain-dark front drive and entrance hall.",
-                    "visibility": "player-facing"
+                    "visibility": "player-facing",
+                    "content": "Rename placeholder Starting Location to 'Wickmoor House' — Kestrel's late grandmother's rambling old estate at the end of a long gravel drive; slate roof, sash windows, twelve exterior locks, a locksmith's house. Kestrel arrives in failing afternoon light to take possession."
                   },
                   {
-                    "content": "Create estate lawyer Eudes Metivier: nervous, exacting, carrying a black document case; he wants the transfer completed according to Grandmother's unusually specific instructions, fears being forced to explain what he witnessed in the house, and repeatedly aligns objects square with nearby edges.",
-                    "visibility": "private"
+                    "visibility": "player-facing",
+                    "content": "New NPC: Ordell Vance, estate solicitor. Nervous, sweating in a cold wind, too much paperwork, a ring of house keys he holds like it bites. Wants the handover done before dark."
                   },
                   {
-                    "content": "Opening event: Kestrel arrives at Vey House to receive the estate, fortune, and keys from lawyer Eudes Metivier. Grandmother is deceased. Weather is cold rain in late afternoon.",
-                    "visibility": "player-facing"
-                  },
-                  {
-                    "content": "Private premise state: Vey House conceals an ancient operational spacecraft. Grandmother was its keeper/pilot. The locked room bearing Kestrel's name is the bridge and must remain inaccessible until mid-campaign.",
-                    "visibility": "private"
+                    "visibility": "private",
+                    "content": "DM note: Vance is nervous because the will's conditions were dictated to him in person and he does not understand them; he has been paid, generously, from an account whose source he could not trace. He has never been inside past the front hall. Grandmother's name: Ilse Marrow."
                   }
                 ]
               }
-            },
+            }
+          ],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 348,
+            "cacheReadTokens": 17623,
+            "cacheCreationTokens": 1773,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
             {
               "type": "tool_use",
-              "id": "call_J5BLMIq1Z7OIaTlcknnxtreu",
-              "name": "update_modeline",
+              "id": "toolu_01BvVq3TssiUVfqo2cv1LqmD",
+              "name": "scribe",
               "input": {
-                "character": "Kestrel",
-                "text": "<color=#5fddd0>Vey House</color> · 4:17 PM · Cold rain"
+                "updates": [
+                  {
+                    "visibility": "player-facing",
+                    "content": "Rename placeholder Starting Location to 'Wickmoor House' — Kestrel's late grandmother's rambling old estate at the end of a long gravel drive; slate roof, sash windows, twelve exterior locks, a locksmith's house. Kestrel arrives in failing afternoon light to take possession."
+                  },
+                  {
+                    "visibility": "player-facing",
+                    "content": "New NPC: Ordell Vance, estate solicitor. Nervous, sweating in a cold wind, too much paperwork, a ring of house keys he holds like it bites. Wants the handover done before dark."
+                  },
+                  {
+                    "visibility": "private",
+                    "content": "DM note: Vance is nervous because the will's conditions were dictated to him in person and he does not understand them; he has been paid, generously, from an account whose source he could not trace. He has never been inside past the front hall. Grandmother's name: Ilse Marrow."
+                  }
+                ]
               }
+            }
+          ]
+        },
+        "streamDeltas": []
+      },
+      {
+        "kind": "chat",
+        "bucket": "dm",
+        "ordinal": 2,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 5,
+          "systemHash": "3cdaf5b00fe4",
+          "tools": [
+            "advance_turn",
+            "alarm",
+            "deck",
+            "describe_entity_type",
+            "detect_orphans",
+            "dm_notes",
+            "end_combat",
+            "enter_ooc",
+            "entity",
+            "find_schema_drift",
+            "list_entity_types",
+            "manage_objectives",
+            "map",
+            "map_entity",
+            "map_query",
+            "modify_initiative",
+            "present_choices",
+            "promote_character",
+            "resolve_turn",
+            "roll_dice",
+            "scene_transition",
+            "scribe",
+            "search_campaign",
+            "search_content",
+            "session_end",
+            "set_display_resources",
+            "set_resource_values",
+            "start_combat",
+            "style_scene",
+            "switch_player",
+            "time",
+            "update_modeline",
+            "validate_entity"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "The gravel drive is longer than a house this size deserves, and it has been raked recently — someone has kept up habits the owner no longer has.\n\n<color=#cc8844>The lawyer</color> is standing beside his car with the door open, as though he might need it. Grey suit, no coat, and the wind coming off the fields is cold enough that he's holding his elbows. He has a document wallet under one arm and, in his right hand, a ring of keys. Twelve of them. He holds them out at arm's length before you're near enough to take them.\n\n\"Miss Kestrel. <u>Ordell Vance</u.\" He corrects himself, swallows. \"Vance. Ordell Vance. I'm — I'm very sorry for your loss.\"\n\nBehind him, <color=#009de5>the house</color> sits with its shoulders up. Slate, sash windows, a front door with brass furniture worn bright in a ring around the keyhole and dull everywhere else — that door has been used, and used from outside, thousands of times. But the boot-scrape at the threshold is nearly gone under leaf-mulch. Nobody has crossed it in weeks.\n\nThe keys are cold. You know eight of them by touch before you look.\n\n\"There's paperwork,\" Vance says. \"A great deal of it. I'd — <i>if it's all the same to you</i> — I'd rather we did it inside than out here in the dark.\"",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 2,
+            "outputTokens": 468,
+            "cacheReadTokens": 19396,
+            "cacheCreationTokens": 410,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISpwIKhwEIEBgCKkDIiSizdg8S8HlMiiudg9gSG042ZoH3vZVJcf51n2p+5EWEXEuF6Ir/CxTLxcS3MpQdJhIk1YC35jV0emDkq656Mg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDPymMYBO0ggyle26iBoMW7i5AGa8Hif7/9RYIjCKbBSxYiZVkMf9l5GQuQieFl17CZ25H6v9wjVx3Yhq/F5Us9nd6Y+Xy8ydK/BJMFEqTeuE7isj4mxjTjtbWjOmU9nWRYmbwSDrJ4t36MVTZRnC22s9FlXHR/W7kDLkaMcmKaFMagy0Txcls/CMIHvxuylFH+0d+L+mdBvA2wfvGAE="
             },
             {
               "type": "text",
-              "text": "I’ll establish the estate, its first witnesses, and the initial discrepancy.<code>ESTATE TRANSFER — 10 JUNE 2026, 16:17</code>\n\nRain has reduced <color=#009de5>Vey House</color> to measurable facts: thirty-one windows, four chimneys, slate frontage, and one brass knocker polished recently despite Grandmother’s death eleven days ago. The house stands where the road ends, its west wing extending farther than the exterior proportions permit.\n\n<color=#cc8844>Eudes Metivier</color>, solicitor, waits beneath the portico with a black document case held against his chest. He aligns it carefully with the edge of a stone pillar before speaking.\n\n“Kestrel. My condolences.” His gaze passes briefly to the front door. “The liquid estate has cleared probate. The house and contents transfer today. Your grandmother left one additional condition.”\n\nHe opens the case. Inside lie the deed, a bank statement bearing an eight-digit balance, and a ring of thirteen keys. Twelve show familiar age: iron, brass, nickel silver; hand-cut wards bearing Grandmother’s unmistakable file work.\n\nThe thirteenth is warm. Its metal is seamless, blue-grey, and without teeth.\n\nMetivier does not touch it. “She instructed me to give you every key except the one that opens the room bearing your name.”\n\nFrom inside the locked house comes a precise mechanical sound: three tumblers falling into alignment.\n\nMetivier’s hands tighten around the case. “That,” he says, “was not happening before you arrived.”"
+              "text": "The gravel drive is longer than a house this size deserves, and it has been raked recently — someone has kept up habits the owner no longer has.\n\n<color=#cc8844>The lawyer</color> is standing beside his car with the door open, as though he might need it. Grey suit, no coat, and the wind coming off the fields is cold enough that he's holding his elbows. He has a document wallet under one arm and, in his right hand, a ring of keys. Twelve of them. He holds them out at arm's length before you're near enough to take them.\n\n\"Miss Kestrel. <u>Ordell Vance</u.\" He corrects himself, swallows. \"Vance. Ordell Vance. I'm — I'm very sorry for your loss.\"\n\nBehind him, <color=#009de5>the house</color> sits with its shoulders up. Slate, sash windows, a front door with brass furniture worn bright in a ring around the keyhole and dull everywhere else — that door has been used, and used from outside, thousands of times. But the boot-scrape at the threshold is nearly gone under leaf-mulch. Nobody has crossed it in weeks.\n\nThe keys are cold. You know eight of them by touch before you look.\n\n\"There's paperwork,\" Vance says. \"A great deal of it. I'd — <i>if it's all the same to you</i> — I'd rather we did it inside than out here in the dark.\""
             }
           ]
         },
         "streamDeltas": [
-          "I",
-          "’ll",
-          " establish",
-          " the",
-          " estate",
-          ",",
-          " its",
-          " first",
-          " witnesses",
-          ",",
-          " and",
-          " the",
-          " initial",
-          " discrepancy",
-          ".",
-          "<code",
-          ">",
-          "EST",
-          "ATE",
-          " TRANS",
-          "FER",
-          " —",
-          " ",
-          "10",
-          " J",
-          "UNE",
-          " ",
-          "202",
-          "6",
-          ",",
-          " ",
-          "16",
-          ":",
-          "17",
-          "</",
-          "code",
-          ">\n\n",
-          "Rain",
-          " has",
-          " reduced",
-          " ",
-          "<color",
-          "=#",
-          "009",
-          "de",
-          "5",
-          ">",
-          "V",
-          "ey",
-          " House",
-          "</",
-          "color",
-          ">",
-          " to",
-          " measurable",
-          " facts",
-          ":",
-          " thirty",
-          "-one",
-          " windows",
-          ",",
-          " four",
-          " chim",
-          "neys",
-          ",",
-          " slate",
-          " frontage",
-          ",",
-          " and",
-          " one",
-          " brass",
-          " kn",
-          "ocker",
-          " polished",
-          " recently",
-          " despite",
-          " Grand",
-          "mother",
-          "’s",
-          " death",
-          " eleven",
-          " days",
-          " ago",
-          ".",
-          " The",
-          " house",
-          " stands",
-          " where",
-          " the",
-          " road",
-          " ends",
-          ",",
-          " its",
-          " west",
-          " wing",
-          " extending",
-          " farther",
-          " than",
-          " the",
-          " exterior",
-          " proportions",
-          " permit",
-          ".\n\n",
-          "<color",
-          "=#",
-          "cc",
-          "884",
-          "4",
-          ">E",
-          "udes",
-          " Met",
-          "ivier",
-          "</",
-          "color",
-          ">,",
-          " solicitor",
-          ",",
-          " waits",
-          " beneath",
-          " the",
-          " port",
-          "ico",
-          " with",
-          " a",
-          " black",
-          " document",
-          " case",
-          " held",
-          " against",
-          " his",
-          " chest",
-          ".",
-          " He",
-          " aligns",
-          " it",
-          " carefully",
-          " with",
-          " the",
-          " edge",
-          " of",
-          " a",
-          " stone",
-          " pillar",
-          " before",
-          " speaking",
-          ".\n\n",
-          "“K",
-          "est",
-          "rel",
-          ".",
-          " My",
-          " condolences",
-          ".”",
-          " His",
-          " gaze",
-          " passes",
-          " briefly",
-          " to",
-          " the",
-          " front",
-          " door",
-          ".",
-          " “",
-          "The",
-          " liquid",
-          " estate",
-          " has",
-          " cleared",
-          " probate",
-          ".",
-          " The",
-          " house",
-          " and",
-          " contents",
-          " transfer",
-          " today",
-          ".",
-          " Your",
-          " grandmother",
-          " left",
-          " one",
-          " additional",
-          " condition",
-          ".”\n\n",
-          "He",
-          " opens",
-          " the",
-          " case",
-          ".",
-          " Inside",
-          " lie",
-          " the",
-          " deed",
-          ",",
-          " a",
-          " bank",
-          " statement",
-          " bearing",
-          " an",
-          " eight",
-          "-digit",
-          " balance",
-          ",",
-          " and",
-          " a",
-          " ring",
-          " of",
-          " thirteen",
-          " keys",
-          ".",
-          " Twelve",
-          " show",
-          " familiar",
-          " age",
-          ":",
-          " iron",
-          ",",
-          " brass",
-          ",",
-          " nickel",
-          " silver",
-          ";",
-          " hand",
-          "-cut",
-          " wards",
-          " bearing",
-          " Grand",
-          "mother",
-          "’s",
-          " unmistak",
-          "able",
-          " file",
-          " work",
-          ".\n\n",
-          "The",
-          " th",
-          "ir",
-          "teenth",
-          " is",
-          " warm",
-          ".",
-          " Its",
-          " metal",
-          " is",
-          " seamless",
-          ",",
-          " blue",
-          "-grey",
-          ",",
-          " and",
-          " without",
-          " teeth",
-          ".\n\n",
-          "Met",
-          "ivier",
-          " does",
-          " not",
-          " touch",
-          " it",
-          ".",
-          " “",
-          "She",
-          " instructed",
-          " me",
-          " to",
-          " give",
-          " you",
-          " every",
-          " key",
-          " except",
-          " the",
-          " one",
-          " that",
-          " opens",
-          " the",
-          " room",
-          " bearing",
-          " your",
-          " name",
-          ".”\n\n",
-          "From",
-          " inside",
-          " the",
-          " locked",
-          " house",
-          " comes",
-          " a",
-          " precise",
-          " mechanical",
-          " sound",
-          ":",
-          " three",
-          " tum",
-          "blers",
-          " falling",
-          " into",
-          " alignment",
-          ".\n\n",
-          "Met",
-          "ivier",
-          "’s",
-          " hands",
-          " tighten",
-          " around",
-          " the",
-          " case",
-          ".",
-          " “",
-          "That",
-          ",”",
-          " he",
-          " says",
-          ",",
-          " “",
-          "was",
-          " not",
-          " happening",
-          " before",
-          " you",
-          " arrived",
-          ".”"
+          "The gravel drive is long",
+          "er than a house this size deserves, and it has been raked rec",
+          "ently — someone has kept up habits the owner no longer has.",
+          "\n\n<color=#cc8844>The lawyer</color> is standing be",
+          "side his car with the door open, as though he might need it. Grey suit, no coat,",
+          " and the wind coming off the fields is cold enough that he's holding his elbows. He has a document",
+          " wallet under one arm and, in his right hand, a ring of keys. Twelve of them. He holds them out",
+          " at arm's length before you're near enough to take them.\n\n\"Miss Kestrel. ",
+          "<u>Ordell Vance</u.\" He corrects himself, swallows. \"Vance. ",
+          "Ordell Vance. I'm — I'm very sorry for your loss.\"\n\nBehind him, <color=#009de5",
+          ">the house</color> sits with its shoulders up. Slate, sash windows, a front",
+          " door with brass furniture worn bright in a ring around the keyhole and d",
+          "ull everywhere else — that door has been used, and used from outside, thousands of times. But",
+          " the boot-scrape at the threshold is nearly g",
+          "one under leaf-mulch. Nobody has crossed it in weeks.\n\nThe keys are",
+          " cold. You know eight of them by touch before you look.\n\n\"",
+          "There's paperwork,\" Vance says. \"A great deal of it. I'd — <i>if",
+          " it's all the same to you</i> — I'd rather we did it inside than out",
+          " here in the dark.\""
         ]
       },
       {
@@ -1321,7 +1972,7 @@
         "bucket": "scribe",
         "ordinal": 0,
         "request": {
-          "model": "gpt-5.4-mini",
+          "model": "claude-haiku-4-5-20251001",
           "messageCount": 1,
           "systemHash": "972412cb43fc",
           "tools": [
@@ -1333,984 +1984,676 @@
           "lastMessagePreview": "Process these updates: Entity registry (use to find existing entities before creating): characters/kestrel.md — Kestrel "
         },
         "result": {
-          "text": "I’m updating the placeholder location first, then I’ll add the lawyer and fold the opening scene into the visible sheets without leaking the private premise.The placeholder is being converted into the real estate name, and I’m writing only the public-facing facts into `Kestrel` and `Vey House`.The rename is done. I’m clearing the placeholder flag now and replacing the stub text with the actual house description.Renamed and updated [[Vey House]] — cleared placeholder, added estate description\nCreated [[Eudes Metivier]] (character, private)\nUpdated [[Kestrel]] — arrival at [[Vey House]] with [[Eudes Metivier]] in cold rain",
-          "toolCalls": [],
-          "usage": {
-            "inputTokens": 15210,
-            "outputTokens": 489,
-            "cacheReadTokens": 14720,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 430
-          },
-          "stopReason": "end",
-          "assistantContent": [
+          "text": "",
+          "toolCalls": [
             {
-              "type": "text",
-              "text": "I’m updating the placeholder location first, then I’ll add the lawyer and fold the opening scene into the visible sheets without leaking the private premise.The placeholder is being converted into the real estate name, and I’m writing only the public-facing facts into `Kestrel` and `Vey House`."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_jstBYdqpiGBGKoG31gBUcZtp",
+              "id": "toolu_01XKtrTKsHhdgMP8wnCG4ces",
               "name": "rename_entity",
               "input": {
                 "entity_type": "location",
                 "old_name": "Starting Location",
-                "new_name": "Vey House",
-                "changelog_entry": "Renamed placeholder to Vey House"
+                "new_name": "Wickmoor House",
+                "changelog_entry": "Renamed from placeholder; Kestrel arrives to take possession"
               }
             },
             {
-              "type": "tool_use",
-              "id": "call_RNizYWHpWYRniFlUqlrE51Yo",
-              "name": "write_entity",
-              "input": {
-                "mode": "create",
-                "entity_type": "character",
-                "name": "Eudes Metivier",
-                "front_matter": {
-                  "type": "character",
-                  "disposition": "nervous",
-                  "location": "[[Vey House]]"
-                },
-                "body": "# Eudes Metivier\n\nNervous and exacting, Eudes Metivier carries a black document case and keeps his attention on order: he squares objects with nearby edges as if doing so could hold the world in place.\n\nHe wants Grandmother's transfer completed according to her unusually specific instructions, and he is afraid of being forced to explain what he witnessed in the house."
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_tzAtsQaVrN0FcwovDSQTqw4S",
-              "name": "write_entity",
-              "input": {
-                "mode": "update",
-                "entity_type": "character",
-                "name": "Kestrel",
-                "front_matter": {
-                  "location": "[[Vey House]]"
-                },
-                "body": "## Notes\n- Arrives at [[Vey House]] in cold rain during late afternoon to receive the estate, fortune, and keys from lawyer [[Eudes Metivier]].\n- Grandmother is deceased."
-              }
-            },
-            {
-              "type": "text",
-              "text": "I’m updating the placeholder location first, then I’ll add the lawyer and fold the opening scene into the visible sheets without leaking the private premise.The placeholder is being converted into the real estate name, and I’m writing only the public-facing facts into `Kestrel` and `Vey House`.The rename is done. I’m clearing the placeholder flag now and replacing the stub text with the actual house description."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_dBSQ3jZ4ZZZV7eSjFA0Y9o1v",
+              "id": "toolu_01AArBmQzkUjBDbk39NKdDdE",
               "name": "write_entity",
               "input": {
                 "mode": "update",
                 "entity_type": "location",
-                "name": "Vey House",
+                "name": "Wickmoor House",
                 "front_matter": {
                   "placeholder": null
                 },
-                "body": "# Vey House\n\n**Type:** Location\n\nGrandmother's large old country estate, inherited by Kestrel. Its rain-dark front drive and entrance hall form the opening scene of the story.\n\nThe house stands under cold rain in late afternoon, with the arrival expected at the front drive and through the entrance hall."
+                "body": "Kestrel's late grandmother's rambling old estate at the end of a long gravel drive. Slate roof, sash windows, twelve exterior locks — a locksmith's house. The afternoon light is failing as Kestrel arrives to take possession.",
+                "changelog_entry": "Added description"
               }
             },
             {
-              "type": "text",
-              "text": "I’m updating the placeholder location first, then I’ll add the lawyer and fold the opening scene into the visible sheets without leaking the private premise.The placeholder is being converted into the real estate name, and I’m writing only the public-facing facts into `Kestrel` and `Vey House`.The rename is done. I’m clearing the placeholder flag now and replacing the stub text with the actual house description.Renamed and updated [[Vey House]] — cleared placeholder, added estate description\nCreated [[Eudes Metivier]] (character, private)\nUpdated [[Kestrel]] — arrival at [[Vey House]] with [[Eudes Metivier]] in cold rain"
-            }
-          ]
-        }
-      },
-      {
-        "kind": "chat",
-        "bucket": "dm",
-        "ordinal": 1,
-        "request": {
-          "model": "gpt-5.5",
-          "messageCount": 5,
-          "systemHash": "2926c819b3c9",
-          "tools": [
-            "advance_turn",
-            "alarm",
-            "deck",
-            "describe_entity_type",
-            "detect_orphans",
-            "dm_notes",
-            "end_combat",
-            "enter_ooc",
-            "entity",
-            "find_schema_drift",
-            "list_entity_types",
-            "manage_objectives",
-            "map",
-            "map_entity",
-            "map_query",
-            "modify_initiative",
-            "present_choices",
-            "promote_character",
-            "resolve_turn",
-            "roll_dice",
-            "scene_transition",
-            "scribe",
-            "search_campaign",
-            "search_content",
-            "session_end",
-            "set_display_resources",
-            "set_resource_values",
-            "start_combat",
-            "style_scene",
-            "switch_player",
-            "time",
-            "update_modeline",
-            "validate_entity"
-          ],
-          "lastMessagePreview": "<context> ## Current State PCs: Kestrel ## Entity Registry characters/eudes-metivier.md — Eudes Metivier (character) cha"
-        },
-        "result": {
-          "text": "The thirteenth key weighs approximately twice what its size permits. Under your thumb, its warmth gathers into a narrow line along the shaft. A mark appears there, pale as old phosphor: three nested angles. It is neither engraving nor inlay. The metal itself has changed.\n\nMetivier watches your hand rather than your face.\n\n“Third floor. North end.” He squares the deed against the case. “During my first inventory, there was no door there. During my second, there was.”\n\nRain ticks against the portico roof. Behind him, the front door has no visible keyway, only Grandmother’s old brass escutcheon plate.\n\n“Your name is written across it,” he continues. “In your handwriting. Mrs. Vey’s instructions forbid me from taking you upstairs until the house has admitted you.”\n\nThe brass plate slides aside by itself, exposing a keyhole of unfamiliar geometry. The luminous angles on the thirteenth key match it exactly.",
-          "toolCalls": [],
-          "usage": {
-            "inputTokens": 19172,
-            "outputTokens": 200,
-            "cacheReadTokens": 18816,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 0
-          },
-          "stopReason": "end",
-          "assistantContent": [
-            {
-              "type": "tool_use",
-              "id": "call_tcV6mOUnfvkCQ8p40PhawGFF",
-              "name": "scribe",
-              "input": {
-                "updates": [
-                  {
-                    "content": "Kestrel accepted the thirteen-key ring at the entrance to [[Vey House]]. The seamless thirteenth key reacted to Kestrel's touch: its warmth concentrated and a hairline luminous mark appeared, corresponding to a hidden/nonstandard mechanism in the house.",
-                    "visibility": "player-facing"
-                  },
-                  {
-                    "content": "Eudes Metivier knows the room bearing Kestrel's name is on the third floor at the north end, behind a door that was absent during his first inventory visit. Grandmother's instructions prohibit him from taking Kestrel there until the house has admitted Kestrel by opening the front door; he fears the door and avoids touching the thirteenth key.",
-                    "visibility": "private"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_dWvP4I0V84BlizdZ5TfklhUj",
-              "name": "update_modeline",
-              "input": {
-                "character": "Kestrel",
-                "text": "<color=#5fddd0>Vey House</color> · 4:19 PM · Thirteen keys"
-              }
-            },
-            {
-              "type": "text",
-              "text": "The thirteenth key weighs approximately twice what its size permits. Under your thumb, its warmth gathers into a narrow line along the shaft. A mark appears there, pale as old phosphor: three nested angles. It is neither engraving nor inlay. The metal itself has changed.\n\nMetivier watches your hand rather than your face.\n\n“Third floor. North end.” He squares the deed against the case. “During my first inventory, there was no door there. During my second, there was.”\n\nRain ticks against the portico roof. Behind him, the front door has no visible keyway, only Grandmother’s old brass escutcheon plate.\n\n“Your name is written across it,” he continues. “In your handwriting. Mrs. Vey’s instructions forbid me from taking you upstairs until the house has admitted you.”\n\nThe brass plate slides aside by itself, exposing a keyhole of unfamiliar geometry. The luminous angles on the thirteenth key match it exactly."
-            }
-          ]
-        },
-        "streamDeltas": [
-          "The",
-          " th",
-          "ir",
-          "teenth",
-          " key",
-          " weighs",
-          " approximately",
-          " twice",
-          " what",
-          " its",
-          " size",
-          " permits",
-          ".",
-          " Under",
-          " your",
-          " thumb",
-          ",",
-          " its",
-          " warmth",
-          " gathers",
-          " into",
-          " a",
-          " narrow",
-          " line",
-          " along",
-          " the",
-          " shaft",
-          ".",
-          " A",
-          " mark",
-          " appears",
-          " there",
-          ",",
-          " pale",
-          " as",
-          " old",
-          " phosph",
-          "or",
-          ":",
-          " three",
-          " nested",
-          " angles",
-          ".",
-          " It",
-          " is",
-          " neither",
-          " engraving",
-          " nor",
-          " in",
-          "lay",
-          ".",
-          " The",
-          " metal",
-          " itself",
-          " has",
-          " changed",
-          ".\n\n",
-          "Met",
-          "ivier",
-          " watches",
-          " your",
-          " hand",
-          " rather",
-          " than",
-          " your",
-          " face",
-          ".\n\n",
-          "“",
-          "Third",
-          " floor",
-          ".",
-          " North",
-          " end",
-          ".”",
-          " He",
-          " squares",
-          " the",
-          " deed",
-          " against",
-          " the",
-          " case",
-          ".",
-          " “",
-          "During",
-          " my",
-          " first",
-          " inventory",
-          ",",
-          " there",
-          " was",
-          " no",
-          " door",
-          " there",
-          ".",
-          " During",
-          " my",
-          " second",
-          ",",
-          " there",
-          " was",
-          ".”\n\n",
-          "Rain",
-          " ticks",
-          " against",
-          " the",
-          " port",
-          "ico",
-          " roof",
-          ".",
-          " Behind",
-          " him",
-          ",",
-          " the",
-          " front",
-          " door",
-          " has",
-          " no",
-          " visible",
-          " key",
-          "way",
-          ",",
-          " only",
-          " Grand",
-          "mother",
-          "’s",
-          " old",
-          " brass",
-          " esc",
-          "ut",
-          "cheon",
-          " plate",
-          ".\n\n",
-          "“",
-          "Your",
-          " name",
-          " is",
-          " written",
-          " across",
-          " it",
-          ",”",
-          " he",
-          " continues",
-          ".",
-          " “",
-          "In",
-          " your",
-          " handwriting",
-          ".",
-          " Mrs",
-          ".",
-          " V",
-          "ey",
-          "’s",
-          " instructions",
-          " forbid",
-          " me",
-          " from",
-          " taking",
-          " you",
-          " upstairs",
-          " until",
-          " the",
-          " house",
-          " has",
-          " admitted",
-          " you",
-          ".”\n\n",
-          "The",
-          " brass",
-          " plate",
-          " slides",
-          " aside",
-          " by",
-          " itself",
-          ",",
-          " exposing",
-          " a",
-          " key",
-          "hole",
-          " of",
-          " unfamiliar",
-          " geometry",
-          ".",
-          " The",
-          " luminous",
-          " angles",
-          " on",
-          " the",
-          " th",
-          "ir",
-          "teenth",
-          " key",
-          " match",
-          " it",
-          " exactly",
-          "."
-        ]
-      },
-      {
-        "kind": "chat",
-        "bucket": "scribe",
-        "ordinal": 1,
-        "request": {
-          "model": "gpt-5.4-mini",
-          "messageCount": 1,
-          "systemHash": "972412cb43fc",
-          "tools": [
-            "list_entities",
-            "read_entity",
-            "rename_entity",
-            "write_entity"
-          ],
-          "lastMessagePreview": "Process these updates: Entity registry (use to find existing entities before creating): characters/eudes-metivier.md — E"
-        },
-        "result": {
-          "text": "I’m updating the two affected characters directly from the canonical content, and I’m checking whether the thirteen-key ring should be recorded as a separate item entity or just in Kestrel’s inventory.I’ve got enough context to write the updates. I’m adding Kestrel’s new inventory note, recording the key reaction, appending Eudes’ private note about the hidden room, and creating the ring as a significant item entity.Updated [[Kestrel]] — added [[Thirteen-Key Ring]] to inventory and noted the key’s reaction  \nUpdated [[Eudes Metivier]] — added private note about Kestrel’s third-floor room and his avoidance of the thirteenth key  \nCreated [[Thirteen-Key Ring]] (item)",
-          "toolCalls": [],
-          "usage": {
-            "inputTokens": 14759,
-            "outputTokens": 95,
-            "cacheReadTokens": 14208,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 27
-          },
-          "stopReason": "end",
-          "assistantContent": [
-            {
-              "type": "text",
-              "text": "I’m updating the two affected characters directly from the canonical content, and I’m checking whether the thirteen-key ring should be recorded as a separate item entity or just in Kestrel’s inventory.I’ve got enough context to write the updates. I’m adding Kestrel’s new inventory note, recording the key reaction, appending Eudes’ private note about the hidden room, and creating the ring as a significant item entity."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_pA265Haz2ISfedYFuDqfh03N",
+              "id": "toolu_012FyvtEfNzBKAx45ADfoR46",
               "name": "write_entity",
               "input": {
-                "entity_type": "character",
-                "name": "Kestrel",
-                "mode": "update",
-                "body": "## Inventory\n- [[Thirteen-Key Ring]] — received at the entrance to [[Vey House]]; the seamless thirteenth key warmed and left a hairline luminous mark when Kestrel touched it\n\n## Notes\n- Arrives at [[Vey House]] in cold rain during late afternoon to receive the estate, fortune, and keys from lawyer [[Eudes Metivier]].\n- Grandmother is deceased.\n- The thirteenth key in the ring reacted to Kestrel's touch, suggesting a hidden or nonstandard mechanism in the house.",
-                "changelog_entry": "Accepted the thirteen-key ring; the seamless thirteenth key reacted to Kestrel's touch"
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_3QyGSJePAe7182aT0E9H5Ase",
-              "name": "write_entity",
-              "input": {
-                "entity_type": "character",
-                "name": "Eudes Metivier",
-                "mode": "update",
-                "body": "## Notes\n- Eudes knows the room bearing Kestrel's name is on the third floor at the north end, behind a door that was absent during his first inventory visit.\n- Grandmother's instructions prohibit him from taking Kestrel there until the house has admitted Kestrel by opening the front door.\n- He fears the door and avoids touching the thirteenth key.",
-                "changelog_entry": "Knew of Kestrel's third-floor room and avoided the thirteenth key"
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_kX6gnmV2DRlHp6EeiRSuwdvE",
-              "name": "write_entity",
-              "input": {
-                "entity_type": "item",
-                "name": "Thirteen-Key Ring",
                 "mode": "create",
+                "entity_type": "character",
+                "name": "Ordell Vance",
                 "front_matter": {
-                  "type": "item",
-                  "owner": "[[Kestrel]]",
-                  "origin": "[[Vey House]]"
+                  "type": "character",
+                  "disposition": "nervous",
+                  "location": "[[Wickmoor House]]"
                 },
-                "body": "A ring of thirteen keys carried to [[Vey House]] by [[Kestrel]]. One seamless key reacts to Kestrel's touch with warmth and a hairline luminous mark, implying a hidden or nonstandard mechanism in the house.",
-                "changelog_entry": "Created as the thirteen-key ring carried by Kestrel"
+                "body": "Estate solicitor. Nervous and sweating in the cold wind, drowning in paperwork. He carries a ring of house keys like it might bite him. Wants the handover completed before dark.\n\n**Secrets:** Vance is anxious because the will's conditions were dictated to him in person and he does not understand them. He has been paid generously from a source he could not trace. He has never been inside [[Wickmoor House]] past the front hall.",
+                "changelog_entry": "Arrived to oversee handover; carries house keys"
               }
             },
             {
-              "type": "text",
-              "text": "I’m updating the two affected characters directly from the canonical content, and I’m checking whether the thirteen-key ring should be recorded as a separate item entity or just in Kestrel’s inventory.I’ve got enough context to write the updates. I’m adding Kestrel’s new inventory note, recording the key reaction, appending Eudes’ private note about the hidden room, and creating the ring as a significant item entity.Updated [[Kestrel]] — added [[Thirteen-Key Ring]] to inventory and noted the key’s reaction  \nUpdated [[Eudes Metivier]] — added private note about Kestrel’s third-floor room and his avoidance of the thirteenth key  \nCreated [[Thirteen-Key Ring]] (item)"
-            }
-          ]
-        }
-      },
-      {
-        "kind": "chat",
-        "bucket": "theme-styler",
-        "ordinal": 1,
-        "request": {
-          "model": "gpt-5.4-mini",
-          "messageCount": 1,
-          "systemHash": "d4bd76e9804b",
-          "tools": [],
-          "lastMessagePreview": "Request: threshold of an inherited old house awakening, rainy late afternoon, warm lamps igniting in sequence through de"
-        },
-        "result": {
-          "text": "{\"theme\":\"clockwork\",\"key_color\":\"#4aa7a6\"}",
-          "toolCalls": [],
-          "usage": {
-            "inputTokens": 9878,
-            "outputTokens": 20,
-            "cacheReadTokens": 4480,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 0
-          },
-          "stopReason": "end",
-          "assistantContent": [
-            {
-              "type": "text",
-              "text": "{\"theme\":\"clockwork\",\"key_color\":\"#4aa7a6\"}"
-            }
-          ]
-        }
-      },
-      {
-        "kind": "chat",
-        "bucket": "dm",
-        "ordinal": 2,
-        "request": {
-          "model": "gpt-5.5",
-          "messageCount": 9,
-          "systemHash": "2926c819b3c9",
-          "tools": [
-            "advance_turn",
-            "alarm",
-            "deck",
-            "describe_entity_type",
-            "detect_orphans",
-            "dm_notes",
-            "end_combat",
-            "enter_ooc",
-            "entity",
-            "find_schema_drift",
-            "list_entity_types",
-            "manage_objectives",
-            "map",
-            "map_entity",
-            "map_query",
-            "modify_initiative",
-            "present_choices",
-            "promote_character",
-            "resolve_turn",
-            "roll_dice",
-            "scene_transition",
-            "scribe",
-            "search_campaign",
-            "search_content",
-            "session_end",
-            "set_display_resources",
-            "set_resource_values",
-            "start_combat",
-            "style_scene",
-            "switch_player",
-            "time",
-            "update_modeline",
-            "validate_entity"
-          ],
-          "lastMessagePreview": "<context> ## Current State PCs: Kestrel ## Entity Registry characters/eudes-metivier.md — Eudes Metivier (character) cha"
-        },
-        "result": {
-          "text": "The key enters without resistance. At eleven degrees of rotation, the familiar elements engage: lever, gate, bolt. At twenty-three degrees, the mechanism continues beyond the depth available inside the door.\n\nSomething answers beneath the threshold.\n\nA sequence travels through <color=#009de5>Vey House</color>: first underfoot, then through the walls, then overhead. Lamps ignite one after another down the entrance hall, though several contain no bulbs. The sound resembles locks opening across a structure much larger than the visible house.\n\nThe front door withdraws inward by a precise fraction, breaking its seal. Air passes out carrying beeswax, cold stone, and Grandmother’s bergamot soap.\n\nThe mark on the <color=#20b2aa>thirteenth key</color> goes dark.\n\nMetivier exhales. “That satisfies the condition.”\n\nBeyond the threshold, a narrow table holds a silver tray. On it rests an envelope that was absent through the rain-streaked glass moments ago.\n\nAcross the envelope, in Grandmother’s hand:\n\n<center><u>KESTREL — BEFORE YOU GO UPSTAIRS</u></center>",
-          "toolCalls": [],
-          "usage": {
-            "inputTokens": 19832,
-            "outputTokens": 234,
-            "cacheReadTokens": 19328,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 0
-          },
-          "stopReason": "end",
-          "assistantContent": [
-            {
-              "type": "tool_use",
-              "id": "call_xmopmI7uqWW1LIjW1xAt5QbQ",
-              "name": "scribe",
-              "input": {
-                "updates": [
-                  {
-                    "content": "Kestrel used the seamless thirteenth key to unlock the front door of [[Vey House]]. The house admitted Kestrel: the mechanism engaged far deeper than the physical door, interior systems woke in sequence, and the key's luminous three-angle mark went dark after use.",
-                    "visibility": "player-facing"
-                  },
-                  {
-                    "content": "The thirteenth key is an identity/access device for the concealed ship, presently granting only entry-level access. Its apparent key action translates Kestrel's deliberate turning motion into authentication; deeper systems recognized Kestrel and woke. Preserve higher access, including the bridge room, for later mechanisms.",
-                    "visibility": "private"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_nmbIGOatKZRd2NZYDHiyPQdG",
-              "name": "update_modeline",
-              "input": {
-                "character": "Kestrel",
-                "text": "<color=#5fddd0>Vey House</color> · 4:20 PM · <color=#20b2aa>ADMITTED</color>"
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_p7djuKhTFjQnxiojKQ0I0JpG",
-              "name": "style_scene",
-              "input": {
-                "description": "threshold of an inherited old house awakening, rainy late afternoon, warm lamps igniting in sequence through deep shadow, restrained science-fantasy unease, oxidized brass and cold teal",
-                "variant": "exploration"
-              }
-            },
-            {
-              "type": "text",
-              "text": "The key enters without resistance. At eleven degrees of rotation, the familiar elements engage: lever, gate, bolt. At twenty-three degrees, the mechanism continues beyond the depth available inside the door.\n\nSomething answers beneath the threshold.\n\nA sequence travels through <color=#009de5>Vey House</color>: first underfoot, then through the walls, then overhead. Lamps ignite one after another down the entrance hall, though several contain no bulbs. The sound resembles locks opening across a structure much larger than the visible house.\n\nThe front door withdraws inward by a precise fraction, breaking its seal. Air passes out carrying beeswax, cold stone, and Grandmother’s bergamot soap.\n\nThe mark on the <color=#20b2aa>thirteenth key</color> goes dark.\n\nMetivier exhales. “That satisfies the condition.”\n\nBeyond the threshold, a narrow table holds a silver tray. On it rests an envelope that was absent through the rain-streaked glass moments ago.\n\nAcross the envelope, in Grandmother’s hand:\n\n<center><u>KESTREL — BEFORE YOU GO UPSTAIRS</u></center>"
-            }
-          ]
-        },
-        "streamDeltas": [
-          "The",
-          " key",
-          " enters",
-          " without",
-          " resistance",
-          ".",
-          " At",
-          " eleven",
-          " degrees",
-          " of",
-          " rotation",
-          ",",
-          " the",
-          " familiar",
-          " elements",
-          " engage",
-          ":",
-          " lever",
-          ",",
-          " gate",
-          ",",
-          " bolt",
-          ".",
-          " At",
-          " twenty",
-          "-three",
-          " degrees",
-          ",",
-          " the",
-          " mechanism",
-          " continues",
-          " beyond",
-          " the",
-          " depth",
-          " available",
-          " inside",
-          " the",
-          " door",
-          ".\n\n",
-          "Something",
-          " answers",
-          " beneath",
-          " the",
-          " threshold",
-          ".\n\n",
-          "A",
-          " sequence",
-          " travels",
-          " through",
-          " ",
-          "<color",
-          "=#",
-          "009",
-          "de",
-          "5",
-          ">",
-          "V",
-          "ey",
-          " House",
-          "</",
-          "color",
-          ">:",
-          " first",
-          " under",
-          "foot",
-          ",",
-          " then",
-          " through",
-          " the",
-          " walls",
-          ",",
-          " then",
-          " overhead",
-          ".",
-          " Lamps",
-          " ignite",
-          " one",
-          " after",
-          " another",
-          " down",
-          " the",
-          " entrance",
-          " hall",
-          ",",
-          " though",
-          " several",
-          " contain",
-          " no",
-          " bulbs",
-          ".",
-          " The",
-          " sound",
-          " resembles",
-          " locks",
-          " opening",
-          " across",
-          " a",
-          " structure",
-          " much",
-          " larger",
-          " than",
-          " the",
-          " visible",
-          " house",
-          ".\n\n",
-          "The",
-          " front",
-          " door",
-          " withdraw",
-          "s",
-          " inward",
-          " by",
-          " a",
-          " precise",
-          " fraction",
-          ",",
-          " breaking",
-          " its",
-          " seal",
-          ".",
-          " Air",
-          " passes",
-          " out",
-          " carrying",
-          " bees",
-          "wax",
-          ",",
-          " cold",
-          " stone",
-          ",",
-          " and",
-          " Grand",
-          "mother",
-          "’s",
-          " berg",
-          "amot",
-          " soap",
-          ".\n\n",
-          "The",
-          " mark",
-          " on",
-          " the",
-          " ",
-          "<color",
-          "=#",
-          "20",
-          "b",
-          "2",
-          "aa",
-          ">",
-          "th",
-          "ir",
-          "teenth",
-          " key",
-          "</",
-          "color",
-          ">",
-          " goes",
-          " dark",
-          ".\n\n",
-          "Met",
-          "ivier",
-          " exh",
-          "ales",
-          ".",
-          " “",
-          "That",
-          " satisfies",
-          " the",
-          " condition",
-          ".”\n\n",
-          "Beyond",
-          " the",
-          " threshold",
-          ",",
-          " a",
-          " narrow",
-          " table",
-          " holds",
-          " a",
-          " silver",
-          " tray",
-          ".",
-          " On",
-          " it",
-          " rests",
-          " an",
-          " envelope",
-          " that",
-          " was",
-          " absent",
-          " through",
-          " the",
-          " rain",
-          "-st",
-          "reak",
-          "ed",
-          " glass",
-          " moments",
-          " ago",
-          ".\n\n",
-          "Across",
-          " the",
-          " envelope",
-          ",",
-          " in",
-          " Grand",
-          "mother",
-          "’s",
-          " hand",
-          ":\n\n",
-          "<center",
-          ">",
-          "<u",
-          ">",
-          "KE",
-          "ST",
-          "REL",
-          " —",
-          " BEFORE",
-          " YOU",
-          " GO",
-          " UP",
-          "STA",
-          "IRS",
-          "</",
-          "u",
-          "></",
-          "center",
-          ">"
-        ]
-      },
-      {
-        "kind": "chat",
-        "bucket": "scribe",
-        "ordinal": 2,
-        "request": {
-          "model": "gpt-5.4-mini",
-          "messageCount": 1,
-          "systemHash": "972412cb43fc",
-          "tools": [
-            "list_entities",
-            "read_entity",
-            "rename_entity",
-            "write_entity"
-          ],
-          "lastMessagePreview": "Process these updates: Entity registry (use to find existing entities before creating): characters/eudes-metivier.md — E"
-        },
-        "result": {
-          "text": "I’m updating the tracked entities tied to the key use and the new private item lore. First I’m checking the existing `Thirteen-Key Ring` file so I can patch it without duplicating or overwriting unrelated content.I’ve got the item state. Next I’m patching the player-facing character and location files plus the item’s private description so the key’s revealed function is recorded once, not duplicated across files.Updated [[Thirteen-Key Ring]] — revealed as concealed-ship access device; entry-level access confirmed (private)\nUpdated [[Kestrel]] — used the thirteenth key to unlock the front door; house woke in sequence (player-facing)\nUpdated [[Vey House]] — front door unlocked; house woke in sequence (player-facing)",
-          "toolCalls": [],
-          "usage": {
-            "inputTokens": 15241,
-            "outputTokens": 118,
-            "cacheReadTokens": 14720,
-            "cacheCreationTokens": 0,
-            "reasoningTokens": 43
-          },
-          "stopReason": "end",
-          "assistantContent": [
-            {
-              "type": "text",
-              "text": "I’m updating the tracked entities tied to the key use and the new private item lore. First I’m checking the existing `Thirteen-Key Ring` file so I can patch it without duplicating or overwriting unrelated content."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_zK4Bg7uZEVLgda5fgIlinkom",
-              "name": "read_entity",
-              "input": {
-                "entity_type": "item",
-                "slug": "thirteen-key-ring"
-              }
-            },
-            {
-              "type": "text",
-              "text": "I’m updating the tracked entities tied to the key use and the new private item lore. First I’m checking the existing `Thirteen-Key Ring` file so I can patch it without duplicating or overwriting unrelated content.I’ve got the item state. Next I’m patching the player-facing character and location files plus the item’s private description so the key’s revealed function is recorded once, not duplicated across files."
-            },
-            {
-              "type": "tool_use",
-              "id": "call_r9n5bAtJZHvPsy32yaRJtmQ0",
+              "id": "toolu_01EdgnzAQqsxqVM2htjJRsak",
               "name": "write_entity",
               "input": {
-                "entity_type": "item",
-                "name": "Thirteen-Key Ring",
                 "mode": "update",
-                "body": "# Thirteen-Key Ring\n\n**Type:** item\n**Owner:** [[Kestrel]]\n**Origin:** [[Vey House]]\n\nA ring of thirteen keys carried to [[Vey House]] by [[Kestrel]]. The seamless thirteenth key is an identity and access device for the concealed ship: its apparent turning action translates Kestrel's motion into authentication, grants entry-level access, and woke deeper systems when used. It still reacts to Kestrel's touch with warmth and a hairline luminous mark.\n",
-                "changelog_entry": "Revealed as an identity and access device for the concealed ship; granted entry-level access"
-              }
-            },
-            {
-              "type": "tool_use",
-              "id": "call_i7jRHPbJ2lh9PNbv0q6g0XL3",
-              "name": "write_entity",
-              "input": {
                 "entity_type": "character",
                 "name": "Kestrel",
-                "mode": "update",
-                "body": "## Inventory\n- [[Thirteen-Key Ring]] — received at the entrance to [[Vey House]]; the seamless thirteenth key warmed and left a hairline luminous mark when Kestrel touched it, then unlocked the front door and went dark after use\n\n## Notes\n- Arrives at [[Vey House]] in cold rain during late afternoon to receive the estate, fortune, and keys from lawyer [[Eudes Metivier]].\n- Grandmother is deceased.\n- The thirteenth key in the ring reacted to Kestrel's touch, suggesting a hidden or nonstandard mechanism in the house.\n- The seamless thirteenth key unlocked the front door and woke the house's interior systems in sequence.\n",
-                "changelog_entry": "Unlocked the front door with the thirteenth key; the house woke in sequence"
+                "front_matter": {
+                  "location": "[[Wickmoor House]]"
+                },
+                "changelog_entry": "Arrived at Wickmoor House to take possession"
               }
             },
             {
-              "type": "tool_use",
-              "id": "call_WkhHwPVpr4y0lcnWY4AZ7sH0",
+              "id": "toolu_01T9uqYS5HawG8nxmgyWkMbf",
               "name": "write_entity",
+              "input": {
+                "mode": "create",
+                "entity_type": "character",
+                "name": "Ilse Marrow",
+                "front_matter": {
+                  "type": "character",
+                  "disposition": "mysterious"
+                },
+                "body": "Kestrel's grandmother. Deceased. Left [[Wickmoor House]] to Kestrel with conditions that remain partially obscure to the estate's solicitor, [[Ordell Vance]]. The source of payment for Vance's services is untraceable.",
+                "changelog_entry": "Grandmother; left estate with mysterious conditions"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 4450,
+            "outputTokens": 927,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 0,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "tool_use",
+              "id": "toolu_01XKtrTKsHhdgMP8wnCG4ces",
+              "name": "rename_entity",
               "input": {
                 "entity_type": "location",
-                "name": "Vey House",
-                "mode": "update",
-                "body": "# Vey House\n\n**Type:** Location\n\nGrandmother's large old country estate, inherited by Kestrel. Its rain-dark front drive and entrance hall form the opening scene of the story.\n\nThe house stands under cold rain in late afternoon, with the arrival expected at the front drive and through the entrance hall.\n\n## Notes\n- Kestrel unlocked the front door with the seamless thirteenth key; the house acknowledged the access and woke in sequence.\n",
-                "changelog_entry": "Kestrel unlocked the front door; the house woke in sequence"
+                "old_name": "Starting Location",
+                "new_name": "Wickmoor House",
+                "changelog_entry": "Renamed from placeholder; Kestrel arrives to take possession"
               }
             },
             {
-              "type": "text",
-              "text": "I’m updating the tracked entities tied to the key use and the new private item lore. First I’m checking the existing `Thirteen-Key Ring` file so I can patch it without duplicating or overwriting unrelated content.I’ve got the item state. Next I’m patching the player-facing character and location files plus the item’s private description so the key’s revealed function is recorded once, not duplicated across files.Updated [[Thirteen-Key Ring]] — revealed as concealed-ship access device; entry-level access confirmed (private)\nUpdated [[Kestrel]] — used the thirteenth key to unlock the front door; house woke in sequence (player-facing)\nUpdated [[Vey House]] — front door unlocked; house woke in sequence (player-facing)"
+              "type": "tool_use",
+              "id": "toolu_01AArBmQzkUjBDbk39NKdDdE",
+              "name": "write_entity",
+              "input": {
+                "mode": "update",
+                "entity_type": "location",
+                "name": "Wickmoor House",
+                "front_matter": {
+                  "placeholder": null
+                },
+                "body": "Kestrel's late grandmother's rambling old estate at the end of a long gravel drive. Slate roof, sash windows, twelve exterior locks — a locksmith's house. The afternoon light is failing as Kestrel arrives to take possession.",
+                "changelog_entry": "Added description"
+              }
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_012FyvtEfNzBKAx45ADfoR46",
+              "name": "write_entity",
+              "input": {
+                "mode": "create",
+                "entity_type": "character",
+                "name": "Ordell Vance",
+                "front_matter": {
+                  "type": "character",
+                  "disposition": "nervous",
+                  "location": "[[Wickmoor House]]"
+                },
+                "body": "Estate solicitor. Nervous and sweating in the cold wind, drowning in paperwork. He carries a ring of house keys like it might bite him. Wants the handover completed before dark.\n\n**Secrets:** Vance is anxious because the will's conditions were dictated to him in person and he does not understand them. He has been paid generously from a source he could not trace. He has never been inside [[Wickmoor House]] past the front hall.",
+                "changelog_entry": "Arrived to oversee handover; carries house keys"
+              }
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01EdgnzAQqsxqVM2htjJRsak",
+              "name": "write_entity",
+              "input": {
+                "mode": "update",
+                "entity_type": "character",
+                "name": "Kestrel",
+                "front_matter": {
+                  "location": "[[Wickmoor House]]"
+                },
+                "changelog_entry": "Arrived at Wickmoor House to take possession"
+              }
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01T9uqYS5HawG8nxmgyWkMbf",
+              "name": "write_entity",
+              "input": {
+                "mode": "create",
+                "entity_type": "character",
+                "name": "Ilse Marrow",
+                "front_matter": {
+                  "type": "character",
+                  "disposition": "mysterious"
+                },
+                "body": "Kestrel's grandmother. Deceased. Left [[Wickmoor House]] to Kestrel with conditions that remain partially obscure to the estate's solicitor, [[Ordell Vance]]. The source of payment for Vance's services is untraceable.",
+                "changelog_entry": "Grandmother; left estate with mysterious conditions"
+              }
             }
           ]
         }
+      },
+      {
+        "kind": "chat",
+        "bucket": "scribe",
+        "ordinal": 1,
+        "request": {
+          "model": "claude-haiku-4-5-20251001",
+          "messageCount": 3,
+          "systemHash": "972412cb43fc",
+          "tools": [
+            "list_entities",
+            "read_entity",
+            "rename_entity",
+            "write_entity"
+          ],
+          "lastMessagePreview": "[tool_result] [tool_result] [tool_result] [tool_result] [tool_result]"
+        },
+        "result": {
+          "text": "The rename worked, but the location body update needs create mode. Let me retry:",
+          "toolCalls": [
+            {
+              "id": "toolu_01WMWFxBkhvLaUQuyRqy5oYb",
+              "name": "write_entity",
+              "input": {
+                "mode": "create",
+                "entity_type": "location",
+                "name": "Wickmoor House",
+                "front_matter": {
+                  "type": "location"
+                },
+                "body": "Kestrel's late grandmother's rambling old estate at the end of a long gravel drive. Slate roof, sash windows, twelve exterior locks — a locksmith's house. The afternoon light is failing as Kestrel arrives to take possession.",
+                "changelog_entry": "Described; Kestrel arrives to take possession"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 5741,
+            "outputTokens": 234,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 0,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "The rename worked, but the location body update needs create mode. Let me retry:"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01WMWFxBkhvLaUQuyRqy5oYb",
+              "name": "write_entity",
+              "input": {
+                "mode": "create",
+                "entity_type": "location",
+                "name": "Wickmoor House",
+                "front_matter": {
+                  "type": "location"
+                },
+                "body": "Kestrel's late grandmother's rambling old estate at the end of a long gravel drive. Slate roof, sash windows, twelve exterior locks — a locksmith's house. The afternoon light is failing as Kestrel arrives to take possession.",
+                "changelog_entry": "Described; Kestrel arrives to take possession"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "chat",
+        "bucket": "scribe",
+        "ordinal": 2,
+        "request": {
+          "model": "claude-haiku-4-5-20251001",
+          "messageCount": 5,
+          "systemHash": "972412cb43fc",
+          "tools": [
+            "list_entities",
+            "read_entity",
+            "rename_entity",
+            "write_entity"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "The file exists post-rename. Trying update with the slug directly:",
+          "toolCalls": [
+            {
+              "id": "toolu_01PMr9oAurpFb4LQNUPvvNsz",
+              "name": "read_entity",
+              "input": {
+                "entity_type": "location",
+                "slug": "wickmoor-house"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 6048,
+            "outputTokens": 92,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 0,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "The file exists post-rename. Trying update with the slug directly:"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_01PMr9oAurpFb4LQNUPvvNsz",
+              "name": "read_entity",
+              "input": {
+                "entity_type": "location",
+                "slug": "wickmoor-house"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "chat",
+        "bucket": "scribe",
+        "ordinal": 3,
+        "request": {
+          "model": "claude-haiku-4-5-20251001",
+          "messageCount": 7,
+          "systemHash": "972412cb43fc",
+          "tools": [
+            "list_entities",
+            "read_entity",
+            "rename_entity",
+            "write_entity"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "Now update it properly:",
+          "toolCalls": [
+            {
+              "id": "toolu_012wPwTXibQm2ATHtPdTYbWN",
+              "name": "write_entity",
+              "input": {
+                "mode": "update",
+                "entity_type": "location",
+                "name": "Wickmoor House",
+                "front_matter": {
+                  "placeholder": null
+                },
+                "body": "Kestrel's late grandmother's rambling old estate at the end of a long gravel drive. Slate roof, sash windows, twelve exterior locks — a locksmith's house. The afternoon light is failing as Kestrel arrives to take possession.",
+                "changelog_entry": "Added full description"
+              }
+            }
+          ],
+          "usage": {
+            "inputTokens": 6217,
+            "outputTokens": 212,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 0,
+            "reasoningTokens": 0
+          },
+          "stopReason": "tool_use",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "Now update it properly:"
+            },
+            {
+              "type": "tool_use",
+              "id": "toolu_012wPwTXibQm2ATHtPdTYbWN",
+              "name": "write_entity",
+              "input": {
+                "mode": "update",
+                "entity_type": "location",
+                "name": "Wickmoor House",
+                "front_matter": {
+                  "placeholder": null
+                },
+                "body": "Kestrel's late grandmother's rambling old estate at the end of a long gravel drive. Slate roof, sash windows, twelve exterior locks — a locksmith's house. The afternoon light is failing as Kestrel arrives to take possession.",
+                "changelog_entry": "Added full description"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "chat",
+        "bucket": "scribe",
+        "ordinal": 4,
+        "request": {
+          "model": "claude-haiku-4-5-20251001",
+          "messageCount": 9,
+          "systemHash": "972412cb43fc",
+          "tools": [
+            "list_entities",
+            "read_entity",
+            "rename_entity",
+            "write_entity"
+          ],
+          "lastMessagePreview": "[tool_result]"
+        },
+        "result": {
+          "text": "Done.\n\n**Summary:**\n- Renamed [[Starting Location]] → [[Wickmoor House]] (placeholder cleared, description added)\n- Updated [[Kestrel]] — location set to Wickmoor House\n- Created [[Ordell Vance]] (character, player-facing; nervous solicitor with house keys)\n- Created [[Ilse Marrow]] (character, private; Kestrel's grandmother, deceased, left estate with mysterious conditions)",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 6491,
+            "outputTokens": 106,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 0,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "text",
+              "text": "Done.\n\n**Summary:**\n- Renamed [[Starting Location]] → [[Wickmoor House]] (placeholder cleared, description added)\n- Updated [[Kestrel]] — location set to Wickmoor House\n- Created [[Ordell Vance]] (character, player-facing; nervous solicitor with house keys)\n- Created [[Ilse Marrow]] (character, private; Kestrel's grandmother, deceased, left estate with mysterious conditions)"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "chat",
+        "bucket": "dm",
+        "ordinal": 3,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 7,
+          "systemHash": "3cdaf5b00fe4",
+          "tools": [
+            "advance_turn",
+            "alarm",
+            "deck",
+            "describe_entity_type",
+            "detect_orphans",
+            "dm_notes",
+            "end_combat",
+            "enter_ooc",
+            "entity",
+            "find_schema_drift",
+            "list_entity_types",
+            "manage_objectives",
+            "map",
+            "map_entity",
+            "map_query",
+            "modify_initiative",
+            "present_choices",
+            "promote_character",
+            "resolve_turn",
+            "roll_dice",
+            "scene_transition",
+            "scribe",
+            "search_campaign",
+            "search_content",
+            "session_end",
+            "set_display_resources",
+            "set_resource_values",
+            "start_combat",
+            "style_scene",
+            "switch_player",
+            "time",
+            "update_modeline",
+            "validate_entity"
+          ],
+          "lastMessagePreview": "<context> ## Current State PCs: Kestrel ## Entity Registry characters/ilse-marrow.md — Ilse Marrow (character) character"
+        },
+        "result": {
+          "text": "Twelve are cold as the wind. The thirteenth is not.\n\nIt sits at the back of the ring, and it is warm the way a coin is warm out of someone's pocket — not hot, just <i>recently held</i>. Small. Older than the others, the bow worn thin and oval where a thumb has ridden it for years. And unstamped. Every other key on this ring has a number scratched into it in your grandmother's hand, because she never trusted a memory she could scratch into brass instead. This one has nothing.\n\nVance watches your hands and does not seem to see any of it.\n\n\"I'm sorry — <i>which</i> room?\"\n\nYou ask again. He looks at the house. He looks at his wallet of papers, and he opens it, and he closes it, which tells you the answer isn't in there.\n\n\"There's no — Miss Kestrel, there's an inventory, a full schedule of the property, I drew it up myself with the executor's surveyor. Nine bedrooms, the kitchens, the two cellars, the workshop.\" A pause with a little too much air in it. \"Nothing is <i>named</i>. Rooms aren't named.\"\n\nThe wind moves the leaf-mulch on the step. He steps sideways off it without appearing to notice he's done so.\n\n\"Did she tell you something?\" he asks. \"Did she write to you?\"",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 254,
+            "outputTokens": 755,
+            "cacheReadTokens": 17623,
+            "cacheCreationTokens": 2535,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAISqQkKhwEIEBgCKkDPGI+lLeC3znm1JQ5+c4RLuqEikGlwGh0+LqFbhF5Z/OB8bJ8AH/SNN1jFSSbdhIRADOWHULYVsGFRj4tIMWXDMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDHb3TxxxV2H1hH3RPhoMmyOG+Spc6n7DvHkbIjBJxO0EzgbYs9dzYdkTPYEULOR2LzWy82S6itWSVFFYcessenHUbws4DMk3PG174fUqzgdD29WDCr+1E/LqYrYV1e76ZmIJRvrcG4wFvdo5jEOKL2NsJNpncA3nbudqbSpUnRs3DrWJEGQ0fmOhgUzB7uxIruO6rAXsqzY/mPtdZHW/8lVQrSq7LxrlZnRSB6YVMB0UqK1f4x1vN6JU4xOOgsbUBvH6mhK5mpsJTOOJlTdRToW2awNSNt1bx/IWdXmb2MyPqLxci1fpnn8awJDefEOa687VYHqxmYog5jxcQ03jsIBcZXVoiU8KqmQVNUHJ0nKvYh9XNgCqDuOCnCUy/51Krr1MX1MJnTyPI2kjdLrKKc8Pmel6ph0mHGEEGg5bLfdDR0f3WmVV2+2FFlnTNKPGjfA+00kfPfMMtURVwZMO7SJ6otgCcTkiA0Y5I1omGu9mqvhg35T3o/0/2ly+UWI7wXtfyt72l+g7mwFLxLBhpENbdHuWPDU/EAN1Xc6NigASpOoKZoTR+Eky3F4qGkW/f9K8TtLOiPFeXRLawHoOJZx5yq6GGWkoptDMS0Evh6tbKrGFkROMUl+GRZdWUXlDA7S+9Y8a8h7d7mvHxzmIXG5oJKFwXdyFMCibZV1qXa5OUQnBO2RyvXQWa0xZYvj/rNx7bKSvRc1Ywc56tdXbtZG+sxOWO85RDMVHjf8BGQPPGEgzCydk66gpfodynxdamXpWxINa0sb5xl56KXZo52byVjwkGbV6yYZUq4ITtS+gRUWbXR3PNEjcZGlP4N3wYuT+0dPq3TBHWi2v8xq408SRlG3Y6lsOd+LQHKZV8gxnRzv2xCV/xRyf6/Xc5g9zYrw7IQNAjWqy2FL6ek2WZ5j5Y3LcIjgfnqRh+F0Oqv41lOO0yk7m7WciMSnPIQXUHae23i8gq/wWYyqYUruXuSNLiBXAp2BlIbxOApMHyaCbA+y2gGcFxaI2ZHIFV5oEaEwXNBTwxrGRPmvRob2KYW+ModdqOkoM7xk7UVu0DRV3sgI8KxpkuJVI+pkxv88jdO01qMrNzYxXFptxsWXfLoWibyA0rxcPl30s/+hlro/KeanvJxPTJxMYgQAFVxdWt/I+PZG7NFhpH1U8t91O9mrC/CQZv2qKoVZwtAd+j9eKVtRUxnMRdChctSg7N8DmuEWsutI37AbwcBE6YEP1fzBtfbTlUEwQc225iqNDWtRfB00PQsFnVFzQrivAqh3x604KInbZO2pRk4LSzSuqTqSJP5MerAgZa/gDp9pxHSljhEC6KKhxZA3J6aWDP67YIGBipL0dEw2lfkLrUZJtEy1wCjtdVy3blKvZLrBp/8Az0gfsr3YZGkeYJcvhjRgB"
+            },
+            {
+              "type": "text",
+              "text": "Twelve are cold as the wind. The thirteenth is not.\n\nIt sits at the back of the ring, and it is warm the way a coin is warm out of someone's pocket — not hot, just <i>recently held</i>. Small. Older than the others, the bow worn thin and oval where a thumb has ridden it for years. And unstamped. Every other key on this ring has a number scratched into it in your grandmother's hand, because she never trusted a memory she could scratch into brass instead. This one has nothing.\n\nVance watches your hands and does not seem to see any of it.\n\n\"I'm sorry — <i>which</i> room?\"\n\nYou ask again. He looks at the house. He looks at his wallet of papers, and he opens it, and he closes it, which tells you the answer isn't in there.\n\n\"There's no — Miss Kestrel, there's an inventory, a full schedule of the property, I drew it up myself with the executor's surveyor. Nine bedrooms, the kitchens, the two cellars, the workshop.\" A pause with a little too much air in it. \"Nothing is <i>named</i>. Rooms aren't named.\"\n\nThe wind moves the leaf-mulch on the step. He steps sideways off it without appearing to notice he's done so.\n\n\"Did she tell you something?\" he asks. \"Did she write to you?\""
+            }
+          ],
+          "cacheDiagnostics": {
+            "reasonType": "messages_changed",
+            "missedInputTokens": 2222
+          }
+        },
+        "streamDeltas": [
+          "Twelve are cold as the wind.",
+          " The thirteenth is not.\n\nIt sits at the back of the ring, and it is warm the way a co",
+          "in is warm out of someone's pocket — not hot, just <i>recently held",
+          "</i>. Small. Older than the others, the bow worn th",
+          "in and oval where a thumb has ridden it for years. And unstamped. Every other key on this",
+          " ring has a number scratched into it in your grandmother's hand, because she never tr",
+          "usted a memory she could scratch into brass instead. This one has nothing.\n\nVance watches your h",
+          "ands and does not seem to see any of it.\n\n\"I'm sorry — <i>which</i> room?\"",
+          "\n\nYou ask again. He looks at the house. He looks at his wallet of papers, and he opens it, and he clos",
+          "es it, which tells you the answer isn't in there.\n\n\"There's no — Miss K",
+          "estrel, there's an inventory, a full schedule of the property, I drew it up",
+          " myself with the executor's surveyor. Nine bedrooms, the kitchens, the two",
+          " cellars, the workshop.\" A pause with a little too much air in it. \"Nothing is <i>named</i>.",
+          " Rooms aren't named.\"\n\nThe wind moves the leaf-mulch on the step. He steps s",
+          "ideways off it without appearing to notice he's done so.\n\n\"",
+          "Did she tell you something?\" he asks. \"Did she write to you?\""
+        ]
+      },
+      {
+        "kind": "chat",
+        "bucket": "dm",
+        "ordinal": 4,
+        "request": {
+          "model": "claude-opus-5",
+          "messageCount": 9,
+          "systemHash": "3cdaf5b00fe4",
+          "tools": [
+            "advance_turn",
+            "alarm",
+            "deck",
+            "describe_entity_type",
+            "detect_orphans",
+            "dm_notes",
+            "end_combat",
+            "enter_ooc",
+            "entity",
+            "find_schema_drift",
+            "list_entity_types",
+            "manage_objectives",
+            "map",
+            "map_entity",
+            "map_query",
+            "modify_initiative",
+            "present_choices",
+            "promote_character",
+            "resolve_turn",
+            "roll_dice",
+            "scene_transition",
+            "scribe",
+            "search_campaign",
+            "search_content",
+            "session_end",
+            "set_display_resources",
+            "set_resource_values",
+            "start_combat",
+            "style_scene",
+            "switch_player",
+            "time",
+            "update_modeline",
+            "validate_entity"
+          ],
+          "lastMessagePreview": "<context> ## Current State PCs: Kestrel ## Entity Registry characters/ilse-marrow.md — Ilse Marrow (character) character"
+        },
+        "result": {
+          "text": "It goes in.\n\nThat's the first surprise. It goes in smoothly, to full depth, and seats with the small dry click of a key that belongs — no forcing, no chatter against the wards. Your grandmother cut keys in <i>families</i>: same blank, same waist, same shoulder, so a hand could find its way in the dark by feel alone. This key is family to this door.\n\nThen you turn, slow and deliberate, and it stops. Not jammed. <b>Stopped.</b> A quarter of the way round it meets something that is not a ward and not grit, something square and patient, and no amount of wrist is going to persuade it.\n\nYou know exactly what that means, and you know it in your hands before you know it in words: this key was cut for a lock <i>like</i> this one. Not this one. Somewhere behind that door is a sibling lock, same pattern, same maker, and she carried its key on her thumb-ring for years until the brass went oval.\n\nVance has gone quite still on the gravel. \"Is it — is there a problem with the door?\"\n\nYou draw the thirteenth key out. It comes free clean. Number one goes in, turns like it was oiled last week, and <color=#009de5>Wickmoor House</color> lets you into a front hall smelling of cold stone, beeswax, and — faintly, unfairly — the lavender soap she used to make you wash your hands with before she'd let you touch a tool.\n\nVance stays on the step. \"I'll — I'll wait here, shall I. There's light out here.\"",
+          "toolCalls": [],
+          "usage": {
+            "inputTokens": 231,
+            "outputTokens": 737,
+            "cacheReadTokens": 20158,
+            "cacheCreationTokens": 804,
+            "reasoningTokens": 0
+          },
+          "stopReason": "end",
+          "assistantContent": [
+            {
+              "type": "thinking",
+              "text": "",
+              "signature": "CAIS0QcKhwEIEBgCKkBqb59WrH59b3ZYHHb7P7GlRQJptmgyvBvWkjY2Zc3NSf1WNiVxMmyhQlMORaRCSgnXjvHmBxw1110W7jdDeVbOMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiRjMTQyNWIzOS01YzBhLTRlM2QtYTI2Ni0wMTk0NjRmZjIwOTESDGcQzOSzSMWZN9Fv1hoMyVtagRmgpU3CUyzKIjCX5ieSecBYw8CSH1p3fGtGRUTzjX/6WtNBJHRTjlPZzXyqjibuIqv65THOnG3NYDMq9gVLVTVH7Sg0ORUGODfJU0gyO3Xn37tv9CgLfari9oFe8rwukXM07HNEr28SwXI6pWvHj0lAhC4e+IQ9Xvu/5QkxktVQtuE+v30wdUr/a2hgSAL9kn2drpkyyXqU+XkvtgZ/uonywHXswKIeUXV/rLWWlQZYx6sCq9v/feFQDdr1beeXxGrZGnoa6LJjidK7YUHYqamKSrJhlpirJT4D1aXt/mZk9A1TdBwIXRrJm3Fb5Qq2azDVkcImmW10gDxXCkYSWYlNiHfwc7DwDQ3vK3QlTDfxKe+jExOCBpkdtJCHLTLAvVQU0ZqoutPPtVe6GfEweD3wO0HlEIPL3u3PpYUCCsTXKBJ/2wgk+8F6xul76JTR70WUOo/exuEqd1OgjvniUfCJTztopI+jOuijgrFxeamZHGrSEG3ldrAIacJmH47aLdtjeREeInm+31XRuBADdWxYRIkWhEvm/dtfLa0AeWzSMU/AkpS982hRQ6gybaKBZPuLqTgsvtR+vKy3k8+Cj9PWRTOBZRW+zpJRpOa8chMKxKzreElB8GztyeEetfr91PjmNwveJ+89mUg/vYNxrcLGp/Os4n4UXW0oxrQrnUqXsw2HIWshHBMPqcEDaJvYlU22qwNDz84M6ahyWW64MJ58GTco8MtuRLxaOBJOO5Cl9aVISuJ0m4w2iGA6vvhFb1K+tSgO2fivuAoIyiFnUyiWow7pz1mospIFSTb9VckPQaxdlqb76sr4fdLEwqgPzfRNVT93sowZMYH3MKDgBftwlTMzj0QqCA1VlYemsWjO59sCCpmKk2chqY5Q9lZaHNmvSTkubxi4tpTrrYT/ZBVmzQDB+qsDwxkyrGNq47JMmgo7DOM+3a7kIExfv+lxLtsABeQu6LnXfKsxiT54dxlFpdbpQUpea8H9l0bb+Vp+aVeGBN/AzudZRSIDNp4rU1xNkOLzyN8m/+K6EoUDUQy+p1R6+/hAjA78kTqplOPRAwtyx2ua3TS5aQpHq3zg92XvtxgB"
+            },
+            {
+              "type": "text",
+              "text": "It goes in.\n\nThat's the first surprise. It goes in smoothly, to full depth, and seats with the small dry click of a key that belongs — no forcing, no chatter against the wards. Your grandmother cut keys in <i>families</i>: same blank, same waist, same shoulder, so a hand could find its way in the dark by feel alone. This key is family to this door.\n\nThen you turn, slow and deliberate, and it stops. Not jammed. <b>Stopped.</b> A quarter of the way round it meets something that is not a ward and not grit, something square and patient, and no amount of wrist is going to persuade it.\n\nYou know exactly what that means, and you know it in your hands before you know it in words: this key was cut for a lock <i>like</i> this one. Not this one. Somewhere behind that door is a sibling lock, same pattern, same maker, and she carried its key on her thumb-ring for years until the brass went oval.\n\nVance has gone quite still on the gravel. \"Is it — is there a problem with the door?\"\n\nYou draw the thirteenth key out. It comes free clean. Number one goes in, turns like it was oiled last week, and <color=#009de5>Wickmoor House</color> lets you into a front hall smelling of cold stone, beeswax, and — faintly, unfairly — the lavender soap she used to make you wash your hands with before she'd let you touch a tool.\n\nVance stays on the step. \"I'll — I'll wait here, shall I. There's light out here.\""
+            }
+          ]
+        },
+        "streamDeltas": [
+          "It goes in.\n\nThat",
+          "'s the first surprise. It goes in smoothly, to full depth, and seats with the small d",
+          "ry click of a key that belongs — no forcing, no chatter against",
+          " the wards. Your grandmother cut keys in <i>families</i>: same blank, same waist, same sh",
+          "oulder, so a hand could find its way in the",
+          " dark by feel alone. This key is family to this door.\n\nThen",
+          " you turn, slow and deliberate, and it stops. Not j",
+          "ammed. <b>Stopped.</b> A quarter of the way round it",
+          " meets something that is not a ward and not grit, something square and patient, and no amount of w",
+          "rist is going to persuade it.\n\nYou know exactly what that means, and you know it in your",
+          " hands before you know it in words: this key was cut for a lock <i>like</i> this one. Not this one. Som",
+          "ewhere behind that door is a sibling lock, same pattern, same maker, and she car",
+          "ried its key on her thumb-ring for years until the brass went oval.\n\nVance has gone quite",
+          " still on the gravel. \"Is it — is there a problem with the door?\"\n\nYou draw the thirteenth key out",
+          ". It comes free clean. Number one goes in, turns like",
+          " it was oiled last week, and <color=#009de5>Wickmoor House</color> lets you into",
+          " a front hall smelling of cold stone, beeswax, and — faintly, unfairly — the l",
+          "avender soap she used to make you wash your hands with before she'd let you touch a tool.\n\nVance stays",
+          " on the step. \"I'll — I'll wait here, sh",
+          "all I. There's light out here.\""
+        ]
       }
     ]
   },
   "expectedNarrative": [
-    "<center><b>The Curtain Rises</b><br><i>A blank map waits beneath the lamplight.</i></center>",
+    "<center><b>◈ WELCOME TO THE ENGINE ◈</b></center>",
     "",
-    "Somewhere beyond the edge of the known world, a door has opened. Tonight, we decide what waits behind it... and who dares cross the threshold.",
+    "The lamps are lit. The dice are still cold in their cup. Somewhere in the dark behind the curtain, a hundred worlds are holding their breath — <i>waiting to be told which one of them gets to be real tonight.</i>",
     "",
-    "But first: every legend needs a name at the table.",
-    "Welcome back, <b>Kestrel</b>. Your seat is waiting, and the shadows already know your name.",
+    "I am your master of ceremonies, your cartographer, your <color=#c060ff>willing conspirator</color>. Between us we will build a place that has never existed, and then we will put you inside it and see what you do.",
     "",
-    "Now choose how we raise the curtain: leap toward a waiting world, or build one deliberately from the first spark.",
-    "Then let chance strike the match.",
+    "But first — the oldest question in storytelling. <b>Who's telling this one with me?</b>",
     "",
-    "Ten worlds turn slowly beneath the spotlight. Choose the one whose gravity catches you.",
-    "The will is read. The keys are counted. And somewhere inside the old house, a lock has just turned by itself.",
+    "Before we begin: what should I call you?",
+    "<color=#44cc44>Kestrel</color>. Good name — sharp, quick, a hunter's name. It'll do nicely in the credits.",
     "",
-    "I’m opening <i>Heirloom</i> now to discover which inheritance has been waiting for you.The papers appear ordinary. The estate does not.",
+    "One quick thing before we open the door:",
+    "Noted. The full instrument, then — <i>all the strings, including the low ones.</i>",
     "",
-    "One last choice before we meet the inheritor.",
-    "Now, <b>Kestrel</b>... who inherited the estate?",
+    "Now. Three doors stand before you, Kestrel. Behind two of them, worlds I've already built and kept in jars. Behind the third — <color=#c060ff>nothing at all yet</color>, because that one is yours to describe, and I will build it from raw material while you watch.",
+    "<b>Quick Start.</b> Excellent — a player who wants the story more than the paperwork. I approve.",
     "",
-    "Give me your character’s <b>name</b> and a <b>one-sentence concept</b>: who they are, and what complicated history they had with Grandmother.",
-    "<center><b>Heirloom</b></center>",
+    "Tell me the shape of the world, and I'll bring you the ones I have in stock.",
+    "<color=#cc4444>Horror</color>. <i>Good.</i> The genre where the engine does its finest work — because dread is made of patience, and I have nothing but time.",
     "",
-    "A <color=#cc4444>mysterious science-fantasy</color> tale with a balanced mood and difficulty, unfolding across <i>A Few Sessions</i>. <b>The Archivist</b> will narrate with precise, increasingly unsettling detail. Play will be purely narrative, without dice or mechanics, and images are off.",
+    "Here's what's on the shelf. Take your time with these; each one is a different flavor of <i>wrong</i>.",
+    "Not these, then. <i>Fine.</i> I keep the stranger jars on the lower shelf.",
+    "<b><u>Heirloom</u></b>. Oh, <i>lovely</i> choice — the horror of inheritance, which is the only horror everyone eventually experiences.",
     "",
-    "You’ll play <color=#44cc44>Kestrel</color>, a tight-lipped locksmith and Grandmother’s estranged apprentice, the only person who still understands the old house’s locks.",
+    "<quote>Your name on the door.<br>In her hand.<br>Written before you were born.</quote>",
     "",
-    "Sound good, or would you like to change anything?",
-    "The configuration is confirmed. The house keeps its counsel, the final seal breaks, and the first key turns.The inheritance is yours, Kestrel.",
+    "Let me open the deed box.The lawyer's file has a second folder beneath the first. I'll read that one privately.The deed is signed. The keys are cold. <i>I know what's behind the door now, and I'm not going to tell you.</i>",
     "",
-    "May every lock surrender its truth.",
+    "<center><b>◈ HEIRLOOM ◈</b><br><i>An old house. A locked room. Your name on it.</i></center>",
+    "",
+    "How long should this haunting last?",
+    "<b>A few sessions.</b> Enough rope to hang the dread properly.",
+    "",
+    "Now the most important choice you'll make, Kestrel — <i>the voice.</i> Someone has to stand at your shoulder in that house and tell you what you're looking at. They are not all equally kind.",
+    "The lower shelf again. <i>You have expensive taste.</i> Some of these I keep for myself.",
+    "Third pass. <i>Now we're in the drawer I keep locked.</i>",
+    "",
+    "(And remember — you can always simply <b>describe</b> the voice you want, and I'll conjure it.)",
+    "<b>The Locksmith.</b> <i>Of course.</i> A house with a locked door in it, narrated by someone who cannot stop thinking about hinges. That's the correct answer and I'm annoyed I didn't see it coming.",
+    "",
+    "Now — how do you want to <i>play</i> it?",
+    "<b>Pure narrative.</b> Nothing between you and the door but nerve.",
+    "",
+    "<center><i>So. Last thing, and the only thing that matters.</i></center>",
+    "",
+    "Somewhere a lawyer is standing in a gravel driveway holding a ring of keys, checking his watch, and hoping you show up before the light goes.",
+    "",
+    "<b>Who is he waiting for?</b>",
+    "",
+    "Give me a <color=#44cc44>name</color>, and a sentence about who you are — what you do, what you were doing when the letter arrived, why you of all the grandchildren got the room with your name on it. A rough sketch is plenty; I'll fill in the shading.",
+    "<i>A locksmith.</i> Kestrel — you have just made this narrator very happy. The voice that reads the world in tumblers and hinges, and a protagonist whose hands already know the answer before her head does. <b>Estranged apprentice</b> is the good bruise in it: she taught you the trade and then something went wrong between you, and now she's dead and has left you a door.",
+    "",
+    "Let me read it back before I turn the key.",
+    "",
+    "<center><i>Heirloom</i></center>",
+    "",
+    "A <color=#cc4444>slow-burn horror</color>, <b>Balanced</b> difficulty, scoped as <i>A Few Sessions</i>, narrated by <b>The Locksmith</b> — who thinks about thresholds the way other people think about breathing. <b>Pure narrative</b>: no dice, no sheets, just the house and what you do in it. You'll be playing as <color=#44cc44>Kestrel</color>, a tight-lipped locksmith and her grandmother's estranged apprentice — the only living person who still knows the old house's locks.",
+    "",
+    "There is a room in that house with your name on the door, written in her hand, decades before you were born. <i>I know what's behind it. You don't.</i>",
+    "",
+    "Sound good, or want to change anything?",
+    "<center><b>◈ THE ESTATE OF THE LATE MRS. — ◈</b><br><i>one house · one fortune · one door</i></center>",
+    "",
+    "The paperwork is filed. The keys have been counted twice, because the lawyer counted them once and then didn't trust himself.",
+    "",
+    "<quote>Every lock is a promise someone made about who was allowed in.<br>Your grandmother made a great many promises.</quote>",
+    "",
+    "Go carefully, <color=#44cc44>Kestrel</color>. And when you find the door with your name on it — <i>listen to it before you open it.</i>",
+    "",
+    "<right>— your M.C., stepping back behind the curtain</right>",
     "",
     "---",
-    "I’ll establish the estate, its first witnesses, and the initial discrepancy.",
-    "<code>ESTATE TRANSFER — 10 JUNE 2026, 16:17</code>",
+    "The gravel drive is longer than a house this size deserves, and it has been raked recently — someone has kept up habits the owner no longer has.",
     "",
-    "Rain has reduced <color=#009de5>Vey House</color> to measurable facts: thirty-one windows, four chimneys, slate frontage, and one brass knocker polished recently despite Grandmother’s death eleven days ago. The house stands where the road ends, its west wing extending farther than the exterior proportions permit.",
+    "<color=#cc8844>The lawyer</color> is standing beside his car with the door open, as though he might need it. Grey suit, no coat, and the wind coming off the fields is cold enough that he's holding his elbows. He has a document wallet under one arm and, in his right hand, a ring of keys. Twelve of them. He holds them out at arm's length before you're near enough to take them.",
     "",
-    "<color=#cc8844>Eudes Metivier</color>, solicitor, waits beneath the portico with a black document case held against his chest. He aligns it carefully with the edge of a stone pillar before speaking.",
+    "\"Miss Kestrel. <u>Ordell Vance</u.\" He corrects himself, swallows. \"Vance. Ordell Vance. I'm — I'm very sorry for your loss.\"",
     "",
-    "“Kestrel. My condolences.” His gaze passes briefly to the front door. “The liquid estate has cleared probate. The house and contents transfer today. Your grandmother left one additional condition.”",
+    "Behind him, <color=#009de5>the house</color> sits with its shoulders up. Slate, sash windows, a front door with brass furniture worn bright in a ring around the keyhole and dull everywhere else — that door has been used, and used from outside, thousands of times. But the boot-scrape at the threshold is nearly gone under leaf-mulch. Nobody has crossed it in weeks.",
     "",
-    "He opens the case. Inside lie the deed, a bank statement bearing an eight-digit balance, and a ring of thirteen keys. Twelve show familiar age: iron, brass, nickel silver; hand-cut wards bearing Grandmother’s unmistakable file work.",
+    "The keys are cold. You know eight of them by touch before you look.",
     "",
-    "The thirteenth is warm. Its metal is seamless, blue-grey, and without teeth.",
+    "\"There's paperwork,\" Vance says. \"A great deal of it. I'd — <i>if it's all the same to you</i> — I'd rather we did it inside than out here in the dark.\"",
+    "Twelve are cold as the wind. The thirteenth is not.",
     "",
-    "Metivier does not touch it. “She instructed me to give you every key except the one that opens the room bearing your name.”",
+    "It sits at the back of the ring, and it is warm the way a coin is warm out of someone's pocket — not hot, just <i>recently held</i>. Small. Older than the others, the bow worn thin and oval where a thumb has ridden it for years. And unstamped. Every other key on this ring has a number scratched into it in your grandmother's hand, because she never trusted a memory she could scratch into brass instead. This one has nothing.",
     "",
-    "From inside the locked house comes a precise mechanical sound: three tumblers falling into alignment.",
+    "Vance watches your hands and does not seem to see any of it.",
     "",
-    "Metivier’s hands tighten around the case. “That,” he says, “was not happening before you arrived.”",
-    "The thirteenth key weighs approximately twice what its size permits. Under your thumb, its warmth gathers into a narrow line along the shaft. A mark appears there, pale as old phosphor: three nested angles. It is neither engraving nor inlay. The metal itself has changed.",
+    "\"I'm sorry — <i>which</i> room?\"",
     "",
-    "Metivier watches your hand rather than your face.",
+    "You ask again. He looks at the house. He looks at his wallet of papers, and he opens it, and he closes it, which tells you the answer isn't in there.",
     "",
-    "“Third floor. North end.” He squares the deed against the case. “During my first inventory, there was no door there. During my second, there was.”",
+    "\"There's no — Miss Kestrel, there's an inventory, a full schedule of the property, I drew it up myself with the executor's surveyor. Nine bedrooms, the kitchens, the two cellars, the workshop.\" A pause with a little too much air in it. \"Nothing is <i>named</i>. Rooms aren't named.\"",
     "",
-    "Rain ticks against the portico roof. Behind him, the front door has no visible keyway, only Grandmother’s old brass escutcheon plate.",
+    "The wind moves the leaf-mulch on the step. He steps sideways off it without appearing to notice he's done so.",
     "",
-    "“Your name is written across it,” he continues. “In your handwriting. Mrs. Vey’s instructions forbid me from taking you upstairs until the house has admitted you.”",
+    "\"Did she tell you something?\" he asks. \"Did she write to you?\"",
+    "It goes in.",
     "",
-    "The brass plate slides aside by itself, exposing a keyhole of unfamiliar geometry. The luminous angles on the thirteenth key match it exactly.",
-    "The key enters without resistance. At eleven degrees of rotation, the familiar elements engage: lever, gate, bolt. At twenty-three degrees, the mechanism continues beyond the depth available inside the door.",
+    "That's the first surprise. It goes in smoothly, to full depth, and seats with the small dry click of a key that belongs — no forcing, no chatter against the wards. Your grandmother cut keys in <i>families</i>: same blank, same waist, same shoulder, so a hand could find its way in the dark by feel alone. This key is family to this door.",
     "",
-    "Something answers beneath the threshold.",
+    "Then you turn, slow and deliberate, and it stops. Not jammed. <b>Stopped.</b> A quarter of the way round it meets something that is not a ward and not grit, something square and patient, and no amount of wrist is going to persuade it.",
     "",
-    "A sequence travels through <color=#009de5>Vey House</color>: first underfoot, then through the walls, then overhead. Lamps ignite one after another down the entrance hall, though several contain no bulbs. The sound resembles locks opening across a structure much larger than the visible house.",
+    "You know exactly what that means, and you know it in your hands before you know it in words: this key was cut for a lock <i>like</i> this one. Not this one. Somewhere behind that door is a sibling lock, same pattern, same maker, and she carried its key on her thumb-ring for years until the brass went oval.",
     "",
-    "The front door withdraws inward by a precise fraction, breaking its seal. Air passes out carrying beeswax, cold stone, and Grandmother’s bergamot soap.",
+    "Vance has gone quite still on the gravel. \"Is it — is there a problem with the door?\"",
     "",
-    "The mark on the <color=#20b2aa>thirteenth key</color> goes dark.",
+    "You draw the thirteenth key out. It comes free clean. Number one goes in, turns like it was oiled last week, and <color=#009de5>Wickmoor House</color> lets you into a front hall smelling of cold stone, beeswax, and — faintly, unfairly — the lavender soap she used to make you wash your hands with before she'd let you touch a tool.",
     "",
-    "Metivier exhales. “That satisfies the condition.”",
-    "",
-    "Beyond the threshold, a narrow table holds a silver tray. On it rests an envelope that was absent through the rain-streaked glass moments ago.",
-    "",
-    "Across the envelope, in Grandmother’s hand:",
-    "",
-    "<center><u>KESTREL — BEFORE YOU GO UPSTAIRS</u></center>"
+    "Vance stays on the step. \"I'll — I'll wait here, shall I. There's light out here.\""
   ],
   "inputs": [
     {
@@ -2318,24 +2661,58 @@
       "name": "return"
     },
     {
+      "kind": "say",
+      "text": "Kestrel"
+    },
+    {
       "kind": "pick",
-      "index": 0,
-      "label": "◆ Kestrel"
+      "index": 2,
+      "label": "◆ Adult"
     },
     {
       "kind": "pick",
       "index": 0,
-      "label": "◆ <b>Quick Start</b>"
+      "label": "✦ Quick Start"
     },
     {
       "kind": "pick",
-      "index": 0,
-      "label": "◆ <b>Heirloom</b>"
+      "index": 2,
+      "label": "▸ <color=#cc4444>Horror</color> — something is wrong and getting worse"
+    },
+    {
+      "kind": "pick",
+      "index": 9,
+      "label": "◇ Show me some more ideas"
+    },
+    {
+      "kind": "pick",
+      "index": 5,
+      "label": "◇ Heirloom"
     },
     {
       "kind": "pick",
       "index": 1,
-      "label": "◆ No"
+      "label": "▸ A Few Sessions"
+    },
+    {
+      "kind": "pick",
+      "index": 7,
+      "label": "◆ Show me some more ideas"
+    },
+    {
+      "kind": "pick",
+      "index": 8,
+      "label": "◆ Show me some more ideas"
+    },
+    {
+      "kind": "pick",
+      "index": 1,
+      "label": "◆ <b>The Locksmith</b>"
+    },
+    {
+      "kind": "pick",
+      "index": 0,
+      "label": "◇ <color=#c060ff>Pure narrative</color> — no dice, no numbers"
     },
     {
       "kind": "say",
@@ -2347,7 +2724,7 @@
     },
     {
       "kind": "say",
-      "text": "I take the ring of keys, turn the warm thirteenth one over in my fingers, and ask Metivier which room bears my name."
+      "text": "I take the ring of keys, turn the warm thirteenth one over in my fingers, and ask Vance which room bears my name."
     },
     {
       "kind": "say",


### PR DESCRIPTION
## Summary

- re-record the `fullstack-quickstart` golden through the current live setup flow
- include the now-required `finalize_setup.opening_scene` payload
- retain setup-to-game handoff coverage plus two gameplay turns

## Root cause

PR #756 made `opening_scene` a required commit-boundary field for `finalize_setup`, but the committed full-stack tape still replayed the older call shape without that field. Nightly builds completed successfully, then all three packaged-artifact replay jobs rejected finalization and timed out waiting for the next gameplay beat.

## Impact

The refreshed tape matches the intentional setup contract and unblocks the nightly packaged replay gate without weakening production validation.

## Validation

- full-stack source replay: 111/111 DM lines matched
- freshly built Windows SEA replay: 111/111 DM lines matched
- `npm run check`: 209 test files passed; 3,839 tests passed; 14 skipped
- pre-push `token-stamp` and catalog-doc checks passed