### PR TITLE
docs: drop the "runs any tabletop RPG" overclaim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,6 @@
 
 Agentic AI Dungeon Master that runs tabletop RPGs in a terminal.
 
-Accuracy note for docs and copy: Machine Violet is **not** system-agnostic and does not
-"run any tabletop RPG." It ships with a small set of bundled systems (`systems/`) plus a
-PDF ingestion path; context limits are the binding constraint on how much rules material a
-system can carry. Don't reintroduce "any tabletop RPG" phrasing.
-
 ## Agent Metadata
 
 Keep shared agent guidance in this file and reusable workflows in `.claude/skills/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,11 @@
 # Machine Violet
 
-Agentic AI Dungeon Master that runs any tabletop RPG in a terminal.
+Agentic AI Dungeon Master that runs tabletop RPGs in a terminal.
+
+Accuracy note for docs and copy: Machine Violet is **not** system-agnostic and does not
+"run any tabletop RPG." It ships with a small set of bundled systems (`systems/`) plus a
+PDF ingestion path; context limits are the binding constraint on how much rules material a
+system can carry. Don't reintroduce "any tabletop RPG" phrasing.
 
 ## Agent Metadata
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Machine Violet Documentation
 
-Agentic AI Dungeon Master that runs any tabletop RPG in a terminal.
+Agentic AI Dungeon Master that runs tabletop RPGs in a terminal.
 Ink (React for CLI) + Anthropic Claude SDK + TypeScript.
 
 ## Quick Navigation

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 # Machine Violet: An Agentic RPG in Your Console
 
-Machine Violet is an agentic DM and game state manager designed to run any tabletop RPG in a terminal. The AI is the Dungeon Master — it narrates, adjudicates, manages the world, and manipulates the UI directly. The player never sees game files or internal state. Everything is narrated.
+Machine Violet is an agentic DM and game state manager designed to run tabletop RPGs in a terminal. The AI is the Dungeon Master — it narrates, adjudicates, manages the world, and manipulates the UI directly. The player never sees game files or internal state. Everything is narrated.
 
 
 ## Architecture
@@ -46,6 +46,12 @@ Two clocks manage time automatically. A **calendar** tracks narrative time and a
 
 
 ## Game Systems
+
+Machine Violet is not system-agnostic: it runs the systems bundled in `systems/` (plus
+whatever a user ingests from PDF), not arbitrary rulesets. The binding constraint is
+context — the DM has to hold a system's mechanics in-window alongside the campaign, so
+lightweight systems play best and rules-dense ones are limited to what rule cards and
+retrieved entity files can cover.
 
 Game system support uses a three-layer content model:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -47,11 +47,10 @@ Two clocks manage time automatically. A **calendar** tracks narrative time and a
 
 ## Game Systems
 
-Machine Violet is not system-agnostic: it runs the systems bundled in `systems/` (plus
-whatever a user ingests from PDF), not arbitrary rulesets. The binding constraint is
-context — the DM has to hold a system's mechanics in-window alongside the campaign, so
-lightweight systems play best and rules-dense ones are limited to what rule cards and
-retrieved entity files can cover.
+Machine Violet plays the systems bundled in `systems/`, plus whatever a user ingests from
+PDF. The binding constraint is context — the DM holds a system's mechanics in-window
+alongside the campaign, so lightweight systems play best and rules-dense ones reach only as
+far as their rule cards and retrieved entity files.
 
 Game system support uses a three-layer content model:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -47,10 +47,10 @@ Two clocks manage time automatically. A **calendar** tracks narrative time and a
 
 ## Game Systems
 
-Machine Violet plays the systems bundled in `systems/`, plus whatever a user ingests from
-PDF. The binding constraint is context — the DM holds a system's mechanics in-window
-alongside the campaign, so lightweight systems play best and rules-dense ones reach only as
-far as their rule cards and retrieved entity files.
+Machine Violet plays the systems bundled in `systems/`, plus whatever a user ingests
+from PDF. The binding constraint is context — the DM holds a system's mechanics
+in-window alongside the campaign, so lightweight systems play best and rules-dense ones
+reach only as far as their rule cards and retrieved entity files.
 
 Game system support uses a three-layer content model:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "machine-violet",
   "version": "1.1.0",
-  "description": "Machine Violet — an agentic AI Dungeon Master that runs any tabletop RPG in a terminal",
+  "description": "Machine Violet — an agentic AI Dungeon Master that runs tabletop RPGs in a terminal",
   "main": "dist/index.js",
   "type": "module",
   "scripts": {

--- a/packages/engine/src/server/server.ts
+++ b/packages/engine/src/server/server.ts
@@ -96,7 +96,7 @@ export async function createServer(
         description: [
           "# Machine Violet Engine API",
           "",
-          "Machine Violet is an agentic AI Dungeon Master that runs any tabletop RPG.",
+          "Machine Violet is an agentic AI Dungeon Master that runs tabletop RPGs.",
           "The engine server exposes game logic over REST (this document) and WebSocket",
           "(see `docs/websocket-api.md` in the repository).",
           "",


### PR DESCRIPTION
Machine Violet is not system-agnostic — it plays the systems bundled in `systems/` (24xx, breathless, cairn, charge, dnd-5e, fate-accelerated, ironsworn) plus whatever a user ingests from PDF. Context is the binding constraint on how much rules material any one system can carry.

The "runs any tabletop RPG" tagline was the upstream source of that overclaim, and it had propagated into the docs, the npm package description, the published OpenAPI blurb, and outward-facing ad copy. Spotted while reviewing website ad copy.

## Changes

Five sites swapped to "runs tabletop RPGs," matching what `README.md`, the release-notes body, and the homebrew formula already said:

| File | Was |
|---|---|
| `CLAUDE.md:3` | "runs any tabletop RPG in a terminal" |
| `docs/index.md:3` | same tagline |
| `docs/overview.md:3` | "designed to run any tabletop RPG in a terminal" |
| `package.json:4` | npm `description` |
| `packages/engine/src/server/server.ts:99` | OpenAPI description (published in the API docs) |

`docs/overview.md` § Game Systems also now states the constraint where a reader would look for it: the DM holds a system's mechanics in-window alongside the campaign, so lightweight systems play best and rules-dense ones reach only as far as their rule cards and retrieved entity files.

`release.yml`, `nightly.yml`, and the homebrew formula already said "tabletop RPGs" without the "any" — left alone.

## Testing

`eslint` and the `server.ts` test file pass (pre-commit ran both). No behavior change — copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)