### PR TITLE
fix: create the config dir before the first write (#768)

### DIFF
--- a/packages/engine/src/config/connections.test.ts
+++ b/packages/engine/src/config/connections.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -105,6 +105,36 @@ describe("saveConnectionStore", () => {
     const leftovers = readdirSync(tempDir).filter((f) => f.startsWith(".connections.json.") && f.endsWith(".tmp"));
     expect(leftovers).toEqual([]);
     expect(readdirSync(tempDir)).toContain("connections.json");
+  });
+
+  it("creates the config dir when it does not exist yet (#768 fresh install)", () => {
+    // On a fresh install the first connection save is the first write into the
+    // config dir — nothing has created it. Before #768 the staged temp write
+    // threw ENOENT and the completed OAuth sign-in was lost.
+    const freshDir = join(tempDir, "MachineViolet");
+    expect(existsSync(freshDir)).toBe(false);
+    const conn: AIConnection = {
+      id: "fresh", provider: "openai-chatgpt", label: "ChatGPT",
+      apiKey: "", chatgptAccount: { id: "acct-1", email: "u@example.com" },
+      models: [], source: "oauth", addedAt: "2026-07-31T00:00:00.000Z",
+    };
+    expect(() => saveConnectionStore(freshDir, {
+      connections: [conn],
+      tierAssignments: { large: null, medium: null, small: null },
+      imageAssignment: null,
+    })).not.toThrow();
+    expect(loadConnectionStore(freshDir).connections).toHaveLength(1);
+    expect(loadConnectionStore(freshDir).connections[0]).toMatchObject(conn);
+  });
+
+  it("creates missing intermediate dirs (config root itself absent)", () => {
+    const nested = join(tempDir, "a", "b", "MachineViolet");
+    saveConnectionStore(nested, {
+      connections: [],
+      tierAssignments: { large: null, medium: null, small: null },
+      imageAssignment: null,
+    });
+    expect(readdirSync(nested)).toContain("connections.json");
   });
 
   it("stays valid JSON across many back-to-back saves (crash/interleave surrogate)", () => {

--- a/packages/engine/src/config/connections.ts
+++ b/packages/engine/src/config/connections.ts
@@ -12,7 +12,7 @@
  * xAI remains implemented for the Grok 4.6 retest tracked in #749, but is
  * deliberately absent from effective/user-visible connections until then.
  */
-import { readFileSync, writeFileSync, renameSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import {
@@ -182,6 +182,13 @@ export function saveConnectionStore(appDir: string, store: ConnectionStore): voi
     imageAssignment: store.imageAssignment,
   };
   const target = join(appDir, STORE_FILENAME);
+  // The config dir is not guaranteed to exist. On a fresh install the first
+  // thing a user does is connect a provider, so this is the very first write
+  // into it — nothing has created it yet, and the temp write below failed
+  // ENOENT (#768). 0o700 matches migrateConfigFromExeDir: the dir holds API
+  // keys and OAuth tokens. Recursive mkdir is idempotent, so the steady-state
+  // cost is one syscall per save.
+  mkdirSync(appDir, { recursive: true, mode: 0o700 });
   // Atomic write: serialize to a unique temp file in the same dir, then rename
   // over the target. A rename is atomic on a filesystem, so a reader — or a
   // concurrent writer, e.g. a second parallel mvplay session whose codex

--- a/packages/engine/src/config/discord.test.ts
+++ b/packages/engine/src/config/discord.test.ts
@@ -46,6 +46,12 @@ describe("saveDiscordSettings", () => {
     expect(result).toEqual({ enabled: false });
   });
 
+  it("creates the config dir when it does not exist yet (#768)", () => {
+    const freshDir = join(tempDir, "MachineViolet");
+    saveDiscordSettings(freshDir, { enabled: false });
+    expect(loadDiscordSettings(freshDir)).toEqual({ enabled: false });
+  });
+
   it("writes valid JSON to disk", () => {
     saveDiscordSettings(tempDir, { enabled: true });
     const raw = readFileSync(join(tempDir, "discord-settings.json"), "utf-8");

--- a/packages/engine/src/config/discord.ts
+++ b/packages/engine/src/config/discord.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 const STORE_FILENAME = "discord-settings.json";
@@ -23,7 +23,10 @@ export function loadDiscordSettings(appDir: string): DiscordSettings {
   }
 }
 
-/** Persist Discord settings to the config directory. */
+/** Persist Discord settings to the config directory. Creates it if needed. */
 export function saveDiscordSettings(appDir: string, settings: DiscordSettings): void {
+  // The config dir may not exist yet — any of its writers can be the first
+  // one on a fresh install (#768).
+  mkdirSync(appDir, { recursive: true, mode: 0o700 });
   writeFileSync(join(appDir, STORE_FILENAME), JSON.stringify(settings, null, 2) + "\n", "utf-8");
 }

--- a/packages/engine/src/config/first-launch.ts
+++ b/packages/engine/src/config/first-launch.ts
@@ -106,7 +106,10 @@ export function migrateConfigFromExeDir(): void {
 /**
  * Load .env from the best available location.
  * Priority: env var already set > config dir > exe directory (legacy) > cwd
- * No-op if ANTHROPIC_API_KEY is already in the environment.
+ *
+ * An ANTHROPIC_API_KEY already in the environment skips the .env *loading*
+ * only — the compiled-mode config migration below still runs, since it is
+ * unrelated to where the key came from (#768).
  */
 export function loadEnv(): void {
   // Migrate any config files left next to the exe from a prior version. This

--- a/packages/engine/src/config/first-launch.ts
+++ b/packages/engine/src/config/first-launch.ts
@@ -109,13 +109,19 @@ export function migrateConfigFromExeDir(): void {
  * No-op if ANTHROPIC_API_KEY is already in the environment.
  */
 export function loadEnv(): void {
+  // Migrate any config files left next to the exe from a prior version. This
+  // runs BEFORE the early return below: migration (and the config-dir mkdir it
+  // does on the way) has nothing to do with whether a key already happens to be
+  // in the environment, and gating it on that left a fresh install with no
+  // config dir at all — the first connection save then died ENOENT (#768).
+  // saveConnectionStore now creates the dir itself; this keeps startup from
+  // silently skipping the migration too.
+  if (isCompiled()) migrateConfigFromExeDir();
+
   if (process.env.ANTHROPIC_API_KEY) return;
 
   // In compiled mode, use the platform config directory
   if (isCompiled()) {
-    // Migrate any config files left next to the exe from a prior version
-    migrateConfigFromExeDir();
-
     const cfgEnv = join(configDir(), ".env");
     if (existsSync(cfgEnv)) {
       dotenvConfig({ path: cfgEnv, quiet: true });

--- a/packages/engine/src/config/machine-settings.test.ts
+++ b/packages/engine/src/config/machine-settings.test.ts
@@ -1,48 +1,58 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readFileSync, writeFileSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { loadMachineSettings, saveMachineSettings } from "./machine-settings.js";
 
-vi.mock("node:fs", () => ({
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
-}));
-
-const mockRead = vi.mocked(readFileSync);
-const mockWrite = vi.mocked(writeFileSync);
+// Real fs against a temp dir (matching discord.test.ts / connections.test.ts)
+// rather than a `node:fs` module mock: the dir-creation behavior these settings
+// depend on (#768) is exactly what a mocked fs can't observe.
+let tempDir: string;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  tempDir = mkdtempSync(join(tmpdir(), "mv-machine-settings-test-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
 });
 
 describe("loadMachineSettings", () => {
   it("returns defaults when file is missing", () => {
-    mockRead.mockImplementation(() => { throw new Error("ENOENT"); });
-    expect(loadMachineSettings("/tmp")).toEqual({ devModeEnabled: false });
+    expect(loadMachineSettings(tempDir)).toEqual({ devModeEnabled: false });
   });
 
   it("returns defaults when file is corrupt", () => {
-    mockRead.mockReturnValue("not json" as never);
-    expect(loadMachineSettings("/tmp")).toEqual({ devModeEnabled: false });
+    writeFileSync(join(tempDir, "machine-settings.json"), "not json", "utf-8");
+    expect(loadMachineSettings(tempDir)).toEqual({ devModeEnabled: false });
   });
 
   it("loads saved settings", () => {
-    mockRead.mockReturnValue(JSON.stringify({ devModeEnabled: true }) as never);
-    expect(loadMachineSettings("/tmp")).toEqual({ devModeEnabled: true });
+    writeFileSync(join(tempDir, "machine-settings.json"), JSON.stringify({ devModeEnabled: true }), "utf-8");
+    expect(loadMachineSettings(tempDir)).toEqual({ devModeEnabled: true });
   });
 
   it("rejects non-boolean devModeEnabled", () => {
-    mockRead.mockReturnValue(JSON.stringify({ devModeEnabled: "yes" }) as never);
-    expect(loadMachineSettings("/tmp")).toEqual({ devModeEnabled: false });
+    writeFileSync(join(tempDir, "machine-settings.json"), JSON.stringify({ devModeEnabled: "yes" }), "utf-8");
+    expect(loadMachineSettings(tempDir)).toEqual({ devModeEnabled: false });
   });
 });
 
 describe("saveMachineSettings", () => {
   it("writes JSON to the correct path", () => {
-    saveMachineSettings("/tmp/cfg", { devModeEnabled: true });
-    expect(mockWrite).toHaveBeenCalledWith(
-      expect.stringContaining("machine-settings.json"),
-      expect.stringContaining('"devModeEnabled": true'),
-      "utf-8",
-    );
+    saveMachineSettings(tempDir, { devModeEnabled: true });
+    const raw = readFileSync(join(tempDir, "machine-settings.json"), "utf-8");
+    expect(JSON.parse(raw)).toEqual({ devModeEnabled: true });
+  });
+
+  it("round-trips through loadMachineSettings", () => {
+    saveMachineSettings(tempDir, { devModeEnabled: true });
+    expect(loadMachineSettings(tempDir)).toEqual({ devModeEnabled: true });
+  });
+
+  it("creates the config dir when it does not exist yet (#768)", () => {
+    const freshDir = join(tempDir, "MachineViolet");
+    saveMachineSettings(freshDir, { devModeEnabled: true });
+    expect(loadMachineSettings(freshDir)).toEqual({ devModeEnabled: true });
   });
 });

--- a/packages/engine/src/config/machine-settings.ts
+++ b/packages/engine/src/config/machine-settings.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 const STORE_FILENAME = "machine-settings.json";
@@ -25,7 +25,10 @@ export function loadMachineSettings(appDir: string): MachineSettings {
   }
 }
 
-/** Persist machine settings to the config directory. */
+/** Persist machine settings to the config directory. Creates it if needed. */
 export function saveMachineSettings(appDir: string, settings: MachineSettings): void {
+  // The config dir may not exist yet — any of its writers can be the first
+  // one on a fresh install (#768).
+  mkdirSync(appDir, { recursive: true, mode: 0o700 });
   writeFileSync(join(appDir, STORE_FILENAME), JSON.stringify(settings, null, 2) + "\n", "utf-8");
 }


### PR DESCRIPTION
Fixes #768. **v1.1.1 release blocker** — the cut is holding for this.

## The bug

On a fresh install, completing the ChatGPT OAuth flow in the reworked Connect-to-AI wizard (#766) died with:

```
ENOENT: no such file or directory, open
'C:\Users\quant\AppData\Roaming\MachineViolet\.connections.json.54768.05ed0c3.tmp'
```

The OAuth itself succeeded — only persistence failed, so the sign-in was silently lost.

`saveConnectionStore` stages its atomic write into a temp file inside `appDir` and renames over the target, but nothing in the module ever created `appDir`. Pre-#766 this was masked: the old flow wrote other config into the dir first. The new wizard makes the connection save the *first* write on a fresh machine, which is the primary new-user path.

## The fix

**At the write sites, where the assumption lives.** `mkdirSync(appDir, { recursive: true, mode: 0o700 })` before writing. `0o700` matches `migrateConfigFromExeDir` — this dir holds API keys and OAuth tokens. Recursive mkdir is idempotent, so the steady-state cost is one syscall per save.

The audit turned up two siblings writing into the same dir under the same assumption, either of which could be the first writer on a fresh install:

| | |
|---|---|
| `saveConnectionStore` | the reported one; also the path ChatGPT token refresh persists through |
| `saveMachineSettings` | |
| `saveDiscordSettings` | |

`client-settings.ts` (client-ink) already `mkdir`'d; nothing else writes there. `config.json` / `.env` have no writer in the current tree — `buildAppConfig` / `buildEnvContent` are referenced only by their own tests.

## One thing the issue didn't call out

`loadEnv()` returned early when `ANTHROPIC_API_KEY` was already in the environment, which skipped `migrateConfigFromExeDir()` — the only thing that created the config dir at startup, **and** the only thing that pulls forward config left next to the exe by an older version. Neither has anything to do with whether a key happens to be set.

The migration now runs before that early return. I can't confirm from here which path left the dir missing on the smoke machine, so treat this as belt to the mkdir's braces — but it's wrong on its own terms, and it un-breaks the exe-dir migration for anyone with an env key set.

## Tests

Saving into a dir that does not exist yet succeeds and round-trips via the matching loader, for all three stores, plus a nested-missing-parents case for connections. **All four fail with the exact production ENOENT when the mkdir is reverted** — verified, not assumed.

`machine-settings.test.ts` moves off its `node:fs` module mock onto a real temp dir (matching `discord.test.ts` / `connections.test.ts`): a mocked fs cannot observe dir creation at all.

`npm run check` green — 210 files, 3899 tests.

## Branch choice

`release` is still at the v1.1.0 promote and doesn't carry the #766 wizard, so the ENOENT stays masked there — no cherry-pick needed. The v1.1.1 promote carries this fix.

## Verification after merge

Rerun the nightly; the install-method smoke resumes from the ChatGPT sign-in step.

## No doc updates

No documented behavior, on-disk format, or contract changed, and nothing in `docs/` describes config-dir creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
