### PR TITLE
fix(tui): content-stable narrative line keys — images no longer remount when indices shift

### DIFF
--- a/packages/client-ink/src/tui/components/NarrativeArea.test.tsx
+++ b/packages/client-ink/src/tui/components/NarrativeArea.test.tsx
@@ -1,14 +1,34 @@
 import React, { useRef, useEffect } from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render } from "ink-testing-library";
 import { Text } from "ink";
 import type { NarrativeLine, ProcessedLine } from "@machine-violet/shared/types/tui.js";
 import { processNarrativeLines, toPlainText } from "../formatting.js";
+import { GameProvider, type GameContextValue } from "../game-context.js";
+import { clearPainters } from "../image/painterRegistry.js";
 import {
   checkpointForScrollOffset,
+  narrativeLineKeys,
   useProcessedLines,
   NarrativeArea,
 } from "./NarrativeArea.js";
+
+// Sharp is mocked so the remount-detection test below can (a) run without real
+// image files and (b) count decode activity: every InlineImage mount calls
+// `sharp(path)` from its metadata + decode effects, so a remount shows up as
+// new calls after the tree has settled.
+vi.mock("sharp", () => ({
+  default: vi.fn(() => ({
+    metadata: async () => ({ width: 64, height: 32 }),
+    resize: (w: number, h: number) => ({
+      ensureAlpha: () => ({
+        raw: () => ({
+          toBuffer: async () => ({ data: Buffer.alloc(w * h * 4), info: { width: w, height: h } }),
+        }),
+      }),
+    }),
+  })),
+}));
 
 
 // ---------------------------------------------------------------------------
@@ -217,5 +237,68 @@ describe("NarrativeArea transcript checkpoints", () => {
     expect(checkpointForScrollOffset(processed, 1, getPosition)?.resourceValues.Aldric.HP).toBe("18/30");
     expect(checkpointForScrollOffset(processed, 1.5, getPosition)?.resourceValues.Aldric.HP).toBe("12/30");
     expect(checkpointForScrollOffset(processed, 3, getPosition)?.resourceValues.Aldric.HP).toBe("12/30");
+  });
+});
+
+describe("narrativeLineKeys", () => {
+  const img = (path: string): ProcessedLine => ({ kind: "image", nodes: [path], intent: "scene_snapshot" } as never);
+  const text = (t: string): ProcessedLine => ({ kind: "dm", nodes: [t] } as never);
+
+  it("keys image lines by path, independent of position (#781)", () => {
+    const image = img("/campaign/images/scene-001.png");
+    const before = narrativeLineKeys([text("a"), image, text("b")]);
+    // Insert two lines above — the image key must not move with its index.
+    const after = narrativeLineKeys([text("x"), text("y"), text("a"), image, text("b")]);
+    expect(before[1]).toBe("img:/campaign/images/scene-001.png:0");
+    expect(after[3]).toBe(before[1]);
+  });
+
+  it("disambiguates repeated paths by append-order occurrence", () => {
+    const p = "/campaign/images/scene-001.png";
+    const keys = narrativeLineKeys([img(p), text("a"), img(p)]);
+    expect(keys[0]).toBe(`img:${p}:0`);
+    expect(keys[2]).toBe(`img:${p}:1`);
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("keeps index keys for non-image lines", () => {
+    expect(narrativeLineKeys([text("a"), text("b")])).toEqual([0, 1]);
+  });
+});
+
+describe("image line remounts (#781)", () => {
+  const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  it("inserting a line above an image does not remount/re-decode it", async () => {
+    const sharp = (await import("sharp")).default as unknown as ReturnType<typeof vi.fn>;
+    clearPainters();
+    const imagePath = "/fake/scene-001.png";
+    const gameCtx = {
+      graphicsCaps: { kitty: false, iterm2: false, sixel: true, cellPixels: { width: 10, height: 20 }, sixelColorRegisters: 256 },
+      stdinFilterChain: null,
+      usageStatus: null,
+    } as unknown as GameContextValue;
+    const image: NarrativeLine = { kind: "image", text: imagePath, intent: "scene_snapshot" };
+    const base: NarrativeLine[] = [dm("Above."), dm(""), image, dm("Below.")];
+
+    const ui = (lines: NarrativeLine[]) => (
+      <GameProvider value={gameCtx}>
+        <NarrativeArea lines={lines} maxRows={16} width={40} viewportTop={0} />
+      </GameProvider>
+    );
+    const { rerender, unmount } = render(ui(base));
+    await delay(120); // metadata + decode effects settle
+    const settled = sharp.mock.calls.length;
+    expect(settled).toBeGreaterThan(0); // the image actually mounted + decoded
+
+    // Reflow: new content ABOVE the image shifts every subsequent index.
+    rerender(ui([dm("Inserted!"), dm(""), ...base]));
+    await delay(120);
+    // Same InlineImage instance → no new metadata read, no re-decode. (With
+    // index keys this was a full remount: dispose + fresh sharp decode.)
+    expect(sharp.mock.calls.length).toBe(settled);
+
+    unmount();
+    clearPainters();
   });
 });

--- a/packages/client-ink/src/tui/components/NarrativeArea.test.tsx
+++ b/packages/client-ink/src/tui/components/NarrativeArea.test.tsx
@@ -268,6 +268,25 @@ describe("narrativeLineKeys", () => {
 
 describe("image line remounts (#781)", () => {
   const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  /**
+   * Wait until `count()` has been stable for `stableMs` (bounded by
+   * `timeoutMs`). Anchored to the observed decode activity instead of a fixed
+   * sleep, so the test doesn't get slower than needed or flaky under CI load.
+   */
+  const quiesce = async (count: () => number, stableMs = 100, timeoutMs = 3000): Promise<void> => {
+    const start = Date.now();
+    let last = count();
+    let lastChange = Date.now();
+    while (Date.now() - lastChange < stableMs) {
+      if (Date.now() - start > timeoutMs) return;
+      await delay(10);
+      const c = count();
+      if (c !== last) {
+        last = c;
+        lastChange = Date.now();
+      }
+    }
+  };
 
   it("inserting a line above an image does not remount/re-decode it", async () => {
     const sharp = (await import("sharp")).default as unknown as ReturnType<typeof vi.fn>;
@@ -287,15 +306,18 @@ describe("image line remounts (#781)", () => {
       </GameProvider>
     );
     const { rerender, unmount } = render(ui(base));
-    await delay(120); // metadata + decode effects settle
+    // Wait for decode activity to start, then for it to stop changing.
+    while (sharp.mock.calls.length === 0) await delay(10);
+    await quiesce(() => sharp.mock.calls.length);
     const settled = sharp.mock.calls.length;
     expect(settled).toBeGreaterThan(0); // the image actually mounted + decoded
 
     // Reflow: new content ABOVE the image shifts every subsequent index.
     rerender(ui([dm("Inserted!"), dm(""), ...base]));
-    await delay(120);
+    await quiesce(() => sharp.mock.calls.length);
     // Same InlineImage instance → no new metadata read, no re-decode. (With
-    // index keys this was a full remount: dispose + fresh sharp decode.)
+    // index keys this was a full remount: dispose + fresh sharp decode —
+    // quiesce would observe the new calls and the count comparison fails.)
     expect(sharp.mock.calls.length).toBe(settled);
 
     unmount();

--- a/packages/client-ink/src/tui/components/NarrativeArea.tsx
+++ b/packages/client-ink/src/tui/components/NarrativeArea.tsx
@@ -161,6 +161,35 @@ export function useProcessedLines(
   return fullResult;
 }
 
+/**
+ * Content-stable React keys for the processed-line list (issue #781).
+ *
+ * Keying by array index remounts components whenever indices shift — and the
+ * incremental pipeline shifts them routinely (tail reprocessing changes line
+ * counts as paragraphs re-wrap; toggling verbose moves every subsequent line).
+ * For text rows a remount is invisible, but an image line remount destroys the
+ * InlineImage instance: painter unregistered, prepared raster disposed, erase
+ * emitted, then a fresh mount re-reads metadata and re-decodes asynchronously —
+ * the image visibly blinks out and back whenever content above it reflows.
+ *
+ * So image lines get a key derived from their path (`nodes[0]`), disambiguated
+ * by occurrence order for repeated paths — stable because the transcript is
+ * append-only, so an image's same-path predecessors never change. Everything
+ * else keeps its index (numeric keys can't collide with the `img:` strings).
+ * Stable image keys also let ScrollView's per-item height cache survive
+ * reflows, since MeasurableItem entries are keyed by child key.
+ */
+export function narrativeLineKeys(lines: readonly ProcessedLine[]): (string | number)[] {
+  const seen = new Map<string, number>();
+  return lines.map((line, i) => {
+    if (line.kind !== "image") return i;
+    const path = typeof line.nodes[0] === "string" ? line.nodes[0] : "";
+    const n = seen.get(path) ?? 0;
+    seen.set(path, n + 1);
+    return `img:${path}:${n}`;
+  });
+}
+
 export type NarrativeAreaHandle = ScrollHandle;
 
 interface NarrativeAreaProps {
@@ -253,6 +282,9 @@ export const NarrativeArea = forwardRef<NarrativeAreaHandle, NarrativeAreaProps>
   // Checkpoints survive this pipeline as zero-height processed rows.
   const processedLines = useProcessedLines(visibleLines, width ?? 0, quoteColor);
 
+  // Content-stable keys so image lines never remount when indices shift (#781).
+  const lineKeys = useMemo(() => narrativeLineKeys(processedLines), [processedLines]);
+
   // Build a clamped ScrollHandle and expose it to both parent and local refs
   useScrollHandle(ref, scrollRef);
   useScrollHandle(localHandleRef, scrollRef);
@@ -339,7 +371,7 @@ export const NarrativeArea = forwardRef<NarrativeAreaHandle, NarrativeAreaProps>
       >
         {processedLines.map((line, i) => (
           <NarrativeLineComponent
-            key={i}
+            key={lineKeys[i]}
             line={line}
             playerColor={playerColor}
             width={width}
@@ -520,3 +552,5 @@ const NarrativeLineComponent = React.memo(function NarrativeLineComponent({
     }
   }
 });
+
+

--- a/packages/test-harness/bin/image-testbed-app.tsx
+++ b/packages/test-harness/bin/image-testbed-app.tsx
@@ -1,19 +1,21 @@
 /**
- * Visual testbed app for the inline-image renderer (issue: spurious blanking +
- * misposition in the scroll viewport).
+ * Visual testbed app for the inline-image renderer (issues #778/#780/#781).
  *
- * A minimal, API-key-free stand-in for the game screen that exercises exactly
- * the layers the bugs live in: real Ink (fullscreen, incremental rendering),
- * the sync-write combiner + painter registry, ScrollView's virtual scroll, and
- * a real InlineImage with forced graphics caps. Drive it from a
- * graphics-capable terminal (or the xterm.js browser rig — see
- * image-testbed-server.mjs in the session scratchpad) and eyeball:
+ * A minimal, API-key-free stand-in for the game screen that exercises the REAL
+ * narrative stack: Ink (fullscreen, incremental rendering), the sync-write
+ * combiner + painter registry, and the production `NarrativeArea` (incremental
+ * line pipeline, ScrollView virtual scroll, content-stable line keys, real
+ * InlineImage wiring) with forced graphics caps. Drive it from a
+ * graphics-capable terminal or the xterm.js browser rig
+ * (`npm run image-testbed` — see image-testbed-server.ts) and eyeball:
  *
  *  - the image renders between its marker lines (IMG-ABOVE / IMG-BELOW);
  *  - PgUp/PgDn/j/k scrolling keeps it glued to those markers, band-cropped at
  *    the viewport edges;
  *  - the 1Hz tick (idle-frame emulation) never blanks it;
- *  - `x` forces an unrelated re-render burst (the old blank trigger).
+ *  - `x` forces an unrelated re-render burst (the old blank trigger);
+ *  - `a` inserts a narrative line ABOVE the image — every line index shifts,
+ *    which used to remount the image and blink it out for a re-decode (#781).
  *
  * Env: COLS, ROWS (terminal size), CELL_W, CELL_H (cell pixels),
  * PROTOCOL (sixel | iterm2 | kitty, default sixel), IMAGE (optional PNG path).
@@ -26,9 +28,10 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import sharp from "sharp";
-import { ScrollView } from "ink-scroll-view";
-import type { ScrollViewRef } from "ink-scroll-view";
-import { InlineImage } from "../../client-ink/src/tui/image/InlineImage.js";
+import type { NarrativeLine } from "@machine-violet/shared/types/tui.js";
+import { NarrativeArea, scrollAmount } from "../../client-ink/src/tui/components/NarrativeArea.js";
+import type { NarrativeAreaHandle } from "../../client-ink/src/tui/components/NarrativeArea.js";
+import { GameProvider, type GameContextValue } from "../../client-ink/src/tui/game-context.js";
 import { OcclusionProvider } from "../../client-ink/src/tui/image/occlusion.js";
 import { installSyncWriteCombiner } from "../../client-ink/src/tui/hooks/syncWriteCombiner.js";
 import { compositePainters, setIncrementalRendering } from "../../client-ink/src/tui/image/painterRegistry.js";
@@ -75,7 +78,18 @@ async function makeTestImage(): Promise<string> {
 const HEADER_ROWS = 1;
 const FOOTER_ROWS = 1;
 const VIEW_ROWS = ROWS - HEADER_ROWS - FOOTER_ROWS;
-const IMAGE_AT = 14; // narrative line index the image sits at
+
+function makeLines(imagePath: string): NarrativeLine[] {
+  const dm = (text: string): NarrativeLine => ({ kind: "dm", text });
+  const lines: NarrativeLine[] = [];
+  for (let i = 0; i < 13; i++) lines.push(dm(`${String(i).padStart(2, "0")} narrative narrative narrative line`));
+  lines.push(dm("13 narrative narrative narrative line >>> IMG-ABOVE <<<"));
+  lines.push({ kind: "separator", text: "" });
+  lines.push({ kind: "image", text: imagePath, intent: "scene_snapshot" });
+  lines.push(dm("15 narrative narrative narrative line >>> IMG-BELOW <<<"));
+  for (let i = 16; i < 60; i++) lines.push(dm(`${String(i).padStart(2, "0")} narrative narrative narrative line`));
+  return lines;
+}
 
 interface AppProps {
   imagePath: string;
@@ -83,11 +97,12 @@ interface AppProps {
 
 function TestbedApp({ imagePath }: AppProps): React.ReactElement {
   const { exit } = useApp();
-  const scrollRef = useRef<ScrollViewRef>(null);
+  const narrativeRef = useRef<NarrativeAreaHandle>(null);
   const [tick, setTick] = useState(0);
   const [ticking, setTicking] = useState(true);
   const [burst, setBurst] = useState(0);
-  const [offset, setOffset] = useState(0);
+  const [lines, setLines] = useState<NarrativeLine[]>(() => makeLines(imagePath));
+  const insertedRef = useRef(0);
 
   useEffect(() => {
     if (!ticking) return;
@@ -95,59 +110,55 @@ function TestbedApp({ imagePath }: AppProps): React.ReactElement {
     return () => clearInterval(t);
   }, [ticking]);
 
+  // Start at the top (NarrativeArea auto-scrolls to the bottom on mount).
+  useEffect(() => {
+    const t = setTimeout(() => narrativeRef.current?.scrollBy(-99999), 50);
+    return () => clearTimeout(t);
+  }, []);
+
   useInput((input, key) => {
-    const sv = scrollRef.current;
+    const sv = narrativeRef.current;
     if (input === "q") exit();
-    else if (key.pageDown) sv?.scrollBy(Math.floor(VIEW_ROWS / 2));
-    else if (key.pageUp) sv?.scrollBy(-Math.floor(VIEW_ROWS / 2));
+    else if (key.pageDown) sv?.scrollBy(scrollAmount(VIEW_ROWS));
+    else if (key.pageUp) sv?.scrollBy(-scrollAmount(VIEW_ROWS));
     else if (input === "j" || key.downArrow) sv?.scrollBy(1);
     else if (input === "k" || key.upArrow) sv?.scrollBy(-1);
-    else if (input === "g") sv?.scrollTo(0);
-    else if (input === "G") sv?.scrollToBottom();
+    else if (input === "g") sv?.scrollBy(-99999);
+    else if (input === "G") sv?.scrollBy(99999);
     else if (input === "t") setTicking((v) => !v);
     else if (input === "x") setBurst((n) => n + 1);
+    else if (input === "a") {
+      // Insert ABOVE the image: shifts every subsequent line index (#781).
+      const n = ++insertedRef.current;
+      setLines((prev) => [{ kind: "dm", text: `-- inserted line ${n} --` }, ...prev]);
+    }
   });
 
-  const lines: React.ReactElement[] = [];
-  for (let i = 0; i < 60; i++) {
-    if (i === IMAGE_AT) {
-      lines.push(
-        <Box key="img" flexDirection="column" marginTop={1} marginBottom={1}>
-          <InlineImage
-            path={imagePath}
-            maxCols={COLS}
-            maxRows={Math.max(6, Math.round(VIEW_ROWS * 0.9))}
-            viewportTop={HEADER_ROWS}
-            viewportRows={VIEW_ROWS}
-            graphicsCaps={caps}
-          />
-        </Box>,
-      );
-      continue;
-    }
-    const marker = i === IMAGE_AT - 1 ? " >>> IMG-ABOVE <<<" : i === IMAGE_AT + 1 ? " >>> IMG-BELOW <<<" : "";
-    lines.push(
-      <Text key={i} wrap="truncate">
-        {`${String(i).padStart(2, "0")} ${"narrative ".repeat(3)}line${marker}`}
-      </Text>,
-    );
-  }
+  const gameCtx = {
+    graphicsCaps: caps,
+    stdinFilterChain: null,
+    usageStatus: null,
+  } as unknown as GameContextValue;
 
   return (
     <OcclusionProvider>
-      <Box width={COLS} height={ROWS} flexDirection="column">
-        <Text wrap="truncate" inverse>
-          {` MV image testbed  tick=${tick}${ticking ? "" : " (paused)"}  burst=${burst}  offset=${offset}  [PgUp/PgDn j/k g/G t x q] `}
-        </Text>
-        <Box height={VIEW_ROWS} flexDirection="column">
-          <ScrollView ref={scrollRef} onScroll={setOffset}>
-            {lines}
-          </ScrollView>
+      <GameProvider value={gameCtx}>
+        <Box width={COLS} height={ROWS} flexDirection="column">
+          <Text wrap="truncate" inverse>
+            {` MV image testbed  tick=${tick}${ticking ? "" : " (paused)"}  burst=${burst}  lines=${lines.length}  [PgUp/PgDn j/k g/G a t x q] `}
+          </Text>
+          <NarrativeArea
+            ref={narrativeRef}
+            lines={lines}
+            maxRows={VIEW_ROWS}
+            width={COLS}
+            viewportTop={HEADER_ROWS}
+          />
+          <Text wrap="truncate" dimColor>
+            {` protocol=${PROTOCOL} cell=${CELL_W}x${CELL_H} view=${COLS}x${VIEW_ROWS} `}
+          </Text>
         </Box>
-        <Text wrap="truncate" dimColor>
-          {` protocol=${PROTOCOL} cell=${CELL_W}x${CELL_H} view=${COLS}x${VIEW_ROWS} `}
-        </Text>
-      </Box>
+      </GameProvider>
     </OcclusionProvider>
   );
 }


### PR DESCRIPTION
Closes #781.

## The bug

`NarrativeArea` keyed processed lines by array index. Indices shift routinely — tail reprocessing changes line counts as paragraphs re-wrap, and toggling verbose moves every subsequent line. A text row remounting is invisible, but an image line remount destroys the `InlineImage` instance (painter unregistered, raster disposed, erase emitted) and the fresh mount re-decodes asynchronously — so the image **blinked out and back whenever content above it reflowed**, mid-play.

## The fix

Image lines get a content-stable key derived from their path, disambiguated by append-order occurrence for repeated paths (stable because the transcript is append-only). Other lines keep their index — numeric keys can''t collide with the `img:` strings. Bonus: stable image keys let ScrollView''s per-item height cache survive reflows, since `MeasurableItem` entries are keyed by child key.

## Verification

- Pure `narrativeLineKeys` unit tests (position independence, duplicate paths, index fallback).
- A remount-detection test: real `NarrativeArea` + `GameProvider` under ink-testing-library with mocked sharp — inserting a line above the image must produce **zero new decode calls**. Confirmed the test fails against index keys before the fix.
- The visual testbed app now drives the **real** `NarrativeArea` (incremental pipeline + ScrollView + production keys) instead of a hand-rolled replica, with a new `a` key inserting lines above the image. Verified live over sixel through the browser rig: 150ms after an insertion the image is already present at its shifted position — no decode blank, markers and band clipping intact.
- Full suite green (3,935 tests), lint + `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)