### PR TITLE
fix: scroll overflowing model assignment lists

### DIFF
--- a/packages/client-ink/src/phases/ConnectionsPhase.test.tsx
+++ b/packages/client-ink/src/phases/ConnectionsPhase.test.tsx
@@ -127,3 +127,57 @@ describe("ConnectionsPhase image model picker", () => {
     });
   });
 });
+
+describe("ConnectionsPhase model picker scrolling", () => {
+  it("keeps the selected model visible and shows scroll availability arrows", async () => {
+    const onSetTier = vi.fn();
+    const models = Array.from({ length: 40 }, (_, i) => ({
+      id: `model-${i}`,
+      displayName: `Model ${i}`,
+      available: true,
+    }));
+    const rendered = render(<ConnectionsPhase {...defaultProps({
+      connections: [{
+        id: "many-models",
+        provider: "custom",
+        label: "Many Models",
+        masked: "***",
+        models,
+        source: "manual",
+        addedAt: "",
+      }],
+      onSetTier,
+    })} />);
+    const press = async (key: string) => {
+      rendered.stdin.write(key);
+      await new Promise((r) => setTimeout(r, 20));
+    };
+
+    await press(DOWN); // Model Assignments
+    await press(ENTER);
+    await press(ENTER); // Large model picker
+
+    await vi.waitFor(() => {
+      const frame = rendered.lastFrame() ?? "";
+      expect(frame).toContain("Select Large Model");
+      expect(frame).toContain("\u25B2");
+      expect(frame).toContain("\u25BC");
+      expect(frame).toContain("\u25C6 Model 0");
+      expect(frame).not.toContain("Model 39");
+    });
+
+    for (let i = 0; i < 39; i++) await press(DOWN);
+
+    await vi.waitFor(() => {
+      const frame = rendered.lastFrame() ?? "";
+      expect(frame).toContain("\u25C6 Model 39");
+      expect(frame).not.toContain("Model 0 ");
+    });
+
+    await press(ENTER);
+    expect(onSetTier).toHaveBeenCalledWith("large", {
+      connectionId: "many-models",
+      modelId: "model-39",
+    });
+  });
+});

--- a/packages/client-ink/src/phases/ConnectionsPhase.test.tsx
+++ b/packages/client-ink/src/phases/ConnectionsPhase.test.tsx
@@ -171,13 +171,75 @@ describe("ConnectionsPhase model picker scrolling", () => {
     await vi.waitFor(() => {
       const frame = rendered.lastFrame() ?? "";
       expect(frame).toContain("\u25C6 Model 39");
-      expect(frame).not.toContain("Model 0 ");
+      expect(frame).not.toContain("Model 0 [Many Models]");
     });
 
     await press(ENTER);
     expect(onSetTier).toHaveBeenCalledWith("large", {
       connectionId: "many-models",
       modelId: "model-39",
+    });
+  });
+
+  it("keeps the selected image model visible while scrolling", async () => {
+    const onSetImage = vi.fn();
+    const knownImageModels = Object.fromEntries(
+      Array.from({ length: 40 }, (_, i) => [
+        `image-${i}`,
+        { provider: "custom", displayName: `Image Model ${i}` },
+      ]),
+    );
+    const rendered = render(<ConnectionsPhase {...defaultProps({
+      connections: [{
+        id: "many-images",
+        provider: "custom",
+        label: "Many Images",
+        masked: "***",
+        models: [{ id: "text-model", displayName: "Text Model", available: true }],
+        source: "manual",
+        addedAt: "",
+      }],
+      tierAssignments: {
+        large: { connectionId: "many-images", modelId: "text-model" },
+        medium: null,
+        small: null,
+      },
+      knownImageModels,
+      onSetImage,
+    })} />);
+    const press = async (key: string) => {
+      rendered.stdin.write(key);
+      await new Promise((r) => setTimeout(r, 20));
+    };
+
+    await press(DOWN); // Model Assignments
+    await press(ENTER);
+    await press(DOWN);
+    await press(DOWN);
+    await press(DOWN); // Image generation
+    await press(ENTER);
+
+    await vi.waitFor(() => {
+      const frame = rendered.lastFrame() ?? "";
+      expect(frame).toContain("Select Image Model");
+      expect(frame).toContain("\u25B2");
+      expect(frame).toContain("\u25BC");
+      expect(frame).toContain("\u25C6 Provider default");
+      expect(frame).not.toContain("Image Model 39");
+    });
+
+    for (let i = 0; i < 40; i++) await press(DOWN);
+
+    await vi.waitFor(() => {
+      const frame = rendered.lastFrame() ?? "";
+      expect(frame).toContain("\u25C6 Image Model 39");
+      expect(frame).not.toContain("Provider default");
+    });
+
+    await press(ENTER);
+    expect(onSetImage).toHaveBeenCalledWith({
+      connectionId: "many-images",
+      modelId: "image-39",
     });
   });
 });

--- a/packages/client-ink/src/phases/ConnectionsPhase.tsx
+++ b/packages/client-ink/src/phases/ConnectionsPhase.tsx
@@ -725,19 +725,21 @@ export function ConnectionsPhase({
     lines.push(<Text key="header" color={dim}>Select model for {TIER_LABELS[tier]}:</Text>);
     lines.push(<Text key="sep"> </Text>);
     const visibleModelRows = termRows - theme.asset.height * 2 - lines.length;
-    const window = getScrollWindow(
+    const scrollWindow = getScrollWindow(
       tierModelIndex,
       allModels.length,
       visibleModelRows,
       tierModelScrollStartRef.current,
     );
-    tierModelScrollStartRef.current = window.start;
-    for (let i = window.start; i < window.end; i++) {
+    tierModelScrollStartRef.current = scrollWindow.start;
+    for (let i = scrollWindow.start; i < scrollWindow.end; i++) {
       const m = allModels[i];
       const selected = i === tierModelIndex;
-      const visibleIndex = i - window.start;
+      const visibleIndex = i - scrollWindow.start;
       const arrow = visibleIndex === 0 ? "\u25B2" : visibleIndex === 1 ? "\u25BC" : " ";
-      const arrowAvailable = visibleIndex === 0 ? window.canScrollUp : window.canScrollDown;
+      const arrowAvailable = visibleIndex === 0
+        ? scrollWindow.canScrollUp
+        : scrollWindow.canScrollDown;
       lines.push(
         <Text key={`${m.connectionId}-${m.modelId}`} color={selected ? accent : fg}>
           {visibleIndex < 2
@@ -761,19 +763,21 @@ export function ConnectionsPhase({
     lines.push(<Text key="header" color={dim}>Select image model for {largeConnection?.label}:</Text>);
     lines.push(<Text key="sep"> </Text>);
     const visibleModelRows = termRows - theme.asset.height * 2 - lines.length;
-    const window = getScrollWindow(
+    const scrollWindow = getScrollWindow(
       imageModelIndex,
       imageModels.length,
       visibleModelRows,
       imageModelScrollStartRef.current,
     );
-    imageModelScrollStartRef.current = window.start;
-    for (let i = window.start; i < window.end; i++) {
+    imageModelScrollStartRef.current = scrollWindow.start;
+    for (let i = scrollWindow.start; i < scrollWindow.end; i++) {
       const m = imageModels[i];
       const selected = i === imageModelIndex;
-      const visibleIndex = i - window.start;
+      const visibleIndex = i - scrollWindow.start;
       const arrow = visibleIndex === 0 ? "\u25B2" : visibleIndex === 1 ? "\u25BC" : " ";
-      const arrowAvailable = visibleIndex === 0 ? window.canScrollUp : window.canScrollDown;
+      const arrowAvailable = visibleIndex === 0
+        ? scrollWindow.canScrollUp
+        : scrollWindow.canScrollDown;
       lines.push(
         <Text key={m.modelId ?? "provider-default"} color={selected ? accent : fg}>
           {visibleIndex < 2

--- a/packages/client-ink/src/phases/ConnectionsPhase.tsx
+++ b/packages/client-ink/src/phases/ConnectionsPhase.tsx
@@ -72,6 +72,44 @@ const TIER_LABELS: Record<string, string> = {
 const TIERS = ["large", "medium", "small"] as const;
 const ASSIGNMENT_ROWS = TIERS.length + 1;
 
+interface ScrollWindow {
+  start: number;
+  end: number;
+  canScrollUp: boolean;
+  canScrollDown: boolean;
+}
+
+/**
+ * Keep a selected one-row item inside a stable viewport. The window only
+ * moves when the selection crosses an edge, matching the choice list in the
+ * PlayingPhase player pane.
+ */
+function getScrollWindow(
+  selectedIndex: number,
+  itemCount: number,
+  visibleRows: number,
+  previousStart: number,
+): ScrollWindow {
+  const rowCount = Math.max(2, visibleRows);
+  const maxStart = Math.max(0, itemCount - rowCount);
+  let start = Math.min(Math.max(0, previousStart), maxStart);
+
+  if (selectedIndex < start) {
+    start = selectedIndex;
+  } else if (selectedIndex >= start + rowCount) {
+    start = selectedIndex - rowCount + 1;
+  }
+  start = Math.min(Math.max(0, start), maxStart);
+
+  const end = Math.min(itemCount, start + rowCount);
+  return {
+    start,
+    end,
+    canScrollUp: start > 0,
+    canScrollDown: end < itemCount,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Usage segment rendering
 // ---------------------------------------------------------------------------
@@ -183,6 +221,8 @@ export function ConnectionsPhase({
   const [tierIndex, setTierIndex] = useState(0);
   const [tierModelIndex, setTierModelIndex] = useState(0);
   const [imageModelIndex, setImageModelIndex] = useState(0);
+  const tierModelScrollStartRef = useRef(0);
+  const imageModelScrollStartRef = useRef(0);
   const [addProviderIndex, setAddProviderIndex] = useState(0);
   const [addProvider, setAddProvider] = useState("");
   const [keyInput, setKeyInput] = useState("");
@@ -400,10 +440,12 @@ export function ConnectionsPhase({
       if (key.return) {
         if (tierIndex < TIERS.length && allModels.length > 0) {
           setTierModelIndex(0);
+          tierModelScrollStartRef.current = 0;
           setScreen("tier-pick");
         } else if (tierIndex === TIERS.length && largeConnection) {
           const currentIndex = imageModels.findIndex((m) => m.modelId === imageAssignment?.modelId);
           setImageModelIndex(Math.max(0, currentIndex));
+          imageModelScrollStartRef.current = 0;
           setScreen("image-pick");
         }
       }
@@ -682,12 +724,28 @@ export function ConnectionsPhase({
     const lines: React.ReactNode[] = [];
     lines.push(<Text key="header" color={dim}>Select model for {TIER_LABELS[tier]}:</Text>);
     lines.push(<Text key="sep"> </Text>);
-    for (let i = 0; i < allModels.length; i++) {
+    const visibleModelRows = termRows - theme.asset.height * 2 - lines.length;
+    const window = getScrollWindow(
+      tierModelIndex,
+      allModels.length,
+      visibleModelRows,
+      tierModelScrollStartRef.current,
+    );
+    tierModelScrollStartRef.current = window.start;
+    for (let i = window.start; i < window.end; i++) {
       const m = allModels[i];
       const selected = i === tierModelIndex;
+      const visibleIndex = i - window.start;
+      const arrow = visibleIndex === 0 ? "\u25B2" : visibleIndex === 1 ? "\u25BC" : " ";
+      const arrowAvailable = visibleIndex === 0 ? window.canScrollUp : window.canScrollDown;
       lines.push(
         <Text key={`${m.connectionId}-${m.modelId}`} color={selected ? accent : fg}>
-          {selected ? "\u25C6 " : "  "}{m.label}
+          {visibleIndex < 2
+            ? arrowAvailable
+              ? <Text color="#aaff00">{arrow}</Text>
+              : <Text dimColor>{arrow}</Text>
+            : arrow}
+          {" "}{selected ? "\u25C6 " : "  "}{m.label}
         </Text>,
       );
     }
@@ -702,12 +760,28 @@ export function ConnectionsPhase({
     const lines: React.ReactNode[] = [];
     lines.push(<Text key="header" color={dim}>Select image model for {largeConnection?.label}:</Text>);
     lines.push(<Text key="sep"> </Text>);
-    for (let i = 0; i < imageModels.length; i++) {
+    const visibleModelRows = termRows - theme.asset.height * 2 - lines.length;
+    const window = getScrollWindow(
+      imageModelIndex,
+      imageModels.length,
+      visibleModelRows,
+      imageModelScrollStartRef.current,
+    );
+    imageModelScrollStartRef.current = window.start;
+    for (let i = window.start; i < window.end; i++) {
       const m = imageModels[i];
       const selected = i === imageModelIndex;
+      const visibleIndex = i - window.start;
+      const arrow = visibleIndex === 0 ? "\u25B2" : visibleIndex === 1 ? "\u25BC" : " ";
+      const arrowAvailable = visibleIndex === 0 ? window.canScrollUp : window.canScrollDown;
       lines.push(
         <Text key={m.modelId ?? "provider-default"} color={selected ? accent : fg}>
-          {selected ? "\u25C6 " : "  "}{m.label}
+          {visibleIndex < 2
+            ? arrowAvailable
+              ? <Text color="#aaff00">{arrow}</Text>
+              : <Text dimColor>{arrow}</Text>
+            : arrow}
+          {" "}{selected ? "\u25C6 " : "  "}{m.label}
         </Text>,
       );
     }


### PR DESCRIPTION
## Summary

- keep text-model assignment pickers within the available terminal viewport
- keep the highlighted model visible as arrow-key navigation crosses viewport edges
- add PlayingPhase-style `▲` / `▼` scroll-availability indicators
- apply the same behavior to image-model assignment pickers

## Why

Model assignment pickers rendered every configured model at once. When the list exceeded the terminal height, Ink clipped the overflow while selection continued moving off-screen, leaving users unable to see the active model.

## User impact

Users with many configured models can now navigate the entire list while the selected row remains visible. The arrows show whether more models are available above or below.

## Validation

- `npx vitest related --run packages/client-ink/src/phases/ConnectionsPhase.tsx packages/client-ink/src/phases/ConnectionsPhase.test.tsx`
- `npm run check` (209 test files; 3,840 passed, 14 skipped)
- pre-push `token-stamp`, `catalog-docs`, and full `check` gates
