### PR TITLE
Lead DM personality choices with The Chronicler

### DIFF
--- a/docs/game-initialization.md
+++ b/docs/game-initialization.md
@@ -199,7 +199,7 @@ The setup agent reports every resolution in `finalize_setup.fork_selections` (`f
 
 ## DM Personalities
 
-The player picks a DM personality during setup — like choosing a narrator in Rimworld. Under the hood, this swaps a personality block into the DM's system prompt. The core DM prompt (role, rules, tool usage) stays the same; the personality block adjusts voice, pacing preferences, and storytelling tendencies.
+The player picks a DM personality during setup — like choosing a narrator in Rimworld. Whenever the setup agent presents personality choices, The Chronicler is always the first option. Under the hood, this swaps a personality block into the DM's system prompt. The core DM prompt (role, rules, tool usage) stays the same; the personality block adjusts voice, pacing preferences, and storytelling tendencies.
 
 Personalities are stored as short prompt fragments shipped with the app. Each is ~100-200 tokens — cheap enough to include in the cached prefix with no meaningful cost impact.
 

--- a/packages/engine/src/agents/subagents/setup-conversation.test.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.test.ts
@@ -912,6 +912,19 @@ describe("createSetupConversation", () => {
     expect(systemPrompt).not.toContain("don't feel bound to this list");
   });
 
+  it("system prompt makes The Chronicler the first DM personality option", async () => {
+    const provider = mockProvider([textResponse("Welcome!")]);
+    const conv = createSetupConversation(provider, "claude-sonnet-4-6");
+    await conv.start(noop);
+
+    const streamCalls = (provider.stream as ReturnType<typeof vi.fn>).mock.calls;
+    const systemPrompt = flattenSystem(streamCalls[0][0].systemPrompt);
+
+    expect(systemPrompt).toContain(
+      "When presenting personality choices, the first option is always The Chronicler.",
+    );
+  });
+
   it("finalize_setup treats literal string 'null' system as null", async () => {
     const input = { ...FINALIZE_INPUT, system: "null" };
     const provider = mockProvider([

--- a/packages/engine/src/agents/subagents/setup-conversation.ts
+++ b/packages/engine/src/agents/subagents/setup-conversation.ts
@@ -727,7 +727,7 @@ function buildSystemPrompt(
 
   blocks.push({
     text: "\n\n## Available campaign worlds\n\nUse these when presenting Quick Start options or campaign ideas. Pick worlds that match the player's genre if known. When presenting worlds as choices, use the name as the choice label and the summary (or description if available) as the choice description. For worlds marked [has detail], call `load_world` with the slug to get the full DM detail and any suboptions to present to the player.\n\n" + seedList +
-      "\n\n## Available DM personalities\n\nWhen presenting personality choices, use the name as the choice label and the description as the choice description. You can also invent new personalities beyond this list — if a campaign calls for a voice that isn't here, or the player asks for something custom, craft a name and prompt fragment in the same style as the examples below.\n\n" + personalityList,
+      "\n\n## Available DM personalities\n\nWhen presenting personality choices, the first option is always The Chronicler. Use the name as the choice label and the description as the choice description. You can also invent new personalities beyond this list — if a campaign calls for a voice that isn't here, or the player asks for something custom, craft a name and prompt fragment in the same style as the examples below.\n\n" + personalityList,
   });
 
   // Name inspiration — same entropy injection the DM gets (see


### PR DESCRIPTION
## Summary

- instruct the game setup agent to always present The Chronicler as the first DM personality option
- add focused regression coverage for the setup system prompt
- document the personality-choice ordering in the game initialization guide

## Why

The Chronicler is the neutral, low-directive DM personality and is a reliable default for any campaign. Leading with it gives players a safe first choice while preserving all existing personality options and custom-personality support.

## Validation

- `npx vitest run packages/engine/src/agents/subagents/setup-conversation.test.ts` (69 passed)
- `npm run golden:verify` (14 passed, 14 skipped)
- `npm run check` (209 files passed; 3,842 tests passed, 14 skipped; lint clean)
- pre-push token stamps and catalog docs checks clean