### PR TITLE
Remove stray console.log from POST /turn/contribute

### DIFF
--- a/packages/engine/src/server/routes/session.ts
+++ b/packages/engine/src/server/routes/session.ts
@@ -44,7 +44,6 @@ export const sessionRoutes: FastifyPluginAsync = async (server: FastifyInstance)
       },
     },
   }, async (request, reply) => {
-    console.log(`[contribute] text="${(request.body as ContributeRequest)?.text?.slice(0, 50)}"`);
     const tm = server.sessionManager.getTurnManager();
     if (!tm) {
       return reply.status(400).send({ error: "No turn manager." });


### PR DESCRIPTION
## Problem

`packages/engine/src/server/routes/session.ts` had an unconditional debug print at the top of the `POST /turn/contribute` handler:

```ts
console.log(`[contribute] text="${(request.body as ContributeRequest)?.text?.slice(0, 50)}"`);
```

The engine server and the Ink TUI client share **one process** (`scripts/launcher.ts` — `startClient()` runs in-process after the server starts), so this wrote a stray line into the player's terminal on every single submitted input, scrolling/dirtying the rendered frame. It also echoed player text to stdout, a privacy wart in any captured log.

Added incidentally in 6dfa93a3 ("Fix openNextTurn: don't bail when gameState is null (setup mode)") — debug residue.

## Fix

Deleted the line, rather than re-routing it through `logEvent(...)`.

No replacement is needed: the structured engine log already records player input at `packages/engine/src/agents/game-engine.ts:669` —

```ts
logEvent("turn:player_input", { character: characterName, textLength: text.length });
```

— and it deliberately logs the *length* rather than the text, so re-routing the print through `logEvent` would only have reintroduced the privacy wart in a different file. The neighbouring rejection path (`server.log.warn` on "no open turn") stays as-is; that's the right altitude for an exceptional case, whereas a per-input trace is not.

## Verification

`npm run check` green — lint clean, 3904 tests passed / 14 skipped across 210 files.

No docs updated: removing a debug print changes no documented behavior (REST contract, state shape, and turn semantics are all unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)